### PR TITLE
Handling the error when service layer is getting loaded

### DIFF
--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -6,6 +6,9 @@
 
 import * as path from 'path';
 import { ExtensionContext } from 'vscode';
+import Utils = require('../models/utils');
+import vscode = require('vscode');
+import Constants = require('../models/constants');
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 
 // The Service Client class handles communication with the VS Code LanguageClient
@@ -48,6 +51,10 @@ export default class SqlToolsServiceClient {
 
         // cache the client instance for later use
         this._client = new LanguageClient('sqlserverclient', serverOptions, clientOptions);
+        this._client.onReady().catch(function (error: any): void {
+              vscode.window.showErrorMessage(Constants.failedToLoadServiceClient);
+              Utils.logDebug(Constants.failedToLoadServiceClient + ' [error: ' + error + ']');
+        });
 
         // Create the language client and start the client.
         let disposable = this._client.start();

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -108,3 +108,5 @@ export const executeQueryErrorLabel = 'Query completed with errors';
 export const executeQuerySuccessLabel = 'Query executed successfully';
 export const executeQueryRowsAffected = ' row(s) affected';
 export const executeQueryCommandCompleted = 'Command(s) completed successfully.';
+
+export const failedToLoadServiceClient = 'Failed to load the service client';


### PR DESCRIPTION
Handling the error when the service layer is getting loaded and showing an error message in the extension. There's an error in vscode-languageclient that's causing the error won't show up in the extension. Assuming the fix in vscode-languageclient will be released soon, this code will handle the error correctly.
