### PR TITLE
Updated test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^6.0.2",
     "gulp-typescript": "^2.13.6",
+    "pm-mocha-jenkins-reporter": "^0.2.6",
     "tslint": "^3.14.0",
     "typescript": "^1.8.9",
     "typemoq": "^0.3.2",
-    "vscode": "^0.11.0",
-    "xunit-file": "^1.0.0"
+    "vscode": "^0.11.0"
   },
   "dependencies": {
     "async": "^2.0.0-rc.3",

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,7 +16,11 @@ let testRunner = require('vscode/lib/testrunner');
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
     ui: 'tdd', 		        // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    reporter: 'xunit-file', // output to file in xunit XML format
+    reporter: 'pm-mocha-jenkins-reporter',
+    reporterOptions: {
+        junit_report_name: 'Tests',
+        junit_report_stack: 1
+    },
     useColors: true         // colored output from test results
 });
 


### PR DESCRIPTION
I found a better test runner that outputs the xunit-style report for Jenkins in addition to printing to the console. Better yet, it won't output a file unless it is specified as a test runner argument/environment variable (which we currently only set on the build servers), so there won't be any more problems out-of-the-box when running tests locally! Sadly, I had to sacrifice was color in the test console, but I'll update this again if I come across a solution.
