### PR TITLE
Added UI for showing inner exceptions when connecting

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -176,8 +176,9 @@ export default class ConnectionManager {
 
                     resolve(true);
                 } else {
-                    Utils.showErrorMsg(Constants.msgError + result.messages);
+                    Utils.showErrorMsg(Constants.msgError + Constants.msgConnectionError);
                     self.statusView.connectError(fileUri, connectionCreds, result.messages);
+                    self.connectionUI.showConnectionErrors(result.messages);
 
                     reject();
                 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -55,6 +55,9 @@ export const msgContentProviderProvideContent = 'Content provider: provideTextDo
 export const msgChooseDatabaseNotConnected = 'Not connected. Please connect to a server first.';
 export const msgChooseDatabasePlaceholder = 'Choose a database from the list below';
 
+export const msgConnectionError = 'Connection failed. See output window for details.';
+export const connectionErrorChannelName = 'Connection Errors';
+
 export const extensionActivated = 'activated.';
 export const extensionDeactivated = 'de-activated.';
 export const msgOpenSqlFile = `To use this command, Open a .sql file -or-

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -14,10 +14,19 @@ const mssql = require('mssql');
 export class ConnectionUI {
     private _context: vscode.ExtensionContext;
     private _prompter: IPrompter;
+    private _errorOutputChannel: vscode.OutputChannel;
 
     constructor(context: vscode.ExtensionContext, prompter: IPrompter) {
         this._context = context;
         this._prompter = prompter;
+        this._errorOutputChannel = vscode.window.createOutputChannel(Constants.connectionErrorChannelName);
+    }
+
+    // Show connection errors in an output window
+    public showConnectionErrors(errorMessages: string): void {
+        this._errorOutputChannel.clear();
+        this._errorOutputChannel.append(errorMessages);
+        this._errorOutputChannel.show(true);
     }
 
     // Helper to let user choose a connection from a picklist


### PR DESCRIPTION
This goes along with PR 27 from the service layer repo [here](https://github.com/Microsoft/sqltoolsservice/pull/27)

This will have to be refactored once Anthony's changes are in to make use of the vscode wrapper and remove direct calls to the vscode API.
