### PR TITLE
Quick fix to improve init test reliability

### DIFF
--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -1,9 +1,24 @@
 import assert = require('assert');
+import vscode = require('vscode');
 
 import * as Extension from '../src/extension';
 import ConnectionManager from '../src/controllers/connectionManager';
 import MainController from '../src/controllers/controller';
 import Telemetry from '../src/models/telemetry';
+
+function ensureExtensionIsActive(): Promise<any> {
+    return new Promise((resolve, reject) => {
+        waitForExtensionToBeActive(resolve);
+    });
+}
+
+function waitForExtensionToBeActive(resolve): void {
+    if (!vscode.extensions.getExtension('microsoft.vscode-mssql').isActive) {
+        setTimeout(waitForExtensionToBeActive.bind(this, resolve), 50);
+    } else {
+        resolve();
+    }
+}
 
 suite('Initialization Tests', () => {
     setup(() => {
@@ -11,10 +26,14 @@ suite('Initialization Tests', () => {
         Telemetry.disable();
     });
 
-    test('Connection manager is initialized properly', () => {
-        // Verify that the connection manager was initialized properly
-        let controller: MainController = Extension.getController();
-        let connectionManager: ConnectionManager = controller.connectionManager;
-        assert.notStrictEqual(undefined, connectionManager.client);
+    test('Connection manager is initialized properly', (done) => {
+        // Wait for the extension to activate
+        ensureExtensionIsActive().then(() => {
+            // Verify that the connection manager was initialized properly
+            let controller: MainController = Extension.getController();
+            let connectionManager: ConnectionManager = controller.connectionManager;
+            assert.notStrictEqual(undefined, connectionManager.client);
+            done();
+        });
     });
 });


### PR DESCRIPTION
This test seems to keep failing on the build server and reports that the controller is undefined. This is initialized during extension activation, so I have a theory that the tests are getting started just before extension activation. I added some code to wait for extension activation prior to running the test.
