### PR TITLE
Removed checks for sql file when connecting and running queries

### DIFF
--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -117,7 +117,16 @@ export default class MainController implements vscode.Disposable {
     // get the T-SQL query from the editor, run it and show output
     public onRunQuery(): void {
         const self = this;
-        if (!this._connectionMgr.isConnected(this._vscodeWrapper.activeTextEditorUri)) {
+        if (!this._vscodeWrapper.isEditingSqlFile) {
+            // Prompt the user to change the language mode to SQL before running a query
+            this._connectionMgr.connectionUI.promptToChangeLanguageMode().then( result => {
+                if (result) {
+                    self.onRunQuery();
+                }
+            }).catch(err => {
+                self._vscodeWrapper.showErrorMessage(Constants.msgError + err);
+            });
+        } else if (!this._connectionMgr.isConnected(this._vscodeWrapper.activeTextEditorUri)) {
             // If we are disconnected, prompt the user to choose a connection before executing
             this.onNewConnection().then(result => {
                 if (result) {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -121,3 +121,5 @@ export const executeQueryCommandCompleted = 'Command(s) completed successfully.'
 export const serviceCompatibleVersion = '1.0.0';
 export const serviceNotCompatibleError = 'Client is not compatiable with the service layer';
 
+export const msgChangeLanguageMode = 'To use this command, you must set the language to \"SQL\". Change language mode?';
+export const timeToWaitForLanguageModeChange = 10000.0;

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -155,8 +155,11 @@ export class Timer {
 
     // Get the duration of time elapsed by the timer, in milliseconds
     public getDuration(): number {
-        if (!this._startTime || !this._endTime) {
+        if (!this._startTime) {
             return -1;
+        } else if (!this._endTime) {
+            let endTime = process.hrtime(this._startTime);
+            return  endTime[0] * 1000 + endTime[1] / 1000000;
         } else {
             return this._endTime[0] * 1000 + this._endTime[1] / 1000000;
         }


### PR DESCRIPTION
This is in response to this [defect](http://sqlbuvsts01:8080/Main/SQL%20Server/_workitems/edit/8298328). Programmatically, there is no vscode API that allows us to change the language mode of a document without involving the user (the user is forced to select a language from a dropdown). So, I talked this over with Eric and it was decided that we would remove the constraint that you must be editing a SQL file in order to connect and run a query. This opens up additional user scenarios, such as running a selected query string in a C# file, for example.

If we don't like this solution, we can discuss what should be done also.
