### PR TITLE
Bump SqlToolsService nuget package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ packages
 *.db
 *.exe
 *.log
+*.nupkg
+*.vsix
 tools
 examples

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ gulp.task('ext:copy-tests', () => {
 });
 
 gulp.task('ext:copy-packages', () => {
-    var serviceHostVersion = "0.0.6";
+    var serviceHostVersion = "0.0.7";
     return gulp.src(config.paths.project.root + '/packages/Microsoft.SqlTools.ServiceLayer.' + serviceHostVersion + '/lib/netcoreapp1.0/**/*')
             .pipe(gulp.dest(config.paths.project.root + '/out/tools/'))
 });

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SqlTools.ServiceLayer" version="0.0.6" />
+  <package id="Microsoft.SqlTools.ServiceLayer" version="0.0.7" />
 </packages>


### PR DESCRIPTION
Bump SqlToolsService to 0.0.7 to pickup SMO autocomplete.  I'm not going to push this until the SMO SqlToolsService PR is complete, but I want to get this ready so I can submit the two changes together.

This is just a package bump, so this is mostly FYI rather than requiring review.
