### PR TITLE
fixed a line too long error in lint

### DIFF
--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -123,8 +123,6 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
         return `
                 <html>
                     <head>
-                        <script   src="https://code.jquery.com/jquery-3.1.0.min.js"   integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="   crossorigin="anonymous"></script>
-
                     </head>
                     <body></body>
                     <script type="text/javascript">


### PR DESCRIPTION
It appears as though when I merged in my code before somehow extra spaces got inserted in a line. We don't actually need it so I deleted it entirely.
