### PR TITLE
Authentication type support in connection wizard

### DIFF
--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -186,7 +186,7 @@ export class ConnectionCredentials implements IConnectionCredentials {
         ];
         // In the case of win32 support integrated. For all others only SqlAuth supported
         if ('win32' === os.platform()) {
-             choices.push({ name: Constants.authTypeIntegrated, value: utils.authTypeToString(AuthenticationTypes.SqlLogin) });
+             choices.push({ name: Constants.authTypeIntegrated, value: utils.authTypeToString(AuthenticationTypes.Integrated) });
         }
         // TODO When Azure Active Directory is supported, add this here
 

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -149,6 +149,7 @@ suite('Connection Profile tests', () => {
         if ('win32' === os.platform()) {
             assert.strictEqual(authChoices.length, 2);
             assert.strictEqual(authChoices[1].name, Constants.authTypeIntegrated);
+            assert.strictEqual(authChoices[1].value, AuthenticationTypes[AuthenticationTypes.Integrated]);
 
             // And on a platform with multiple choices, should prompt for input
             assert.strictEqual(authQuestion.shouldPrompt(answers), true);


### PR DESCRIPTION
- Fix issue where SqlLogin was set as the value for Integrated auth and updated test to cover this
- Verified this works End to End now
