### PR TITLE
Fix Capitalization error in credentialstore refs

### DIFF
--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -6,8 +6,8 @@ import Utils = require('../models/utils');
 import ValidationException from '../utils/validationException';
 import { ConnectionCredentials } from '../models/connectionCredentials';
 import { IConnectionCredentials, IConnectionProfile, IConnectionCredentialsQuickPickItem, CredentialsQuickPickItemType } from '../models/interfaces';
-import { ICredentialStore } from '../credentialStore/icredentialstore';
-import { CredentialStore } from '../credentialStore/credentialstore';
+import { ICredentialStore } from '../credentialstore/icredentialstore';
+import { CredentialStore } from '../credentialstore/credentialstore';
 
 /**
  * Manages the connections list including saved profiles and the most recently used connections

--- a/test/connectionStore.test.ts
+++ b/test/connectionStore.test.ts
@@ -6,7 +6,7 @@ import vscode = require('vscode');
 import * as utils from '../src/models/utils';
 import { TestExtensionContext, TestMemento } from './stubs';
 import { IConnectionProfile } from '../src/models/interfaces';
-import { CredentialStore } from '../src/credentialStore/credentialstore';
+import { CredentialStore } from '../src/credentialstore/credentialstore';
 import { ConnectionProfile } from '../src/models/connectionProfile';
 import { ConnectionStore } from '../src/models/connectionStore';
 


### PR DESCRIPTION
- On Linux strict capitalization is enforced. Fixing references to credentialstore folder that broke due to this
