### PR TITLE
remove resize call in tab.ts because of bug with small result sets

### DIFF
--- a/src/views/htmlcontent/src/app/tab.ts
+++ b/src/views/htmlcontent/src/app/tab.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import { Component, Input, ContentChild, AfterContentChecked, AfterViewInit, ElementRef, forwardRef, Inject } from '@angular/core';
+import { Component, Input, ContentChild, AfterViewInit, ElementRef, forwardRef, Inject } from '@angular/core';
 import { SlickGrid } from './slickgrid/SlickGrid';
 
 enum SelectedTab {
@@ -14,7 +14,6 @@ enum SelectedTab {
  * Defines a Tab component which is the content of a tab on the page (to be used with the Tabs
  * component)
  */
-
 @Component({
     selector: 'tab',
     styles: [`
@@ -26,7 +25,7 @@ enum SelectedTab {
         <ng-content></ng-content>
         </div>`
 })
-export class Tab implements AfterContentChecked, AfterViewInit {
+export class Tab implements AfterViewInit {
     @Input('tabTitle') title: string;
     @Input() id: SelectedTab;
     @Input() show: boolean;
@@ -51,15 +50,6 @@ export class Tab implements AfterContentChecked, AfterViewInit {
 
     public get active(): boolean {
         return this._active;
-    }
-
-    /**
-     * Called by angular
-     */
-    ngAfterContentChecked(): void {
-        if (this.slickgrid) {
-            this.slickgrid.onResize();
-        }
     }
 
     /**


### PR DESCRIPTION
Not sure if I would call it a bug in slickgrid, but the constant call to resize was surfacing an odd interaction with slickgrid and small result sets. This call I found out is no longer needed because of how I refactored the angular rendering. Therefore removing it fixes the bug and helps with performance.
