### PR TITLE
Fixed incorrect telemetry library version in shrinkwrap file

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2868,9 +2868,9 @@
       "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz",
       "dependencies": {
         "applicationinsights": {
-          "version": "0.15.6",
-          "from": "applicationinsights@0.15.6",
-          "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
+          "version": "0.15.19",
+          "from": "applicationinsights@0.15.19",
+          "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.19.tgz"
         }
       }
     },


### PR DESCRIPTION
Replaced buggy version of the applicationinsights library that was being used. Telemetry was not being collected due to a bug in the older version of the library.

This was accidentally introduced in an earlier commit about a month ago. Any ideas on how we could prevent this in the future? npm-shrinkwrap was the only way I could find to do dependency injection of a specific version of a library into one of our node modules. We could potentially take in vscode-extension-telemetry within our code base (since it is MIT licensed) and take dependency on the newer version of applicationinsights within package.json to solve the issue, but I'm curious if there is a simpler way.
