### PR TITLE
Clicking the status bar when connected lets user change db

### DIFF
--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -101,7 +101,7 @@ export default class StatusView implements vscode.Disposable {
 
     public connectSuccess(fileUri: string, connCreds: Interfaces.IConnectionCredentials): void {
         let bar = this.getStatusBar(fileUri);
-        bar.statusConnection.command = Constants.cmdConnect;
+        bar.statusConnection.command = Constants.cmdChooseDatabase;
         bar.statusConnection.text = ConnInfo.getConnectionDisplayString(connCreds);
         bar.statusConnection.tooltip = ConnInfo.getTooltip(connCreds);
         this.showStatusBarItem(fileUri, bar.statusConnection);


### PR DESCRIPTION
Clicking the status bar will now prompt the user to change database while connected instead of listing connection profiles to connect to.
