### PR TITLE
Feature/internal user check

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,15 @@
     "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "^1.0.0",
     "pretty-data": "^0.40.0",
-    "regedit": "^2.2.6",
     "request": "^2.73.0",
     "tmp": "^0.0.28",
     "underscore": "^1.8.3",
     "vscode-extension-telemetry": "^0.0.5",
     "applicationinsights": "^0.15.0",
     "vscode-languageclient": "^2.5.0"
+  },
+  "optionalDependencies": {
+    "regedit": "^2.2.6"
   },
   "contributes": {
     "languages": [

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "^1.0.0",
     "pretty-data": "^0.40.0",
+    "regedit": "^2.2.6",
     "request": "^2.73.0",
     "tmp": "^0.0.28",
     "underscore": "^1.8.3",

--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -1,12 +1,47 @@
 'use strict';
+import os = require('os');
 import vscode = require('vscode');
 import Utils = require('./utils');
 import TelemetryReporter from 'vscode-extension-telemetry';
+
+const dns = require('dns');
+const regedit = require('regedit');
 
 export namespace Telemetry {
     let reporter: TelemetryReporter;
     let userId: string;
     let disabled: boolean;
+    let internalUser: boolean;
+
+    /**
+     * List of all Microsoft internal domains.
+     */
+    const microsoftInternalDomainList: string[] = [
+        'redmond.corp.microsoft.com',
+        'northamerica.corp.microsoft.com',
+        'fareast.corp.microsoft.com',
+        'ntdev.corp.microsoft.com',
+        'wingroup.corp.microsoft.com',
+        'southpacific.corp.microsoft.com',
+        'wingroup.windeploy.ntdev.microsoft.com',
+        'ddnet.microsoft.com'
+    ];
+
+    const sqmClientRegKey = 'HKLM\\Software\\Policies\\Microsoft\\SQMClient';
+    const msftInternalRegValue = 'MSFTInternal';
+
+    function getIsUserInternal(): Promise<boolean> {
+        return new Promise<boolean>(resolve => {
+            if (typeof(internalUser) === 'undefined') {
+                isUserInternal().then(result => {
+                    internalUser = result;
+                    resolve(result);
+                });
+            } else {
+                resolve(internalUser);
+            }
+        });
+    }
 
     // Get the unique ID for the current user of the extension
     function getUserId(): Promise<string> {
@@ -20,6 +55,61 @@ export namespace Telemetry {
                 });
             } else {
                 resolve(userId);
+            }
+        });
+    }
+
+    function checkIfOnInternalNetwork(resolve: (value?: boolean | PromiseLike<boolean>) => void): void {
+        // Check if any DNS hostnames are Microsoft internal
+        let servers: string[] = dns.getServers();
+        lookupDnsHostnames(servers, [], 0).then(hostnames => {
+            for (let i = 0; i < hostnames.length; i++) {
+                for (let j = 0; j < microsoftInternalDomainList.length; j++) {
+                    if (hostnames[i].indexOf(microsoftInternalDomainList[j]) !== -1) {
+                        resolve(true);
+                        return;
+                    }
+                }
+            }
+            resolve(false);
+        });
+    }
+
+    function isUserInternal(): Promise<boolean> {
+        return new Promise<boolean>(resolve => {
+            if (os.platform() === 'win32') {
+                // Check the windows registry for the internal Microsoft key
+                regedit.list(sqmClientRegKey, (err, result) => {
+                    if (!err &&
+                        result &&
+                        result[sqmClientRegKey] &&
+                        result[sqmClientRegKey].values &&
+                        result[sqmClientRegKey].values[msftInternalRegValue] &&
+                        result[sqmClientRegKey].values[msftInternalRegValue].value === 1) {
+                        resolve(true);
+                    } else {
+                        checkIfOnInternalNetwork(resolve);
+                    }
+                });
+            } else {
+                checkIfOnInternalNetwork(resolve);
+            }
+        });
+    }
+
+    function lookupDnsHostnames(servers: string[], serverHostnames: string[], index: number): Promise<string[]> {
+        return new Promise<string[]>(resolve => {
+            if (index >= servers.length) {
+                resolve(serverHostnames);
+            } else {
+                dns.reverse(servers[index], (err, domains) => {
+                    if (!err) {
+                        serverHostnames = serverHostnames.concat(domains);
+                    }
+                    lookupDnsHostnames(servers, serverHostnames, ++index).then(hostnames => {
+                        resolve(hostnames);
+                    });
+                });
             }
         });
     }
@@ -63,10 +153,28 @@ export namespace Telemetry {
         }
 
         // Augment the properties structure with additional common properties before sending
-        getUserId().then( id => {
-            properties['userId'] = id;
+        getIsUserInternal().then(internal => {
+            getUserId().then( id => {
+                measures['isUserInternal'] = internal ? 1 : 0;
+                properties['userId'] = id;
+                properties['computerName'] = '';
+                properties['userName'] = '';
 
-            reporter.sendTelemetryEvent(eventName, properties, measures);
+                if (internal) { // Capture personal information only if we are Microsoft internal
+                    properties['computerName'] = os.hostname();
+                    if (os.platform() === 'win32') {
+                        properties['userName'] = process.env['USERNAME'];
+                    } else {
+                        if (process.env['LOGNAME']) {
+                            properties['userName'] = process.env['LOGNAME'];
+                        } else {
+                            properties['userName'] = process.env['USER'];
+                        }
+                    }
+                }
+
+                reporter.sendTelemetryEvent(eventName, properties, measures);
+            });
         });
     }
 }

--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -5,7 +5,6 @@ import Utils = require('./utils');
 import TelemetryReporter from 'vscode-extension-telemetry';
 
 const dns = require('dns');
-const regedit = require('regedit');
 
 export namespace Telemetry {
     let reporter: TelemetryReporter;
@@ -79,6 +78,7 @@ export namespace Telemetry {
         return new Promise<boolean>(resolve => {
             if (os.platform() === 'win32') {
                 // Check the windows registry for the internal Microsoft key
+                const regedit = require('regedit');
                 regedit.list(sqmClientRegKey, (err, result) => {
                     if (!err &&
                         result &&


### PR DESCRIPTION
- Added checks to see if the user is Microsoft internal. This is primarily done by checking if the user is using a known Microsoft domain server (the registry is also checked for a special key on Windows).
- If the user is Microsoft internal, we will capture the computer name and username when sending telemetry
