### PR TITLE
Fix case-sensitive file references breaking Linux builds.

### DIFF
--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -2,7 +2,7 @@
 *  Class for handler and distributing notification coming from the
 *  service layer
 */
-import QueryRunner from './queryRunner';
+import QueryRunner from './QueryRunner';
 import SqlToolsServiceClient from '../languageservice/serviceclient';
 import {QueryExecuteCompleteNotification} from '../models/contracts/queryExecute';
 import {NotificationHandler} from 'vscode-languageclient';

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { SqlOutputContentProvider } from '../models/sqlOutputContentProvider';
+import { SqlOutputContentProvider } from '../models/SqlOutputContentProvider';
 import StatusView from '../views/statusView';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import {QueryNotificationHandler} from './QueryNotificationHandler';

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -8,7 +8,7 @@ import * as events from 'events';
 import vscode = require('vscode');
 import Constants = require('../models/constants');
 import Utils = require('../models/utils');
-import { SqlOutputContentProvider } from '../models/sqlOutputContentProvider';
+import { SqlOutputContentProvider } from '../models/SqlOutputContentProvider';
 import StatusView from '../views/statusView';
 import ConnectionManager from './connectionManager';
 import SqlToolsServerClient from '../languageservice/serviceclient';

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -6,7 +6,7 @@ import Constants = require('./constants');
 import LocalWebService from '../controllers/localWebService';
 import Utils = require('./utils');
 import Interfaces = require('./interfaces');
-import QueryRunner from '../controllers/queryRunner';
+import QueryRunner from '../controllers/QueryRunner';
 import ResultsSerializer from  '../models/resultsSerializer';
 import StatusView from '../views/statusView';
 import VscodeWrapper from './../controllers/vscodeWrapper';

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -1,8 +1,8 @@
 import * as TypeMoq from 'typemoq';
 import assert = require('assert');
-import QueryRunner from './../src/controllers/queryRunner';
+import QueryRunner from './../src/controllers/QueryRunner';
 import { QueryNotificationHandler } from './../src/controllers/QueryNotificationHandler';
-import { SqlOutputContentProvider } from './../src/models/sqlOutputContentProvider';
+import { SqlOutputContentProvider } from './../src/models/SqlOutputContentProvider';
 import SqlToolsServerClient from './../src/languageservice/serviceclient';
 import { QueryExecuteParams, QueryExecuteCompleteNotificationResult } from './../src/models/contracts/queryExecute';
 import VscodeWrapper from './../src/controllers/vscodeWrapper';


### PR DESCRIPTION
File paths on Linux are case-sensitive so we need to be care to use consistent casing.
