### PR TITLE
Fix a regressions from latest merges

### DIFF
--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -185,7 +185,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
 
     public runQuery(statusView, uri: string, selection: ISelectionData, title: string): void {
         // Reuse existing query runner if it exists
-        let resultsUri = this.getResultsUri(uri).toString();
+        let resultsUri = decodeURIComponent(this.getResultsUri(uri));
         let queryRunner: QueryRunner;
         if (this._queryResultsMap.has(resultsUri)) {
             queryRunner = this._queryResultsMap.get(resultsUri);
@@ -223,7 +223,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
      */
     public onUntitledFileSaved(untitledUri: string, savedUri: string): void {
         // If we don't have any query runners mapped to this uri, don't do anything
-        let untitledResultsUri = this.getResultsUri(untitledUri);
+        let untitledResultsUri = decodeURIComponent(this.getResultsUri(untitledUri));
         if (!this._queryResultsMap.has(untitledResultsUri)) {
             return;
         }
@@ -232,7 +232,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
         // the old uri. As long as we make requests to the service against that uri, we'll be good.
 
         // Remap the query runner in the map
-        let savedResultUri = this.getResultsUri(savedUri);
+        let savedResultUri = decodeURIComponent(this.getResultsUri(savedUri));
         this._queryResultsMap.set(savedResultUri, this._queryResultsMap.get(untitledResultsUri));
         this._queryResultsMap.delete(untitledResultsUri);
     }

--- a/src/models/resultsSerializer.ts
+++ b/src/models/resultsSerializer.ts
@@ -66,7 +66,7 @@ export default class ResultsSerializer {
             }
         ];
         return this._prompter.prompt(questions).then(answers => {
-            if (answers[Constants.filepathPrompt] ) {
+            if (answers && answers[Constants.filepathPrompt] ) {
                 // return filename if file does not exist or if user opted to overwrite file
                 if (!prompted || (prompted && answers[Constants.overwritePrompt])) {
                      return answers[Constants.filepathPrompt];
@@ -244,8 +244,9 @@ export default class ResultsSerializer {
 
         // prompt for filepath
         return self.promptForFilepath().then(function(filePath): void {
-            self.sendRequestToService( filePath, batchIndex, resultSetNo, format, selection ? selection[0] : undefined);
-
+            if (!Utils.isEmpty(filePath)) {
+                self.sendRequestToService(filePath, batchIndex, resultSetNo, format, selection ? selection[0] : undefined);
+            }
         });
     }
 


### PR DESCRIPTION
The query results view is broken on Windows following latest merges.  It looks like the URIs are not being consistently decoded and some file paths have "c:/" and others have "c%###/" format, which makes the getBatches lookup to fail.

Also, fix a couple unhandled exceptions when canceling Save to JSON and Save to XML wizards.
