### PR TITLE
Update for snippet naming

### DIFF
--- a/snippets/mssql.json
+++ b/snippets/mssql.json
@@ -1,14 +1,14 @@
 {
 	"Get extension help": {
-		"prefix": "sql.extensionhelp",
+		"prefix": "sqlExtensionHelp",
 		"body": [
 			"/*",
-			"vscode-mssql getting started:",
+			"mssql getting started:",
 			"-----------------------------",
 			"1. Change language mode to SQL: Open a .sql file or press Ctrl+K M (Cmd+K M on Mac) and choose 'SQL'.",
-			"2. Connect to a database: Press F1 to show the command palette, type 'mssql' then click 'Connect to a database'.",
-			"3. Use the T-SQL editor: Type T-SQL statements in the editor. Type 'sql' to see a list of code snippets you can tweak & reuse.",
-			"4. Run T-SQL statements: Press Ctrl+Shift+e (Cmd+Shift+e on Mac) to execute all the T-SQL code in the editor.",
+			"2. Connect to a database: Press F1 to show the command palette, type 'sqlcon' or 'sql' then click 'Connect'.",
+			"3. Use the T-SQL editor: Type T-SQL statements in the editor using T-SQL IntelliSense or type 'sql' to see a list of code snippets you can tweak & reuse.",
+			"4. Run T-SQL statements: Press F1 and type 'sqlex' or press Ctrl+Shift+e (Cmd+Shift+e on Mac) to execute all the T-SQL code in the editor.",
 			"",
 			"Tip #1: Put GO on a line by itself to separate T-SQL batches.",
 			"Tip #2: Select some T-SQL text in the editor and press `Ctrl+Shift+e` (`Cmd+Shift+e` on Mac) to execute the selection",
@@ -18,7 +18,7 @@
 	},
 
 	"Create a new Database": {
-		"prefix": "sql.createdatabase",
+		"prefix": "sqlCreateDatabase",
 		"body": [
 			"-- Create a new database called '${DatabaseName}'",
 			"-- Connect to the 'master' database to run this snippet",
@@ -40,7 +40,7 @@
 	},
 
 	"Drop a Database": {
-		"prefix": "sql.dropdatabase",
+		"prefix": "sqlDropDatabase",
 		"body": [
 			"-- Drop the database '${DatabaseName}'",
 			"-- Connect to the 'master' database to run this snippet",
@@ -59,7 +59,7 @@
 	},
 
 	"Create a new Table": {
-		"prefix": "sql.createtable",
+		"prefix": "sqlCreateTable",
 		"body": [
 			"-- Create a new table called '${TableName}' in schema '${SchemaName}'",
 			"-- Drop the table if it already exists",
@@ -81,7 +81,7 @@
 	},
 
 	"Drop a Table": {
-		"prefix": "sql.droptable",
+		"prefix": "sqlDropTable",
 		"body": [
 			"-- Drop the table '${TableName}' in schema '${SchemaName}'",
 			"IF EXISTS (",
@@ -99,7 +99,7 @@
 	},
 
 	"Add a new column to a Table": {
-		"prefix": "sql.addcolumn",
+		"prefix": "sqlAddColumn",
 		"body": [
 			"-- Add a new column '$(NewColumnName)' to table '${TableName}' in schema '${SchemaName}'",
 			"ALTER TABLE ${SchemaName}.${TableName}",
@@ -110,7 +110,7 @@
 	},
 
 	"Drop a column from a Table": {
-		"prefix": "sql.dropcolumn",
+		"prefix": "sqlDropColumn",
 		"body": [
 			"-- Drop '$(ColumnName)' from table '${TableName}' in schema '${SchemaName}'",
 			"ALTER TABLE ${SchemaName}.${TableName}",
@@ -121,7 +121,7 @@
 	},
 
 	"Select rows from a Table or a View": {
-		"prefix": "sql.select",
+		"prefix": "sqlSelect",
 		"body": [
 			"-- Select rows from a Table or View '${TableOrViewName}' in schema '${SchemaName}'",
 			"SELECT * FROM ${SchemaName}.${TableOrViewName}",
@@ -132,7 +132,7 @@
 	},
 
 	"Insert rows into a Table": {
-		"prefix": "sql.insertrows",
+		"prefix": "sqlInsertRows",
 		"body": [
 			"-- Insert rows into table '${TableName}'",
 			"INSERT INTO ${TableName}",
@@ -153,7 +153,7 @@
 	},
 
 	"Delete rows from a Table": {
-		"prefix": "sql.deleterows",
+		"prefix": "sqlDeleteRows",
 		"body": [
 			"-- Delete rows from table '${TableName}'",
 			"DELETE FROM ${TableName}",
@@ -164,7 +164,7 @@
 	},
 
 	"Update rows in a Table": {
-		"prefix": "sql.updaterows",
+		"prefix": "sqlUpdateRows",
 		"body": [
 			"-- Update rows in table '${TableName}'",
 			"UPDATE ${TableName}",
@@ -179,7 +179,7 @@
 	},
 
 	"Create a stored procedure": {
-		"prefix": "sql.createstoredproc",
+		"prefix": "sqlCreateStoredProc",
 		"body": [
 			"-- Create a new stored procedure called '${StoredProcedureName}' in schema '$(SchemaName)'",
 			"-- Drop the stored procedure if it already exists",
@@ -208,7 +208,7 @@
 	},
 
 	"Drop a stored procedure": {
-		"prefix": "sql.dropstoredproc",
+		"prefix": "sqlDropStoredProc",
 		"body": [
 			"-- Drop the stored procedure called '${StoredProcedureName}' in schema '$(SchemaName)'",
 			"IF EXISTS (",
@@ -224,12 +224,9 @@
 	},
 
 	"List tables": {
-		"prefix": "sql.listtables",
+		"prefix": "sqlListTablesAndViews",
 		"body": [
 			"-- Get a list of tables and views in the current database",
-			"-- Connect to the 'master' database to run this snippet",
-			"USE master",
-			"GO",
 			"SELECT table_catalog [database], table_schema [schema], table_name name, table_type type",
 			"FROM information_schema.tables",
 			"GO"
@@ -238,12 +235,9 @@
 	},
 
 	"List databases": {
-		"prefix": "sql.listdatabases",
+		"prefix": "sqlListDatabases",
 		"body": [
 			"-- Get a list of databases",
-			"-- Connect to the 'master' database to run this snippet",
-			"USE master",
-			"GO",
 			"SELECT name FROM sys.databases",
 			"GO"
 		],


### PR DESCRIPTION
Change 1. 
Need: Current sql.<snippet_name> format requires a change to work with T-SQL IntelliSense where '.' is the activator for suggestion list. UX conflicts due to this reason. This change is to introduce CamelToe formatting for snippet names. For example, sql.listdatabase snippet is changed to sqlListDatabase

Change 2. 
Update of snippet description to keep the content up-to-date with the current functionality (10/17/2016). 

Change 3.
Modified the name of sql.listtables to sqlListTablesAndViews because this snippet lists both tables and view in the connected database. 

Change 4.
Removal of unnecessary USE master statement from sqlListTablesAndViews and sqlListDatabase. For these two snippets, USE master statement is unnecessary and incorrect for sqlListTablesAndView. Also USE master changes the database connection context to master and persists so it should be used only when needed to minimize the risk of accidental execution of sql statements in master 
