### PR TITLE
Feature/editormenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,12 +106,6 @@
       }
     ],
      "menus": {
-       "editor/title": [
-         {
-           "command": "extension.runQuery",
-           "when": "editorLangId == sql"
-         }
-       ],
         "editor/context": [
          {
            "command": "extension.runQuery",


### PR DESCRIPTION
Adding "Execute Query" menu item to the editor's context menu only when it's SQL 
