### PR TITLE
Adding nl2br pipe method

### DIFF
--- a/src/views/htmlcontent/src/app/Nl2Br.Pipe.ts
+++ b/src/views/htmlcontent/src/app/Nl2Br.Pipe.ts
@@ -1,0 +1,38 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'nl2br',
+    pure: true
+})
+export class Nl2BrPipe implements PipeTransform {
+
+    private entityMap = {
+        '&':  '&amp;',
+        '<':  '&lt;',
+        '>':  '&gt;',
+        '"':  '&quot;',
+        '\'': '&apos;',
+        '/':  '&#x2F;',
+        '`':  '&#x60;',
+        '=':  '&@x3D'
+    };
+    private mapToEnity(key: string): string {
+        return this.entityMap[key];
+    }
+
+    /**
+     * Converts newlines (of all flavors) to br tags. It also performs a HTML escape as per
+     * Mustache.js's escape HTML method such that this can be used for any InnerHtml bindings.
+     */
+    public transform(str: string): any {
+        // Escape all HTML
+        str = str.replace(/[&<>"'`=\/]/g, this.mapToEnity);
+
+        // Replace all newlines with a br tag
+        return str.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br />$2');
+    }
+}

--- a/src/views/htmlcontent/src/app/app.html
+++ b/src/views/htmlcontent/src/app/app.html
@@ -45,9 +45,7 @@
                 </tr>
                 <tr *ngFor="let message of imessage.messages">
                     <td></td>
-                    <td [class.errorMessage]="imessage.hasError" style="padding-left: 20px">
-                        {{message.message}}
-                    </td>
+                    <td [class.errorMessage]="imessage.hasError" [innerHTML]="message.message | nl2br" style="padding-left: 20px"></td>
                 </tr>
                 <tr *ngIf="imessage.selection">
                     <td>[{{imessage.messages[imessage.messages.length - 1].time}}]</td>

--- a/src/views/htmlcontent/src/app/app.module.ts
+++ b/src/views/htmlcontent/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { SlickGrid } from './slickgrid/SlickGrid';
 import { NavigatorComponent } from './navigation.component';
 import { HttpModule, JsonpModule } from '@angular/http';
 import { ScrollDirective } from './scroll.directive';
+import { Nl2BrPipe } from './Nl2Br.Pipe';
 
 /**
  * Top level angular module, no actual content here
@@ -23,7 +24,7 @@ import { ScrollDirective } from './scroll.directive';
               JsonpModule,
               FormsModule
            ],
-  declarations: [ AppComponent, SlickGrid, NavigatorComponent, ScrollDirective],
+  declarations: [ AppComponent, SlickGrid, NavigatorComponent, ScrollDirective, Nl2BrPipe ],
   bootstrap:    [ AppComponent ]
 })
 export class AppModule { }


### PR DESCRIPTION
One small issue I noticed a while back was that messages from the service are technically split into multiple lines with a newline operator but when displayed in the preview pane, they are condensed into a single line. This is because the linebreaks are generated from the service via \r\n or \n (depending on OS), but they need to be <br> tags in order to be rendered in the preview pane. In PHP, the generic way to convert the newline to <br> is to use a method "nl2br". So, in a (probably naïve) way, I've added a new pipe transform to our angular implementation to convert newlines to <br> tags. Since the only way to get Angular to accept HTML as-is, we need to utilize the innerHTML (case-sensitive) binding, I've also added HTML escaping functionality to protect against html injection/xss.

So, long story short, messages can now be multiple lines.
![nl2brworking](https://cloud.githubusercontent.com/assets/585878/19455425/d4871870-9471-11e6-94bb-5877a462a29e.PNG)
