### PR TITLE
fix shortcut for toggleMessagePane

### DIFF
--- a/src/views/htmlcontent/src/app/shortcuts.json
+++ b/src/views/htmlcontent/src/app/shortcuts.json
@@ -1,6 +1,6 @@
 {
     "ctrl+alt+r": "event.toggleResultPane",
-    "ctrl+alt+t": "event.toggleMessagePane",
+    "ctrl+alt+y": "event.toggleMessagePane",
     "ctrl+up": "event.prevGrid",
     "ctrl+down": "event.nextGrid",
     "ctrl+c": "event.copySelection"


### PR DESCRIPTION
change of ctrl+alt+t for toggleMessagePane to ctrl+alt+y.

reason for change: 
1. ctrl+alt+m is taken by MAC os
2. ctrl+alt+t is not recognized by vs code
3. 'y' is on the right side of 'r' and it's available for the combination.
