### PR TITLE
Bump extension to version 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 
   "name": "mssql",
   "displayName": "mssql",
-  "version": "0.0.11",
+  "version": "0.1.1",
   "description": "Connect to SQL Server and Azure SQL databases, run T-SQL queries and see results in a grid.",
   "publisher": "Microsoft",
   "preview": "true",


### PR DESCRIPTION
Dump to version 0.1.1.  Plan is for CTP 1.0 release to be numbered 0.1.N where N is number of internal releases we have leading up to CTP build.
