### PR TITLE
Refactored telemetry to not need the extension context for events

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -250,7 +250,7 @@ export default class ConnectionManager {
 
         connection.extensionTimer.end();
 
-        Telemetry.sendTelemetryEvent(this._context, 'DatabaseConnected', {
+        Telemetry.sendTelemetryEvent('DatabaseConnected', {
             connectionType: connection.serverInfo ? (connection.serverInfo.isCloud ? 'Azure' : 'Standalone') : '',
             serverVersion: connection.serverInfo ? connection.serverInfo.serverVersion : '',
             serverOs: connection.serverInfo ? connection.serverInfo.osVersion : ''

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -140,10 +140,13 @@ export default class MainController implements vscode.Disposable {
                 // Init connection manager and connection MRU
                 self._connectionMgr = new ConnectionManager(self._context, self._statusview, self._prompter);
 
+                // Initialize telemetry
+                Telemetry.initialize(self._context);
+
                 activationTimer.end();
 
                 // telemetry for activation
-                Telemetry.sendTelemetryEvent(self._context, 'ExtensionActivated', {},
+                Telemetry.sendTelemetryEvent('ExtensionActivated', {},
                     { activationTime: activationTimer.getDuration() }
                 );
 

--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -32,14 +32,27 @@ export namespace Telemetry {
         [key: string]: number;
     }
 
-    // Disable telemetry reporting
+    /**
+     * Disable telemetry reporting
+     */
     export function disable(): void {
         disabled = true;
     }
 
-    // Send a telemetry event using application insights
+    /**
+     * Initialize the telemetry reporter for use.
+     */
+    export function initialize(context: vscode.ExtensionContext): void {
+        if (typeof reporter === 'undefined') {
+            let packageInfo = Utils.getPackageInfo(context);
+            reporter = new TelemetryReporter('vscode-mssql', packageInfo.version, packageInfo.aiKey);
+        }
+    }
+
+    /**
+     * Send a telemetry event using application insights
+     */
     export function sendTelemetryEvent(
-        context: vscode.ExtensionContext,
         eventName: string,
         properties?: ITelemetryEventProperties,
         measures?: ITelemetryEventMeasures): void {
@@ -47,19 +60,13 @@ export namespace Telemetry {
         if (typeof disabled === 'undefined') {
             disabled = false;
         }
-        if (disabled) {
+        if (disabled || typeof(reporter) === 'undefined') {
             // Don't do anything if telemetry is disabled
             return;
         }
 
         if (typeof properties === 'undefined') {
             properties = {};
-        }
-
-        // Initialize the telemetry reporter if necessary
-        let packageInfo = Utils.getPackageInfo(context);
-        if (typeof reporter === 'undefined') {
-            reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
         }
 
         // Augment the properties structure with additional common properties before sending


### PR DESCRIPTION
This should make instrumentation easier in areas that don't directly have access to the extension context. (e.g. [this PR](https://github.com/Microsoft/vscode-mssql/pull/194))
