### PR TITLE
Added telemetry opt-out

### DIFF
--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -44,6 +44,12 @@ export namespace Telemetry {
      */
     export function initialize(context: vscode.ExtensionContext): void {
         if (typeof reporter === 'undefined') {
+            // Check if the user has opted out of telemetry
+            if (!vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
+                disable();
+                return;
+            }
+
             let packageInfo = Utils.getPackageInfo(context);
             reporter = new TelemetryReporter('vscode-mssql', packageInfo.version, packageInfo.aiKey);
         }


### PR DESCRIPTION
Allow the user to opt-out of telemetry using the built-in vscode setting, per https://code.visualstudio.com/Docs/supporting/FAQ#_how-to-disable-telemetry-reporting