### PR TITLE
Feature/editor config

### DIFF
--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -59,9 +59,10 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             let theme: string = req.query.theme;
             let backgroundcolor: string = req.query.backgroundcolor;
             let color: string = req.query.color;
-            let fontfamily = self._vscodeWrapper.getConfiguration('editor').get<string>('fontFamily');
-            let fontsize = self._vscodeWrapper.getConfiguration('editor').get<number>('fontSize') + 'px';
-            let fontweight = self._vscodeWrapper.getConfiguration('editor').get<string>('fontWeight');
+            let editorConfig = self._vscodeWrapper.getConfiguration('editor');
+            let fontfamily = editorConfig.get<string>('fontFamily');
+            let fontsize = editorConfig.get<number>('fontSize') + 'px';
+            let fontweight = editorConfig.get<string>('fontWeight');
             res.render(path.join(LocalWebService.staticContentPath, Constants.msgContentProviderSqlOutputHtml),
                 {
                     uri: uri,


### PR DESCRIPTION
Pulls the font family, font size and font weight form the vscode editor config rather than from what they provide on the html.