### PR TITLE
Support Cobertura reports in coverage

### DIFF
--- a/coverconfig.json
+++ b/coverconfig.json
@@ -3,5 +3,7 @@
     "relativeSourcePath": "../src",
     "relativeCoverageDir": "../../coverage",
     "ignorePatterns": ["**/node_modules/**", "**/libs/**", "**/lib/**", "**/*.min.js", "**/*.bundle.js"],
+    "includePid": false,
+    "reports": ["lcov", "cobertura"],
     "verbose": false
 }

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -1,7 +1,12 @@
 var gulp = require('gulp');
+var del = require('del');
 var jeditor = require("gulp-json-editor");
 
-gulp.task('cover:enable', () => {
+gulp.task('cover:clean', function (done) {
+    return del('coverage', done);
+});
+
+gulp.task('cover:enableconfig',() => {
     return gulp.src("./coverconfig.json")
     .pipe(jeditor(function(json) {
         json.enabled = true;
@@ -9,6 +14,9 @@ gulp.task('cover:enable', () => {
     }))
     .pipe(gulp.dest("./out", {'overwrite':true}));
 });
+
+gulp.task('cover:enable', gulp.series('cover:clean', 'cover:enableconfig'));
+
 gulp.task('cover:disable', () => {
     return gulp.src("./coverconfig.json")
     .pipe(jeditor(function(json) {

--- a/test/istanbultestrunner.ts
+++ b/test/istanbultestrunner.ts
@@ -40,7 +40,7 @@ function _mkDirIfExists(dir: string): void {
 
 function _readCoverOptions(testsRoot: string): ITestRunnerOptions {
     let coverConfigPath = paths.join(testsRoot, testOptions.coverConfig);
-    let coverConfig = undefined;
+    let coverConfig: ITestRunnerOptions = undefined;
     if (fs.existsSync(coverConfigPath)) {
         let configContent = fs.readFileSync(coverConfigPath);
         coverConfig = JSON.parse(configContent);
@@ -92,6 +92,8 @@ interface ITestRunnerOptions {
     relativeCoverageDir: string;
     relativeSourcePath: string;
     ignorePatterns: string[];
+    includePid?: boolean;
+    reports?: string[];
     verbose?: boolean;
 }
 
@@ -196,7 +198,7 @@ class CoverageRunner {
 
         // TODO Allow config of reporting directory with
         let reportingDir = paths.join(self.testsRoot, self.options.relativeCoverageDir);
-        let includePid = true;
+        let includePid = self.options.includePid;
         let pidExt = includePid ? ('-' + process.pid) : '',
         coverageFile = paths.resolve(reportingDir, 'coverage' + pidExt + '.json');
 
@@ -213,7 +215,8 @@ class CoverageRunner {
         }});
 
         let reporter = new istanbul.Reporter(undefined, reportingDir);
-        reporter.addAll(['lcov']);
+        let reportTypes = (self.options.reports instanceof Array) ? self.options.reports : ['lcov'];
+        reporter.addAll(reportTypes);
         reporter.write(remappedCollector, true, () => {
             console.log(`reports written to ${reportingDir}`);
         });


### PR DESCRIPTION
- Added Cobertura reporting and moved logic to the coverconfig.json so it can easily be changed on demand
- Clean up the coverage folder on each coverage run, and no longer create a new json file for each run