### PR TITLE
Fixed connection tests

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -256,7 +256,7 @@ export default class ConnectionManager {
             connectionType: connection.serverInfo ? (connection.serverInfo.isCloud ? 'Azure' : 'Standalone') : '',
             serverVersion: connection.serverInfo ? connection.serverInfo.serverVersion : '',
             serverEdition: connection.serverInfo ? connection.serverInfo.serverEdition : '',
-            serverOs: connection.serverInfo.osVersion ? this.getIsServerLinux(connection.serverInfo.osVersion) : ''
+            serverOs: connection.serverInfo ? this.getIsServerLinux(connection.serverInfo.osVersion) : ''
         }, {
             isEncryptedConnection: connection.credentials.encrypt ? 1 : 0,
             isIntegratedAuthentication: connection.credentials.authenticationType === 'Integrated' ? 1 : 0,


### PR DESCRIPTION
Fixed connection tests that broke when I changed osVersion telemetry.

Checking for connection.serverInfo.osVersion can fail if serverInfo is undefined, hence the failing tests. This might also be a problem in CTP1 if for some reason the serverInfo can't be retrieved by the service host, so we should port it to master.