### PR TITLE
Update platform.ts for elementary OS 0.4

### DIFF
--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -79,6 +79,7 @@ export function getCurrentPlatform(): Platform {
                 // Oracle Linux is binary compatible with CentOS
                 return Platform.CentOS;
             case 'elementary OS':
+            case 'elementary':
                 const eOSVersionId = getValue('VERSION_ID');
                 if (eOSVersionId.startsWith('0.3')) {
                     // Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04


### PR DESCRIPTION
Update platform script to correctly detect elementary OS 0.4 ID value. ID is 'elementary' rather than 'elementary OS'. Added fall-through case statement value to handle both values. Currently it is defaulting to Windows and generating a "Failed to load SQL Tools Service" message when attempting to install.