### PR TITLE
Remove USE Database shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,12 +185,6 @@
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "extension.chooseDatabase",
-        "key": "ctrl+shift+u",
-        "mac": "cmd+shift+u",
-        "when": "editorTextFocus && editorLangId == 'sql'"
       }
     ],
     "configuration": {


### PR DESCRIPTION
- Fixes #335.
- This shortcut conflicted with the View Output command which we want users to have so they can diagnose connection errors