### PR TITLE
Reverted change to slickgrid dependency. Now using HTTPS instead of SSH

### DIFF
--- a/src/views/htmlcontent/package.json
+++ b/src/views/htmlcontent/package.json
@@ -13,7 +13,7 @@
     "@angular/router": "~3.1.2",
     "@angular/upgrade": "~2.1.2",
     "angular-in-memory-web-api": "~0.1.13",
-    "angular2-slickgrid": "git+ssh://git@github.com:microsoft/angular2-slickgrid",
+    "angular2-slickgrid": "github:microsoft/angular2-slickgrid",
     "core-js": "^2.4.1",
     "jasmine-core": "~2.4.1",
     "moment": "^2.15.1",


### PR DESCRIPTION
We no longer need git+ssh for this dependency since angular2-slickgrid is public