### PR TITLE
Extension no longer activates on all startup contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,13 @@
     "Azure SQL Data Warehouse"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:sql",
+    "onCommand:extension.connect",
+    "onCommand:extension.runQuery",
+    "onCommand:extension.disconnect",
+    "onCommand:extension.manageProfiles",
+    "onCommand:extension.chooseDatabase",
+    "onCommand:extension.cancelQuery"
   ],
   "main": "./out/src/extension",
   "extensionDependencies": [


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-mssql/issues/352

Changed it so that we only activate once a SQL file is opened or the user tries to run one of our commands. It adds a bit of a delay to the first use (less than a second), but makes sure our extension doesn't load if the user doesn't need it.

Used this as a guide: https://code.visualstudio.com/docs/extensionAPI/activation-events