### PR TITLE
Publish docs during build

### DIFF
--- a/tasks/htmltasks.js
+++ b/tasks/htmltasks.js
@@ -193,6 +193,17 @@ gulp.task('html:copy:assets', (done) => {
 
     promises.push(new Promise((resolve) => {
             gulp.src([
+                    config.paths.html.root + '/src/docs/**/*'
+                ])
+                .pipe(gulp.dest(config.paths.html.out + '/dist/docs'))
+                .on('end', () => {
+                    resolve();
+                })
+        })
+    );
+
+    promises.push(new Promise((resolve) => {
+            gulp.src([
                 config.paths.html.root + '/src/images/*'
             ])
             .pipe(gulp.dest(config.paths.html.out + '/dist/images'))


### PR DESCRIPTION
Publish docs during HTML build.  This change got lost during merge from master to dev.