### PR TITLE
Fixing issue where very fast web socket calls might fail

### DIFF
--- a/src/controllers/localWebService.ts
+++ b/src/controllers/localWebService.ts
@@ -98,7 +98,7 @@ export default class LocalWebService {
             this.wsMap.set(uri, mapping);
         } else {
             // Make sure the web socket server is open, then fire away
-            if (mapping.webSocketServer.readyState === ws.OPEN) {
+            if (mapping.webSocketServer && mapping.webSocketServer.readyState === ws.OPEN) {
                 mapping.webSocketServer.send(JSON.stringify(message));
             }
         }


### PR DESCRIPTION
This is a high-pri bug that needs to go in ASAP. In a slight oversight on my part, I missed the possibility of the mapping for url to web socket server existing, but the socket not existing yet. The result is that very fast queries would not send anything more than their first update.