### PR TITLE
Filter error paths to only include source files.

### DIFF
--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -71,6 +71,21 @@ export namespace Telemetry {
     }
 
     /**
+     * Filters error paths to only include source files. Exported to support testing
+     */
+    export function FilterErrorPath(line: string): string {
+        if (line) {
+            let values: string[] = line.split('/out/');
+            if (values.length <= 1) {
+                // Didn't match expected format
+                return line;
+            } else {
+                return values[1];
+            }
+        }
+    }
+
+    /**
      * Send a telemetry event for an exception
      */
     export function sendTelemetryEventForException(
@@ -82,6 +97,7 @@ export namespace Telemetry {
                 stackArray = err.stack.split('\n');
                 if (stackArray !== undefined && stackArray.length >= 2) {
                     firstLine = stackArray[1]; // The fist line is the error message and we don't want to send that telemetry event
+                    firstLine = FilterErrorPath(firstLine);
                 }
             }
 

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,5 +1,6 @@
 import assert = require('assert');
 import vscode = require('vscode');
+import Telemetry from '../src/models/telemetry';
 
 suite('Telemetry Tests', () => {
     test('Correct version of applicationInsights is installed', () => {
@@ -25,5 +26,18 @@ suite('Telemetry Tests', () => {
             versionOk = true;
         }
         assert.ok(versionOk, 'Version of applicationInsights must be greater than or equal to 0.15.19. Detected version was ' + versionString);
+    });
+
+    test('Path before /out/ is stripped', () => {
+        let errorString = '/User/myuser/vscode/extensions/ms-mssql.mssql-0.1.5/out/src/controller/mainController.js:216.45';
+        let expectedErrorString = 'src/controller/mainController.js:216.45';
+        let actualErrorString = Telemetry.FilterErrorPath(errorString);
+        assert.equal(actualErrorString, expectedErrorString);
+    });
+
+    test('Path without /out/ is retained', () => {
+        let errorString = '/User/should/never/happen/src/controller/mainController.js:216.45';
+        let actualErrorString = Telemetry.FilterErrorPath(errorString);
+        assert.equal(actualErrorString, errorString);
     });
 });


### PR DESCRIPTION
- minimize path sent via telemetry as we only want the path after the /out/ section of the path