### PR TITLE
Fix junit report path so tests work when launched from VSCode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -116,7 +116,7 @@ module.exports = function(config) {
       }
     },
     junitReporter: {
-      outputDir: 'test-reports/'
+      outputDir: __dirname + '/test-reports'
     },
 
     port: 9876,

--- a/test/index.ts
+++ b/test/index.ts
@@ -23,7 +23,7 @@ testRunner.configure(
         reporter: 'pm-mocha-jenkins-reporter',
         reporterOptions: {
             junit_report_name: 'Extension Tests',
-            junit_report_path: '../test-reports/extension_tests.xml',
+            junit_report_path: __dirname + '/../../test-reports/extension_tests.xml',
             junit_report_stack: 1
         },
         useColors: true         // colored output from test results


### PR DESCRIPTION
- Relative path means that when launched from VSCode, tests wrote results to a protected directory and failed
- Use standard path based on location of the /out/ directory which should work on build machines and locally