### PR TITLE
Fix password saving for the Credential Store when savePassword is enabled 

### DIFF
--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -119,7 +119,7 @@ export class ConnectionCredentials implements IConnectionCredentials {
                     // then transfer the password to the credential store
                     if (profile.savePassword && !wasPasswordEmptyInConfigFile) {
                         // Remove profile, but keep credential store if savePassword was enabled
-                        connectionStore.removeProfile(profile, profile.savePassword).then(() => {
+                        connectionStore.removeProfile(profile, true).then(() => {
                             connectionStore.saveProfile(profile);
                         });
                     // Or, if the user answered any additional questions for the profile, be sure to save it

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -118,7 +118,8 @@ export class ConnectionCredentials implements IConnectionCredentials {
                     // If this is a profile, and the user has set save password to true and stored the password in the config file,
                     // then transfer the password to the credential store
                     if (profile.savePassword && !wasPasswordEmptyInConfigFile) {
-                        connectionStore.removeProfile(profile).then(() => {
+                        // Remove profile, but keep credential store if savePassword was enabled
+                        connectionStore.removeProfile(profile, profile.savePassword).then(() => {
                             connectionStore.saveProfile(profile);
                         });
                     // Or, if the user answered any additional questions for the profile, be sure to save it

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -311,7 +311,7 @@ export class ConnectionStore {
      * @param {Boolean} keepCredentialStore optional value to keep the credential store after a profile removal
      * @returns {Promise<boolean>} true if successful
      */
-    public removeProfile(profile: IConnectionProfile, keepCredentialStore: Boolean = false): Promise<boolean> {
+    public removeProfile(profile: IConnectionProfile, keepCredentialStore: boolean = false): Promise<boolean> {
         const self = this;
         return new Promise<boolean>((resolve, reject) => {
             self._connectionConfig.removeConnection(profile).then(profileFound => {

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -308,10 +308,10 @@ export class ConnectionStore {
      * from the credential store
      *
      * @param {IConnectionProfile} profile the profile to be removed
-     * @param {Boolean} removeCredentialStore optional value to keep the credential store after a profile removal
+     * @param {Boolean} keepCredentialStore optional value to keep the credential store after a profile removal
      * @returns {Promise<boolean>} true if successful
      */
-    public removeProfile(profile: IConnectionProfile, removeCredentialStore: Boolean = true): Promise<boolean> {
+    public removeProfile(profile: IConnectionProfile, keepCredentialStore: Boolean = false): Promise<boolean> {
         const self = this;
         return new Promise<boolean>((resolve, reject) => {
             self._connectionConfig.removeConnection(profile).then(profileFound => {
@@ -330,7 +330,7 @@ export class ConnectionStore {
             });
         }).then(profileFound => {
             // Now remove password from credential store. Currently do not care about status unless an error occurred
-            if (profile.savePassword === true && removeCredentialStore) {
+            if (profile.savePassword === true && !keepCredentialStore) {
                 let credentialId = ConnectionStore.formatCredentialId(profile.server, profile.database, profile.user, ConnectionStore.CRED_PROFILE_USER);
                 self._credentialStore.deleteCredential(credentialId).then(undefined, rejected => {
                     throw new Error(rejected);

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -308,9 +308,10 @@ export class ConnectionStore {
      * from the credential store
      *
      * @param {IConnectionProfile} profile the profile to be removed
+     * @param {Boolean} removeCredentialStore optional value to keep the credential store after a profile removal
      * @returns {Promise<boolean>} true if successful
      */
-    public removeProfile(profile: IConnectionProfile): Promise<boolean> {
+    public removeProfile(profile: IConnectionProfile, removeCredentialStore: Boolean = true): Promise<boolean> {
         const self = this;
         return new Promise<boolean>((resolve, reject) => {
             self._connectionConfig.removeConnection(profile).then(profileFound => {
@@ -329,12 +330,13 @@ export class ConnectionStore {
             });
         }).then(profileFound => {
             // Now remove password from credential store. Currently do not care about status unless an error occurred
-            if (profile.savePassword === true) {
+            if (profile.savePassword === true && removeCredentialStore) {
                 let credentialId = ConnectionStore.formatCredentialId(profile.server, profile.database, profile.user, ConnectionStore.CRED_PROFILE_USER);
                 self._credentialStore.deleteCredential(credentialId).then(undefined, rejected => {
                     throw new Error(rejected);
                 });
             }
+
             return profileFound;
         });
     }

--- a/test/connectionStore.test.ts
+++ b/test/connectionStore.test.ts
@@ -216,6 +216,32 @@ suite('ConnectionStore tests', () => {
             }).catch(err => done(new Error(err)));
     });
 
+    test('RemoveProfile should not remove password from CredentialStore if keepCredentialStore is enabled', (done) => {
+        // Given have 2 profiles
+        let profile = Object.assign(new ConnectionProfile(), defaultNamedProfile, {
+            profileName: 'otherServer-bcd-cde',
+            server: 'otherServer',
+            savePassword: true
+        });
+        connectionConfig.setup(x => x.removeConnection(TypeMoq.It.isAny())).returns(p => Promise.resolve(p));
+        credentialStore.setup(x => x.deleteCredential(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
+
+        globalstate.setup(x => x.update(TypeMoq.It.isAnyString(), TypeMoq.It.isAny())).returns(() => Promise.resolve());
+        let connectionStore = new ConnectionStore(context.object, credentialStore.object, connectionConfig.object);
+
+        let keepCredentialStore: Boolean = true;
+
+        // deleteCredential should never be called when keepCredentialStore is set to true
+        connectionStore.removeProfile(profile, keepCredentialStore)
+            .then(success => {
+                // Then expect that profile's password to be removed from connectionConfig but kept in the credential store
+                assert.ok(success);
+                connectionConfig.verify(x => x.removeConnection(TypeMoq.It.isAny()), TypeMoq.Times.once());
+                credentialStore.verify(x => x.deleteCredential(TypeMoq.It.isAny()), TypeMoq.Times.never());
+                done();
+            }).catch(err => done(new Error(err)));
+    });
+
     test('RemoveProfile finds and removes profile with no profile name', (done) => {
         // Given have 2 profiles
         let unnamedProfile = Object.assign(new ConnectionProfile(), defaultNamedProfile, {


### PR DESCRIPTION
Fixes #353 Modified the removeProfile function to accept an optional boolean for keeping Credential Store profiles. Also added a test to for this option. 