### PR TITLE
Batch start notification

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "0.1.4-alpha.5",
+        "version": "0.1.4-alpha.4",
         "downloadFileNames": {
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",
             "OSX_10_11_64": "osx-x64-netcoreapp1.0.tar.gz",

--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -6,6 +6,7 @@ import QueryRunner from './QueryRunner';
 import SqlToolsServiceClient from '../languageservice/serviceclient';
 import {
     QueryExecuteCompleteNotification,
+    QueryExecuteBatchStartNotification,
     QueryExecuteBatchCompleteNotification,
     QueryExecuteResultSetCompleteNotification
 } from '../models/contracts/queryExecute';
@@ -28,6 +29,7 @@ export class QueryNotificationHandler {
     // register the handler to handle notifications for queries
     private initialize(): void {
         SqlToolsServiceClient.instance.onNotification(QueryExecuteCompleteNotification.type, this.handleCompleteNotification());
+        SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchStartNotification.type, this.handleBatchStartNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchCompleteNotification.type, this.handleBatchCompleteNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteResultSetCompleteNotification.type, this.handleResultSetCompleteNotification());
     }
@@ -45,6 +47,14 @@ export class QueryNotificationHandler {
 
             // There should be no more notifications for this query, so unbind it
             self._queryRunners.delete(event.ownerUri);
+        };
+    }
+
+    // Distributes batch start notification to appropriate methods
+    private handleBatchStartNotification(): NotificationHandler<any> {
+        const self = this;
+        return (event) => {
+            self._queryRunners.get(event.ownerUri).handleBatchStart(event);
         };
     }
 

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -9,7 +9,7 @@ import { BatchSummary, QueryExecuteParams, QueryExecuteRequest,
     QueryExecuteCompleteNotificationResult, QueryExecuteSubsetResult,
     QueryExecuteResultSetCompleteNotificationParams, ResultSetSummary,
     QueryExecuteSubsetParams, QueryDisposeParams, QueryExecuteSubsetRequest,
-    QueryDisposeRequest, QueryExecuteBatchCompleteNotificationResult } from '../models/contracts/queryExecute';
+    QueryDisposeRequest, QueryExecuteBatchNotificationParams } from '../models/contracts/queryExecute';
 import { QueryCancelParams, QueryCancelResult, QueryCancelRequest } from '../models/contracts/QueryCancel';
 import { ISlickRange, ISelectionData } from '../models/interfaces';
 import Constants = require('../models/constants');
@@ -181,7 +181,7 @@ export default class QueryRunner {
         this.eventEmitter.emit('complete');
     }
 
-    public handleBatchComplete(result: QueryExecuteBatchCompleteNotificationResult): void {
+    public handleBatchComplete(result: QueryExecuteBatchNotificationParams): void {
         let batch = result.batchSummary;
         if (batch.selection) {
             batch.selection.startLine = batch.selection.startLine + this._resultLineOffset;

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -294,8 +294,11 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             queryRunner.eventEmitter.on('resultSet', (resultSet) => {
                 this._service.broadcast(resultsUri, 'resultSet', resultSet);
             });
-            queryRunner.eventEmitter.on('batch', (batch) => {
-                this._service.broadcast(resultsUri, 'batch', batch);
+            queryRunner.eventEmitter.on('batchStart', (batch) => {
+                this._service.broadcast(resultsUri, 'batchStart', batch);
+            });
+            queryRunner.eventEmitter.on('batchComplete', (batch) => {
+                this._service.broadcast(resultsUri, 'batchComplete', batch);
             });
             queryRunner.eventEmitter.on('complete', () => {
                 this._service.broadcast(resultsUri, 'complete');

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -55,24 +55,31 @@ export class QueryExecuteCompleteNotificationResult {
 
 // -------------------------- </ Query Execution Complete Notification > -------------------------------
 
-// -------------------------- < Query Batch Complete Notification > -------------------------------
-export namespace QueryExecuteBatchCompleteNotification {
-    export const type: NotificationType<QueryExecuteBatchCompleteNotificationResult> = {
-                                                                                            get method(): string {
-                                                                                                return 'query/batchComplete';
-                                                                                            }
-                                                                                        };
-}
-
-export class QueryExecuteBatchCompleteNotificationResult {
+// Query Batch Notification -----------------------------------------------------------------------
+export class QueryExecuteBatchNotificationParams {
     batchSummary: BatchSummary;
     ownerUri: string;
 }
 
-// -------------------------- </ Query Batch Complete Notification > -------------------------------
+// Query Batch Start Notification -----------------------------------------------------------------
+export namespace QueryExecuteBatchStartNotification {
+    export const type: NotificationType<QueryExecuteBatchNotificationParams> = {
+        get method(): string {
+            return 'query/batchStart';
+        }
+    };
+}
+
+// Query Batch Complete Notification --------------------------------------------------------------
+export namespace QueryExecuteBatchCompleteNotification {
+    export const type: NotificationType<QueryExecuteBatchNotificationParams> = {
+        get method(): string {
+            return 'query/batchComplete';
+        }
+    };
+}
 
 // Query ResultSet Complete Notification -----------------------------------------------------------
-
 export namespace QueryExecuteResultSetCompleteNotification {
     export const type: NotificationType<QueryExecuteResultSetCompleteNotificationParams> = {
         get method(): string {

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -316,32 +316,43 @@ export class AppComponent implements OnInit, AfterViewChecked {
                     self.complete = true;
                     self.messagesAdded = true;
                 break;
-                case 'batch':
-                    let batch = event.data;
+                case 'batchStart':
+                    let startedBatch = event.data;
+
+                    // Create the messages holder for the batch
+                    let messages: IMessages = {
+                        messages: [],
+                        hasError: false,
+                        selection: startedBatch.selection,
+                        startTime: new Date(startedBatch.executionStart).toLocaleTimeString(),
+                        endTime: undefined
+                    };
+                    self.messages[startedBatch.id] = messages;
+                break;
+                case 'batchComplete':
+                    let completedBatch = event.data;
 
                     // Store the elapsed time of the batch
-                    let exeTime = Utils.parseTimeString(batch.executionElapsed);
+                    let exeTime = Utils.parseTimeString(completedBatch.executionElapsed);
                     if (exeTime) {
                         this.totalElapsedExecution += <number>exeTime;
                     }
 
-                    // Store the messages for the batch
-                    let messages: IMessages = {
-                        messages: batch.messages.map(m => {
-                            return {
-                                time: new Date(m.time).toLocaleTimeString(),
-                                message: m.message
-                            };
-                        }),
-                        hasError: batch.hasError,
-                        selection: batch.selection,
-                        startTime: new Date(batch.executionStart).toLocaleTimeString(),
-                        endTime: new Date(batch.executionEnd).toLocaleTimeString()
-                    };
-                    if (batch.hasError) {
+                    // Set the values we didn't have before
+                    let batchMessages = self.messages[completedBatch.id];
+                    batchMessages.messages = completedBatch.messages.map(m => {
+                        return {
+                            time: new Date(m.time).toLocaleTimeString(),
+                            message: m.message
+                        };
+                    });
+                    batchMessages.hasError = completedBatch.hasError;
+                    batchMessages.endTime = new Date(completedBatch.executionEnd).toLocaleTimeString();
+
+                    // If we have an error, set the messages to be shown
+                    if (completedBatch.hasError) {
                         self._messageActive = true;
                     }
-                    self.messages.push(messages);
                     self.messagesAdded = true;
                 break;
                 case 'resultSet':

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -102,7 +102,7 @@ const template = `
                         <td class="messageValue" [class.errorMessage]="imessage.hasError" style="padding-left: 20px">{{message.message}}</td>
                     </tr>
                 </template>
-                <tr *ngIf="!complete">
+                <tr id='executionSpinner' *ngIf="!complete">
                     <td><span *ngIf="messages.length === 0">[{{startString}}]</span></td>
                     <td>
                         <img src="dist/images/progress_36x_animation.gif" height="18px" />

--- a/src/views/htmlcontent/test/app.component.spec.ts
+++ b/src/views/htmlcontent/test/app.component.spec.ts
@@ -10,6 +10,7 @@ import { AppComponent } from './../src/js/components/app.component';
 import * as Constants from './../src/js/constants';
 import resultSetSmall from './testResources/mockResultSetSmall.spec';
 import resultSetBig from './testResources/mockResultSetBig.spec';
+import batchStart from './testResources/mockBatchStart.spec';
 import batch1 from './testResources/mockBatch1.spec';
 import batch2 from './testResources/mockBatch2.spec';
 
@@ -19,9 +20,15 @@ const completeEvent = {
 
 function sendDataSets(ds: MockDataService, batch: WebSocketEvent, result: WebSocketEvent, count: number): void {
     for (let i = 0; i < count; i++) {
+        // Send a batch start
+        let batchStartEvent = <WebSocketEvent> JSON.parse(JSON.stringify(batchStart));
+        batchStartEvent.data.id = i;
+        ds.sendWSEvent(batchStartEvent);
+
         // Send a result set completion
         let resultSetEvent = <WebSocketEvent> JSON.parse(JSON.stringify(result));
         resultSetEvent.data.id = i;
+        resultSetEvent.data.batchId = i;
         ds.sendWSEvent(resultSetEvent);
 
         // Send the batch completion
@@ -270,14 +277,101 @@ describe('AppComponent', function (): void {
             ele = fixture.nativeElement;
         });
 
+        it('should have started showing messages after the batch start command', () => {
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
+            fixture.detectChanges();
+
+            let results = ele.querySelector('#results');
+            expect(results).toBeNull('results pane is visible');
+
+            // Messages should be visible
+            let messages = ele.querySelector('#messages');
+            expect(messages).not.toBeNull('messages pane is not visible');
+            expect(messages.className.indexOf('hidden')).toEqual(-1);
+            expect(messages.getElementsByTagName('tr').length).toEqual(2);  // One for "started" message, one for spinner
+        });
+
         it('should have initilized the grids correctly', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
+            dataService.sendWSEvent(completeEvent);
             fixture.detectChanges();
+
+            // Results pane should be visible
             let results = ele.querySelector('#results');
             expect(results).not.toBeNull('results pane is not visible');
             expect(results.getElementsByTagName('slick-grid').length).toEqual(1);
+
+            // Messages pane should be visible
+            let messages = ele.querySelector('#messages');
+            expect(messages).not.toBeNull('messages pane is not visible');
+            expect(messages.className.indexOf('hidden')).toEqual(-1);
+        });
+    });
+
+    describe('spinner behavior', () => {
+        beforeEach(() => {
+            fixture = TestBed.createComponent<AppComponent>(AppComponent);
+            fixture.detectChanges();
+            comp = fixture.componentInstance;
+            ele = fixture.nativeElement;
+        });
+
+        it('should be visible at before any command', () => {
+            fixture.detectChanges();
+
+            // Spinner should be visible
+            let spinner = ele.querySelector('#executionSpinner');
+            expect(spinner).not.toBeNull('spinner is not visible');
+        });
+
+        it('should be visible after a batch starts', () => {
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
+            fixture.detectChanges();
+
+            // Spinner should be visible
+            let spinner = ele.querySelector('#executionSpinner');
+            expect(spinner).not.toBeNull('spinner is not visible');
+        });
+
+        it('should be be visible after a result completes', () => {
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
+            dataService.sendWSEvent(resultSetSmall);
+            fixture.detectChanges();
+
+            // Spinner should be visible
+            let spinner = ele.querySelector('#executionSpinner');
+            expect(spinner).not.toBeNull('spinner is not visible');
+        });
+
+        it('should be be visible after a batch completes', () => {
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
+            dataService.sendWSEvent(resultSetSmall);
+            dataService.sendWSEvent(batch2);
+            fixture.detectChanges();
+
+            // Spinner should be visible
+            let spinner = ele.querySelector('#executionSpinner');
+            expect(spinner).not.toBeNull('spinner is not visible');
+        });
+
+        it('should be hidden after a query completes', () => {
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
+            dataService.sendWSEvent(resultSetSmall);
+            dataService.sendWSEvent(batch2);
+            dataService.sendWSEvent(completeEvent);
+            fixture.detectChanges();
+
+            // Spinner should not be visible
+            let spinner = ele.querySelector('#executionSpinner');
+            expect(spinner).toBeNull('spinner is visible');
         });
     });
 
@@ -301,6 +395,7 @@ describe('AppComponent', function (): void {
 
         it('should hide message pane on click when there is data', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -316,6 +411,7 @@ describe('AppComponent', function (): void {
 
         it('should hide the results pane on click when there is data', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -349,6 +445,7 @@ describe('AppComponent', function (): void {
 
         it('should open context menu when event is fired', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -374,6 +471,7 @@ describe('AppComponent', function (): void {
         it('should send save requests when the icons are clicked', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
             spyOn(dataService, 'sendSaveRequest');
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -390,8 +488,10 @@ describe('AppComponent', function (): void {
 
         it('should have maximized the grid when the icon is clicked', (done) => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetBig);
             dataService.sendWSEvent(batch1);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -424,6 +524,7 @@ describe('AppComponent', function (): void {
             let shortcutService = <MockShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.toggleResultPane'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -452,6 +553,7 @@ describe('AppComponent', function (): void {
             let shortcutService = <MockShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.toggleResultPane'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -471,6 +573,7 @@ describe('AppComponent', function (): void {
             let shortcutService = <MockShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.toggleMessagePane'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -491,6 +594,7 @@ describe('AppComponent', function (): void {
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.copySelection'));
             spyOn(dataService, 'copyResults');
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch1);
             dataService.sendWSEvent(completeEvent);
@@ -509,6 +613,7 @@ describe('AppComponent', function (): void {
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.copyWithHeaders'));
             spyOn(dataService, 'copyResults');
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch1);
             dataService.sendWSEvent(completeEvent);
@@ -527,8 +632,10 @@ describe('AppComponent', function (): void {
             let shortcutService = <MockShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.maximizeGrid'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetBig);
             dataService.sendWSEvent(batch1);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -550,6 +657,7 @@ describe('AppComponent', function (): void {
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.saveAsJSON'));
             spyOn(dataService, 'sendSaveRequest');
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -568,6 +676,7 @@ describe('AppComponent', function (): void {
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.saveAsCSV'));
             spyOn(dataService, 'sendSaveRequest');
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -586,8 +695,10 @@ describe('AppComponent', function (): void {
             let shortcutService = <ShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.nextGrid'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetBig);
             dataService.sendWSEvent(batch1);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -611,8 +722,10 @@ describe('AppComponent', function (): void {
             let shortcutService = <ShortcutService> fixture.componentRef.injector.get(ShortcutService);
             spyOn(shortcutService, 'buildEventString').and.returnValue('');
             spyOn(shortcutService, 'getEvent').and.returnValue(Promise.resolve('event.prevGrid'));
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetBig);
             dataService.sendWSEvent(batch1);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetSmall);
             dataService.sendWSEvent(batch2);
             dataService.sendWSEvent(completeEvent);
@@ -634,6 +747,7 @@ describe('AppComponent', function (): void {
 
         it('event select all', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(batchStart);
             dataService.sendWSEvent(resultSetBig);
             dataService.sendWSEvent(batch1);
             dataService.sendWSEvent(completeEvent);

--- a/src/views/htmlcontent/test/testResources/mockBatch1.spec.ts
+++ b/src/views/htmlcontent/test/testResources/mockBatch1.spec.ts
@@ -1,7 +1,7 @@
 import { WebSocketEvent } from './../../src/js/interfaces';
 
 const batch: WebSocketEvent = {
-  type: 'batch',
+  type: 'batchComplete',
   data: {
   'executionElapsed': '00:00:00.1879820',
   'executionEnd': '2016-11-10T17:39:27.9893860-08:00',

--- a/src/views/htmlcontent/test/testResources/mockBatch2.spec.ts
+++ b/src/views/htmlcontent/test/testResources/mockBatch2.spec.ts
@@ -1,7 +1,7 @@
 import { WebSocketEvent } from './../../src/js/interfaces';
 
 const batch: WebSocketEvent = {
-  type: 'batch',
+  type: 'batchComplete',
   data: {
   'executionElapsed': '00:00:00.1879820',
   'executionEnd': '2016-11-10T17:39:27.9893860-08:00',

--- a/src/views/htmlcontent/test/testResources/mockBatchStart.spec.ts
+++ b/src/views/htmlcontent/test/testResources/mockBatchStart.spec.ts
@@ -1,0 +1,24 @@
+import { WebSocketEvent } from './../../src/js/interfaces';
+
+
+// NOTE: nulls are used here because those are the same as what comes back from the service
+const batchStart: WebSocketEvent = {
+    type: 'batchStart',
+    data: {
+        'executionElapsed': null,   // tslint:disable-line:no-null-keyword
+        'executionEnd': null,       // tslint:disable-line:no-null-keyword
+        'executionStart': '2016-11-10T17:39:27.8014040-08:00',
+        'hasError': false,
+        'id': 0,
+        'selection': {
+            'endColumn': 1,
+            'endLine': 5,
+            'startColumn': 0,
+            'startLine': 3
+        },
+        'messages': null,           // tslint:disable-line:no-null-keyword
+        'resultSetSummaries': null  // tslint:disable-line:no-null-keyword
+    }
+};
+
+export default batchStart;

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -8,7 +8,7 @@ import SqlToolsServerClient from './../src/languageservice/serviceclient';
 import {
     QueryExecuteParams,
     QueryExecuteCompleteNotificationResult,
-    QueryExecuteBatchCompleteNotificationResult,
+    QueryExecuteBatchNotificationParams,
     QueryExecuteResultSetCompleteNotificationParams,
     ResultSetSummary
 } from './../src/models/contracts/queryExecute';
@@ -116,7 +116,7 @@ suite('Query Runner tests', () => {
 
     test('Notification - Batch Complete', () => {
         // Setup: Create a batch completion result
-        let batchComplete: QueryExecuteBatchCompleteNotificationResult = {
+        let batchComplete: QueryExecuteBatchNotificationParams = {
             ownerUri: 'uri',
             batchSummary: {
                 executionElapsed: undefined,

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -114,6 +114,41 @@ suite('Query Runner tests', () => {
         });
     });
 
+    test('Notification - Batch Start', () => {
+        // Setup: Create a batch start notification with appropriate values
+        // NOTE: nulls are used because that's what comes back from the service.
+        let batchStart: QueryExecuteBatchNotificationParams = {
+            ownerUri: 'uri',
+            batchSummary: {
+                executionElapsed: null,     // tslint:disable-line:no-null-keyword
+                executionEnd: null,         // tslint:disable-line:no-null-keyword
+                executionStart: new Date().toISOString(),
+                hasError: false,
+                id: 0,
+                selection: {startLine: 0, endLine: 0, startColumn: 3, endColumn: 3},
+                messages: null,             // tslint:disable-line:no-null-keyword
+                resultSetSummaries: null    // tslint:disable-line:no-null-keyword
+            }
+        };
+
+        // If: I submit a batch start notification to the query runner
+        let queryRunner = new QueryRunner(
+            '', '',
+            testStatusView.object,
+            testSqlToolsServerClient.object,
+            testQueryNotificationHandler.object,
+            testVscodeWrapper.object
+        );
+        let mockEventEmitter = TypeMoq.Mock.ofType(EventEmitter, TypeMoq.MockBehavior.Strict);
+        mockEventEmitter.setup(x => x.emit('batchStart', TypeMoq.It.isAny()));
+        queryRunner.eventEmitter = mockEventEmitter.object;
+        queryRunner.handleBatchStart(batchStart);
+
+        // Then: It should store the batch and emit a batch start
+        assert.equal(queryRunner.batchSets.indexOf(batchStart.batchSummary), 0);
+        mockEventEmitter.verify(x => x.emit('batchStart', TypeMoq.It.isAny()), TypeMoq.Times.once());
+    });
+
     test('Notification - Batch Complete', () => {
         // Setup: Create a batch completion result
         let batchComplete: QueryExecuteBatchNotificationParams = {
@@ -130,7 +165,7 @@ suite('Query Runner tests', () => {
             }
         };
 
-        // If: I submit a batch completion notification to the query runner...
+        // If: I submit a batch completion notification to the query runner that has a batch already started
         let queryRunner = new QueryRunner(
             '',
             '',
@@ -139,14 +174,34 @@ suite('Query Runner tests', () => {
             testQueryNotificationHandler.object,
             testVscodeWrapper.object
         );
+        queryRunner.batchSets[0] = {
+            executionElapsed: null,         // tslint:disable-line:no-null-keyword
+            executionEnd: null,             // tslint:disable-line:no-null-keyword
+            executionStart: new Date().toISOString(),
+            hasError: false,
+            id: 0,
+            selection: {startLine: 0, endLine: 0, startColumn: 3, endColumn: 3},
+            messages: null,                 // tslint:disable-line:no-null-keyword
+            resultSetSummaries: null        // tslint:disable-line:no-null-keyword
+        };
         let mockEventEmitter = TypeMoq.Mock.ofType(EventEmitter, TypeMoq.MockBehavior.Strict);
-        mockEventEmitter.setup(x => x.emit('batch', TypeMoq.It.isAny()));
+        mockEventEmitter.setup(x => x.emit('batchComplete', TypeMoq.It.isAny()));
         queryRunner.eventEmitter = mockEventEmitter.object;
         queryRunner.handleBatchComplete(batchComplete);
 
-        // Then: It should store the batch and emit a batch complete notification
-        assert.equal(queryRunner.batchSets.indexOf(batchComplete.batchSummary), 0);
-        mockEventEmitter.verify(x => x.emit('batch', TypeMoq.It.isAny()), TypeMoq.Times.once());
+        // Then: It should the remainder of the information and emit a batch complete notification
+        assert.equal(queryRunner.batchSets.length, 1);
+        let storedBatch = queryRunner.batchSets[0];
+        assert.equal(storedBatch.executionElapsed, undefined);
+        assert.equal(typeof(storedBatch.executionEnd), typeof(batchComplete.batchSummary.executionEnd));
+        assert.equal(typeof(storedBatch.executionStart), typeof(batchComplete.batchSummary.executionStart));
+        assert.equal(storedBatch.hasError, batchComplete.batchSummary.hasError);
+        assert.equal(storedBatch.messages, batchComplete.batchSummary.messages);
+
+        // ... Result sets should not be set by the batch complete notification
+        assert.equal(storedBatch.resultSetSummaries, null); // tslint:disable-line:no-null-keyword
+
+        mockEventEmitter.verify(x => x.emit('batchComplete', TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 
     test('Notification - ResultSet Complete w/no previous results', () => {
@@ -167,17 +222,23 @@ suite('Query Runner tests', () => {
             testSqlToolsServerClient.object,
             testQueryNotificationHandler.object,
             testVscodeWrapper.object);
+        queryRunner.batchSets[0] = {
+            executionElapsed: null,         // tslint:disable-line:no-null-keyword
+            executionEnd: null,             // tslint:disable-line:no-null-keyword
+            executionStart: new Date().toISOString(),
+            hasError: false,
+            id: 0,
+            selection: {startLine: 0, endLine: 0, startColumn: 3, endColumn: 3},
+            messages: null,                 // tslint:disable-line:no-null-keyword
+            resultSetSummaries: null        // tslint:disable-line:no-null-keyword
+        };
         let mockEventEmitter = TypeMoq.Mock.ofType(EventEmitter, TypeMoq.MockBehavior.Strict);
         mockEventEmitter.setup(x => x.emit('resultSet', TypeMoq.It.isAny()));
         queryRunner.eventEmitter = mockEventEmitter.object;
         queryRunner.handleResultSetComplete(resultSetComplete);
 
         // Then:
-        // ... It should create a batch summary to hold the result
-        assert.equal(queryRunner.batchSets.length, 1);
-        assert.equal(queryRunner.batchSets[0].id, 0);
-
-        // ... The batch that was created should contain the result set we got back
+        // ... The pre-existing batch should contain the result set we got back
         assert.equal(queryRunner.batchSets[0].resultSetSummaries.length, 1);
         assert.equal(queryRunner.batchSets[0].resultSetSummaries[0], resultSetComplete.resultSetSummary);
 
@@ -208,6 +269,16 @@ suite('Query Runner tests', () => {
             testSqlToolsServerClient.object,
             testQueryNotificationHandler.object,
             testVscodeWrapper.object);
+        queryRunner.batchSets[0] = {
+            executionElapsed: null,         // tslint:disable-line:no-null-keyword
+            executionEnd: null,             // tslint:disable-line:no-null-keyword
+            executionStart: new Date().toISOString(),
+            hasError: false,
+            id: 0,
+            selection: {startLine: 0, endLine: 0, startColumn: 3, endColumn: 3},
+            messages: null,                 // tslint:disable-line:no-null-keyword
+            resultSetSummaries: null        // tslint:disable-line:no-null-keyword
+        };
         queryRunner.eventEmitter = mockEventEmitter.object;
         queryRunner.handleResultSetComplete(resultSetComplete1);
 
@@ -215,10 +286,6 @@ suite('Query Runner tests', () => {
         queryRunner.handleResultSetComplete(resultSetComplete2);
 
         // Then:
-        // ... There should only be one batch summary created to hold the results
-        assert.equal(queryRunner.batchSets.length, 1);
-        assert.equal(queryRunner.batchSets[0].id, 0);
-
         // ... There should be two results in the batch summary
         assert.equal(queryRunner.batchSets[0].resultSetSummaries.length, 2);
         assert.equal(queryRunner.batchSets[0].resultSetSummaries[0], resultSetComplete1.resultSetSummary);


### PR DESCRIPTION
This is the change to the extension that corresponds to Microsoft/sqltoolsservice#169, which sends a notification to indicate that a batch has completed execution. This change makes it so that the batch start message is visible as soon as the batch starts executing, and allows for more accurate time of the batch start to be visible.