### PR TITLE
Bump extension version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## Version 0.2.0
+* Release date: December, 2016
+* Release status: Public Preview
+
+## What's new in this version
+* Peek Definition and Go To Definition support for Tables, Views and Stored Procedures. For a query such as `select * from dbo.Person` you can right-click on `dbo.Person` and see it as a `CREATE TABLE` script.
+* Support for additional operating systems including Linux Mint and Elementary OS. See [Operating Systems] for the list of supported OSes.
+* Output window now shows status of SQL tools service installation to make it easier to track install-time issues.
+* Progressive Result Sets: when running multiple queries at once, you'll now see result sets appear as soon as they are done processing instead of waiting for all queries to complete.
+The extension supports result set-level updates with per-row updates coming in a future update.
+* Multiple results view improvements: improved keyboard navigation, configuration settings to alter default font style and size, support for copying with column headers.
+* Multiple IntelliSense improvements: Support using  `[bracket].[syntax]`, handling of `"` at the end of a word, improved performance when connecting to same DB from a new file.
+
 ## Version 0.1.5
 * Release date: Nov 16, 2016
 * Release status: Public Preview
@@ -57,3 +70,4 @@ Report issues to [Github Issue Tracker] and provide your feedback.
 [manage connection profiles]:https://github.com/Microsoft/vscode-mssql/wiki/manage-connection-profiles
 [OpenSSL requirement on macOS]:https://github.com/Microsoft/vscode-mssql/wiki/OpenSSL-Configuration
 [Windows 10 Universal C Runtime requirement]:https://github.com/Microsoft/vscode-mssql/wiki/windows10-universal-c-runtime-requirement
+[Operating Systems]:https://github.com/Microsoft/vscode-mssql/wiki/operating-systems

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [customize options] and [manage connection profiles] for more details.
 ```
 
 ## Change Log
-The current version is ```0.1.5```. See the [change log] for more detail.
+The current version is ```0.2.0```. See the [change log] for more detail.
 
 ## Support
 Support for this extension is provided on our [GitHub Issue Tracker]. You can submit a [bug report], a [feature suggestion] or participate in [discussions].

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "Microsoft",
   "preview": true,


### PR DESCRIPTION
Fixes #485. Added initial Changelog notes, though this will likely move to the main Readme.md page before release.