### PR TITLE
fixed results pane for various queries

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -122,6 +122,7 @@ export default class QueryRunner {
         });
 
         return this._client.sendRequest(QueryExecuteRequest.type, queryDetails).then(result => {
+            self.eventEmitter.emit('start');
             if (result.messages) { // Show informational messages if there was no query to execute
                 self._statusView.executedQuery(self.uri);
                 self._isExecuting = false;
@@ -140,7 +141,7 @@ export default class QueryRunner {
                 // register with the Notification Handler
                 self._notificationHandler.registerRunner(self, queryDetails.ownerUri);
             }
-            self.eventEmitter.emit('start');
+            self.eventEmitter.emit('complete');
         }, error => {
             self._statusView.executedQuery(self.uri);
             self._isExecuting = false;

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -137,6 +137,8 @@ export default class QueryRunner {
                         executionStart: undefined
                     }];
                 self.dataResolveReject.resolve();
+                this.eventEmitter.emit('batchStart', self._batchSets[0]);
+                this.eventEmitter.emit('batchComplete', self._batchSets[0]);
             } else {
                 // register with the Notification Handler
                 self._notificationHandler.registerRunner(self, queryDetails.ownerUri);

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -144,6 +144,10 @@ export default class QueryRunner {
         }, error => {
             self._statusView.executedQuery(self.uri);
             self._isExecuting = false;
+
+            // if the query failed, then create a new empty pane and close it
+            self.eventEmitter.emit('start');
+            self.eventEmitter.emit('complete');
             self._vscodeWrapper.showErrorMessage('Execution failed: ' + error);
         });
     }
@@ -166,6 +170,7 @@ export default class QueryRunner {
                 executionStart: undefined
             }];
             this.dataResolveReject.resolve(this.batchSets);
+            this.eventEmitter.emit('complete');
             return;
         }
         this.batchSets = result.batchSummaries;


### PR DESCRIPTION
This fixes problems #484 and #345 where compiling a native function gives a spinning wheel forever with the message "Executing query...". It also fixes another bug, where if you execute 2 or more different queries, then an unsuccessful query retained the result from a previous successful query or a successful query retained the error message from a previous unsuccessful query.