### PR TITLE
added safe list to build so we can build pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: required
 dist: trusty
 
+# safelist
+branches:
+  only:
+  - master
+  - dev
+
 language: node_js
 node_js:
   - "6.9.1"


### PR DESCRIPTION
I realized that the coverage comments were breaking because we weren't building when someone merges a PR, this adds a build only for dev. It should still build PR's though.