### PR TITLE
Removed workaround for showTextDocument

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -339,22 +339,12 @@ export default class QueryRunner {
         const self = this;
         return new Promise<void>((resolve, reject) => {
             self._vscodeWrapper.openTextDocument(self._vscodeWrapper.parseUri(self.uri)).then((doc) => {
-                let docEditors = self._vscodeWrapper.visibleEditors.filter((editor) => {
-                    return editor.document === doc;
-                });
-                if (docEditors.length !== 0) {
-                    docEditors[0].selection = self._vscodeWrapper.selection(
-                                              self._vscodeWrapper.position(selection.startLine, selection.startColumn),
-                                              self._vscodeWrapper.position(selection.endLine, selection.endColumn));
+                self._vscodeWrapper.showTextDocument(doc).then((editor) => {
+                    editor.selection = self._vscodeWrapper.selection(
+                                    self._vscodeWrapper.position(selection.startLine, selection.startColumn),
+                                    self._vscodeWrapper.position(selection.endLine, selection.endColumn));
                     resolve();
-                } else {
-                    self._vscodeWrapper.showTextDocument(doc).then((editor) => {
-                        editor.selection = self._vscodeWrapper.selection(
-                                        self._vscodeWrapper.position(selection.startLine, selection.startColumn),
-                                        self._vscodeWrapper.position(selection.endLine, selection.endColumn));
-                        resolve();
-                    });
-                }
+                });
             });
         });
     }


### PR DESCRIPTION
Fixes #482. Removed the workaround for `showTextDocument`. This change relies on updates that are present in VS Code - Insiders, but are not yet present in standard VS Code. This change was tested with the most recent VS Code - Insiders build (1.8.0-insider, commit 40243d1e01f426f54670f3dbaa6b77d18469310d). 

I looked through the code and didn't find anywhere else where an obvious workaround is present. It would be best if someone else double-check that, though.




