### PR TITLE
Check if properties is null in sendTelemetryEvent

### DIFF
--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -126,7 +126,7 @@ export namespace Telemetry {
             return;
         }
 
-        if (typeof properties === 'undefined') {
+        if (!properties || typeof properties === 'undefined') {
             properties = {};
         }
 


### PR DESCRIPTION
Fixes sendTelemetryEvent throwing nullref exception #500.