### PR TITLE
setting the telemtry proeprties to empty list if it's null

### DIFF
--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -126,7 +126,7 @@ export namespace Telemetry {
             return;
         }
 
-        if (typeof properties === 'undefined') {
+        if (typeof properties === 'undefined' || !properties) {
             properties = {};
         }
 


### PR DESCRIPTION
When the server sends the telemetry notification, the properties can be null when is not set in server. Client was only checking for  "unidentified" so the null properties was causing an error. 