### PR TITLE
Fix multi-line display formatting and copy formatting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.intelliSense.enableQuickInfo": true,
     "mssql.intelliSense.lowerCaseSuggestions": false,
     "mssql.resultsFontFamily": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-    "mssql.resultsFontSize": 12
+    "mssql.resultsFontSize": 12,
+    "mssql.copyRemoveNewLine" : true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -424,7 +424,13 @@
           "type": "boolean",
           "description": "[Optional] Configuration options for copying results from the Results View",
           "default": false
+        },
+        "mssql.copyRemoveNewLine": {
+          "type": "boolean",
+          "description": "[Optional] Configuration options for copying multi-line results from the Results View",
+          "default": true
         }
+
       }
     }
   },

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -354,8 +354,8 @@ export default class QueryRunner {
     private removeNewLines(inputString: string): string {
         // This regex removes all newlines in all OS types
         // Windows(CRLF): \r\n
-        // Linux(LF): \n
-        // MacOS(CR): \r
+        // Linux(LF)/Modern MacOS: \n
+        // Old MacOs: \r
         let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
         return outputString;
     }

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -352,7 +352,7 @@ export default class QueryRunner {
     }
 
     private removeNewLines(inputString: string): string {
-        // This regex removes all newlines in all OStypes
+        // This regex removes all newlines in all OS types
         // Windows(CRLF): \n\r
         // Linux(LF): \n
         // MacOS(CR): \r

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -353,7 +353,7 @@ export default class QueryRunner {
 
     private removeNewLines(inputString: string): string {
         // This regex removes all newlines in all OS types
-        // Windows(CRLF): \n\r
+        // Windows(CRLF): \r\n
         // Linux(LF): \n
         // MacOS(CR): \r
         let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -308,7 +308,12 @@ export default class QueryRunner {
                         for (let row of result.resultSubset.rows) {
                             // iterate over the cells we want from that row
                             for (let cell = range.fromCell; cell <= range.toCell; cell++) {
-                                copyString += row[cell] + '\t';
+                                if (self.shouldRemoveNewLines()) {
+                                    // This regex removes all new lines in all forms of new line
+                                    copyString += self.removeNewLines(row[cell]) + '\t';
+                                } else {
+                                    copyString += row[cell] + '\t';
+                                }
                             }
                             copyString += '\r\n';
                         }
@@ -337,6 +342,22 @@ export default class QueryRunner {
         let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName);
         includeHeaders = config[Constants.copyIncludeHeaders];
         return !!includeHeaders;
+    }
+
+    private shouldRemoveNewLines(): boolean {
+        // get config copyRemoveNewLine option from vscode config
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName);
+        let removeNewLines: boolean = config[Constants.configCopyRemoveNewLine];
+        return removeNewLines;
+    }
+
+    private removeNewLines(inputString: string): string {
+        // This regex removes all newlines in all OStypes
+        // Windows(CRLF): \n\r
+        // Linux(LF): \n
+        // MacOS(CR): \r
+        let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
+        return outputString;
     }
 
     /**

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -161,7 +161,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             let numberOfRows = req.query.numberOfRows;
             let uri: string = req.query.uri;
             self._queryResultsMap.get(uri).queryRunner.getRows(rowStart, numberOfRows, batchId, resultId).then(results => {
-                let json = JSON.stringify(results.resultSubset).replace(/(\\r\\n|\\n|\\r)/gm, '\\t');
+                let json = JSON.stringify(results.resultSubset);
                 res.send(json);
             });
         });

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -161,7 +161,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             let numberOfRows = req.query.numberOfRows;
             let uri: string = req.query.uri;
             self._queryResultsMap.get(uri).queryRunner.getRows(rowStart, numberOfRows, batchId, resultId).then(results => {
-                let json = JSON.stringify(results.resultSubset);
+                let json = JSON.stringify(results.resultSubset).replace(/(\\r\\n|\\n|\\r)/gm, '\\t');
                 res.send(json);
             });
         });

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -53,6 +53,7 @@ export const configSaveAsCsv = 'saveAsCsv';
 export const configSaveAsJson = 'saveAsJson';
 export const configRecentConnections = 'recentConnections';
 export const configMaxRecentConnections = 'maxRecentConnections';
+export const configCopyRemoveNewLine = 'copyRemoveNewLine';
 
 
 // localizable strings

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -363,9 +363,15 @@ export class AppComponent implements OnInit, AfterViewChecked {
                         return new Promise<IGridDataRow[]>((resolve, reject) => {
                             self.dataService.getRows(offset, count, resultSet.batchId, resultSet.id).subscribe(rows => {
                                 let gridData: IGridDataRow[] = [];
-                                for (let i = 0; i < rows.rows.length; i++) {
+                                for (let row = 0; row < rows.rows.length; row++) {
+                                    // Replace each cell's newline with spaces
+                                    for (let col = 0; col < rows.rows[row].length; col++) {
+                                        rows.rows[row][col] = rows.rows[row][col].replace(/(\r\n|\n|\r)/gm, ' ');
+                                    }
+
+                                    // Push row values onto end of gridData for slickgrid
                                     gridData.push({
-                                        values: rows.rows[i]
+                                        values: rows.rows[row]
                                     });
                                 }
                                 resolve(gridData);

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -364,11 +364,6 @@ export class AppComponent implements OnInit, AfterViewChecked {
                             self.dataService.getRows(offset, count, resultSet.batchId, resultSet.id).subscribe(rows => {
                                 let gridData: IGridDataRow[] = [];
                                 for (let row = 0; row < rows.rows.length; row++) {
-                                    // Replace each cell's newline with spaces
-                                    for (let col = 0; col < rows.rows[row].length; col++) {
-                                        rows.rows[row][col] = rows.rows[row][col].replace(/(\r\n|\n|\r)/gm, ' ');
-                                    }
-
                                     // Push row values onto end of gridData for slickgrid
                                     gridData.push({
                                         values: rows.rows[row]
@@ -539,13 +534,13 @@ export class AppComponent implements OnInit, AfterViewChecked {
     }
 
     /**
-     * Format all text to replace /n with spaces
+     * Format all text to replace all new lines with spaces
      */
     textFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
         let valueToDisplay = value;
         let cellClasses = 'grid-cell-value-container';
         if (value) {
-            valueToDisplay = value.replace(/\n/g, ' ');
+            valueToDisplay = value.replace(/(\r\n|\n|\r)/g, ' ');
         } else {
             cellClasses += ' missing-value';
         }


### PR DESCRIPTION
Fixes #511 by adding a property to the settings file 'copyRemoveNewLine' that determines if newlines are removed when data is copied from results grid (default is true). Also always replaces newlines with spaces for data displayed in the results grid (same as SSMS).