### PR TITLE
Revert the default font size to 13px to match Preview 1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.intelliSense.enableQuickInfo": true,
     "mssql.intelliSense.lowerCaseSuggestions": false,
     "mssql.resultsFontFamily": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-    "mssql.resultsFontSize": 12
+    "mssql.resultsFontSize": 13
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -409,7 +409,7 @@
         "mssql.resultsFontSize": {
           "type": "number",
           "description": "Set the font size for the results grid; set to blank to use the editor size",
-          "default": 12
+          "default": 13
         },
         "mssql.saveAsCsv": {
           "type": "object",


### PR DESCRIPTION
The default font size was 13 in the Preview 1 release, but was changed to 12 at some point since.  Also removing the bootstrap.css files subtly changed the grid appearance, but I switching this back makes it look basically the same.