### PR TITLE
Add back Getting Started Guide command

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "onCommand:extension.disconnect",
     "onCommand:extension.manageProfiles",
     "onCommand:extension.chooseDatabase",
-    "onCommand:extension.cancelQuery"
+    "onCommand:extension.cancelQuery",
+    "onCommand:extension.showGettingStarted"
   ],
   "main": "./out/src/extension",
   "extensionDependencies": [
@@ -172,6 +173,11 @@
       {
         "command": "extension.chooseDatabase",
         "title": "Use Database",
+        "category": "MS SQL"
+      },
+      {
+        "command": "extension.showGettingStarted",
+        "title": "Getting Started Guide",
         "category": "MS SQL"
       }
     ],


### PR DESCRIPTION
The Getting Started Guide command was removed from the package.json file, apparently as the result of a mismerge.  Unfortunately 0.2.0 went out without this command, but we should add it back unless it was an explicit decision to remove this command.