### PR TITLE
added new command to create new SQL query document

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,11 +205,6 @@
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "extension.newQuery",
-        "key": "ctrl+shift+n",
-        "mac": "cmd+shift+n+q"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "onCommand:extension.manageProfiles",
     "onCommand:extension.chooseDatabase",
     "onCommand:extension.cancelQuery",
-    "onCommand:extension.showGettingStarted"
+    "onCommand:extension.showGettingStarted",
+    "onCommand:extension.newQuery"
   ],
   "main": "./out/src/extension",
   "extensionDependencies": [
@@ -179,6 +180,11 @@
         "command": "extension.showGettingStarted",
         "title": "Getting Started Guide",
         "category": "MS SQL"
+      },
+      {
+        "command": "extension.newQuery",
+        "title": "New query",
+        "category": "MS SQL"
       }
     ],
     "keybindings": [
@@ -199,6 +205,11 @@
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "extension.newQuery",
+        "key": "ctrl+shift+n",
+        "mac": "cmd+shift+n+q"
       }
     ],
     "configuration": {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -16,6 +16,7 @@ import { IPrompter } from '../prompts/question';
 import CodeAdapter from '../prompts/adapter';
 import Telemetry from '../models/telemetry';
 import VscodeWrapper from './vscodeWrapper';
+import UntitledSqlDocumentService from './untitledSqlDocumentService';
 import { ISelectionData } from './../models/interfaces';
 import * as path from 'path';
 import fs = require('fs');
@@ -38,6 +39,7 @@ export default class MainController implements vscode.Disposable {
     private _lastSavedTimer: Utils.Timer;
     private _lastOpenedUri: string;
     private _lastOpenedTimer: Utils.Timer;
+    private _untitledSqlDocumentService: UntitledSqlDocumentService;
 
     /**
      * The main controller constructor
@@ -45,13 +47,21 @@ export default class MainController implements vscode.Disposable {
      */
     constructor(context: vscode.ExtensionContext,
                 connectionManager?: ConnectionManager,
-                vscodeWrapper?: VscodeWrapper) {
+                vscodeWrapper?: VscodeWrapper,
+                untitledSqlDocumentService?: UntitledSqlDocumentService) {
         this._context = context;
         if (connectionManager) {
             this._connectionMgr = connectionManager;
         }
         if (vscodeWrapper) {
             this._vscodeWrapper = vscodeWrapper;
+        } else {
+            this._vscodeWrapper = new VscodeWrapper();
+        }
+        if (untitledSqlDocumentService) {
+            this._untitledSqlDocumentService = untitledSqlDocumentService;
+        } else {
+            this._untitledSqlDocumentService = new UntitledSqlDocumentService(this._vscodeWrapper);
         }
     }
 
@@ -104,8 +114,10 @@ export default class MainController implements vscode.Disposable {
         this._event.on(Constants.cmdCancelQuery, () => { self.onCancelQuery(); });
         this.registerCommand(Constants.cmdShowGettingStarted);
         this._event.on(Constants.cmdShowGettingStarted, () => { self.launchGettingStartedPage(); });
+        this.registerCommand(Constants.cmdNewQuery);
+        this._event.on(Constants.cmdNewQuery, () => { self.runAndLogErrors(self.onNewQuery(), 'onNewQuery'); });
 
-        this._vscodeWrapper = new VscodeWrapper();
+        // this._vscodeWrapper = new VscodeWrapper();
 
         // Add handlers for VS Code generated commands
         this._vscodeWrapper.onDidCloseTextDocument(params => this.onDidCloseTextDocument(params));
@@ -306,6 +318,10 @@ export default class MainController implements vscode.Disposable {
         this._connectionMgr = connectionManager;
     }
 
+    public set untitledSqlDocumentService(untitledSqlDocumentService: UntitledSqlDocumentService) {
+        this._untitledSqlDocumentService = untitledSqlDocumentService;
+    }
+
 
     /**
      * Verifies the extension is initilized and if not shows an error message
@@ -358,6 +374,15 @@ export default class MainController implements vscode.Disposable {
       */
     private launchGettingStartedPage(): void {
         opener(Constants.gettingStartedGuideLink);
+    }
+
+    /**
+     * Opens a new query and creates new connection
+     */
+    public onNewQuery(): Promise<boolean> {
+        return this._untitledSqlDocumentService.newQuery().then(x => {
+            return this._connectionMgr.onNewConnection();
+        });
     }
 
     /**

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -52,11 +52,8 @@ export default class MainController implements vscode.Disposable {
         if (connectionManager) {
             this._connectionMgr = connectionManager;
         }
-        if (vscodeWrapper) {
-            this._vscodeWrapper = vscodeWrapper;
-        } else {
-            this._vscodeWrapper = new VscodeWrapper();
-        }
+        this._vscodeWrapper = vscodeWrapper || new VscodeWrapper();
+
         this._untitledSqlDocumentService = new UntitledSqlDocumentService(this._vscodeWrapper);
     }
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -47,8 +47,7 @@ export default class MainController implements vscode.Disposable {
      */
     constructor(context: vscode.ExtensionContext,
                 connectionManager?: ConnectionManager,
-                vscodeWrapper?: VscodeWrapper,
-                untitledSqlDocumentService?: UntitledSqlDocumentService) {
+                vscodeWrapper?: VscodeWrapper) {
         this._context = context;
         if (connectionManager) {
             this._connectionMgr = connectionManager;
@@ -58,11 +57,7 @@ export default class MainController implements vscode.Disposable {
         } else {
             this._vscodeWrapper = new VscodeWrapper();
         }
-        if (untitledSqlDocumentService) {
-            this._untitledSqlDocumentService = untitledSqlDocumentService;
-        } else {
-            this._untitledSqlDocumentService = new UntitledSqlDocumentService(this._vscodeWrapper);
-        }
+        this._untitledSqlDocumentService = new UntitledSqlDocumentService(this._vscodeWrapper);
     }
 
     /**

--- a/src/controllers/untitledSqlDocumentService.ts
+++ b/src/controllers/untitledSqlDocumentService.ts
@@ -1,0 +1,62 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import VscodeWrapper from './vscodeWrapper';
+import vscode = require('vscode');
+import path = require('path');
+import os = require('os');
+const fs = require('fs');
+
+/**
+ * Service for creating untitled documents for SQL query
+ */
+export default class UntitledSqlDocumentService {
+    private _counter: number = 1;
+
+    constructor(private vscodeWrapper: VscodeWrapper) {
+    }
+
+    /**
+     * Creates new untitled document for SQL query and opens in new editor tab
+     */
+    public newQuery(): Promise<boolean> {
+
+        return new Promise<boolean>((resolve, reject) => {
+            try {
+                let filePath = this.createUntitledFilePath();
+                let docUri: vscode.Uri = vscode.Uri.parse('untitled:' + filePath);
+
+                // Open an untitled document. So the  file doesn't have to exist in disk
+                this.vscodeWrapper.openTextDocument(docUri).then(doc => {
+                    // Show the new untitled document in the editor's first tab and change the focus to it.
+                    this.vscodeWrapper.showTextDocument(doc, 1, false).then(textDoc => {
+                        this._counter++;
+                        resolve(true);
+                    });
+                });
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    private createUntitledFilePath(): string {
+        let filePath = UntitledSqlDocumentService.createFilePath(this._counter);
+        while (fs.existsSync(filePath)) {
+            this._counter++;
+            filePath = UntitledSqlDocumentService.createFilePath(this._counter);
+        }
+        while (this.vscodeWrapper.textDocuments.find(x => x.fileName.toUpperCase() === filePath.toUpperCase())) {
+            this._counter++;
+            filePath = UntitledSqlDocumentService.createFilePath(this._counter);
+        }
+        return filePath;
+    }
+
+    public static createFilePath(counter: number): string {
+        return path.join(os.tmpdir(), `SQLQuery${counter}.sql`);
+    }
+}
+

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -15,6 +15,7 @@ export const cmdDisconnect = 'extension.disconnect';
 export const cmdChooseDatabase = 'extension.chooseDatabase';
 export const cmdShowReleaseNotes = 'extension.showReleaseNotes';
 export const cmdShowGettingStarted = 'extension.showGettingStarted';
+export const cmdNewQuery = 'extension.newQuery';
 export const cmdManageConnectionProfiles = 'extension.manageProfiles';
 
 export const sqlDbPrefix = '.database.windows.net';

--- a/test/untitledSqlDocumentService.test.ts
+++ b/test/untitledSqlDocumentService.test.ts
@@ -1,0 +1,128 @@
+import * as TypeMoq from 'typemoq';
+import vscode = require('vscode');
+import UntitledSqlDocumentService from '../src/controllers/untitledSqlDocumentService';
+import VscodeWrapper from '../src/controllers/VscodeWrapper';
+const fse = require('fs-extra');
+const fs = require('fs');
+
+interface IFixture {
+    openDocResult: Promise<vscode.TextDocument>;
+    showDocResult: Promise<vscode.TextEditor>;
+    vscodeWrapper: TypeMoq.Mock<VscodeWrapper>;
+    service: UntitledSqlDocumentService;
+    textDocuments: vscode.TextDocument[];
+}
+
+suite('UntitledSqlDocumentService Tests', () => {
+
+     function createTextDocumentObject(fileName: string = ''): vscode.TextDocument {
+         return {
+            uri: undefined,
+            fileName: fileName,
+            getText: undefined,
+            getWordRangeAtPosition: undefined,
+            isDirty: true,
+            isUntitled: true,
+            languageId: 'sql',
+            lineAt: undefined,
+            lineCount: undefined,
+            offsetAt: undefined,
+            positionAt: undefined,
+            save: undefined,
+            validatePosition: undefined,
+            validateRange: undefined,
+            version: undefined
+        };
+     }
+
+     function createUntitledSqlDocumentService(fixture: IFixture): IFixture {
+         let vscodeWrapper: TypeMoq.Mock<VscodeWrapper>;
+         vscodeWrapper = TypeMoq.Mock.ofType(VscodeWrapper);
+
+         vscodeWrapper.setup(x => x.textDocuments).returns(() => { return fixture.textDocuments; });
+         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny()))
+         .returns(() => { return Promise.resolve(createTextDocumentObject()); });
+         vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+         .returns(() => { return Promise.resolve(TypeMoq.It.isAny()); });
+         fixture.vscodeWrapper = vscodeWrapper;
+         fixture.service = new UntitledSqlDocumentService(vscodeWrapper.object);
+         return fixture;
+     }
+
+     test('newQuery should open a new untitled document and show in new tab' , () => {
+        let fixture: IFixture = {
+            openDocResult: Promise.resolve(createTextDocumentObject()),
+            showDocResult: Promise.resolve(TypeMoq.It.isAny()),
+            service: undefined,
+            vscodeWrapper: undefined,
+            textDocuments: []
+        };
+        fixture = createUntitledSqlDocumentService(fixture);
+
+        return fixture.service.newQuery().then(result => {
+            fixture.vscodeWrapper.verify(x => x.openTextDocument(
+                TypeMoq.It.is<vscode.Uri>(d => d.scheme === 'untitled')), TypeMoq.Times.once());
+            fixture.vscodeWrapper.verify(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
+        });
+     });
+
+     test('newQuery should increment the counter for untitled document if file exits' , () => {
+        let fixture: IFixture = {
+            openDocResult: Promise.resolve(createTextDocumentObject()),
+            showDocResult: Promise.resolve(TypeMoq.It.isAny()),
+            service: undefined,
+            vscodeWrapper: undefined,
+            textDocuments: []
+        };
+        let counter = getCounterForUntitledFile(1);
+        fixture = createUntitledSqlDocumentService(fixture);
+        let filePath = UntitledSqlDocumentService.createFilePath(counter);
+        if (!fs.existsSync(filePath)) {
+            fs.writeFileSync(filePath, 'test');
+        }
+        return fixture.service.newQuery().then(result => {
+            fixture.vscodeWrapper.verify(x => x.openTextDocument(
+                TypeMoq.It.is<vscode.Uri>(d => verifyDocumentUri(d, counter + 1))), TypeMoq.Times.once());
+            fixture.vscodeWrapper.verify(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
+            if (!fs.existsSync(filePath)) {
+                fse.remove(filePath, undefined);
+            }
+        });
+     });
+
+     function verifyDocumentUri(uri: vscode.Uri, expectedNumber: number): boolean {
+         return uri.scheme === 'untitled' && uri.path.endsWith(`${expectedNumber}.sql`);
+     }
+
+     function getCounterForUntitledFile(start: number): number {
+        let counter = start;
+        let filePath = UntitledSqlDocumentService.createFilePath(counter);
+        while (fs.existsSync(filePath)) {
+            counter++;
+            filePath = UntitledSqlDocumentService.createFilePath(counter);
+        }
+        return counter;
+     }
+
+     test('newQuery should increment the counter for untitled document given text documents already open with current counter' , () => {
+        let counter = getCounterForUntitledFile(1);
+        let fixture: IFixture = {
+            openDocResult: Promise.resolve(createTextDocumentObject()),
+            showDocResult: Promise.resolve(TypeMoq.It.isAny()),
+            service: undefined,
+            vscodeWrapper: undefined,
+            textDocuments: [
+                createTextDocumentObject(UntitledSqlDocumentService.createFilePath(counter + 1)),
+                createTextDocumentObject(UntitledSqlDocumentService.createFilePath(counter))]
+        };
+        fixture = createUntitledSqlDocumentService(fixture);
+        let service = fixture.service;
+
+        return service.newQuery().then(result => {
+            fixture.vscodeWrapper.verify(x => x.openTextDocument(
+                TypeMoq.It.is<vscode.Uri>(d => verifyDocumentUri(d, counter + 2))), TypeMoq.Times.once());
+            fixture.vscodeWrapper.verify(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
+        });
+     });
+});
+

--- a/test/untitledSqlDocumentService.test.ts
+++ b/test/untitledSqlDocumentService.test.ts
@@ -1,7 +1,7 @@
 import * as TypeMoq from 'typemoq';
 import vscode = require('vscode');
 import UntitledSqlDocumentService from '../src/controllers/untitledSqlDocumentService';
-import VscodeWrapper from '../src/controllers/VscodeWrapper';
+import VscodeWrapper from '../src/controllers/vscodeWrapper';
 const fse = require('fs-extra');
 const fs = require('fs');
 


### PR DESCRIPTION
- Added new command "mssql: New query" TODO: not sure what to use for the short but
- The new command creates new SQL query untitled document in the temp folder but because it's untitled, the file doesn't get created so user can decide to save it or not

- the new query command activates the extension is not already activated. 
- The name of the document will be SQLQuery[number].sql 
- after a new SQL query is created the new connection command will be called for user to open a connection 