### PR TITLE
Removing DataSet/BatchSet Promise

### DIFF
--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -366,7 +366,6 @@ suite('Query Runner tests', () => {
     });
 
     test('Handles result correctly', () => {
-        let resolveRan = false;
         let result: QueryExecuteCompleteNotificationResult = {
             ownerUri: 'uri',
             message: undefined,
@@ -398,13 +397,9 @@ suite('Query Runner tests', () => {
 
         queryRunner.eventEmitter = mockEventEmitter.object;
         queryRunner.uri = '';
-        queryRunner.dataResolveReject = {resolve: () => {
-            resolveRan = true;
-        }};
         queryRunner.handleResult(result);
         testStatusView.verify(x => x.executedQuery(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
         mockEventEmitter.verify(x => x.emit('complete'), TypeMoq.Times.once());
-        assert.equal(resolveRan, true);
     });
 
     test('Correctly handles subset', () => {
@@ -570,9 +565,6 @@ suite('Query Runner tests', () => {
                 testVscodeWrapper.object
             );
             queryRunner.uri = testuri;
-            queryRunner.dataResolveReject = {resolve: () => {
-                // Needed to handle the result callback
-            }};
             // Call handleResult to ensure column header info is seeded
             queryRunner.handleResult(result);
             return queryRunner.copyResults(testRange, 0, 0).then(() => {
@@ -596,9 +588,6 @@ suite('Query Runner tests', () => {
                 testVscodeWrapper.object
             );
             queryRunner.uri = testuri;
-            queryRunner.dataResolveReject = {resolve: () => {
-                // Needed to handle the result callback
-            }};
             // Call handleResult to ensure column header info is seeded
             queryRunner.handleResult(result);
 
@@ -624,9 +613,6 @@ suite('Query Runner tests', () => {
                 testVscodeWrapper.object
             );
             queryRunner.uri = testuri;
-            queryRunner.dataResolveReject = {resolve: () => {
-                // Needed to handle the result callback
-            }};
             // Call handleResult to ensure column header info is seeded
             queryRunner.handleResult(result);
 


### PR DESCRIPTION
Removing dead code that is no longer being used now that we have the websocket implementation. As far as I can tell, these web server handlers are no longer being called from the preview pane and since they were the only things that hinged on the dataset/batchset promise, we should be able to safely remove these.