### PR TITLE
Fix/html encode display values

### DIFF
--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -517,35 +517,33 @@ export class AppComponent implements OnInit, AfterViewChecked {
     }
 
     /**
-     * Format xml field into a hyperlink
+     * Format xml field into a hyperlink and performs HTML entity encoding
      */
-    public hyperLinkFormatter(row: number, cell: any, value: any, columnDef: any, dataContext: any): string {
-        let valueToDisplay = (value + '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    public hyperLinkFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
+        let valueToDisplay = Utils.htmlEntities(value);
         let cellClasses = 'grid-cell-value-container';
         if (value) {
             cellClasses += ' xmlLink';
-            return '<a class="' + cellClasses + '" href="#" >'
-                + valueToDisplay
-                + '</a>';
+            return `<a class="${cellClasses}" href="#" >${valueToDisplay}</a>`;
         } else {
             cellClasses += ' missing-value';
-            return '<span title="' + valueToDisplay + '" class="' + cellClasses + '">' + valueToDisplay + '</span>';
+            return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
         }
     }
 
     /**
-     * Format all text to replace all new lines with spaces
+     * Format all text to replace all new lines with spaces and performs HTML entity encoding
      */
     textFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
         let valueToDisplay = value;
         let cellClasses = 'grid-cell-value-container';
         if (value) {
-            valueToDisplay = value.replace(/(\r\n|\n|\r)/g, ' ');
+            valueToDisplay = Utils.htmlEntities(value.replace(/(\r\n|\n|\r)/g, ' '));
         } else {
             cellClasses += ' missing-value';
         }
 
-        return '<span title="' + valueToDisplay + '" class="' + cellClasses + '">' + valueToDisplay + '</span>';
+        return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
     }
 
     /**

--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -66,13 +66,14 @@ export function parseNumAsTimeString(value: number): string {
 }
 
 /**
- * Converts <, >, &, and any characters that are outside \u00A0 to numeric HTML entity values
+ * Converts <, >, &, ", ', and any characters that are outside \u00A0 to numeric HTML entity values
  * like &#123;
+ * (Adapted from http://stackoverflow.com/a/18750001)
  * @param str String to convert
  * @return String with characters replaced.
  */
 export function htmlEntities(str: string): string {
-    return str.replace(/[\u00A0-\u9999<>\&]/gim, (i) => {
+    return str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => {
         return `&#${i.charCodeAt(0)};`;
     });
 }

--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -64,3 +64,15 @@ export function parseNumAsTimeString(value: number): string {
 
     return tempVal > 0 ? rs + '.' + mss : rs;
 }
+
+/**
+ * Converts <, >, &, and any characters that are outside \u00A0 to numeric HTML entity values
+ * like &#123;
+ * @param str String to convert
+ * @return String with characters replaced.
+ */
+export function htmlEntities(str: string): string {
+    return str.replace(/[\u00A0-\u9999<>\&]/gim, (i) => {
+        return `&#${i.charCodeAt(0)};`;
+    });
+}

--- a/src/views/htmlcontent/test/utils.spec.ts
+++ b/src/views/htmlcontent/test/utils.spec.ts
@@ -32,4 +32,19 @@ describe('utils', () => {
             expect(Utils.parseNumAsTimeString(5002)).toEqual('00:00:05.002');
         });
     });
+
+    describe('htmlEntities', () => {
+        it('Encodes characters properly', () => {
+            ['\u00A0', '\u1000', '\u8000', '\u9999', '\'', '"', '<', '>', '&'].forEach((item) => {
+                let expectedValue = `&#${item.charCodeAt(0)};`;
+                expect(Utils.htmlEntities(item)).toEqual(expectedValue);
+            });
+        });
+
+        it('Does not encode characters outside the range', () => {
+            ['a', 'A', '$', '0'].forEach((item) => {
+                expect(Utils.htmlEntities(item)).toEqual(item);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Addresses #587 

Adding a fairly robust utility function to encode results from databases with HTML entities -- since JS doesn't have a built in one. This fixes issues where displaying result sets with HTML would fail. It also fixes an undiscovered issue where tooltips for cells would be cut off if they contained a `'` or `"`. Since the change is in the presentation layer, copy/paste and save as functionality still works as expected.