### PR TITLE
Fix copy bug by adding null check

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -295,7 +295,7 @@ export default class QueryRunner {
                         for (let row of result.resultSubset.rows) {
                             // iterate over the cells we want from that row
                             for (let cell = range.fromCell; cell <= range.toCell; cell++) {
-                                if (row[cell] && self.shouldRemoveNewLines()) {
+                                if (self.shouldRemoveNewLines()) {
                                     // This regex removes all new lines in all forms of new line
                                     copyString += self.removeNewLines(row[cell]) + '\t';
                                 } else {
@@ -343,6 +343,11 @@ export default class QueryRunner {
         // Windows(CRLF): \r\n
         // Linux(LF)/Modern MacOS: \n
         // Old MacOs: \r
+        if (!inputString) {
+            // We must return null here to stay consistent with our respresentation
+            return null; // tslint:disable-line
+        }
+        
         let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
         return outputString;
     }

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -295,7 +295,7 @@ export default class QueryRunner {
                         for (let row of result.resultSubset.rows) {
                             // iterate over the cells we want from that row
                             for (let cell = range.fromCell; cell <= range.toCell; cell++) {
-                                if (self.shouldRemoveNewLines() && row[cell]) {
+                                if (row[cell] && self.shouldRemoveNewLines()) {
                                     // This regex removes all new lines in all forms of new line
                                     copyString += self.removeNewLines(row[cell]) + '\t';
                                 } else {

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -347,7 +347,7 @@ export default class QueryRunner {
             // We must return null here to stay consistent with our respresentation
             return null; // tslint:disable-line
         }
-        
+
         let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
         return outputString;
     }

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -295,7 +295,7 @@ export default class QueryRunner {
                         for (let row of result.resultSubset.rows) {
                             // iterate over the cells we want from that row
                             for (let cell = range.fromCell; cell <= range.toCell; cell++) {
-                                if (self.shouldRemoveNewLines()) {
+                                if (self.shouldRemoveNewLines() && row[cell]) {
                                     // This regex removes all new lines in all forms of new line
                                     copyString += self.removeNewLines(row[cell]) + '\t';
                                 } else {


### PR DESCRIPTION
Fixes #596. Note that the value in `row` comes back as `null` and not `undefined` for `null` data. 