### PR TITLE
Small html coverage/test fixed

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -98,7 +98,7 @@ module.exports = function(config) {
       "/base/out/src/views/htmlcontent/src/": '/base/out/src/views/htmlcontent/dist/'
     },
     exclude: [],
-    reporters: ['progress','karma-remap-istanbul', 'junit'],
+    reporters: ['progress', 'junit'],
     customLaunchers: {
         Chrome_travis_ci: {
             base: 'Chrome',
@@ -113,22 +113,23 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome_travis_ci'],
     singleRun: true
   }
 
   if (coverconfig && coverconfig.enabled) {
-    config.preprocessors = {
+    configuration.preprocessors = {
       'out/src/views/htmlcontent/dist/**/!(*spec)*.js': 'coverage'
     };
-    config.reporters.push('coverage');
-    config.coverageReporter = {
+    configuration.reporters.push('coverage');
+    configuration.reporters.push('karma-remap-istanbul')
+    configuration.coverageReporter = {
       dir : 'coverage/',
       reporters: [
         {type: 'json'}
       ]
     };
-    config.remapIstanbulReporter = {
+    configuration.remapIstanbulReporter = {
       reports: {
         json: 'coverage/coverage-html.json',
         // uncomment below for html only coverage

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -42,4 +42,4 @@ gulp.task('cover:combine', () => {
 });
 
 // for running on the jenkins build system
-gulp.task('cover:jenkins', gulp.series('cover:clean', 'html:test', 'cover:enableconfig', 'ext:test', 'cover:combine'));
+gulp.task('cover:jenkins', gulp.series('cover:clean', 'cover:enableconfig', 'html:test', 'ext:test', 'cover:combine'));


### PR DESCRIPTION
- Jenkins was not enabling config before running html test which meant coverage was not being run.
- Coverage was not setting params on the right object
- Changed chrome launcher to use --no-sandbox which seems to have fixed the launcher problems.