### PR TITLE
Add QueryRunner queue to ensure correct notification ordering

### DIFF
--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -16,6 +16,7 @@ import { NotificationHandler } from 'vscode-languageclient';
 export class QueryNotificationHandler {
     private static _instance: QueryNotificationHandler;
     private _queryRunners = new Map<string, QueryRunner>();
+    private _handlerCallbackQueue: ((run: QueryRunner) => void)[];
 
     static get instance(): QueryNotificationHandler {
         if (QueryNotificationHandler._instance) {
@@ -34,21 +35,54 @@ export class QueryNotificationHandler {
         SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchCompleteNotification.type, this.handleBatchCompleteNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteResultSetCompleteNotification.type, this.handleResultSetCompleteNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteMessageNotification.type, this.handleMessageNotification());
+        this._handlerCallbackQueue = [];
     }
 
-    // registers queryRunners with their uris to distribute notifications
+    // Registers queryRunners with their uris to distribute notifications.
+    // Ensures that notifications are handled in the correct order by handling
+    // enqueued handlers first.
     public registerRunner(runner: QueryRunner, uri: string): void {
-        this._queryRunners.set(uri, runner);
+        // If enqueueOrRun was called before registerRunner for the current query,
+        // _handlerCallbackQueue will be non-empty. Run all handlers in the queue first
+        // so that notifications are handled in order they arrived
+        while (this._handlerCallbackQueue.length > 0) {
+            let handler: NotificationHandler<any> = this._handlerCallbackQueue.shift();
+            handler(runner);
+        }
+
+        // Set the runner for any other handlers if the runner is in use by the
+        // current query or a subsequent query
+        if (!runner.hasCompleted) {
+            this._queryRunners.set(uri, runner);
+        }
+    }
+
+    // Handles logic to run the given handlerCallback at the appropriate time. If the given runner is
+    // undefined, the handlerCallback is put on the _handlerCallbackQueue to be run once the runner is set
+    private enqueueOrRun(handlerCallback: (runnerParam: QueryRunner) => void, runner: QueryRunner): void {
+        if (runner === undefined) {
+            this._handlerCallbackQueue.push(handlerCallback);
+        } else {
+            handlerCallback(runner);
+        }
     }
 
     // Distributes result completion notification to appropriate methods
     private handleQueryCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
-            self._queryRunners.get(event.ownerUri).handleQueryComplete(event);
+            let handlerCallback = (runner: QueryRunner) => {
+                runner.handleQueryComplete(event);
 
-            // There should be no more notifications for this query, so unbind it
-            self._queryRunners.delete(event.ownerUri);
+                // There should be no more notifications for this query, so unbind the QueryRunner if it
+                // is present in the map. If it is not present, handleQueryCompleteNotification must have been
+                // called before registerRunner
+                if (self._queryRunners.get(event.ownerUri) !== undefined) {
+                    self._queryRunners.delete(event.ownerUri);
+                }
+            };
+
+            self.enqueueOrRun(handlerCallback, self._queryRunners.get(event.ownerUri));
         };
     }
 
@@ -56,7 +90,10 @@ export class QueryNotificationHandler {
     private handleBatchStartNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
-            self._queryRunners.get(event.ownerUri).handleBatchStart(event);
+            let handlerCallback = (runner: QueryRunner) => {
+                runner.handleBatchStart(event);
+            };
+            self.enqueueOrRun(handlerCallback, self._queryRunners.get(event.ownerUri));
         };
     }
 
@@ -64,7 +101,10 @@ export class QueryNotificationHandler {
     private handleBatchCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
-            self._queryRunners.get(event.ownerUri).handleBatchComplete(event);
+            let handlerCallback = (runner: QueryRunner) => {
+                runner.handleBatchComplete(event);
+            };
+            self.enqueueOrRun(handlerCallback, self._queryRunners.get(event.ownerUri));
         };
     }
 
@@ -72,14 +112,20 @@ export class QueryNotificationHandler {
     private handleResultSetCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
-            self._queryRunners.get(event.ownerUri).handleResultSetComplete(event);
+            let handlerCallback = (runner: QueryRunner) => {
+                runner.handleResultSetComplete(event);
+            };
+            self.enqueueOrRun(handlerCallback, self._queryRunners.get(event.ownerUri));
         };
     }
 
     private handleMessageNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
-            self._queryRunners.get(event.ownerUri).handleMessage(event);
+            let handlerCallback = (runner: QueryRunner) => {
+                runner.handleMessage(event);
+            };
+            self.enqueueOrRun(handlerCallback, self._queryRunners.get(event.ownerUri));
         };
     }
 }

--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -56,7 +56,7 @@ export class QueryNotificationHandler {
 
         // Set the runner for any other handlers if the runner is in use by the
         // current query or a subsequent query
-        if (runner.hasCompleted === false) {
+        if (!runner.hasCompleted) {
             this._queryRunners.set(uri, runner);
         }
     }

--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -15,8 +15,12 @@ import { NotificationHandler } from 'vscode-languageclient';
 
 export class QueryNotificationHandler {
     private static _instance: QueryNotificationHandler;
-    private _queryRunners = new Map<string, QueryRunner>();
-    private _handlerCallbackQueue: ((run: QueryRunner) => void)[];
+
+    // public for testing only
+    public _queryRunners = new Map<string, QueryRunner>();
+
+    // public for testing only
+    public _handlerCallbackQueue: ((run: QueryRunner) => void)[] = [];
 
     static get instance(): QueryNotificationHandler {
         if (QueryNotificationHandler._instance) {
@@ -35,12 +39,12 @@ export class QueryNotificationHandler {
         SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchCompleteNotification.type, this.handleBatchCompleteNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteResultSetCompleteNotification.type, this.handleResultSetCompleteNotification());
         SqlToolsServiceClient.instance.onNotification(QueryExecuteMessageNotification.type, this.handleMessageNotification());
-        this._handlerCallbackQueue = [];
     }
 
     // Registers queryRunners with their uris to distribute notifications.
     // Ensures that notifications are handled in the correct order by handling
     // enqueued handlers first.
+    // public for testing only
     public registerRunner(runner: QueryRunner, uri: string): void {
         // If enqueueOrRun was called before registerRunner for the current query,
         // _handlerCallbackQueue will be non-empty. Run all handlers in the queue first
@@ -52,13 +56,14 @@ export class QueryNotificationHandler {
 
         // Set the runner for any other handlers if the runner is in use by the
         // current query or a subsequent query
-        if (!runner.hasCompleted) {
+        if (runner.hasCompleted === false) {
             this._queryRunners.set(uri, runner);
         }
     }
 
     // Handles logic to run the given handlerCallback at the appropriate time. If the given runner is
     // undefined, the handlerCallback is put on the _handlerCallbackQueue to be run once the runner is set
+    // public for testing only
     private enqueueOrRun(handlerCallback: (runnerParam: QueryRunner) => void, runner: QueryRunner): void {
         if (runner === undefined) {
             this._handlerCallbackQueue.push(handlerCallback);
@@ -68,7 +73,8 @@ export class QueryNotificationHandler {
     }
 
     // Distributes result completion notification to appropriate methods
-    private handleQueryCompleteNotification(): NotificationHandler<any> {
+    // public for testing only
+    public handleQueryCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
             let handlerCallback = (runner: QueryRunner) => {
@@ -87,7 +93,8 @@ export class QueryNotificationHandler {
     }
 
     // Distributes batch start notification to appropriate methods
-    private handleBatchStartNotification(): NotificationHandler<any> {
+    // public for testing only
+    public handleBatchStartNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
             let handlerCallback = (runner: QueryRunner) => {
@@ -98,7 +105,8 @@ export class QueryNotificationHandler {
     }
 
     // Distributes batch completion notification to appropriate methods
-    private handleBatchCompleteNotification(): NotificationHandler<any> {
+    // public for testing only
+    public handleBatchCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
             let handlerCallback = (runner: QueryRunner) => {
@@ -109,7 +117,8 @@ export class QueryNotificationHandler {
     }
 
     // Distributes result set completion notification to appropriate methods
-    private handleResultSetCompleteNotification(): NotificationHandler<any> {
+    // public for testing only
+    public handleResultSetCompleteNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
             let handlerCallback = (runner: QueryRunner) => {
@@ -119,7 +128,9 @@ export class QueryNotificationHandler {
         };
     }
 
-    private handleMessageNotification(): NotificationHandler<any> {
+    // Distributes message notifications
+    // public for testing only
+    public handleMessageNotification(): NotificationHandler<any> {
         const self = this;
         return (event) => {
             let handlerCallback = (runner: QueryRunner) => {

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -34,6 +34,7 @@ export default class QueryRunner {
     private _title: string;
     private _resultLineOffset: number;
     private _totalElapsedMilliseconds: number;
+    private _hasCompleted: boolean;
     public eventEmitter: EventEmitter = new EventEmitter();
 
     // CONSTRUCTOR /////////////////////////////////////////////////////////
@@ -61,6 +62,7 @@ export default class QueryRunner {
         this._title = _editorTitle;
         this._isExecuting = false;
         this._totalElapsedMilliseconds = 0;
+        this._hasCompleted = false;
     }
 
     // PROPERTIES //////////////////////////////////////////////////////////
@@ -91,6 +93,10 @@ export default class QueryRunner {
 
     get isExecutingQuery(): boolean {
         return this._isExecuting;
+    }
+
+    get hasCompleted(): boolean {
+        return this._hasCompleted;
     }
 
     // PUBLIC METHODS ======================================================
@@ -136,6 +142,7 @@ export default class QueryRunner {
 
         // Store the batch sets we got back as a source of "truth"
         this._isExecuting = false;
+        this._hasCompleted = true;
         this._batchSets = result.batchSummaries;
 
         this._batchSets.map((batch) => {
@@ -346,5 +353,9 @@ export default class QueryRunner {
                 });
             });
         });
+    }
+
+    public ResetHasCompleted(): void {
+        this._hasCompleted = false;
     }
 }

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -358,4 +358,9 @@ export default class QueryRunner {
     public resetHasCompleted(): void {
         this._hasCompleted = false;
     }
+
+    // public for testing only - used to mock handleQueryComplete
+    public _setHasCompleted(): void {
+        this._hasCompleted = true;
+    }
 }

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -355,7 +355,7 @@ export default class QueryRunner {
         });
     }
 
-    public ResetHasCompleted(): void {
+    public resetHasCompleted(): void {
         this._hasCompleted = false;
     }
 }

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -226,6 +226,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
 
             // If the query is not in progress, we can reuse the query runner
             queryRunner = existingRunner;
+            queryRunner.ResetHasCompleted();
 
             // update the open pane assuming its open (if its not its a bug covered by the previewhtml command later)
             this.update(vscode.Uri.parse(resultsUri));

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -226,7 +226,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
 
             // If the query is not in progress, we can reuse the query runner
             queryRunner = existingRunner;
-            queryRunner.ResetHasCompleted();
+            queryRunner.resetHasCompleted();
 
             // update the open pane assuming its open (if its not its a bug covered by the previewhtml command later)
             this.update(vscode.Uri.parse(resultsUri));

--- a/test/queryNotificationHandler.test.ts
+++ b/test/queryNotificationHandler.test.ts
@@ -1,0 +1,157 @@
+import * as TypeMoq from 'typemoq';
+import assert = require('assert');
+import QueryRunner from './../src/controllers/QueryRunner';
+import { QueryNotificationHandler } from './../src/controllers/QueryNotificationHandler';
+import { NotificationHandler } from 'vscode-languageclient';
+
+// TESTS //////////////////////////////////////////////////////////////////////////////////////////
+suite('QueryNotificationHandler tests', () => {
+
+    let notificationHandler: QueryNotificationHandler;
+    let eventData: any;
+    let runnerMock: TypeMoq.Mock<QueryRunner>;
+
+    let batchStartHandlerCalled: boolean;
+    let messageHandlerCalled: boolean;
+    let resultSetCompleteHandlerCalled: boolean;
+    let batchCompleteHandlerCalled: boolean;
+    let queryCompleteHandlerCalled: boolean;
+
+    let batchStartHandler: NotificationHandler<any>;
+    let messageHandler: NotificationHandler<any>;
+    let resultSetCompleteHandler: NotificationHandler<any>;
+    let batchCompleteHandler: NotificationHandler<any>;
+    let queryCompleteHandler: NotificationHandler<any>;
+
+    setup(() => {
+        notificationHandler = new QueryNotificationHandler();
+        eventData = { ownerUri: 'testUri' };
+
+        // Setup mock - Use the same QueryRunner for the whole test - this tests if it can be reused
+        runnerMock = TypeMoq.Mock.ofType(QueryRunner, TypeMoq.MockBehavior.Loose);
+        runnerMock.setup(x => x.hasCompleted).callBase();
+        runnerMock.setup(x => x._setHasCompleted()).callBase();
+        runnerMock.setup(x => x.handleBatchStart(TypeMoq.It.isAny())).callback((event) => {
+            batchStartHandlerCalled = true;
+        });
+        runnerMock.setup(x => x.handleMessage(TypeMoq.It.isAny())).callback((event) => {
+            messageHandlerCalled = true;
+        });
+        runnerMock.setup(x => x.handleResultSetComplete(TypeMoq.It.isAny())).callback((event) => {
+            resultSetCompleteHandlerCalled = true;
+        });
+        runnerMock.setup(x => x.handleBatchComplete(TypeMoq.It.isAny())).callback((event) => {
+            batchCompleteHandlerCalled = true;
+        });
+        runnerMock.setup(x => x.handleQueryComplete(TypeMoq.It.isAny())).callback((event) => {
+            queryCompleteHandlerCalled = true;
+            runnerMock.object._setHasCompleted();
+        });
+
+        // Get handlers
+        batchStartHandler = notificationHandler.handleBatchStartNotification();
+        messageHandler = notificationHandler.handleMessageNotification();
+        resultSetCompleteHandler = notificationHandler.handleResultSetCompleteNotification();
+        batchCompleteHandler = notificationHandler.handleBatchCompleteNotification();
+        queryCompleteHandler = notificationHandler.handleQueryCompleteNotification();
+    });
+
+    // Setup booleans to track if handlers were called
+    function resetBools(): void {
+        batchStartHandlerCalled = false;
+        messageHandlerCalled = false;
+        resultSetCompleteHandlerCalled = false;
+        batchCompleteHandlerCalled = false;
+        queryCompleteHandlerCalled = false;
+        runnerMock.object.resetHasCompleted();
+    }
+
+    test('QueryNotificationHandler handles registerRunner at the beginning of the event flow', done => {
+        resetBools();
+
+        // If registerRunner is called, the query runner map should be populated
+        notificationHandler.registerRunner(runnerMock.object, eventData.ownerUri);
+        assert.equal(notificationHandler._queryRunners.size, 1);
+
+        // If the notifications are fired, the callbacks should be immediately fired too
+        batchStartHandler(eventData);
+        assert.equal(batchStartHandlerCalled, true);
+        messageHandler(eventData);
+        assert.equal(messageHandlerCalled, true);
+        resultSetCompleteHandler(eventData);
+        assert.equal(resultSetCompleteHandlerCalled, true);
+        batchCompleteHandler(eventData);
+        assert.equal(batchCompleteHandlerCalled, true);
+        queryCompleteHandler(eventData);
+        assert.equal(queryCompleteHandlerCalled, true);
+
+        // And cleanup should happen after queryCompleteHandlerCalled
+        assert.equal(notificationHandler._queryRunners.size, 0, 'Query runner map not cleared after call to handleQueryCompleteNotification()');
+        assert.equal(notificationHandler._handlerCallbackQueue.length, 0, 'Handler queue populated despite QueryRunner being present');
+
+        done();
+    });
+
+    test('QueryNotificationHandler handles registerRunner in the middle of th event flow', done => {
+        resetBools();
+
+        // If some notifications are fired before registerRunner
+        batchStartHandler(eventData);
+        messageHandler(eventData);
+
+        // The queue should be populated with the run notifications, and the callbacks should not be fired
+        assert.equal(notificationHandler._handlerCallbackQueue.length, 2);
+        assert.equal(batchStartHandlerCalled, false);
+        assert.equal(messageHandlerCalled, false);
+
+        // If register runner is then called, the query runner map should be populated and the callbacks should occur
+        notificationHandler.registerRunner(runnerMock.object, eventData.ownerUri);
+        assert.equal(notificationHandler._queryRunners.size, 1);
+        assert.equal(batchStartHandlerCalled, true);
+        assert.equal(messageHandlerCalled, true);
+
+        // If the rest of the notifications are fired, the callbacks should be immediately fired too
+        resultSetCompleteHandler(eventData);
+        assert.equal(resultSetCompleteHandlerCalled, true);
+        batchCompleteHandler(eventData);
+        assert.equal(batchCompleteHandlerCalled, true);
+        queryCompleteHandler(eventData);
+        assert.equal(queryCompleteHandlerCalled, true);
+
+        // And cleanup should happen after queryCompleteHandlerCalled
+        assert.equal(notificationHandler._queryRunners.size, 0, 'Query runner map not cleared after call to handleQueryCompleteNotification()');
+        assert.equal(notificationHandler._handlerCallbackQueue.length, 0, 'Handler queue populated despite QueryRunner being present');
+
+        done();
+    });
+
+    test('QueryNotificationHandler handles registerRunner at the end of the event flow', done => {
+        resetBools();
+
+        // If all notifications are fired before registerRunner
+        batchStartHandler(eventData);
+        messageHandler(eventData);
+        resultSetCompleteHandler(eventData);
+        batchCompleteHandler(eventData);
+        queryCompleteHandler(eventData);
+
+        // The queue should be populated with the run notifications, and the callbacks should not be fired
+        assert.equal(notificationHandler._handlerCallbackQueue.length, 5);
+        assert.equal(batchStartHandlerCalled, false);
+        assert.equal(messageHandlerCalled, false);
+        assert.equal(resultSetCompleteHandlerCalled, false);
+        assert.equal(batchCompleteHandlerCalled, false);
+        assert.equal(queryCompleteHandlerCalled, false);
+
+        // If register runner is then called, the callbacks should occur and the map should not be populated
+        notificationHandler.registerRunner(runnerMock.object, eventData.ownerUri);
+        assert.equal(batchStartHandlerCalled, true);
+        assert.equal(messageHandlerCalled, true);
+        assert.equal(resultSetCompleteHandlerCalled, true);
+        assert.equal(batchCompleteHandlerCalled, true);
+        assert.equal(queryCompleteHandlerCalled, true);
+        assert.equal(notificationHandler._queryRunners.size, 0);
+
+        done();
+   });
+});


### PR DESCRIPTION
Fixes #613. If `registerRunner` is not called first, notifications are put in a queue and are run once `registerRunner` is called.

I was thinking of writing tests for this, but was unsure how. Is it possible to fire fake notifications using a real or mock `SqlToolsServiceClient`? 