### PR TITLE
Fix for execution time not resetting on a no-op

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -121,6 +121,7 @@ export default class QueryRunner {
         // Update internal state to show that we're executing the query
         this._resultLineOffset = selection ? selection.startLine : 0;
         this._isExecuting = true;
+        this._totalElapsedMilliseconds = 0;
         this._statusView.executingQuery(this.uri);
 
         // Send the request to execute the query
@@ -367,5 +368,9 @@ export default class QueryRunner {
     // public for testing only - used to mock handleQueryComplete
     public _setHasCompleted(): void {
         this._hasCompleted = true;
+    }
+
+    get totalElapsedMilliseconds(): number {
+        return this._totalElapsedMilliseconds;
     }
 }

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -96,8 +96,9 @@ suite('Query Runner tests', () => {
             testStatusView.verify<void>(x => x.executingQuery(standardUri), TypeMoq.Times.once());
             testVscodeWrapper.verify<void>(x => x.logToOutputChannel(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
 
-            // ... The query runner should indicate that it is running a query
+            // ... The query runner should indicate that it is running a query and elapsed time should be set to 0
             assert.equal(queryRunner.isExecutingQuery, true);
+            assert.equal(queryRunner.totalElapsedMilliseconds, 0);
         });
     });
 


### PR DESCRIPTION
Fixes #627. 
- Reset the `totalElapsedMilliseconds` to 0 in the `queryRunner` when running a new query. 
- Added new assertion in query runner tests to check that `totalElapsedMilliseconds` has been successfully reset.