### PR TITLE
Added support for Windows x86 platform

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -3,6 +3,7 @@
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
         "version": "0.2.0-alpha.18",
         "downloadFileNames": {
+            "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",
             "OSX_10_11_64": "osx-x64-netcoreapp1.0.tar.gz",
             "CentOS_7": "centos-x64-netcoreapp1.0.tar.gz",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -3,6 +3,7 @@
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
         "version": "0.2.0-alpha.6",
         "downloadFileNames": {
+            "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",
             "OSX_10_11_64": "osx-x64-netcoreapp1.0.tar.gz",
             "CentOS_7": "centos-x64-netcoreapp1.0.tar.gz",

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -14,6 +14,7 @@ const unknown = 'unknown';
 export enum Runtime {
     UnknownRuntime = <any>'Unknown',
     UnknownVersion = <any>'Unknown',
+    Windows_7_86 = <any>'Windows_7_86',
     Windows_7_64 = <any>'Windows_7_64',
     OSX_10_11_64 = <any> 'OSX_10_11_64',
     CentOS_7 = <any>'CentOS_7',
@@ -28,6 +29,8 @@ export enum Runtime {
 export function getRuntimeDisplayName(runtime: Runtime): string {
     switch (runtime) {
         case Runtime.Windows_7_64:
+            return 'Windows';
+        case Runtime.Windows_7_86:
             return 'Windows';
         case Runtime.OSX_10_11_64:
             return 'OSX';
@@ -201,7 +204,7 @@ export class PlatformInformation {
         switch (platform) {
             case 'win32':
                 switch (architecture) {
-                    case 'x86': return Runtime.UnknownRuntime;
+                    case 'x86': return Runtime.Windows_7_86;
                     case 'x86_64': return Runtime.Windows_7_64;
                     default:
                 }

--- a/tasks/packagetasks.js
+++ b/tasks/packagetasks.js
@@ -61,6 +61,7 @@ gulp.task('package:offline', () => {
 
     var packages = [];
     packages.push({rid: 'win7-x64', runtime: Runtime.Windows_7_64});
+    packages.push({rid: 'win7-x86', runtime: Runtime.Windows_7_86});
     packages.push({rid: 'osx.10.11-x64', runtime: Runtime.OSX_10_11_64});
     packages.push({rid: 'centos.7-x64', runtime: Runtime.CentOS_7});
     packages.push({rid: 'debian.8-x64', runtime: Runtime.Debian_8});

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -61,6 +61,12 @@ suite('Platform Tests', () => {
         expect(platformInfo.runtimeId).to.equal(Runtime.Windows_7_64.toString());
     });
 
+    test('Compute correct RID for Windows 86-bit', () => {
+        const platformInfo = new PlatformInformation('win32', 'x86');
+
+        expect(platformInfo.runtimeId).to.equal(Runtime.Windows_7_86.toString());
+    });
+
     test('Compute no RID for Windows with bad architecture', () => {
         const platformInfo = new PlatformInformation('win32', 'bad');
 


### PR DESCRIPTION
We already had a service package for windows x86. The only change needed to support Windows x86 platform in the extension was to add the url to the config to be installed correctly and to add win x86 as a supported platform. 