### PR TITLE
Upgrading TypeScript to 2.1.5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('ext:compile-src', (done) => {
                 config.paths.project.root + '/typings/**/*.ts',
                 '!' + config.paths.project.root + '/src/views/htmlcontent/**/*'])
                 .pipe(srcmap.init())
-                .pipe(ts(tsProject))
+                .pipe(tsProject())
                 .on('error', function() {
                     if (process.env.BUILDMACHINE) {
                         done('Extension Tests failed to build. See Above.');
@@ -57,7 +57,7 @@ gulp.task('ext:compile-tests', (done) => {
                 config.paths.project.root + '/test/**/*.ts',
                 config.paths.project.root + '/typings/**/*.ts'])
                 .pipe(srcmap.init())
-                .pipe(ts(tsProject))
+                .pipe(tsProject())
                 .on('error', function() {
                     if (process.env.BUILDMACHINE) {
                         done('Extension Tests failed to build. See Above.');

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^6.0.2",
-    "gulp-typescript": "^2.13.6",
+    "gulp-typescript": "^3.1.4",
     "gulp-uglify": "^2.0.0",
     "istanbul": "^0.4.5",
     "jasmine-core": "~2.4.1",
@@ -80,7 +80,7 @@
     "systemjs-builder": "^0.15.32",
     "tslint": "^3.14.0",
     "typemoq": "^0.3.2",
-    "typescript": "^1.8.9",
+    "typescript": "^2.1.5",
     "uglify-js": "mishoo/UglifyJS2#harmony",
     "vscode": "^0.11.0",
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"

--- a/src/languageservice/httpClient.ts
+++ b/src/languageservice/httpClient.ts
@@ -22,19 +22,19 @@ export default class HttpClient implements IHttpClient {
     * Downloads a file and stores the result in the temp file inside the package object
     */
     public downloadFile(urlString: string, pkg: IPackage, logger: ILogger, statusView: IStatusView, proxy?: string, strictSSL?: boolean): Promise<void> {
+        const self = this;
         const url = parseUrl(urlString);
         let options = this.getHttpClientOptions(url, proxy, strictSSL);
-        let client = url.protocol === 'http:' ? http : https;
 
         return new Promise<void>((resolve, reject) => {
             if (!pkg.tmpFile || pkg.tmpFile.fd === 0) {
                 return reject(new PackageError('Temporary package file unavailable', pkg));
             }
 
-            let request = client.request(options, response => {
+            function responseHandler(response: http.IncomingMessage): void {
                 if (response.statusCode === 301 || response.statusCode === 302) {
                     // Redirect - download from new location
-                    return resolve(this.downloadFile(response.headers.location, pkg, logger, statusView, proxy, strictSSL));
+                    return resolve(self.downloadFile(response.headers.location, pkg, logger, statusView, proxy, strictSSL));
                 }
 
                 if (response.statusCode !== 200) {
@@ -44,12 +44,19 @@ export default class HttpClient implements IHttpClient {
                 }
 
                 // If status code is 200
-                this.handleSuccessfulResponse(pkg, response, logger, statusView).then(_ => {
+                self.handleSuccessfulResponse(pkg, response, logger, statusView).then(_ => {
                     resolve();
                 }).catch(err => {
                     reject(err);
                 });
-            });
+            }
+
+            let request;
+            if (url.protocol === 'http:') {
+                request = http.request(options, (response) => { responseHandler(response); });
+            } else {
+                request = https.request(options, (response) => { responseHandler(response); });
+            }
 
             request.on('error', error => {
                 reject(new PackageError(`Request error: ${error.code || 'NONE'}`, pkg, error));

--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -131,7 +131,7 @@ export namespace Telemetry {
         }
 
         // Augment the properties structure with additional common properties before sending
-        Promise.all([getUserId(), getPlatformInformation()]).then(() => {
+        Promise.all([getUserId, getPlatformInformation]).then(() => {
             properties['userId'] = userId;
             properties['distribution'] = (platformInformation && platformInformation.distribution) ?
                 `${platformInformation.distribution.name}, ${platformInformation.distribution.version}` : '';

--- a/src/views/htmlcontent/tsconfig.json
+++ b/src/views/htmlcontent/tsconfig.json
@@ -5,6 +5,6 @@
         "module": "commonjs",
         "sourceMap": true,
         "rootDir": ".",
-        "target": "es6"
+        "target": "ES6"
     }
 }

--- a/tasks/htmltasks.js
+++ b/tasks/htmltasks.js
@@ -30,9 +30,9 @@ gulp.task('html:lint', () => {
 gulp.task('html:compile-src', () => {
   return gulp
     .src([config.paths.html.root + '/src/js/**/*.ts',
-        config.paths.html.root + '/typings/**/*'])
+    config.paths.html.root + '/typings/**/*.d.ts'])
     .pipe(srcmap.init())
-    .pipe(ts(tsProject))
+    .pipe(tsProject())
     .pipe(srcmap.write('.', {
         sourceRoot: function(file){ return file.cwd + '/src/views/htmlcontent'; }
     }))
@@ -42,9 +42,9 @@ gulp.task('html:compile-src', () => {
 gulp.task('html:compile-test', () => {
   return gulp
     .src([config.paths.html.root + '/test/**/*.ts',
-        config.paths.html.root + '/typings/**/*'])
+        config.paths.html.root + '/typings/**/*.d.ts'])
     .pipe(srcmap.init())
-    .pipe(ts(tsProject))
+    .pipe(tsProject())
     .pipe(srcmap.write('.', {
         sourceRoot: function(file){ return file.cwd + '/src/views/htmlcontent'; }
     }))


### PR DESCRIPTION
Addresses #637
- Changed TypeScript package to 2.1.5
- Changed Gulp-TypeScript package to 3.1.4
- Fixed gulp-typescript breaking changes
- Fixed typescript's breaking changes
(make sure to run `npm install` from root to update your npm packages)

Everything compiles fine and the components that I had to manually change were tested.
Also performed a fresh install from alpha. 
Any other verifications I can perform?