### PR TITLE
Fix issue where clicking header scrolls to top

### DIFF
--- a/src/views/htmlcontent/src/js/slick.dragrowselector.js
+++ b/src/views/htmlcontent/src/js/slick.dragrowselector.js
@@ -273,7 +273,7 @@
                 _ranges.push(new Slick.Range(0, last, _grid.getDataLength()-1, last));
             } else {
                 _ranges = [new Slick.Range(0, columnIndex, _grid.getDataLength()-1, columnIndex)];
-                _grid.setActiveCell(0, columnIndex + 1);
+                _grid.resetActiveCell();
             }
             setSelectedRanges(_ranges);
             e.stopImmediatePropagation();


### PR DESCRIPTION
Fixes #198 and #622. I simply removed the call to `setActiveCell()`. Cell highlighting, copy/paste, and selection are unaffected due to the call to `setSelectedRanges()`. This removes the outline that appears around the header cell when it is clicked. 