### PR TITLE
Fixing bug where entities were being replaced on undefined/null

### DIFF
--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -479,10 +479,11 @@ export class AppComponent implements OnInit, AfterViewChecked {
      * Format xml field into a hyperlink and performs HTML entity encoding
      */
     public hyperLinkFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
-        let valueToDisplay = Utils.htmlEntities(value);
+        let valueToDisplay = value;
         let cellClasses = 'grid-cell-value-container';
         if (value) {
             cellClasses += ' xmlLink';
+            valueToDisplay = Utils.htmlEntities(value);
             return `<a class="${cellClasses}" href="#" >${valueToDisplay}</a>`;
         } else {
             cellClasses += ' missing-value';

--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -25,7 +25,7 @@ export function isNumber(val: any): boolean {
  * @return String with characters replaced.
  */
 export function htmlEntities(str: string): string {
-    return str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => {
-        return `&#${i.charCodeAt(0)};`;
-    });
+    return typeof(str) === 'string'
+        ? str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => { return `&#${i.charCodeAt(0)};`; })
+        : undefined;
 }

--- a/src/views/htmlcontent/test/utils.spec.ts
+++ b/src/views/htmlcontent/test/utils.spec.ts
@@ -6,7 +6,7 @@ describe('Utility Tests', () => {
             expect(Utils.isNumber(0)).toBe(true);
             expect(Utils.isNumber(1)).toBe(true);
             expect(Utils.isNumber(false)).toBe(false);
-            expect(Utils.isNumber(null)).toBe(false);   // tslint:disable-line
+            expect(Utils.isNumber(null)).toBe(false);   // tslint:disable-line:no-null-keyword
             expect(Utils.isNumber(undefined)).toBe(false);
         });
     });
@@ -20,8 +20,15 @@ describe('Utility Tests', () => {
         });
 
         it('Does not encode characters outside the range', () => {
-            ['a', 'A', '$', '0'].forEach((item) => {
+            ['a', 'A', '$', '0', ''].forEach((item) => {
                 expect(Utils.htmlEntities(item)).toEqual(item);
+            });
+        });
+
+        it('Does not attempt encoding if the value is null or undefined', () => {
+            // We're explicitly checking null b/c this is what comes back from the service
+            [null, undefined].forEach((item) => {                       // tslint:disable-line:no-null-keyword
+                expect(Utils.htmlEntities(item)).toEqual(undefined);
             });
         });
     });


### PR DESCRIPTION
Fixes #649 

There was a bug where the hyperlink formatter for the grid would throw when attempting to format a null value. Solution was to 1) only perform html entity formatting if there is a value to format, and 2) make the html entity formatter more robust to null/undefined/anything that isn't a string. A unit test has been added for scenario of null/undefined/anything that isn't a string.