### PR TITLE
Fix header scroll/selection issues

### DIFF
--- a/src/views/htmlcontent/src/js/slick.dragrowselector.js
+++ b/src/views/htmlcontent/src/js/slick.dragrowselector.js
@@ -273,7 +273,7 @@
                 _ranges.push(new Slick.Range(0, last, _grid.getDataLength()-1, last));
             } else {
                 _ranges = [new Slick.Range(0, columnIndex, _grid.getDataLength()-1, columnIndex)];
-                _grid.setActiveCell(0, columnIndex + 1);
+                _grid.resetActiveCell();
             }
             setSelectedRanges(_ranges);
             e.stopImmediatePropagation();

--- a/src/views/htmlcontent/src/js/slick.dragrowselector.js
+++ b/src/views/htmlcontent/src/js/slick.dragrowselector.js
@@ -18,6 +18,7 @@
         var _self = this;
         var _dragging = false;
         var _lastSelectedCell = 0;
+        var _columnResized = false;
 
         function init(grid) {
             _grid = grid;
@@ -29,6 +30,7 @@
             _grid.onDragStart.subscribe(handleDragStart);
             _grid.onDragEnd.subscribe(handleDragEnd);
             _grid.onHeaderClick.subscribe(handleHeaderClick);
+            _grid.onColumnsResized.subscribe(handleColumnsResized);
         }
 
         function destroy() {
@@ -40,6 +42,7 @@
             _grid.onDragStart.unsubscribe(handleDragStart);
             _grid.onDragEnd.unsubscribe(handleDragEnd);
             _grid.onHeaderClick.unsubscribe(handleHeaderClick);
+            _grid.onColumnsResized.unsubscribe(handleColumnsResized);
         }
 
         function rangesToRows(ranges) {
@@ -255,11 +258,22 @@
             }
         }
 
+        function handleColumnsResized(e, args) {
+            _columnResized = true;
+            setTimeout(function() {
+                _columnResized = false;
+            }, 10);
+        }
+
         function handleHeaderClick(e, args) {
+            if (_columnResized) {
+                _columnResized = false;
+                return true;
+            }
+
             var columnIndex = _grid.getColumnIndex(args.column.id);
             if (e.ctrlKey || e.metaKey){
                 _ranges.push(new Slick.Range(0, columnIndex, _grid.getDataLength()-1, columnIndex));
-                _grid.setActiveCell(0, columnIndex + 1);
             } else if (e.shiftKey && _ranges.length) {
                 var last = _ranges.pop().fromCell;
                 var from = Math.min(columnIndex, last);
@@ -273,8 +287,9 @@
                 _ranges.push(new Slick.Range(0, last, _grid.getDataLength()-1, last));
             } else {
                 _ranges = [new Slick.Range(0, columnIndex, _grid.getDataLength()-1, columnIndex)];
-                _grid.resetActiveCell();
             }
+
+            _grid.resetActiveCell();
             setSelectedRanges(_ranges);
             e.stopImmediatePropagation();
             return true;


### PR DESCRIPTION
Fixes #622. Specifically, this fixes some of the annoying behavior regarding what happens when columns are resized or when the column headers are clicked. 

Currently, if a `click` event occurs in the column header, all cells for that column are selected. Additionally, when resizing a column, if the `click` event occurs in the header, all cells in the modified column would become selected and the column would be resized. The ideal behavior would be to disable the "select all cells in this column" behavior for the next click if a column is resized. This can be accomplished by ignoring the next click all together after a column resize. 

A `click` event is only fired by the DOM if `mousedown` and `mouseup` occur in the same HTML element. Also, SlickGrid only exposes `click` (not `mousedown` and `mouseup`). So it seems that the events exposed by SlickGrid are insufficient to correctly check for all cases that can occur. The missing case is when a `mousedown` for a column resize occurs in the headers, and the respective `mouseup` occurs outside the headers. For this case I added the `setTimeout` to act as somewhat of a "mock `mouseup`". This is fairly janky, so let me know if this is not acceptable and if you have any other ideas to solve the issue. 




