### PR TITLE
Fix: Updated query execution command to stay in sync with tools service

### DIFF
--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -108,7 +108,7 @@ export class QueryExecuteMessageParams {
 export namespace QueryExecuteRequest {
     export const type: RequestType<QueryExecuteParams, QueryExecuteResult, void> = {
         get method(): string {
-            return 'query/execute';
+            return 'query/executeDocumentSelection';
         }
     };
 }


### PR DESCRIPTION
Fixes #660 

- Changed `query/execute` to `query/executeDocumentSelection`