### PR TITLE
Fix: SqlToolsService update 

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "0.2.0-alpha.18",
+        "version": "0.2.0-alpha.23",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -108,7 +108,7 @@ export class QueryExecuteMessageParams {
 export namespace QueryExecuteRequest {
     export const type: RequestType<QueryExecuteParams, QueryExecuteResult, void> = {
         get method(): string {
-            return 'query/execute';
+            return 'query/executeDocumentSelection';
         }
     };
 }


### PR DESCRIPTION
Fixes #660 .

- Updated `query/execute` command to `query/executeDocumentSelection`
- Updated sqltoolsservice version to 0.2.0-alpha.23 and verified installation worked 
