### PR TITLE
Fix Results Panel not Refreshing Automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Release status: Public Preview
 
 ## What's new in this version
-* HotFix for issue [#669] "Results Panel not Refreshing Automatically". This issue affects users on VSCode 1.9.0 or greater.
+* HotFix for issue [#669] "Results Panel not Refreshing Automatically". This issue impacts users on VSCode 1.9.0 or greater.
 
 ## Version 0.2.0
 * Release date: December, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Version 0.2.1
+* Release date: February 2, 2016
+* Release status: Public Preview
+
+## What's new in this version
+* HotFix for issue [#669] "Results Panel not Refreshing Automatically". This issue affects users on VSCode 1.9.0 or greater.
+
 ## Version 0.2.0
 * Release date: December, 2016
 * Release status: Public Preview
@@ -71,3 +78,4 @@ Report issues to [Github Issue Tracker] and provide your feedback.
 [OpenSSL requirement on macOS]:https://github.com/Microsoft/vscode-mssql/wiki/OpenSSL-Configuration
 [Windows 10 Universal C Runtime requirement]:https://github.com/Microsoft/vscode-mssql/wiki/windows10-universal-c-runtime-requirement
 [Operating Systems]:https://github.com/Microsoft/vscode-mssql/wiki/operating-systems
+[#669]:https://github.com/Microsoft/vscode-mssql/issues/669

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See [the SQL developer tutorial] to develop an app with C#, Java, Node.js, PHP, 
 
 <img src="https://github.com/Microsoft/vscode-mssql/raw/master/images/mssql-demo.gif" alt="demo" style="width:480px;"/>
 
+## What's new in 0.2.1
+* HotFix for issue [#669] "Results Panel not Refreshing Automatically". This issue impacts users on VSCode 1.9.0 or greater.
 
 ## What's new in 0.2.0
 * Peek Definition and Go To Definition support for Tables, Views and Stored Procedures.
@@ -146,4 +148,5 @@ This extension is [licensed under the MIT License]. Please see the [third-party 
 [Microsoft Open Source Code of Conduct]:https://opensource.microsoft.com/codeofconduct/
 [Code of Conduct FAQ]:https://opensource.microsoft.com/codeofconduct/faq/
 [opencode@microsoft.com]:mailto:opencode@microsoft.com
+[#669]:https://github.com/Microsoft/vscode-mssql/issues/669
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": true,

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -411,13 +411,13 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
     public provideTextDocumentContent(uri: vscode.Uri): string {
         // URI needs to be encoded as a component for proper inclusion in a url
         let encodedUri = encodeURIComponent(uri.toString());
-
-        // return dummy html content that redirects to 'http://localhost:<port>' after the page loads
+        let timeNow = new Date().getTime();
         return `
         <html>
         <head>
             <script type="text/javascript">
                 window.onload = function(event) {
+                    console.log('reloaded results window at time ${timeNow}ms');
                     var doc = document.documentElement;
                     var styles = window.getComputedStyle(doc);
                     var backgroundcolor = styles.getPropertyValue('--background-color');

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -411,6 +411,10 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
     public provideTextDocumentContent(uri: vscode.Uri): string {
         // URI needs to be encoded as a component for proper inclusion in a url
         let encodedUri = encodeURIComponent(uri.toString());
+
+        // Fix for issue #669 "Results Panel not Refreshing Automatically" - always include a unique time
+        // so that the content returned is different. Otherwise VSCode will not refresh the document since it
+        // thinks that there is nothing to be updated.
         let timeNow = new Date().getTime();
         return `
         <html>

--- a/src/views/htmlcontent/src/docs/index.html
+++ b/src/views/htmlcontent/src/docs/index.html
@@ -1,6 +1,16 @@
 <html><head></head>
 <body><div id="markdown-container"><h1 id="0">Change Log</h1>
 
+<h2 id="7">Version 0.2.1</h2>
+<ul>
+<li>Release date: February 2, 2016</li>
+<li>Release status: Public Preview</li>
+</ul>
+<h2 id="8">What's new in this version</h2>
+<ul>
+<li>HotFix for issue #669 "Results Panel not Refreshing Automatically". This issue impacts users on VSCode 1.9.0 or greater.</li>
+</ul>
+
 <h2 id="7">Version 0.2.0</h2>
 <ul>
 <li>Release date: December, 2016</li>


### PR DESCRIPTION
- Fixes #669
- Ensures that TextDocumentContentProvider.provideTextDocumentContent always provides an updated string when being refreshed. In VSCode 1.9.0, it's vital to do this as there is a diff on the provided content and the document is only refreshed if this is different