### PR TITLE
Fix: cleaning previewHtml api calling logic

### DIFF
--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -289,6 +289,9 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
 
     // Function to render resultspane content
     public displayResultPane(resultsUri: string, paneTitle: string): void {
+        // Get the active text editor
+        let activeTextEditor = this._vscodeWrapper.activeTextEditor;
+
         // Check if the results window already exists
         if (this.doesResultPaneExist(resultsUri)) {
             // Update the existing results pane with the given reusltsUri
@@ -307,7 +310,6 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
                     resultPaneColumn = resultPaneTextEditor.viewColumn;
                 }
 
-                let activeTextEditor = this._vscodeWrapper.activeTextEditor;
                 // only reset focus to the text editor if it's in a different column then the results window
                 if (resultPaneColumn !== undefined
                     && resultPaneColumn !== activeTextEditor.viewColumn) {

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -293,13 +293,11 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
         let activeTextEditor = this._vscodeWrapper.activeTextEditor;
 
         // Check if the results window already exists
-        if (this.doesResultPaneExist(resultsUri)) {
-            // Update the existing results pane with the given reusltsUri
-            this.update(vscode.Uri.parse(resultsUri));
-        } else {
+        if (!this.doesResultPaneExist(resultsUri)) {
             // Wrapper tells us where the new results pane should be placed
             let resultPaneColumn = this.newResultPaneViewColumn();
-            // Open new window then reset focus back to the editor
+
+            // Try and Open new window then reset focus back to the editor
             vscode.commands.executeCommand('vscode.previewHtml', resultsUri, resultPaneColumn, paneTitle).then(() => {
                 // get the result pane text editor to determine which column it was shown in
                 let resultPaneTextEditor = this._vscodeWrapper.visibleEditors.find(
@@ -315,6 +313,9 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
                     && resultPaneColumn !== activeTextEditor.viewColumn) {
                     this._vscodeWrapper.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
                 }
+            }, err => {
+                // Output to console if an error occurs
+                Utils.logToOutputChannel(err);
             });
         }
     };

--- a/src/models/SqlOutputContentProvider.ts
+++ b/src/models/SqlOutputContentProvider.ts
@@ -290,35 +290,31 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
     // Function to render resultspane content
     public displayResultPane(resultsUri: string, paneTitle: string): void {
         // Check if the results window already exists
-        let activeTextEditor = this._vscodeWrapper.activeTextEditor;
-        let previewCommandPromise;
-        let resultPaneColumn;
         if (this.doesResultPaneExist(resultsUri)) {
-            // Implicity Use existing results window by not providing a pane
-            previewCommandPromise = vscode.commands.executeCommand('vscode.previewHtml', resultsUri, paneTitle);
+            // Update the existing results pane with the given reusltsUri
+            this.update(vscode.Uri.parse(resultsUri));
         } else {
             // Wrapper tells us where the new results pane should be placed
-            resultPaneColumn = this.newResultPaneViewColumn();
-            previewCommandPromise = vscode.commands.executeCommand('vscode.previewHtml', resultsUri, resultPaneColumn, paneTitle);
+            let resultPaneColumn = this.newResultPaneViewColumn();
+            // Open new window then reset focus back to the editor
+            vscode.commands.executeCommand('vscode.previewHtml', resultsUri, resultPaneColumn, paneTitle).then(() => {
+                // get the result pane text editor to determine which column it was shown in
+                let resultPaneTextEditor = this._vscodeWrapper.visibleEditors.find(
+                    editor => editor.document.uri.toString() === resultsUri);
+
+                // get the result pane column from the text editor
+                if (resultPaneTextEditor !== undefined) {
+                    resultPaneColumn = resultPaneTextEditor.viewColumn;
+                }
+
+                let activeTextEditor = this._vscodeWrapper.activeTextEditor;
+                // only reset focus to the text editor if it's in a different column then the results window
+                if (resultPaneColumn !== undefined
+                    && resultPaneColumn !== activeTextEditor.viewColumn) {
+                    this._vscodeWrapper.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
+                }
+            });
         }
-
-        // reset focus back to the text document after showing query results window
-        previewCommandPromise.then(() => {
-            // get the result pane text editor to determine which column it was shown in
-            let resultPaneTextEditor = this._vscodeWrapper.visibleEditors.find(
-                editor => editor.document.uri.toString() === resultsUri);
-
-            // get the result pane column from the text editor
-            if (resultPaneTextEditor !== undefined) {
-                resultPaneColumn = resultPaneTextEditor.viewColumn;
-            }
-
-            // only reset focus to the text editor if it's in a different column then the results window
-            if (resultPaneColumn !== undefined
-                && resultPaneColumn !== activeTextEditor.viewColumn) {
-                this._vscodeWrapper.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
-            }
-        });
     };
 
     public cancelQuery(input: QueryRunner | string): void {


### PR DESCRIPTION
Fixes #676 . 

- Only calling this.update when a results pane is already open 
- Bug where an open results pane that is hidden cannot be found by `this.doesResultPaneExist(resultsUri)` is still present 
(This issue is going to be raised to the vscode team, because it looks like it is a bug in the `vscode.workspace.textDocuments` api call which is not able to find hidden previewHtml documents)