### PR TITLE
Fix: Removed trailing tabs from copy/paste

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -15,6 +15,7 @@ import { QueryCancelParams, QueryCancelResult, QueryCancelRequest } from '../mod
 import { ISlickRange, ISelectionData } from '../models/interfaces';
 import Constants = require('../models/constants');
 import * as Utils from './../models/utils';
+import * as os from 'os';
 
 const ncp = require('copy-paste');
 
@@ -275,7 +276,7 @@ export default class QueryRunner {
                         if (self.shouldIncludeHeaders(includeHeaders)) {
                             let columnHeaders = self.getColumnHeaders(batchId, resultId, range);
                             if (columnHeaders !== undefined) {
-                                copyString += columnHeaders.join('\t') + '\r\n';
+                                copyString += columnHeaders.join('\t') + os.EOL;
                             }
                         }
 
@@ -286,7 +287,7 @@ export default class QueryRunner {
                                 // Remove all new lines from cells
                                 cells = cells.map(x => self.removeNewLines(x));
                             }
-                            copyString += cells.join('\t') + '\r\n';
+                            copyString += cells.join('\t') + os.EOL;
                         }
                     });
                 };

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -275,32 +275,18 @@ export default class QueryRunner {
                         if (self.shouldIncludeHeaders(includeHeaders)) {
                             let columnHeaders = self.getColumnHeaders(batchId, resultId, range);
                             if (columnHeaders !== undefined) {
-                                for (let index = 0; index < columnHeaders.length; index++) {
-                                    if (index !== 0) {
-                                        copyString += '\t';
-                                    }
-                                    copyString += columnHeaders[index];
-                                }
-                                copyString += '\r\n';
+                                copyString += columnHeaders.join('\t') + '\r\n';
                             }
                         }
 
-                        // iterate over the rows to paste into the copy string
+                        // Iterate over the rows to paste into the copy string
                         for (let row of result.resultSubset.rows) {
-                            // iterate over the cells we want from that row
-                            for (let cell = range.fromCell; cell <= range.toCell; cell++) {
-                                if (cell !== range.fromCell) {
-                                    copyString += '\t';
-                                }
-
-                                if (self.shouldRemoveNewLines()) {
-                                    // This regex removes all new lines in all forms of new line
-                                    copyString += self.removeNewLines(row[cell]);
-                                } else {
-                                    copyString += row[cell];
-                                }
+                            let cells = row.slice(range.fromCell, (range.toCell + 1));
+                            if (self.shouldRemoveNewLines()) {
+                                // Remove all new lines from cells
+                                cells = cells.map(x => self.removeNewLines(x));
                             }
-                            copyString += '\r\n';
+                            copyString += cells.join('\t') + '\r\n';
                         }
                     });
                 };

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -275,8 +275,11 @@ export default class QueryRunner {
                         if (self.shouldIncludeHeaders(includeHeaders)) {
                             let columnHeaders = self.getColumnHeaders(batchId, resultId, range);
                             if (columnHeaders !== undefined) {
-                                for (let header of columnHeaders) {
-                                    copyString += header + '\t';
+                                for (let index = 0; index < columnHeaders.length; index++) {
+                                    if (index !== 0) {
+                                        copyString += '\t';
+                                    }
+                                    copyString += columnHeaders[index];
                                 }
                                 copyString += '\r\n';
                             }
@@ -286,11 +289,15 @@ export default class QueryRunner {
                         for (let row of result.resultSubset.rows) {
                             // iterate over the cells we want from that row
                             for (let cell = range.fromCell; cell <= range.toCell; cell++) {
+                                if (cell !== range.fromCell) {
+                                    copyString += '\t';
+                                }
+
                                 if (self.shouldRemoveNewLines()) {
                                     // This regex removes all new lines in all forms of new line
-                                    copyString += self.removeNewLines(row[cell]) + '\t';
+                                    copyString += self.removeNewLines(row[cell]);
                                 } else {
-                                    copyString += row[cell] + '\t';
+                                    copyString += row[cell];
                                 }
                             }
                             copyString += '\r\n';

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -21,6 +21,7 @@ import {
     ISelectionData
  } from './../src/models/interfaces';
 import * as stubs from './stubs';
+import * as os from 'os';
 
 // CONSTANTS //////////////////////////////////////////////////////////////////////////////////////
 const ncp = require('copy-paste');
@@ -478,11 +479,11 @@ suite('Query Runner tests', () => {
         // ------ Common inputs and setup for copy tests  -------
         const TAB = '\t';
         const CLRF = '\r\n';
-        const finalStringNoHeader = '1' + TAB + '2' + CLRF +
-                            '3' + TAB + '4' + CLRF +
-                            '5' + TAB + '6' + CLRF +
-                            '7' + TAB + '8' + CLRF +
-                            '9' + TAB + '10' + CLRF;
+        const finalStringNoHeader = '1' + TAB + '2' + os.EOL +
+                            '3' + TAB + '4' + os.EOL +
+                            '5' + TAB + '6' + os.EOL +
+                            '7' + TAB + '8' + os.EOL +
+                            '9' + TAB + '10' + os.EOL;
 
         const finalStringWithHeader = 'Col1' + TAB + 'Col2' + CLRF + finalStringNoHeader;
 

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -478,12 +478,12 @@ suite('Query Runner tests', () => {
     suite('Copy Tests', () => {
         // ------ Common inputs and setup for copy tests  -------
         const TAB = '\t';
-        const CLRF = '\r\n';
-        const finalStringNoHeader = '1' + TAB + '2' + os.EOL +
-                            '3' + TAB + '4' + os.EOL +
-                            '5' + TAB + '6' + os.EOL +
-                            '7' + TAB + '8' + os.EOL +
-                            '9' + TAB + '10' + os.EOL;
+        const CLRF = os.EOL;
+        const finalStringNoHeader = '1' + TAB + '2' + CLRF +
+                            '3' + TAB + '4' + CLRF +
+                            '5' + TAB + '6' + CLRF +
+                            '7' + TAB + '8' + CLRF +
+                            '9' + TAB + '10' + CLRF;
 
         const finalStringWithHeader = 'Col1' + TAB + 'Col2' + CLRF + finalStringNoHeader;
 

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -478,13 +478,13 @@ suite('Query Runner tests', () => {
         // ------ Common inputs and setup for copy tests  -------
         const TAB = '\t';
         const CLRF = '\r\n';
-        const finalStringNoHeader = '1' + TAB + '2' + TAB + CLRF +
-                            '3' + TAB + '4' + TAB + CLRF +
-                            '5' + TAB + '6' + TAB + CLRF +
-                            '7' + TAB + '8' + TAB + CLRF +
-                            '9' + TAB + '10' + TAB + CLRF;
+        const finalStringNoHeader = '1' + TAB + '2' + CLRF +
+                            '3' + TAB + '4' + CLRF +
+                            '5' + TAB + '6' + CLRF +
+                            '7' + TAB + '8' + CLRF +
+                            '9' + TAB + '10' + CLRF;
 
-        const finalStringWithHeader = 'Col1' + TAB + 'Col2' + TAB + CLRF + finalStringNoHeader;
+        const finalStringWithHeader = 'Col1' + TAB + 'Col2' + CLRF + finalStringNoHeader;
 
         const testuri = 'test';
         const testresult = {


### PR DESCRIPTION
Fixes #668.
This was code I recently touched, so I figured I would take a look and the fix was simple. 

- Prevents tabs from being placed at the end of a line 