### PR TITLE
Fix for gulp-cli install failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -501,6 +501,6 @@
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "install-packages": "npm install github:gulpjs/gulp#4.0 && npm install gulp-install && gulp --gulpfile install.js install"
+    "install-packages": "npm install -g gulp-cli && npm install gulp-install && gulp --gulpfile install.js install"
   }
 }


### PR DESCRIPTION
- The workaround for gulp install stopped working as the necessary gulp cli version no longer worked. This was breaking Jenkins builds
- Updated per recommendation in https://github.com/gulpjs/gulp-cli/issues/84