### PR TITLE
Fix VSIX package load due to missing vscode-nls

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "mssql",
-  "version": "0.1.5",
+  "version": "0.3.0",
   "dependencies": {
     "accepts": {
       "version": "1.3.3",
@@ -484,7 +484,7 @@
     },
     "iconv-lite": {
       "version": "0.4.13",
-      "from": "iconv-lite@>=0.4.11 <0.5.0",
+      "from": "iconv-lite@0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
@@ -499,7 +499,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@2.0.3",
+      "from": "inherits@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "ipaddr.js": {
@@ -676,7 +676,7 @@
     },
     "once": {
       "version": "1.3.3",
-      "from": "once@>=1.3.2 <2.0.0",
+      "from": "once@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "opener": {
@@ -766,7 +766,7 @@
     },
     "readable-stream": {
       "version": "2.2.2",
-      "from": "readable-stream@>=2.0.0 <3.0.0",
+      "from": "readable-stream@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
     },
     "request": {
@@ -855,7 +855,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@^1.1.0",
+          "from": "minimist@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
@@ -883,7 +883,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.8 <2.4.0",
+      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "tmp": {
@@ -929,12 +929,12 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@>=1.7.0 <2.0.0",
+      "from": "underscore@>=1.8.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@>=1.0.0 <1.1.0",
+      "from": "unpipe@1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "util-deprecate": {
@@ -986,8 +986,13 @@
     },
     "vscode-languageserver-types": {
       "version": "1.0.4",
-      "from": "vscode-languageserver-types@>=1.0.3 <2.0.0",
+      "from": "vscode-languageserver-types@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-1.0.4.tgz"
+    },
+    "vscode-nls": {
+      "version": "2.0.2",
+      "from": "vscode-nls@latest",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz"
     },
     "winreg": {
       "version": "0.0.13",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "typescript": "^2.1.5",
     "uglify-js": "mishoo/UglifyJS2#harmony",
     "vscode": "^0.11.0",
-    "vscode-nls": "^2.0.2",
     "vscode-nls-dev": "https://github.com/Raymondd/vscode-nls-dev/releases/download/2.0.2/build.tar.gz",
     "xmldom": "^0.1.27",
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
@@ -110,6 +109,7 @@
     "underscore": "^1.8.3",
     "vscode-extension-telemetry": "^0.0.5",
     "vscode-languageclient": "^2.5.0",
+    "vscode-nls": "^2.0.2",
     "ws": "^1.1.1"
   },
   "contributes": {


### PR DESCRIPTION
- vscode-nls needed to be a regular dependency, but was a dev dependency
- installed and updated shrinkwrap