### PR TITLE
Fix release notes and 1 config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Version 0.3.0
-* Release date: February 2, 2016
+* Release date: February 24, 2016
 * Release status: Public Preview
 
 ## What's new in this version

--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ See [customize options] and [manage connection profiles] for more details.
     },
     "mssql.messagesDefaultOpen": true,
     "mssql.logDebugInfo": false,
-    "mssql.saveAsCSV": {
-        "includeHeaders": true
-    },
+    "mssql.saveAsCSV.includeHeaders": true,
     "mssql.enableIntelliSense": true,
     "mssql.intelliSense.enableErrorChecking": true,
     "mssql.intelliSense.enableSuggestions": true,
@@ -108,7 +106,16 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.intelliSense.lowerCaseSuggestions": false,
     "mssql.resultsFontFamily": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
     "mssql.resultsFontSize": 13,
-    "mssql.copyRemoveNewLine" : true
+    "mssql.copyIncludeHeaders": false,
+    "mssql.copyRemoveNewLine" : true,
+    "mssql.splitPaneSelection": "next",
+    "mssql.format.alignColumnDefinitionsInColumns": false,
+    "mssql.format.datatypeCasing": "none",
+    "mssql.format.keywordCasing": "none",
+    "mssql.format.placeCommasBeforeNextStatement": false,
+    "mssql.format.placeSelectStatementReferencesOnNewLine": false,
+    "mssql.applyLocalization": false,
+    "mssql.query.displayBitAsNumber": true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -433,14 +433,10 @@
           "description": "Set the font size for the results grid; set to blank to use the editor size",
           "default": 13
         },
-        "mssql.saveAsCsv": {
-          "type": "object",
-          "description": "[Optional] Configuration options for saving results as CSV",
-          "includeHeaders": {
-            "type": "boolean",
-            "default": true,
-            "description": "[Optional] When true, column headers are included in CSV"
-          }
+        "mssql.saveAsCsv.includeHeaders": {
+          "type": "boolean",
+          "description": "[Optional] When true, column headers are included when saving results as CSV",
+          "default": true
         },
         "mssql.copyIncludeHeaders": {
           "type": "boolean",

--- a/src/views/htmlcontent/src/docs/index.html
+++ b/src/views/htmlcontent/src/docs/index.html
@@ -3,7 +3,7 @@
 
 <h2 id="7">Version 0.3.0</h2>
 <ul>
-<li>Release date: February, 2016</li>
+<li>Release date: February 24, 2016</li>
 <li>Release status: Public Preview</li>
 </ul>
 <h2 id="8">What's new in this version</h2>
@@ -15,7 +15,7 @@ schema changes</li>
 <li><strong>New Query</strong> command added. This opens a new .sql file and connects to a server, making it quicker to get started with your queries</li>
 <li>Fixed support for SQL Data Warehouse connections.</li>
 <li>Prototype localization support added. We will be adding full localization support in a future update.</li>
-<li>mproved Peek Definition support. Multiple bug fixes, and additional supported types.</li>
+<li>Improved Peek Definition support. Multiple bug fixes, and additional supported types.</li>
 <li>Support for Windows x86 machines</li>
 <li>Fix for issue #604 where results that included HTML were not rendered correctly</li>
 <li>Multiple fixes for syntax highlighting</li>


### PR DESCRIPTION
- Config option was not setup to support discovery of the "saveAsCsv.IncludeHeaders" option - it only gave an empty object instead of the true/false option that's standard for other settings. Updated & verified that the option is still correctly passed through to the SqlToolsService
- Updated release notes, readme & changelog to reflect new release
- Updated Readme to include all config options