### PR TITLE
renamed the 'Clear Intellisense Cache' command to 'Refresh Intellisense Cache'

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
       },
       {
         "command": "extension.rebuildIntelliSenseCache",
-        "title": "Clear IntelliSense Cache",
+        "title": "Refresh IntelliSense Cache",
         "category": "MS SQL"
       }
     ],


### PR DESCRIPTION
The new command title was 'Refresh IntelliSense Cache' in the readme and release changes but in the extension it was 'ClearIntelliSense Cache'. So renamed it to be 'Refresh IntelliSense Cache'  everywhere.

