### PR TITLE
Telemetry fix: promise.all not receiving promises

### DIFF
--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -131,7 +131,7 @@ export namespace Telemetry {
         }
 
         // Augment the properties structure with additional common properties before sending
-        Promise.all([getUserId, getPlatformInformation]).then(() => {
+        Promise.all<string|PlatformInformation>([getUserId(), getPlatformInformation()]).then(() => {
             properties['userId'] = userId;
             properties['distribution'] = (platformInformation && platformInformation.distribution) ?
                 `${platformInformation.distribution.name}, ${platformInformation.distribution.version}` : '';


### PR DESCRIPTION
- Promise.all requires either an array of PromiseLike objects or objects of type T. A change when upgrading to Typescript 2.1.5 caused us to pass in the functions, rather than the promises returned by those functions as previously happened. This meant that Promises.all returned immediately as it thought it was returning an array of functions.
- Fix is to explicitly define the promise return types, and go back to calling the methods so that we get promises back to wait on.