### PR TITLE
Fix #711 MSSQL Extension will not run

### DIFF
--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -142,26 +142,13 @@ export class PlatformInformation {
     }
 
     private static GetWindowsArchitecture(): Promise<string> {
-        return this.execChildProcess('wmic os get osarchitecture')
-            .then(architecture => {
-                if (architecture) {
-                    let archArray: string[] = architecture.split(os.EOL);
-                    if (archArray.length >= 2) {
-                        let arch = archArray[1].trim();
-
-                        // Note: This string can be localized. So, we'll just check to see if it contains 32 or 64.
-                        if (arch.indexOf('64') >= 0) {
-                            return 'x86_64';
-                        } else if (arch.indexOf('32') >= 0) {
-                            return 'x86';
-                        }
-                    }
-                }
-
-                return unknown;
-            }).catch((error) => {
-                return unknown;
-            });
+        return new Promise<string>((resolve, reject) => {
+             if (process.env.PROCESSOR_ARCHITECTURE === 'x86' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
+                 resolve('x86');
+             } else {
+                 resolve('x86_64');
+             }
+        });
     }
 
     private static GetUnixArchitecture(): Promise<string> {

--- a/test/mainController.test.ts
+++ b/test/mainController.test.ts
@@ -8,6 +8,8 @@ import UntitledSqlDocumentService from '../src/controllers/untitledSqlDocumentSe
 import * as Extension from '../src/extension';
 import Constants = require('../src/constants/constants');
 import LocalizedConstants = require('../src/constants/localizedConstants');
+import VscodeWrapper from '../src/controllers/vscodeWrapper';
+import { TestExtensionContext } from './stubs';
 import assert = require('assert');
 
 suite('MainController Tests', () => {
@@ -88,7 +90,6 @@ suite('MainController Tests', () => {
             done(new Error(err));
         }
     });
-
 
     // Renamed file event test
     test('onDidCloseTextDocument should call renamedDoc function when rename occurs' , done => {
@@ -177,6 +178,20 @@ suite('MainController Tests', () => {
         } catch (err) {
             done(new Error(err));
         }
+    });
+
+    test('TextDocument Events should handle non-initialized connection manager' , done => {
+        let contextMock: TypeMoq.Mock<vscode.ExtensionContext> = TypeMoq.Mock.ofType(TestExtensionContext);
+        let vscodeWrapperMock: TypeMoq.Mock<VscodeWrapper> = TypeMoq.Mock.ofType(VscodeWrapper);
+        let controller: MainController = new MainController(contextMock.object,
+            undefined,  // ConnectionManager
+            vscodeWrapperMock.object);
+
+        // None of the TextDocument events should throw exceptions, they should cleanly exit instead.
+        controller.onDidOpenTextDocument(document);
+        controller.onDidSaveTextDocument(document);
+        controller.onDidCloseTextDocument(document);
+        done();
     });
 
     test('onNewQuery should call the new query and new connection' , () => {


### PR DESCRIPTION
- Update GetWindowsArchitecture to use new, simpler and more reliable method taken from the Omnisharp-VSCode implementation
- Fixed issues where we were not returning promises as expected, and where we were accessing the _connectionManager even though it was not defined yet, since the extension was still initializing. This will help with overall reliability
- Added test to verify handling of null ConnectionManager