### PR TITLE
Fixed an issue with not sending telemetry event for unsupported platform

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -138,6 +138,9 @@ export default class MainController implements vscode.Disposable {
 
         // initialize language service client
         return new Promise<boolean>( (resolve, reject) => {
+                // Initialize telemetry
+                Telemetry.initialize(self._context);
+
                 SqlToolsServerClient.instance.initialize(self._context).then(serverResult => {
 
                 // Init status bar
@@ -154,8 +157,7 @@ export default class MainController implements vscode.Disposable {
                 // Init connection manager and connection MRU
                 self._connectionMgr = new ConnectionManager(self._context, self._statusview, self._prompter);
 
-                // Initialize telemetry
-                Telemetry.initialize(self._context);
+
 
                 activationTimer.end();
 


### PR DESCRIPTION
The problem was the telemetry service was initializing after the service initialization. So if the service failed to initialize, the telemetry service couldn't send event. Move the telemetry initialization to the top so it get's ready before everything else  