### PR TITLE
Fix changelog open broken by VSCode 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Version 0.3.0
-* Release date: February 28, 2016
+* Release date: March 1, 2016
 * Release status: Public Preview
 
 ## What's new in this version

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [customize options] and [manage connection profiles] for more details.
 ```
 
 ## Change Log
-The current version is ```0.2.0```. See the [change log] for a detailed list of changes in each version.
+The current version is ```0.3.0```. See the [change log] for a detailed list of changes in each version.
 
 ## Supported Operating Systems
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -47,6 +47,7 @@ export const renamedOpenTimeThreshold = 10.0;
 export const timeToWaitForLanguageModeChange = 10000.0;
 export const macOpenSslHelpLink = 'https://github.com/Microsoft/vscode-mssql/wiki/OpenSSL-Configuration';
 export const gettingStartedGuideLink = 'https://aka.ms/mssql-getting-started';
+export const changelogLink = 'https://aka.ms/vscode-mssql-changelog';
 export const sqlToolsServiceCrashLink = 'https://github.com/Microsoft/vscode-mssql/wiki/SqlToolsService-Known-Issues';
 
 // Configuration Constants

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -372,17 +372,7 @@ export default class MainController implements vscode.Disposable {
      * Shows the release notes page in the preview browser
      */
     private launchReleaseNotesPage(): void {
-        // get the URI for the release notes page
-        let docUri = vscode.Uri.file(
-            this._context.asAbsolutePath(
-                'out/src/views/htmlcontent/dist/docs/index.html'));
-
-        // show the release notes page in the preview window
-        vscode.commands.executeCommand(
-            'vscode.previewHtml',
-            docUri,
-            vscode.ViewColumn.One,
-            'mssql for VS Code Release Notes');
+        opener(Constants.changelogLink);
     }
 
      /**

--- a/src/views/htmlcontent/src/docs/index.html
+++ b/src/views/htmlcontent/src/docs/index.html
@@ -3,7 +3,7 @@
 
 <h2 id="7">Version 0.3.0</h2>
 <ul>
-<li>Release date: February 28, 2016</li>
+<li>Release date: March 1, 2016</li>
 <li>Release status: Public Preview</li>
 </ul>
 <h2 id="8">What's new in this version</h2>


### PR DESCRIPTION
- Opening a local file in the HTML Preview pan is broken in 1.10. It looks like this is a bug in VSCode that isn't in the Insiders build
- Moving to opening the Master changelog.md in the users default browser instead. This is consistent with our GettingStarted action.