### PR TITLE
Updater extension to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typemoq": "^0.3.2",
     "typescript": "^2.1.5",
     "uglify-js": "mishoo/UglifyJS2#harmony",
-    "vscode": "https://github.com/Raymondd/vscode-extension-vscode/releases/download/1.0.5/vscode-extension-vscode-0.11.17.2.tar.gz",
+    "vscode": "^1.0.5",
     "vscode-nls-dev": "https://github.com/Raymondd/vscode-nls-dev/releases/download/2.0.2/build.tar.gz",
     "xmldom": "^0.1.27",
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": true,


### PR DESCRIPTION
- This will make detecting dev users easier since we're already on a newer version than the publicly released version.