### PR TITLE
using the new VS code API to create untitled document for SQL language

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
   "engines": {
-    "vscode": "^1.4.0"
+    "vscode": "^1.9.0"
   },
   "categories": [
     "Languages"

--- a/src/controllers/untitledSqlDocumentService.ts
+++ b/src/controllers/untitledSqlDocumentService.ts
@@ -4,16 +4,11 @@
  * ------------------------------------------------------------------------------------------ */
 
 import VscodeWrapper from './vscodeWrapper';
-import vscode = require('vscode');
-import path = require('path');
-import os = require('os');
-const fs = require('fs');
 
 /**
  * Service for creating untitled documents for SQL query
  */
 export default class UntitledSqlDocumentService {
-    private _counter: number = 1;
 
     constructor(private vscodeWrapper: VscodeWrapper) {
     }
@@ -25,14 +20,11 @@ export default class UntitledSqlDocumentService {
 
         return new Promise<boolean>((resolve, reject) => {
             try {
-                let filePath = this.createUntitledFilePath();
-                let docUri: vscode.Uri = vscode.Uri.parse('untitled:' + filePath);
 
                 // Open an untitled document. So the  file doesn't have to exist in disk
-                this.vscodeWrapper.openTextDocument(docUri).then(doc => {
+                this.vscodeWrapper.openMsSqlTextDocument().then(doc => {
                     // Show the new untitled document in the editor's first tab and change the focus to it.
                     this.vscodeWrapper.showTextDocument(doc, 1, false).then(textDoc => {
-                        this._counter++;
                         resolve(true);
                     });
                 });
@@ -40,23 +32,6 @@ export default class UntitledSqlDocumentService {
                 reject(error);
             }
         });
-    }
-
-    private createUntitledFilePath(): string {
-        let filePath = UntitledSqlDocumentService.createFilePath(this._counter);
-        while (fs.existsSync(filePath)) {
-            this._counter++;
-            filePath = UntitledSqlDocumentService.createFilePath(this._counter);
-        }
-        while (this.vscodeWrapper.textDocuments.find(x => x.fileName.toUpperCase() === filePath.toUpperCase())) {
-            this._counter++;
-            filePath = UntitledSqlDocumentService.createFilePath(this._counter);
-        }
-        return filePath;
-    }
-
-    public static createFilePath(counter: number): string {
-        return path.join(os.tmpdir(), `SQLQuery${counter}.sql`);
     }
 }
 

--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -142,6 +142,21 @@ export default class VscodeWrapper {
     }
 
     /**
+     * Opens an untitled SQL document.
+     * [open document](#workspace.onDidOpenTextDocument)-event fires.
+     * The document to open is denoted by the [uri](#Uri). Two schemes are supported:
+     *
+     * Uris with other schemes will make this method return a rejected promise.
+     *
+     * @param uri Identifies the resource to open.
+     * @return A promise that resolves to a [document](#TextDocument).
+     * @see vscode.workspace.openTextDocument
+     */
+    public openMsSqlTextDocument(): Thenable<vscode.TextDocument> {
+        return vscode.workspace.openTextDocument({ language: 'sql'});
+    }
+
+    /**
      * Helper to log messages to "MSSQL" output channel.
      */
     public logToOutputChannel(msg: any): void {

--- a/test/mainController.test.ts
+++ b/test/mainController.test.ts
@@ -112,14 +112,17 @@ suite('MainController Tests', () => {
     // Saved Untitled file event test
     test('onDidCloseTextDocument should call untitledDoc function when an untitled file is saved' , done => {
         // Scheme of older doc must be untitled
-        document.uri.scheme = LocalizedConstants.untitledScheme;
+        let document2 = <vscode.TextDocument> {
+            uri : vscode.Uri.parse(`${LocalizedConstants.untitledScheme}:${docUri}`),
+            languageId : 'sql'
+        };
 
-        // A save untitled doc constitutes an saveDoc event directly followed by a closeDoc event
+        // // A save untitled doc constitutes an saveDoc event directly followed by a closeDoc event
         mainController.onDidSaveTextDocument(newDocument);
-        mainController.onDidCloseTextDocument(document);
+        mainController.onDidCloseTextDocument(document2);
         try {
             connectionManager.verify(x => x.transferFileConnection(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
-            assert.equal(docUriCallback, document.uri.toString());
+            assert.equal(docUriCallback, document2.uri.toString());
             assert.equal(newDocUriCallback, newDocument.uri.toString());
             done();
         } catch (err) {

--- a/test/mainController.test.ts
+++ b/test/mainController.test.ts
@@ -117,7 +117,7 @@ suite('MainController Tests', () => {
             languageId : 'sql'
         };
 
-        // // A save untitled doc constitutes an saveDoc event directly followed by a closeDoc event
+        // A save untitled doc constitutes an saveDoc event directly followed by a closeDoc event
         mainController.onDidSaveTextDocument(newDocument);
         mainController.onDidCloseTextDocument(document2);
         try {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -41,6 +41,10 @@ class TestTextEditor implements vscode.TextEditor {
     revealRange(range: vscode.Range, revealType?: vscode.TextEditorRevealType): void { return undefined; };
     show(column?: vscode.ViewColumn): void { return undefined; };
     hide(): void { return undefined; };
+    insertSnippet(snippet: vscode.SnippetString, location?: vscode.Position | vscode.Range | vscode.Position[] | vscode.Range[], options?:
+    { undoStopBefore: boolean; undoStopAfter: boolean; }): Thenable<boolean> {
+        return undefined;
+    }
 }
 
 class TestMemento implements vscode.Memento {
@@ -64,12 +68,19 @@ function createWorkspaceConfiguration(items: {[key: string]: any}): vscode.Works
                 val = defaultValue;
             }
             return val;
+        },
+        inspect<T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T } | undefined {
+            return undefined;
+        },
+        update(section: string, value: any, global?: boolean): Thenable<void> {
+            this[section] = value;
+            return undefined;
         }
     };
 
     // Copy properties across so that indexer works as expected
     Object.keys(items).forEach((key) => {
-        result[key] = items[key];
+        result.update(key, items[key]);
     });
 
     return Object.freeze(result);


### PR DESCRIPTION
- had to update the vs code engine to 1.9.0 to use the new API

- had to fix some codes in test classes because of using new engine version

- removed some of the tests for untitledSqlDocumentService because the code in the service related to tests were removed. 