### PR TITLE
fixed the issue with downloading using proxy settings

### DIFF
--- a/src/languageservice/httpClient.ts
+++ b/src/languageservice/httpClient.ts
@@ -10,6 +10,7 @@ import {parse as parseUrl, Url} from 'url';
 import * as https from 'https';
 import * as http from 'http';
 import {getProxyAgent} from './proxy';
+import * as Utils from '../models/utils';
 
 let fs = require('fs');
 
@@ -21,9 +22,16 @@ export default class HttpClient implements IHttpClient {
    /*
     * Downloads a file and stores the result in the temp file inside the package object
     */
-    public downloadFile(urlString: string, pkg: IPackage, logger: ILogger, statusView: IStatusView, proxy?: string, strictSSL?: boolean): Promise<void> {
+    public downloadFile(
+        urlString: string,
+        pkg: IPackage,
+        logger: ILogger,
+        statusView: IStatusView,
+        proxy?: string,
+        strictSSL?: boolean,
+        authorization?: string): Promise<void> {
         const url = parseUrl(urlString);
-        let options = this.getHttpClientOptions(url, proxy, strictSSL);
+        let options = this.getHttpClientOptions(url, proxy, strictSSL, authorization);
         let clientRequest = url.protocol === 'http:' ? http.request : https.request;
 
         return new Promise<void>((resolve, reject) => {
@@ -34,7 +42,7 @@ export default class HttpClient implements IHttpClient {
             let request = clientRequest(options, response => {
                 if (response.statusCode === 301 || response.statusCode === 302) {
                     // Redirect - download from new location
-                    return resolve(this.downloadFile(response.headers.location, pkg, logger, statusView, proxy, strictSSL));
+                    return resolve(this.downloadFile(response.headers.location, pkg, logger, statusView, proxy, strictSSL, authorization));
                 }
 
                 if (response.statusCode !== 200) {
@@ -60,14 +68,13 @@ export default class HttpClient implements IHttpClient {
         });
     }
 
-    private getHttpClientOptions(url: Url, proxy?: string, strictSSL?: boolean): any {
+    private getHttpClientOptions(url: Url, proxy?: string, strictSSL?: boolean, authorization?: string): any {
         const agent = getProxyAgent(url, proxy, strictSSL);
 
         let options: http.RequestOptions = {
             host: url.hostname,
             path: url.path,
-            agent: agent,
-            port: +url.port
+            agent: agent
         };
 
         if (url.protocol === 'https:') {
@@ -75,9 +82,12 @@ export default class HttpClient implements IHttpClient {
                     host: url.hostname,
                     path: url.path,
                     agent: agent,
-                    port: +url.port
+                    rejectUnauthorized: Utils.isBoolean(strictSSL) ? strictSSL : true
             };
             options = httpsOptions;
+        }
+        if (authorization) {
+            options.headers = Object.assign(options.headers || {}, { 'Proxy-Authorization': authorization });
         }
 
         return options;

--- a/src/languageservice/httpClient.ts
+++ b/src/languageservice/httpClient.ts
@@ -9,8 +9,7 @@ import  {ILogger} from '../models/interfaces';
 import {parse as parseUrl, Url} from 'url';
 import * as https from 'https';
 import * as http from 'http';
-import {getProxyAgent} from './proxy';
-import * as Utils from '../models/utils';
+import {getProxyAgent, isBoolean} from './proxy';
 
 let fs = require('fs');
 
@@ -82,7 +81,7 @@ export default class HttpClient implements IHttpClient {
                     host: url.hostname,
                     path: url.path,
                     agent: agent,
-                    rejectUnauthorized: Utils.isBoolean(strictSSL) ? strictSSL : true
+                    rejectUnauthorized: isBoolean(strictSSL) ? strictSSL : true
             };
             options = httpsOptions;
         }

--- a/src/languageservice/interfaces.ts
+++ b/src/languageservice/interfaces.ts
@@ -39,7 +39,8 @@ export class PackageError extends Error {
 }
 
 export interface IHttpClient {
-    downloadFile(urlString: string, pkg: IPackage, logger: ILogger, statusView: IStatusView, proxy: string, strictSSL: boolean): Promise<void>;
+    downloadFile(urlString: string, pkg: IPackage, logger: ILogger, statusView: IStatusView, proxy: string, strictSSL: boolean, authorization?: string):
+    Promise<void>;
 }
 
 export interface IDecompressProvider {

--- a/src/languageservice/proxy.ts
+++ b/src/languageservice/proxy.ts
@@ -6,7 +6,6 @@
 'use strict';
 
 import { Url, parse as parseUrl } from 'url';
-import * as Utils from '../models/utils';
 let HttpProxyAgent = require('http-proxy-agent');
 let HttpsProxyAgent = require('https-proxy-agent');
 
@@ -18,6 +17,10 @@ function getSystemProxyURL(requestURL: Url): string {
     }
 
     return undefined;
+}
+
+export function isBoolean(obj: any): obj is boolean {
+    return obj === true || obj === false;
 }
 
 /*
@@ -40,7 +43,7 @@ export function getProxyAgent(requestURL: Url, proxy?: string, strictSSL?: boole
          host: proxyEndpoint.hostname,
          port: Number(proxyEndpoint.port),
          auth: proxyEndpoint.auth,
-         rejectUnauthorized: Utils.isBoolean(strictSSL) ? strictSSL : true
+         rejectUnauthorized: isBoolean(strictSSL) ? strictSSL : true
      };
 
     return requestURL.protocol === 'http:' ? new HttpProxyAgent(opts) : new HttpsProxyAgent(opts);

--- a/src/languageservice/proxy.ts
+++ b/src/languageservice/proxy.ts
@@ -6,6 +6,7 @@
 'use strict';
 
 import { Url, parse as parseUrl } from 'url';
+import * as Utils from '../models/utils';
 let HttpProxyAgent = require('http-proxy-agent');
 let HttpsProxyAgent = require('https-proxy-agent');
 
@@ -35,13 +36,11 @@ export function getProxyAgent(requestURL: Url, proxy?: string, strictSSL?: boole
         return undefined;
     }
 
-    strictSSL = strictSSL || true;
-
     const opts = {
          host: proxyEndpoint.hostname,
          port: Number(proxyEndpoint.port),
          auth: proxyEndpoint.auth,
-         rejectUnauthorized: strictSSL
+         rejectUnauthorized: Utils.isBoolean(strictSSL) ? strictSSL : true
      };
 
     return requestURL.protocol === 'http:' ? new HttpProxyAgent(opts) : new HttpsProxyAgent(opts);

--- a/src/languageservice/serviceDownloadProvider.ts
+++ b/src/languageservice/serviceDownloadProvider.ts
@@ -91,6 +91,7 @@ export default class ServiceDownloadProvider {
     public installSQLToolsService(platform: Runtime): Promise<boolean> {
         const proxy = <string>this._config.getWorkspaceConfig('http.proxy');
         const strictSSL = this._config.getWorkspaceConfig('http.proxyStrictSSL', true);
+        const authorization = this._config.getWorkspaceConfig('http.proxyAuthorization');
 
         return new Promise<boolean>((resolve, reject) => {
             const fileName = this.getDownloadFileName(platform);
@@ -108,7 +109,7 @@ export default class ServiceDownloadProvider {
             this.createTempFile(pkg).then(tmpResult => {
                 pkg.tmpFile = tmpResult;
 
-                this._httpClient.downloadFile(pkg.url, pkg, this._logger, this._statusView, proxy, strictSSL).then(_ => {
+                this._httpClient.downloadFile(pkg.url, pkg, this._logger, this._statusView, proxy, strictSSL, authorization).then(_ => {
 
                     this._logger.logDebug(`Downloaded to ${pkg.tmpFile.name}...`);
                     this._logger.appendLine(' Done!');

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -324,6 +324,10 @@ export function parseTimeString(value: string): number | boolean {
     return ms + (h * msInH) + (m * msInM) + (s * msInS);
 }
 
+export function isBoolean(obj: any): obj is boolean {
+    return obj === true || obj === false;
+}
+
 /**
  * Takes a number of milliseconds and converts it to a string like HH:MM:SS.fff
  * @param value The number of milliseconds to convert to a timespan string

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -129,6 +129,7 @@ suite('ServiceDownloadProvider Tests', () => {
              config.setup(x => x.getSqlToolsPackageVersion()).returns(() => version);
              config.setup(x => x.getWorkspaceConfig('http.proxy')).returns(() => <any>'proxy');
              config.setup(x => x.getWorkspaceConfig('http.proxyStrictSSL', true)).returns(() => <any>true);
+             config.setup(x => x.getWorkspaceConfig('http.proxyAuthorization')).returns(() => '');
              testStatusView.setup(x => x.installingService());
              testStatusView.setup(x => x.serviceInstalled());
              testLogger.setup(x => x.append(TypeMoq.It.isAny()));
@@ -137,7 +138,7 @@ suite('ServiceDownloadProvider Tests', () => {
              testDecompressProvider.setup(x => x.decompress(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
              .returns(() => { return fixture.decompressResult; });
              testHttpClient.setup(x => x.downloadFile(downloadUrl, TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(),
-             TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+             TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
              .returns(() => { return fixture.downloadResult; });
              let downloadProvider = new ServiceDownloadProvider(config.object, testLogger.object, testStatusView.object,
              testHttpClient.object, testDecompressProvider.object);
@@ -157,7 +158,7 @@ suite('ServiceDownloadProvider Tests', () => {
         fixture = createDownloadProvider(fixture);
         return fixture.downloadProvider.installSQLToolsService(Runtime.Windows_7_64).then(_ => {
             testHttpClient.verify(x => x.downloadFile(fixture.downloadUrl, TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(),
-            TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once());
             testDecompressProvider.verify(x => x.decompress(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once());
@@ -177,7 +178,7 @@ suite('ServiceDownloadProvider Tests', () => {
         fixture = createDownloadProvider(fixture);
         return fixture.downloadProvider.installSQLToolsService(Runtime.Windows_7_64).catch(_ => {
             testHttpClient.verify(x => x.downloadFile(fixture.downloadUrl, TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(),
-            TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once());
             testDecompressProvider.verify(x => x.decompress(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.never());
@@ -197,7 +198,7 @@ suite('ServiceDownloadProvider Tests', () => {
         fixture = createDownloadProvider(fixture);
         return fixture.downloadProvider.installSQLToolsService(Runtime.Windows_7_64).catch(_ => {
             testHttpClient.verify(x => x.downloadFile(fixture.downloadUrl, TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(),
-            TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once());
             testDecompressProvider.verify(x => x.decompress(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once());


### PR DESCRIPTION
- removed the port from http request option and that fixed the downloading issue using proxy. Verified that it works with urls from Microsoft download center. 

- setting the Proxy-Authorization in http header if http.proxyAuthorization is defined in the settings. I copied the code from vs code and I'm not able to verify it. but it seems to be necessary if user needs to set the authorization to download the service 
