### PR TITLE
Utilize the DbCellValue type

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "0.3.0-alpha.23",
+        "version": "0.3.0-alpha.26",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "0.3.0-alpha.23",
+        "version": "0.3.0-alpha.26",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -130,7 +130,6 @@ export class ResultSetSubset {
 }
 
 export class QueryExecuteSubsetResult {
-    message: string;
     resultSubset: ResultSetSubset;
 }
 

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -119,9 +119,14 @@ export class QueryExecuteSubsetParams {
     rowsCount: number;
 }
 
+export class DbCellValue {
+    displayValue: string;
+    isNull: boolean;
+}
+
 export class ResultSetSubset {
     rowCount: number;
-    rows: any[][];
+    rows: DbCellValue[][];
 }
 
 export class QueryExecuteSubsetResult {

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -570,17 +570,18 @@ export class AppComponent implements OnInit, AfterViewChecked {
     /**
      * Format xml field into a hyperlink and performs HTML entity encoding
      */
-    public hyperLinkFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
-        let valueToDisplay = value;
+    public hyperLinkFormatter(row: number, cell: any, value: any, columnDef: any, dataContext: any): string {
         let cellClasses = 'grid-cell-value-container';
-        if (value) {
+        let valueToDisplay: string;
+        if (Utils.isDbCellValue(value)) {
             cellClasses += ' xmlLink';
-            valueToDisplay = Utils.htmlEntities(value);
+            valueToDisplay = Utils.htmlEntities(value.displayValue);
             return `<a class="${cellClasses}" href="#" >${valueToDisplay}</a>`;
-        } else {
-            cellClasses += ' missing-value';
-            return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
         }
+
+        // If we make it to here, we don't have a DbCellValue
+        cellClasses += ' missing-value';
+        return `<span class="${cellClasses}"></span>`;
     }
 
     /**

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -15,7 +15,8 @@ import { MessagesContextMenu } from './messagescontextmenu.component';
 import {
     IGridIcon,
     IMessage,
-    IRange
+    IRange// ,
+    // DbCellValue
 } from './../interfaces';
 
 import * as Constants from './../constants';
@@ -586,13 +587,16 @@ export class AppComponent implements OnInit, AfterViewChecked {
     /**
      * Format all text to replace all new lines with spaces and performs HTML entity encoding
      */
-    textFormatter(row: number, cell: any, value: string, columnDef: any, dataContext: any): string {
-        let valueToDisplay = value;
+    textFormatter(row: number, cell: any, value: any, columnDef: any, dataContext: any): string {
         let cellClasses = 'grid-cell-value-container';
-        if (value) {
-            valueToDisplay = Utils.htmlEntities(value.replace(/(\r\n|\n|\r)/g, ' '));
+        let valueToDisplay: string;
+        if (AppComponent.isDbCellValue(value)) {
+            valueToDisplay = Utils.htmlEntities(value.displayValue.replace(/(\r\n|\n|\r)/g, ' '));
+            if (value.isNull) {
+                cellClasses += ' missing-value';
+            }
         } else {
-            cellClasses += ' missing-value';
+            valueToDisplay = '';
         }
 
         return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
@@ -774,5 +778,9 @@ export class AppComponent implements OnInit, AfterViewChecked {
                     grid.resized.emit();
                 }
         });
+    }
+
+    static isDbCellValue(object: any): boolean {
+        return (object.displayValue !== undefined && object.isNull !== undefined);
     }
 }

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -15,8 +15,7 @@ import { MessagesContextMenu } from './messagescontextmenu.component';
 import {
     IGridIcon,
     IMessage,
-    IRange// ,
-    // DbCellValue
+    IRange
 } from './../interfaces';
 
 import * as Constants from './../constants';
@@ -590,7 +589,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
     textFormatter(row: number, cell: any, value: any, columnDef: any, dataContext: any): string {
         let cellClasses = 'grid-cell-value-container';
         let valueToDisplay: string;
-        if (AppComponent.isDbCellValue(value)) {
+        if (Utils.isDbCellValue(value)) {
             valueToDisplay = Utils.htmlEntities(value.displayValue.replace(/(\r\n|\n|\r)/g, ' '));
             if (value.isNull) {
                 cellClasses += ' missing-value';
@@ -778,9 +777,5 @@ export class AppComponent implements OnInit, AfterViewChecked {
                     grid.resized.emit();
                 }
         });
-    }
-
-    static isDbCellValue(object: any): boolean {
-        return (object.displayValue !== undefined && object.isNull !== undefined);
     }
 }

--- a/src/views/htmlcontent/src/js/interfaces.ts
+++ b/src/views/htmlcontent/src/js/interfaces.ts
@@ -41,9 +41,14 @@ export interface IDbColumn {
     dataTypeName: string;
 }
 
+export class DbCellValue {
+    displayValue: string;
+    isNull: boolean;
+}
+
 export class ResultSetSubset {
     rowCount: number;
-    rows: any[][];
+    rows: DbCellValue[][];
 }
 
 export class ResultSetSummary {

--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -29,3 +29,12 @@ export function htmlEntities(str: string): string {
         ? str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => { return `&#${i.charCodeAt(0)};`; })
         : undefined;
 }
+
+/**
+ * Determines if an object is a DbCellValue based on the properties it exposes
+ * @param object The object to check
+ * @returns True if the object is a DbCellValue, false otherwise
+ */
+export function isDbCellValue(object: any): boolean {
+    return (object.displayValue !== undefined && object.isNull !== undefined);
+}

--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -36,5 +36,7 @@ export function htmlEntities(str: string): string {
  * @returns True if the object is a DbCellValue, false otherwise
  */
 export function isDbCellValue(object: any): boolean {
-    return (object.displayValue !== undefined && object.isNull !== undefined);
+    return object !== undefined
+        && object.displayValue !== undefined
+        && object.isNull !== undefined;
 }

--- a/src/views/htmlcontent/test/testResources/mockGetRows1.spec.ts
+++ b/src/views/htmlcontent/test/testResources/mockGetRows1.spec.ts
@@ -3,9 +3,7 @@ import { ResultSetSubset } from './../../src/js/interfaces';
 const rows: ResultSetSubset = {
     rowCount: 50,
     rows: [
-        [
-            'data'
-        ]
+        [{displayValue: 'data', isNull: false}]
     ]
 };
 

--- a/src/views/htmlcontent/test/utils.spec.ts
+++ b/src/views/htmlcontent/test/utils.spec.ts
@@ -1,4 +1,5 @@
 import * as Utils from './../src/js/utils';
+import { DbCellValue } from './../src/js/interfaces';
 
 describe('Utility Tests', () => {
     describe('IsNumber', () => {
@@ -31,5 +32,17 @@ describe('Utility Tests', () => {
                 expect(Utils.htmlEntities(item)).toEqual(undefined);
             });
         });
+    });
+
+    describe('isDbCellValue', () => {
+        it('Detects a DbCellValue properly', () => {
+            let dbCellValue: DbCellValue = {displayValue: 'qqq', isNull: false};
+            expect(Utils.isDbCellValue(dbCellValue)).toEqual(true);
+        });
+
+        it('Detects a non-DbCellValue properly', () => {
+            let nonDbCellValue: string = 'qqq';
+            expect(Utils.isDbCellValue(nonDbCellValue)).toEqual(false);
+        })
     });
 });

--- a/src/views/htmlcontent/test/utils.spec.ts
+++ b/src/views/htmlcontent/test/utils.spec.ts
@@ -35,6 +35,11 @@ describe('Utility Tests', () => {
     });
 
     describe('isDbCellValue', () => {
+        it('Detects undefined properly', () => {
+            let dbCellValue = undefined;
+            expect(Utils.isDbCellValue(dbCellValue)).toEqual(false);
+        });
+
         it('Detects a DbCellValue properly', () => {
             let dbCellValue: DbCellValue = {displayValue: 'qqq', isNull: false};
             expect(Utils.isDbCellValue(dbCellValue)).toEqual(true);

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -10,7 +10,8 @@ import {
     QueryExecuteCompleteNotificationResult,
     QueryExecuteBatchNotificationParams,
     QueryExecuteResultSetCompleteNotificationParams,
-    ResultSetSummary
+    ResultSetSummary,
+    QueryExecuteSubsetResult
 } from './../src/models/contracts/queryExecute';
 import VscodeWrapper from './../src/controllers/vscodeWrapper';
 import StatusView from './../src/views/statusView';
@@ -412,16 +413,15 @@ suite('Query Runner tests', () => {
 
     test('Correctly handles subset', () => {
         let testuri = 'test';
-        let testresult = {
-            message: '',
+        let testresult: QueryExecuteSubsetResult = {
             resultSubset: {
                 rowCount: 5,
                 rows: [
-                    ['1', '2'],
-                    ['3', '4'],
-                    ['5', '6'],
-                    ['7', '8'],
-                    ['9', '10']
+                    [{isNull: false, displayValue: '1'}, {isNull: false, displayValue: '2'}],
+                    [{isNull: false, displayValue: '3'}, {isNull: false, displayValue: '4'}],
+                    [{isNull: false, displayValue: '5'}, {isNull: false, displayValue: '6'}],
+                    [{isNull: false, displayValue: '7'}, {isNull: false, displayValue: '8'}],
+                    [{isNull: false, displayValue: '9'}, {isNull: false, displayValue: '10'}]
                 ]
             }
         };
@@ -489,16 +489,15 @@ suite('Query Runner tests', () => {
         const finalStringWithHeader = 'Col1' + TAB + 'Col2' + CLRF + finalStringNoHeader;
 
         const testuri = 'test';
-        const testresult = {
-            message: '',
+        let testresult: QueryExecuteSubsetResult = {
             resultSubset: {
                 rowCount: 5,
                 rows: [
-                    ['1', '2'],
-                    ['3', '4'],
-                    ['5', '6'],
-                    ['7', '8'],
-                    ['9', '10']
+                    [{isNull: false, displayValue: '1'}, {isNull: false, displayValue: '2'}],
+                    [{isNull: false, displayValue: '3'}, {isNull: false, displayValue: '4'}],
+                    [{isNull: false, displayValue: '5'}, {isNull: false, displayValue: '6'}],
+                    [{isNull: false, displayValue: '7'}, {isNull: false, displayValue: '8'}],
+                    [{isNull: false, displayValue: '9'}, {isNull: false, displayValue: '10'}]
                 ]
             }
         };


### PR DESCRIPTION
The query/subset API from the tools service now return a DbCellValue[][] as part of the ResultSetSubset. These changes are made to take the DbCellValue and properly determine how to display it in SlickGrid. Contains a vBump for the tools service version.