### PR TITLE
Fix issue where grid is not sized properly when there are exactly 8 rows 

### DIFF
--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -356,7 +356,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
                     let maxHeight = resultSet.rowCount < self._defaultNumShowingRows
                         ? Math.max((resultSet.rowCount + 1) * self._rowHeight, self.dataIcons.length * 30) + 10
                         : 'inherit';
-                    let minHeight = resultSet.rowCount > self._defaultNumShowingRows
+                    let minHeight = resultSet.rowCount >= self._defaultNumShowingRows
                         ? (self._defaultNumShowingRows + 1) * self._rowHeight + 10
                         : maxHeight;
 


### PR DESCRIPTION
Fixes #815. When there were exactly 8 rows, both the `minHeight` and `maxHeight` would remain `inherit` which causes wonkiness when the window is small. 