### PR TITLE
Fix an issue where intelliSense settings were not exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.messagesDefaultOpen": true,
     "mssql.logDebugInfo": false,
     "mssql.saveAsCSV.includeHeaders": true,
-    "mssql.enableIntelliSense": true,
+    "mssql.intelliSense.enableIntelliSense": true,
     "mssql.intelliSense.enableErrorChecking": true,
     "mssql.intelliSense.enableSuggestions": true,
     "mssql.intelliSense.enableQuickInfo": true,

--- a/package.json
+++ b/package.json
@@ -504,6 +504,31 @@
           "type": "boolean",
           "default": true,
           "description": "Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'"
+        },
+        "mssql.intelliSense.enableIntelliSense": {
+          "type": "boolean",
+          "default": true,
+          "description": "Should IntelliSense be enabled"
+        },
+        "mssql.intelliSense.enableErrorChecking": {
+          "type": "boolean",
+          "default": true,
+          "description": "Should IntelliSense error checking be enabled"
+        },
+        "mssql.intelliSense.enableSuggestions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Should IntelliSense suggestions be enabled"
+        },
+        "mssql.intelliSense.enableQuickInfo": {
+          "type": "boolean",
+          "default": true,
+          "description": "Should IntelliSense quick info be enabled"
+        },
+        "mssql.intelliSense.lowerCaseSuggestions": {
+          "type": "boolean",
+          "default": false,
+          "description": "Should IntelliSense suggestions be lowercase"
         }
       }
     }


### PR DESCRIPTION
Fixes #835 

Adds the mssql.intelliSense configurations shown in our readme file to package.json in order to let users set them. mssql.enableIntelliSense is renamed to mssql.intelliSense.enableIntelliSense in order to match how it is handled in SqlToolsService