### PR TITLE
Use version 0.1.3 of xvfb-maybe for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - npm install -g npm
 install:
   - npm install -g --silent gulp-cli
-  - npm install -g --silent xvfb-maybe
+  - npm install -g --silent xvfb-maybe@0.1.3
   - npm install
   - gulp install
 script:


### PR DESCRIPTION
xvfb-maybe was bumped to version 0.2.0 today and now Travis builds are failing. Downgrading back to 0.1.3 to get builds working again while I investigate it some more.