### PR TITLE
Use --color-content for message table cells

### DIFF
--- a/src/views/htmlcontent/src/css/styles.css
+++ b/src/views/htmlcontent/src/css/styles.css
@@ -75,6 +75,7 @@ table {
 
 #messageTable td {
   padding-right: 20px;
+  color: var(--color-content);
 }
 
 #messageTable tbody tr:last-child > td {


### PR DESCRIPTION
Fixes #847 

A change in VSCode theming broke our text coloring in message table cells. This change explicitly applies --color-content as the color for message table cells in order to fix that issue. 