### PR TITLE
Changes to vscode-mssql extension allowing empty passwords for SqlLogin

### DIFF
--- a/package.json
+++ b/package.json
@@ -398,6 +398,10 @@
               "savePassword": {
                 "type": "boolean",
                 "description": "[Optional] When set to 'true', the password for SQL Server authentication is saved in the secure store of your operating system such as KeyChain in MacOS or Secure Store in Windows."
+              },
+              "emptyPasswordInput": {
+                "type": "boolean",
+                "description": "[Optional] Indicates whether this profile has an empty password explicitly set."
               }
             }
           }

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -115,9 +115,10 @@ export class ConnectionCredentials implements IConnectionCredentials {
                 if (isProfile) {
                     let profile: IConnectionProfile = <IConnectionProfile>credentials;
 
-                    // If this is a profile, and the user has set save password to true and stored the password in the config file,
+                    // If this is a profile, and the user has set save password to true and either
+                    // stored the password in the config file or purposefully set an empty password
                     // then transfer the password to the credential store
-                    if (profile.savePassword && !wasPasswordEmptyInConfigFile) {
+                    if (profile.savePassword && (!wasPasswordEmptyInConfigFile || profile.emptyPasswordInput)) {
                         // Remove profile, then save profile without plain text password
                         connectionStore.removeProfile(profile).then(() => {
                             connectionStore.saveProfile(profile);
@@ -180,7 +181,7 @@ export class ConnectionCredentials implements IConnectionCredentials {
                     credentials.authenticationType = value;
                 }
             },
-            // Username must be pressent
+            // Username must be present
             {
                 type: QuestionTypes.input,
                 name: LocalizedConstants.usernamePrompt,
@@ -204,7 +205,10 @@ export class ConnectionCredentials implements IConnectionCredentials {
                     }
                     return undefined;
                 },
-                onAnswered: (value) => credentials.password = value
+                onAnswered: (value) => {
+                    credentials.password = value;
+                    (<IConnectionProfile>credentials).emptyPasswordInput = utils.isEmpty(credentials.password);
+                }
             }
         ];
         return questions;
@@ -214,8 +218,13 @@ export class ConnectionCredentials implements IConnectionCredentials {
         return utils.isEmpty(credentials.user) && ConnectionCredentials.isPasswordBasedCredential(credentials);
     }
 
+    // Prompt for password if this is a password based credential and the password for the profile was empty
+    // and not explicitly set as empty. If it was explicitly set as empty, only prompt if pw not saved
     private static shouldPromptForPassword(credentials: IConnectionCredentials): boolean {
-        return utils.isEmpty(credentials.password) && ConnectionCredentials.isPasswordBasedCredential(credentials);
+        return utils.isEmpty(credentials.password)
+            && ConnectionCredentials.isPasswordBasedCredential(credentials)
+            && (!((<IConnectionProfile>credentials).emptyPasswordInput) ||
+             ((<IConnectionProfile>credentials).emptyPasswordInput && !(<IConnectionProfile>credentials).savePassword));
     }
 
     public static isPasswordBasedCredential(credentials: IConnectionCredentials): boolean {

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -207,7 +207,9 @@ export class ConnectionCredentials implements IConnectionCredentials {
                 },
                 onAnswered: (value) => {
                     credentials.password = value;
-                    (<IConnectionProfile>credentials).emptyPasswordInput = utils.isEmpty(credentials.password);
+                    if (typeof((<IConnectionProfile>credentials)) !== 'undefined') {
+                        (<IConnectionProfile>credentials).emptyPasswordInput = utils.isEmpty(credentials.password);
+                    }
                 }
             }
         ];

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -116,7 +116,7 @@ export class ConnectionCredentials implements IConnectionCredentials {
                     let profile: IConnectionProfile = <IConnectionProfile>credentials;
 
                     // If this is a profile, and the user has set save password to true and either
-                    // stored the password in the config file or purposefully set an empty password
+                    // stored the password in the config file or purposefully set an empty password,
                     // then transfer the password to the credential store
                     if (profile.savePassword && (!wasPasswordEmptyInConfigFile || profile.emptyPasswordInput)) {
                         // Remove profile, then save profile without plain text password
@@ -221,10 +221,13 @@ export class ConnectionCredentials implements IConnectionCredentials {
     // Prompt for password if this is a password based credential and the password for the profile was empty
     // and not explicitly set as empty. If it was explicitly set as empty, only prompt if pw not saved
     private static shouldPromptForPassword(credentials: IConnectionCredentials): boolean {
+        let isSavedEmptyPassword: boolean = (<IConnectionProfile>credentials).emptyPasswordInput
+            && (<IConnectionProfile>credentials).savePassword;
+
         return utils.isEmpty(credentials.password)
             && ConnectionCredentials.isPasswordBasedCredential(credentials)
-            && (!((<IConnectionProfile>credentials).emptyPasswordInput) ||
-             ((<IConnectionProfile>credentials).emptyPasswordInput && !(<IConnectionProfile>credentials).savePassword));
+            && !isSavedEmptyPassword;
+
     }
 
     public static isPasswordBasedCredential(credentials: IConnectionCredentials): boolean {

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -13,6 +13,7 @@ import * as utils from './utils';
 export class ConnectionProfile extends ConnectionCredentials implements IConnectionProfile {
     public profileName: string;
     public savePassword: boolean;
+    public emptyPasswordInput: boolean;
 
     /**
      * Creates a new profile by prompting the user for information.
@@ -22,14 +23,14 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
      */
     public static createProfile(prompter: IPrompter, defaultProfileValues?: IConnectionProfile): Promise<IConnectionProfile> {
         let profile: ConnectionProfile = new ConnectionProfile();
-        // Ensure all core propertiesare entered
+        // Ensure all core properties are entered
         let authOptions: INameValueChoice[] = ConnectionCredentials.getAuthenticationTypesChoice();
         if (authOptions.length === 1) {
             // Set default value as there is only 1 option
             profile.authenticationType = authOptions[0].value;
         }
 
-        let questions: IQuestion[] = ConnectionCredentials.getRequiredCredentialValuesQuestions(profile, true, true, defaultProfileValues);
+        let questions: IQuestion[] = ConnectionCredentials.getRequiredCredentialValuesQuestions(profile, true, false, defaultProfileValues);
         // Check if password needs to be saved
         questions.push(
             {

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -126,16 +126,14 @@ export class ConnectionStore {
     public addSavedPassword(credentialsItem: IConnectionCredentialsQuickPickItem): Promise<IConnectionCredentialsQuickPickItem> {
         let self = this;
         return new Promise<IConnectionCredentialsQuickPickItem>( (resolve, reject) => {
-            let isEmptyPasswordInput: boolean = typeof(credentialsItem.connectionCreds['emptyPasswordInput'] !== 'undefined')
-                && credentialsItem.connectionCreds['emptyPasswordInput'];
-
             if (typeof(credentialsItem.connectionCreds['savePassword']) === 'undefined' ||
                 credentialsItem.connectionCreds['savePassword'] === false) {
                 // Don't try to lookup a saved password if savePassword is set to false for the credential
                 resolve(credentialsItem);
+            // Note that 'emptyPasswordInput' property is only present for connection profiles
             } else if (ConnectionCredentials.isPasswordBasedCredential(credentialsItem.connectionCreds)
                     && Utils.isEmpty(credentialsItem.connectionCreds.password)
-                    && !isEmptyPasswordInput) {
+                    && credentialsItem.connectionCreds['emptyPasswordInput']) {
                 let credentialId = ConnectionStore.formatCredentialIdForCred(credentialsItem.connectionCreds, credentialsItem.quickPickItemType);
                 self._credentialStore.readCredential(credentialId)
                 .then(savedCred => {

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -126,13 +126,16 @@ export class ConnectionStore {
     public addSavedPassword(credentialsItem: IConnectionCredentialsQuickPickItem): Promise<IConnectionCredentialsQuickPickItem> {
         let self = this;
         return new Promise<IConnectionCredentialsQuickPickItem>( (resolve, reject) => {
+            let isEmptyPasswordInput: boolean = typeof(credentialsItem.connectionCreds['emptyPasswordInput'] !== 'undefined')
+                && credentialsItem.connectionCreds['emptyPasswordInput'];
+
             if (typeof(credentialsItem.connectionCreds['savePassword']) === 'undefined' ||
                 credentialsItem.connectionCreds['savePassword'] === false) {
                 // Don't try to lookup a saved password if savePassword is set to false for the credential
                 resolve(credentialsItem);
             } else if (ConnectionCredentials.isPasswordBasedCredential(credentialsItem.connectionCreds)
                     && Utils.isEmpty(credentialsItem.connectionCreds.password)
-                    && credentialsItem.connectionCreds['emptyPasswordInput'] === false) {
+                    && !isEmptyPasswordInput) {
                 let credentialId = ConnectionStore.formatCredentialIdForCred(credentialsItem.connectionCreds, credentialsItem.quickPickItemType);
                 self._credentialStore.readCredential(credentialId)
                 .then(savedCred => {

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -131,8 +131,8 @@ export class ConnectionStore {
                 // Don't try to lookup a saved password if savePassword is set to false for the credential
                 resolve(credentialsItem);
             } else if (ConnectionCredentials.isPasswordBasedCredential(credentialsItem.connectionCreds)
-                    && Utils.isEmpty(credentialsItem.connectionCreds.password)) {
-
+                    && Utils.isEmpty(credentialsItem.connectionCreds.password)
+                    && credentialsItem.connectionCreds['emptyPasswordInput'] === false) {
                 let credentialId = ConnectionStore.formatCredentialIdForCred(credentialsItem.connectionCreds, credentialsItem.quickPickItemType);
                 self._credentialStore.readCredential(credentialId)
                 .then(savedCred => {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -194,6 +194,7 @@ export interface IConnectionCredentials {
 export interface IConnectionProfile extends IConnectionCredentials {
     profileName: string;
     savePassword: boolean;
+    emptyPasswordInput: boolean;
 }
 
 export enum CredentialsQuickPickItemType {

--- a/test/connectionCredentials.test.ts
+++ b/test/connectionCredentials.test.ts
@@ -79,9 +79,8 @@ suite('ConnectionCredentials Tests', () => {
     }
 
     function ensureRequestAndSavePassword(emptyPassword: boolean): (done: MochaDone) => void {
-
         return (done: MochaDone) => {
-            // Setup Profile Information to have savePassword off and blank
+            // Setup Profile Information to have savePassword on and blank
             let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
                 savePassword: true,
                 emptyPasswordInput: emptyPassword,

--- a/test/connectionCredentials.test.ts
+++ b/test/connectionCredentials.test.ts
@@ -78,6 +78,51 @@ suite('ConnectionCredentials Tests', () => {
             connectionStore.object);
     }
 
+    function ensureRequestAndSavePassword(emptyPassword: boolean): (done: MochaDone) => void {
+
+        return (done: MochaDone) => {
+            // Setup Profile Information to have savePassword off and blank
+            let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
+                savePassword: true,
+                emptyPasswordInput: emptyPassword,
+                password: ''
+            });
+
+            // Setup input paramaters
+            let isProfile: boolean = true;
+            let isPasswordRequired: boolean = false;
+            let wasPasswordEmptyInConfigFile: boolean = emptyPassword;
+            let passwordQuestion: IQuestion[];
+            let answers = {};
+
+            // Mocking functions
+            connectionStore.setup(x => x.removeProfile(TypeMoq.It.isAny())).returns((profile1: IConnectionProfile) => (Promise.resolve(true)));
+            connectionStore.setup(x => x.saveProfile(TypeMoq.It.isAny())).returns((profile1: IConnectionProfile) => (Promise.resolve(profile1)));
+            prompter.setup(x => x.prompt(TypeMoq.It.isAny())).callback(questions => {
+                    passwordQuestion = questions.filter(question => question.name === LocalizedConstants.passwordPrompt);
+                    answers[LocalizedConstants.passwordPrompt] = emptyPassword ? '' : 'newPassword';
+                    passwordQuestion[0].onAnswered(answers[LocalizedConstants.passwordPrompt]);
+                })
+                .returns((questions: IQuestion[]) => Promise.resolve(answers));
+
+            // Call function to test
+            ConnectionCredentials.ensureRequiredPropertiesSet(
+                profile,
+                isProfile,
+                isPasswordRequired,
+                wasPasswordEmptyInConfigFile,
+                prompter.object,
+                connectionStore.object).then( success => {
+                    assert.ok(success);
+                    // Checking to see password question was prompted
+                    assert.ok(passwordQuestion);
+                    assert.equal(success.password, answers[LocalizedConstants.passwordPrompt]);
+                    connectionStore.verify(x => x.removeProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
+                    connectionStore.verify(x => x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
+                    done();
+                }).catch(err => done(new Error(err)));
+        };
+    }
 
     // Connect with savePassword true and filled password and ensure password is saved and removed from plain text
     test('ensureRequiredPropertiesSet should remove password from plain text and save password to Credential Store', done => {
@@ -130,48 +175,30 @@ suite('ConnectionCredentials Tests', () => {
         }).catch(err => done(new Error(err)));
     });
 
-    // Connect with savePassword true and blank password and
-    // confirm password is prompted for and saved
-    test('ensureRequiredPropertiesSet should request password and save it', done => {
+    // Connect with savePassword false and ensure empty password is never saved
+    test('ensureRequiredPropertiesSet should not save password, empty password case', done => {
         // Setup Profile Information to have savePassword off and blank
         let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
-            savePassword: true,
+            savePassword: false,
             password: ''
         });
 
-        // Setup input paramaters
-        let isProfile: boolean = true;
-        let isPasswordRequired: boolean = false;
-        let wasPasswordEmptyInConfigFile: boolean = false;
-        let passwordQuestion: IQuestion[];
-        let answers = {};
-
-
-        // Mocking functions
-        connectionStore.setup(x => x.removeProfile(TypeMoq.It.isAny())).returns((profile1: IConnectionProfile) => (Promise.resolve(true)));
-        connectionStore.setup(x => x.saveProfile(TypeMoq.It.isAny())).returns((profile1: IConnectionProfile) => (Promise.resolve(profile1)));
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny())).callback(questions => {
-                passwordQuestion = questions.filter(question => question.name === LocalizedConstants.passwordPrompt);
-                answers[LocalizedConstants.passwordPrompt] = 'newPassword';
-                passwordQuestion[0].onAnswered(answers[LocalizedConstants.passwordPrompt]);
-            })
-            .returns((questions: IQuestion[]) => Promise.resolve(answers));
-
-        // Call function to test
-        ConnectionCredentials.ensureRequiredPropertiesSet(
-            profile,
-            isProfile,
-            isPasswordRequired,
-            wasPasswordEmptyInConfigFile,
-            prompter.object,
-            connectionStore.object).then( success => {
-                assert.ok(success);
-                // Checking to see password question was prompted
-                assert.ok(passwordQuestion);
-                assert.equal(success.password, answers[LocalizedConstants.passwordPrompt]);
-                connectionStore.verify(x => x.removeProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
-                connectionStore.verify(x => x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
-                done();
-            }).catch(err => done(new Error(err)));
+        let emptyPassword = true;
+        connectProfile(profile, emptyPassword).then( success => {
+            assert.ok(success);
+            connectionStore.verify(x => x.removeProfile(TypeMoq.It.isAny()), TypeMoq.Times.never());
+            connectionStore.verify(x => x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.never());
+            done();
+        }).catch(err => done(new Error(err)));
     });
+
+    // Connect with savePassword true and blank password and
+    // confirm password is prompted for and saved for non-empty password
+    test('ensureRequiredPropertiesSet should request password and save it for non-empty passwords', ensureRequestAndSavePassword(false));
+
+    // Connect with savePassword true and blank password and
+    // confirm password is prompted for and saved correctly for an empty password
+    test('ensureRequiredPropertiesSet should request password and save it correctly for empty passswords', ensureRequestAndSavePassword(true));
+
 });
+


### PR DESCRIPTION
Allowing empty passwords for SqlLogin. Adding in new emptyPasswordInput property for profiles. This is paired with a PR to sqltoolsservice to allow empty passwords