### PR TITLE
Support connecting with connection strings

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -90,10 +90,10 @@
             <source xml:lang="en">{{put-server-name-here}}</source>
         </trans-unit>
         <trans-unit id="serverPrompt">
-            <source xml:lang="en">Server name</source>
+            <source xml:lang="en">Server name or ADO.NET connection string</source>
         </trans-unit>
         <trans-unit id="serverPlaceholder">
-            <source xml:lang="en">hostname\\instance or &lt;server&gt;.database.windows.net</source>
+            <source xml:lang="en">hostname\\instance or &lt;server&gt;.database.windows.net or ADO.NET connection string</source>
         </trans-unit>
         <trans-unit id="databasePrompt">
             <source xml:lang="en">Database name</source>

--- a/package.json
+++ b/package.json
@@ -391,6 +391,11 @@
                 ],
                 "description": "[Optional] Indicates which server type the provider will expose through the DataReader."
               },
+              "connectionString": {
+                "type": "string",
+                "default": "",
+                "description": "[Optional] The ADO.NET connection string to use for the connection. Overrides any other options given in this connection."
+              },
               "profileName": {
                 "type": "string",
                 "description": "[Optional] Specify a custom name for this connection profile to easily browse and search in the command palette of Visual Studio Code."

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.0.0-alpha.2",
+        "version": "1.0.0-alpha.7",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.0.0-alpha.2",
+        "version": "1.0.0-alpha.7",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp1.0.zip",
             "Windows_7_64": "win-x64-netcoreapp1.0.zip",

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -69,8 +69,8 @@ export class ConnectionConfig implements IConnectionConfig {
         let profiles: IConnectionProfile[] = [];
         let compareProfileFunc = (a, b) => {
             // Sort by profile name if available, otherwise fall back to server name or connection string
-            let nameA = a.profileName ? a.profileName : a.server ? a.server : a.connectionString;
-            let nameB = b.profileName ? b.profileName : b.server ? b.server : b.connectionString;
+            let nameA = a.profileName ? a.profileName : (a.server ? a.server : a.connectionString);
+            let nameB = b.profileName ? b.profileName : (b.server ? b.server : b.connectionString);
             return nameA.localeCompare(nameB);
         };
 

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -68,30 +68,15 @@ export class ConnectionConfig implements IConnectionConfig {
     public getConnections(getWorkspaceConnections: boolean): IConnectionProfile[] {
         let profiles: IConnectionProfile[] = [];
         let compareProfileFunc = (a, b) => {
-            // Sort by profile name if available, otherwise fall back to server name
-            let nameA = a.profileName ? a.profileName : a.server;
-            let nameB = b.profileName ? b.profileName : b.server;
+            // Sort by profile name if available, otherwise fall back to server name or connection string
+            let nameA = a.profileName ? a.profileName : a.server ? a.server : a.connectionString;
+            let nameB = b.profileName ? b.profileName : b.server ? b.server : b.connectionString;
             return nameA.localeCompare(nameB);
         };
 
         // Read from user settings
         let parsedSettingsFile = this.readAndParseSettingsFile(ConnectionConfig.configFilePath);
         let userProfiles = this.getProfilesFromParsedSettingsFile(parsedSettingsFile);
-
-        // Initialize any profiles with connection strings
-        userProfiles = userProfiles.map(profile => {
-            if (profile.connectionString) {
-                return
-            } else {
-                return profile;
-            }
-        })
-
-        userProfiles.forEach(profile => {
-            if (profile.connectionString) {
-                profile =
-            }
-        })
 
         userProfiles.sort(compareProfileFunc);
         profiles = profiles.concat(userProfiles);
@@ -106,7 +91,7 @@ export class ConnectionConfig implements IConnectionConfig {
 
         if (profiles.length > 0) {
             profiles = profiles.filter(conn => {
-                // filter any connection missing a server name or the sample that's shown by default
+                // filter any connection missing a connection string and server name or the sample that's shown by default
                 return conn.connectionString || !!(conn.server) && conn.server !== LocalizedConstants.SampleServerName;
             });
         }

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -66,7 +66,7 @@ export class ConnectionConfig implements IConnectionConfig {
      * and next alphabetically by profile/server name.
      */
     public getConnections(getWorkspaceConnections: boolean): IConnectionProfile[] {
-        let profiles = [];
+        let profiles: IConnectionProfile[] = [];
         let compareProfileFunc = (a, b) => {
             // Sort by profile name if available, otherwise fall back to server name
             let nameA = a.profileName ? a.profileName : a.server;
@@ -77,6 +77,22 @@ export class ConnectionConfig implements IConnectionConfig {
         // Read from user settings
         let parsedSettingsFile = this.readAndParseSettingsFile(ConnectionConfig.configFilePath);
         let userProfiles = this.getProfilesFromParsedSettingsFile(parsedSettingsFile);
+
+        // Initialize any profiles with connection strings
+        userProfiles = userProfiles.map(profile => {
+            if (profile.connectionString) {
+                return
+            } else {
+                return profile;
+            }
+        })
+
+        userProfiles.forEach(profile => {
+            if (profile.connectionString) {
+                profile =
+            }
+        })
+
         userProfiles.sort(compareProfileFunc);
         profiles = profiles.concat(userProfiles);
 
@@ -91,7 +107,7 @@ export class ConnectionConfig implements IConnectionConfig {
         if (profiles.length > 0) {
             profiles = profiles.filter(conn => {
                 // filter any connection missing a server name or the sample that's shown by default
-                return !!(conn.server) && conn.server !== LocalizedConstants.SampleServerName;
+                return conn.connectionString || !!(conn.server) && conn.server !== LocalizedConstants.SampleServerName;
             });
         }
 

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -519,6 +519,11 @@ export default class ConnectionManager {
                 }
             });
 
+            // Process a connection string if present
+            if (connectionCreds.connectionString) {
+                connectionCreds = ConnectionCredentials.createConnectionCredentialsFromString(connectionCreds.connectionString);
+            }
+
             // package connection details for request message
             const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionCreds);
             let connectParams = new ConnectionContracts.ConnectParams();

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -519,11 +519,6 @@ export default class ConnectionManager {
                 }
             });
 
-            // Process a connection string if present
-            if (connectionCreds.connectionString) {
-                connectionCreds = ConnectionCredentials.createConnectionCredentialsFromString(connectionCreds.connectionString);
-            }
-
             // package connection details for request message
             const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionCreds);
             let connectParams = new ConnectionContracts.ConnectParams();

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -159,9 +159,7 @@ export class ConnectionCredentials implements IConnectionCredentials {
 
         let authenticationChoices: INameValueChoice[] = ConnectionCredentials.getAuthenticationTypesChoice();
 
-        let connectionStringSet: () => boolean = () => {
-            return Boolean(credentials.connectionString);
-        };
+        let connectionStringSet: () => boolean = () => Boolean(credentials.connectionString);
 
         let questions: IQuestion[] = [
             // Server or connection string must be present

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -37,11 +37,17 @@ export class ConnectionCredentials implements IConnectionCredentials {
     public multipleActiveResultSets: boolean;
     public packetSize: number;
     public typeSystemVersion: string;
+    public connectionString: string;
 
     /**
      * Create a connection details contract from connection credentials.
      */
     public static createConnectionDetails(credentials: IConnectionCredentials): ConnectionDetails {
+        // If there is a connection string, use it to create the connection details
+        // // if (credentials.connectionString) {
+        // //     return ConnectionCredentials.createConnectionDetailsFromConnectionString(credentials.connectionString);
+        // // }
+
         let details: ConnectionDetails = new ConnectionDetails();
         details.options['server'] = credentials.server;
         if (credentials.port && details.options['server'].indexOf(',') === -1) {
@@ -247,5 +253,81 @@ export class ConnectionCredentials implements IConnectionCredentials {
 
         return choices;
     }
+
+    public static createConnectionCredentialsFromString(connectionString: string): ConnectionCredentials {
+        let credentials = new ConnectionCredentials();
+        let connectionStringParts = connectionString.split(';');
+        connectionStringParts.forEach(parameter => {
+            let splitIndex = parameter.indexOf('=');
+            let key = parameter.slice(0, splitIndex).toLowerCase();
+            let value = parameter.slice(splitIndex + 1);
+            let credentialsPropertyName = ConnectionCredentials.credentialsPropertyNameMap[key];
+
+            // If the key doesn't correspond to a property, ignore it
+            if (credentialsPropertyName) {
+                credentials[credentialsPropertyName] = value;
+            }
+        });
+
+        return credentials;
+    }
+
+    private static credentialsPropertyNameMap = {
+        'addr': 'server',
+        'address': 'server',
+        'app': 'applicationName',
+        'application name': 'applicationName',
+        'application intent': 'applicationIntent',
+        'attachdbfilename': 'attachDbFilename',
+        'extended properties': 'attachDbFilename',
+        'initial file name': 'attachDbFilename',
+        'authentication': 'authenticationType',
+        'connect timeout': 'connectTimeout',
+        'connection timeout': 'connectTimeout',
+        'timeout': 'connectTimeout',
+        'connection lifetime': 'loadBalanceTimeout',
+        'load balance timeout': 'loadBalanceTimeout',
+        'connectretrycount': 'connectRetryCount',
+        'connectretryinterval': 'connectRetryInterval',
+        'current language': 'currentLanguage',
+        'language': 'currentLanguage',
+        'data source': 'server',
+        'server': 'server',
+        'network address': 'server',
+        'encrypt': 'encrypt',
+        'failover partner': 'failoverPartner',
+        'initial catalog': 'database',
+        'database': 'database',
+        'max pool size': 'maxPoolSize',
+        'min pool size': 'minPoolSize',
+        'mutipleactiveresultsets': 'mutipleActiveResultSets',
+        'multisubnetfailover': 'multiSubnetFailover',
+        'packet size': 'packetSize',
+        'password': 'password',
+        'pwd': 'password',
+        'persist security info': 'persistSecurityInfo',
+        'persistsecurityinfo': 'persistSecurityInfo',
+        'pooling': 'pooling',
+        'replication': 'replication',
+        'trustservercertificate': 'trustServerCertificate',
+        'type system version': 'typeSystemVersion',
+        'user id': 'user',
+        'uid': 'user',
+        'workstation id': 'workstationId',
+        'wsid': 'workstationId'
+    };
+
+    // // private static createConnectionDetailsFromConnectionString(connectionString: string): ConnectionDetails {
+    // //     let connectionDetails: ConnectionDetails = new ConnectionDetails();
+    // //     let connectionStringParts = connectionString.split(';');
+    // //     connectionStringParts.forEach(parameter => {
+    // //         let splitIndex = parameter.indexOf('=');
+    // //         let key = parameter.slice(0, splitIndex);
+    // //         let value = parameter.slice(splitIndex + 1);
+    // //         connectionDetails.options[key] = value;
+    // //     });
+
+    // //     return connectionDetails;
+    // // }
 }
 

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -116,7 +116,7 @@ export function getConnectionDisplayString(creds: Interfaces.IConnectionCredenti
     // Update the connection text
     let text: string;
     if (creds.connectionString) {
-        // If a connection string is present, try to display the profile name instead
+        // If a connection string is present, try to display the profile name
         if ((<IConnectionProfile>creds).profileName) {
             text = (<IConnectionProfile>creds).profileName;
             text = appendIfNotEmpty(text, creds.connectionString);

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -113,14 +113,19 @@ export function getPicklistDetails(connCreds: Interfaces.IConnectionCredentials)
  */
 export function getConnectionDisplayString(creds: Interfaces.IConnectionCredentials): string {
     // Update the connection text
-    let text: string = creds.server;
-    if (creds.database !== '') {
-        text = appendIfNotEmpty(text, creds.database);
+    let text: string;
+    if (creds.connectionString) {
+        text = creds.connectionString;
     } else {
-        text = appendIfNotEmpty(text, LocalizedConstants.defaultDatabaseLabel);
+        text = creds.server;
+        if (creds.database !== '') {
+            text = appendIfNotEmpty(text, creds.database);
+        } else {
+            text = appendIfNotEmpty(text, LocalizedConstants.defaultDatabaseLabel);
+        }
+        let user: string = getUserNameOrDomainLogin(creds);
+        text = appendIfNotEmpty(text, user);
     }
-    let user: string = getUserNameOrDomainLogin(creds);
-    text = appendIfNotEmpty(text, user);
 
     // Limit the maximum length of displayed text
     if (text.length > Constants.maxDisplayedStatusTextLength) {

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -2,6 +2,7 @@
 import Constants = require('../constants/constants');
 import LocalizedConstants = require('../constants/localizedConstants');
 import Interfaces = require('./interfaces');
+import { IConnectionProfile } from '../models/interfaces';
 import * as ConnectionContracts from '../models/contracts/connection';
 import * as Utils from './utils';
 
@@ -75,7 +76,7 @@ export function getPicklistLabel(connCreds: Interfaces.IConnectionCredentials, i
     if (profile.profileName) {
         return profile.profileName;
     } else {
-        return connCreds.server;
+        return connCreds.server ? connCreds.server : connCreds.connectionString;
     }
 }
 
@@ -115,7 +116,13 @@ export function getConnectionDisplayString(creds: Interfaces.IConnectionCredenti
     // Update the connection text
     let text: string;
     if (creds.connectionString) {
-        text = creds.connectionString;
+        // If a connection string is present, try to display the profile name instead
+        if ((<IConnectionProfile>creds).profileName) {
+            text = (<IConnectionProfile>creds).profileName;
+            text = appendIfNotEmpty(text, creds.connectionString);
+        } else {
+            text = creds.connectionString;
+        }
     } else {
         text = creds.server;
         if (creds.database !== '') {
@@ -172,10 +179,11 @@ export function getUserNameOrDomainLogin(creds: Interfaces.IConnectionCredential
  */
 export function getTooltip(connCreds: Interfaces.IConnectionCredentials, serverInfo?: ConnectionContracts.ServerInfo): string {
     let tooltip: string =
-           'Server name: ' + connCreds.server + '\r\n' +
+           connCreds.connectionString ? 'Connection string: ' + connCreds.connectionString :
+           ('Server name: ' + connCreds.server + '\r\n' +
            'Database name: ' + (connCreds.database ? connCreds.database : '<connection default>') + '\r\n' +
            'Login name: ' + connCreds.user + '\r\n' +
-           'Connection encryption: ' + (connCreds.encrypt ? 'Encrypted' : 'Not encrypted') + '\r\n';
+           'Connection encryption: ' + (connCreds.encrypt ? 'Encrypted' : 'Not encrypted') + '\r\n');
     if (serverInfo && serverInfo.serverVersion) {
         tooltip += 'Server version: ' + serverInfo.serverVersion + '\r\n';
     }

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -179,7 +179,7 @@ export function getUserNameOrDomainLogin(creds: Interfaces.IConnectionCredential
  */
 export function getTooltip(connCreds: Interfaces.IConnectionCredentials, serverInfo?: ConnectionContracts.ServerInfo): string {
     let tooltip: string =
-           connCreds.connectionString ? 'Connection string: ' + connCreds.connectionString :
+           connCreds.connectionString ? 'Connection string: ' + connCreds.connectionString + '\r\n' :
            ('Server name: ' + connCreds.server + '\r\n' +
            'Database name: ' + (connCreds.database ? connCreds.database : '<connection default>') + '\r\n' +
            'Login name: ' + connCreds.user + '\r\n' +

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -36,7 +36,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
                 type: QuestionTypes.confirm,
                 name: LocalizedConstants.msgSavePassword,
                 message: LocalizedConstants.msgSavePassword,
-                shouldPrompt: (answers) => ConnectionCredentials.isPasswordBasedCredential(profile),
+                shouldPrompt: (answers) => !profile.connectionString && ConnectionCredentials.isPasswordBasedCredential(profile),
                 onAnswered: (value) => profile.savePassword = value
             },
             {
@@ -60,8 +60,12 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
         });
     }
 
-    // Assumption: having server + profile name indicates all requirements were met
+    // Assumption: having connection string or server + profile name indicates all requirements were met
     private isValidProfile(): boolean {
+        if (this.connectionString) {
+            return true;
+        }
+
         if (this.authenticationType) {
             if (this.authenticationType === AuthenticationTypes[AuthenticationTypes.Integrated]) {
                 return utils.isNotEmpty(this.server);

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -187,6 +187,11 @@ export interface IConnectionCredentials {
      * Gets or sets a string value that indicates the type system the application expects.
      */
     typeSystemVersion: string;
+
+    /**
+     * Gets or sets the connection string to use for this connection
+     */
+    connectionString: string;
 }
 
 // A Connection Profile contains all the properties of connection credentials, with additional

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -245,7 +245,7 @@ export function isSameProfile(currentProfile: interfaces.IConnectionProfile, exp
  * @returns boolean that is true if the connections match
  */
 export function isSameConnection(conn: interfaces.IConnectionCredentials, expectedConn: interfaces.IConnectionCredentials): boolean {
-    return conn.connectionString || expectedConn.connectionString ? conn.connectionString === expectedConn.connectionString :
+    return (conn.connectionString || expectedConn.connectionString) ? conn.connectionString === expectedConn.connectionString :
         expectedConn.server === conn.server
         && isSameDatabase(expectedConn.database, conn.database)
         && isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType)

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -225,6 +225,9 @@ export function isSameProfile(currentProfile: interfaces.IConnectionProfile, exp
     } else if (currentProfile.profileName) {
         // This has a profile name but expected does not - can break early
         return false;
+    } else if (currentProfile.connectionString || expectedProfile.connectionString) {
+        // If either profile uses connection strings, compare them directly
+        return currentProfile.connectionString === expectedProfile.connectionString;
     }
     return expectedProfile.server === currentProfile.server
         && isSameDatabase(expectedProfile.database, currentProfile.database)

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -237,7 +237,7 @@ export function isSameProfile(currentProfile: interfaces.IConnectionProfile, exp
 
 /**
  * Compares 2 connections to see if they match. Logic for matching:
- * match on all key properties (server, db, auth type, user) being identical.
+ * match on all key properties (connectionString or server, db, auth type, user) being identical.
  * Other properties are ignored for this purpose
  *
  * @param {IConnectionCredentials} conn the connection to check
@@ -245,7 +245,8 @@ export function isSameProfile(currentProfile: interfaces.IConnectionProfile, exp
  * @returns boolean that is true if the connections match
  */
 export function isSameConnection(conn: interfaces.IConnectionCredentials, expectedConn: interfaces.IConnectionCredentials): boolean {
-    return expectedConn.server === conn.server
+    return conn.connectionString || expectedConn.connectionString ? conn.connectionString === expectedConn.connectionString :
+        expectedConn.server === conn.server
         && isSameDatabase(expectedConn.database, conn.database)
         && isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType)
         && expectedConn.user === conn.user;

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -383,6 +383,13 @@ export class ConnectionUI {
     }
 
     private fillOrPromptForMissingInfo(selection: IConnectionCredentialsQuickPickItem): Promise<IConnectionCredentials> {
+        // If a connection string is present, don't prompt for any other info
+        if (selection.connectionCreds.connectionString) {
+            return new Promise<IConnectionCredentials> ((resolve, reject) => {
+                resolve(selection.connectionCreds);
+            });
+        }
+
         const passwordEmptyInConfigFile: boolean = Utils.isEmpty(selection.connectionCreds.password);
         return this._connectionStore.addSavedPassword(selection)
         .then(sel => {

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -305,6 +305,11 @@ suite('Connection Profile tests', () => {
         let prompter: TypeMoq.Mock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
         prompter.setup(x => x.prompt(TypeMoq.It.isAny())).returns(questions => {
             questions.filter(question => question.name === LocalizedConstants.serverPrompt)[0].onAnswered(answers[LocalizedConstants.serverPrompt]);
+            questions.filter(question => question.name !== LocalizedConstants.serverPrompt && question.name !== LocalizedConstants.profileNamePrompt)
+                .forEach(question => {
+                    // Verify that none of the other questions prompt once a connection string is given
+                    assert.equal(question.shouldPrompt(answers), false);
+                });
             return Promise.resolve(answers);
         });
 

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -42,7 +42,8 @@ function createTestCredentials(): IConnectionCredentials {
         multiSubnetFailover:            false,
         multipleActiveResultSets:       false,
         packetSize:                     8192,
-        typeSystemVersion:              'Latest'
+        typeSystemVersion:              'Latest',
+        connectionString:               ''
     };
     return creds;
 }

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -296,5 +296,23 @@ suite('Connection Profile tests', () => {
             done(err);
         });
     });
+
+    test('Profile can be created from a connection string', done => {
+        let answers = {};
+        answers[LocalizedConstants.serverPrompt] = 'Server=my-server';
+
+        // Set up the prompter to answer the server prompt with the connection string
+        let prompter: TypeMoq.Mock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny())).returns(questions => {
+            questions.filter(question => question.name === LocalizedConstants.serverPrompt)[0].onAnswered(answers[LocalizedConstants.serverPrompt]);
+            return Promise.resolve(answers);
+        });
+
+        // Verify that a profile was created
+        ConnectionProfile.createProfile(prompter.object).then( profile => {
+            assert.equal(Boolean(profile), true);
+            done();
+        });
+    });
 });
 

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -55,7 +55,8 @@ function createTestCredentials(): IConnectionCredentials {
         multiSubnetFailover:            false,
         multipleActiveResultSets:       false,
         packetSize:                     8192,
-        typeSystemVersion:              'Latest'
+        typeSystemVersion:              'Latest',
+        connectionString:               ''
     };
     return creds;
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import * as Utils from './../src/models/utils';
+import Constants = require('../src/constants/constants');
+import { ConnectionCredentials } from '../src/models/connectionCredentials';
 
 suite('Utility Tests - parseTimeString', () => {
     test('should return false if nothing passed', () => {
@@ -30,5 +32,53 @@ suite('Utility Tests - parseNumAsTimeString', () => {
         expect(Utils.parseNumAsTimeString(220)).to.equal('00:00:00.220');
         expect(Utils.parseNumAsTimeString(0)).to.equal('00:00:00');
         expect(Utils.parseNumAsTimeString(5002)).to.equal('00:00:05.002');
+    });
+});
+
+suite('Utility Tests - isSameConnection', () => {
+    let server = 'my-server';
+    let database = 'my-db';
+    let authType = Constants.sqlAuthentication;
+    let user = 'my-user';
+    let connection1 = Object.assign(new ConnectionCredentials(), {
+        server: server,
+        database: database,
+        authenticationType: authType,
+        user: user
+    });
+    let connection2 = Object.assign(new ConnectionCredentials(), {
+        server: server,
+        database: database,
+        authenticationType: authType,
+        user: user
+    });
+    let connectionString = 'Server=my-server;Database=my-db;Authentication=Sql Password;User ID=my-user';
+    let connection3 = Object.assign(new ConnectionCredentials(), {
+        connectionString: connectionString
+    });
+    let connection4 = Object.assign(new ConnectionCredentials(), {
+        connectionString: connectionString
+    });
+
+    test('should return true for matching non-connectionstring connections', () => {
+        expect(Utils.isSameConnection(connection1, connection2)).to.equal(true);
+    });
+
+    test('should return true for non-matching non-connectionstring connections', () => {
+        connection2.server = 'some-other-server';
+        expect(Utils.isSameConnection(connection1, connection2)).to.equal(false);
+    });
+
+    test('should return true for matching connectionstring connections', () => {
+        expect(Utils.isSameConnection(connection3, connection4)).to.equal(true);
+    });
+
+    test('should return false for non-matching connectionstring connections', () => {
+        connection4.connectionString = 'Server=some-other-server';
+        expect(Utils.isSameConnection(connection3, connection4)).to.equal(false);
+    });
+
+    test('should return false for connectionstring and non-connectionstring connections', () => {
+        expect(Utils.isSameConnection(connection1, connection3)).to.equal(false);
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -64,7 +64,7 @@ suite('Utility Tests - isSameConnection', () => {
         expect(Utils.isSameConnection(connection1, connection2)).to.equal(true);
     });
 
-    test('should return true for non-matching non-connectionstring connections', () => {
+    test('should return false for non-matching non-connectionstring connections', () => {
         connection2.server = 'some-other-server';
         expect(Utils.isSameConnection(connection1, connection2)).to.equal(false);
     });


### PR DESCRIPTION
Adds connection string support, including
- Allows connection credentials to have connection strings
- Ignores other parameters when a connection string is given in credentials
- Allows user to create profiles with connection strings by giving one in place of the server prompt
- Tests connection string behavior