### PR TITLE
Removing falsey check when removing newlines from cell values

### DIFF
--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -331,10 +331,6 @@ export default class QueryRunner {
         // Windows(CRLF): \r\n
         // Linux(LF)/Modern MacOS: \n
         // Old MacOs: \r
-        if (!inputString) {
-            return 'null';
-        }
-
         let outputString: string = inputString.replace(/(\r\n|\n|\r)/gm, '');
         return outputString;
     }


### PR DESCRIPTION
This solves #864 by removing a check that would override falsey display values (ie, empty strings) with null. Display values from the DbCellValue should always be used when displaying or copying.

Test used to verify:
```
CREATE TABLE T4(id int, va VARCHAR(10));
INSERT INTO T4 VALUES(1, NULL);
INSERT INTO T4 VALUES(2, 'NOT NULL');
INSERT INTO T4 VALUES(3, NULL);
INSERT INTO T4 VALUES(4, 'NOT NULL');
SELECT id, ISNULL([va],'') as IsNullVa, va FROM T4;
```

When copying into a text editor, and replacing the \t with |
```
1||NULL
2|NOT NULL|NOT NULL
3||NULL
4|NOT NULL|NOT NULL
```