### PR TITLE
Stop using localized constants in debug logged strings

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -2,15 +2,6 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" original="extension.i18ntest.JSON" source-language="en">
     <body>
-        <trans-unit id="configMyConnectionsNoServerName">
-            <source xml:lang="en">Missing server name in user preferences connection: </source>
-        </trans-unit>
-        <trans-unit id="msgLocalWebserviceStaticContent">
-            <source xml:lang="en">LocalWebService: added static html content path: </source>
-        </trans-unit>
-        <trans-unit id="msgLocalWebserviceStarted">
-            <source xml:lang="en">LocalWebService listening on port </source>
-        </trans-unit>
         <trans-unit id="msgStartedExecute">
             <source xml:lang="en">Started query execution for document "{0}"</source>
         </trans-unit>
@@ -55,12 +46,6 @@
         </trans-unit>
         <trans-unit id="msgPromptClearRecentConnections">
             <source xml:lang="en">Confirm to clear recent connections list</source>
-        </trans-unit>
-        <trans-unit id="extensionActivated">
-            <source xml:lang="en">activated.</source>
-        </trans-unit>
-        <trans-unit id="extensionDeactivated">
-            <source xml:lang="en">de-activated.</source>
         </trans-unit>
         <trans-unit id="msgOpenSqlFile">
             <source xml:lang="en">To use this command, Open a .sql file -or- Change editor language to "SQL" -or- Select T-SQL text in the active SQL editor.</source>

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tslint": "^3.14.0",
     "typemoq": "^0.3.2",
     "typescript": "^2.1.5",
-    "uglify-js": "mishoo/UglifyJS2#harmony",
+    "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
     "vscode": "^1.0.5",
     "vscode-nls-dev": "https://github.com/Raymondd/vscode-nls-dev/releases/download/2.0.2/build.tar.gz",
     "xmldom": "^0.1.27",

--- a/src/controllers/localWebService.ts
+++ b/src/controllers/localWebService.ts
@@ -4,7 +4,6 @@ import * as ws from 'ws';
 import url = require('url');
 import querystring = require('querystring');
 import Utils = require('../models/utils');
-import LocalizedConstants = require('../constants/localizedConstants');
 import Constants = require('../constants/constants');
 import Interfaces = require('../models/interfaces');
 import http = require('http');
@@ -40,7 +39,7 @@ export default class LocalWebService {
         this.app.use(express.static(LocalWebService.staticContentPath));
         this.app.use(bodyParser.json({limit: '50mb', type: 'application/json'}));
         this.app.set('view engine', 'ejs');
-        Utils.logDebug(LocalizedConstants.msgLocalWebserviceStaticContent + LocalWebService.staticContentPath);
+        Utils.logDebug(`LocalWebService: added static html content path: ${LocalWebService.staticContentPath}`);
         this.server.on('request', this.app);
 
         // Handle new connections to the web socket server
@@ -130,7 +129,7 @@ export default class LocalWebService {
 
     start(): void {
         const port = this.server.listen(0).address().port; // 0 = listen on a random port
-        Utils.logDebug(LocalizedConstants.msgLocalWebserviceStarted + port);
+        Utils.logDebug(`LocalWebService listening on port ${port}`);
         LocalWebService._servicePort = port.toString();
     }
 }

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -80,7 +80,7 @@ export default class MainController implements vscode.Disposable {
      * Deactivates the extension
      */
     public deactivate(): void {
-        Utils.logDebug(LocalizedConstants.extensionDeactivated);
+        Utils.logDebug('de-activated.');
         this.onDisconnect();
         this._statusview.dispose();
     }
@@ -168,7 +168,7 @@ export default class MainController implements vscode.Disposable {
 
                 self.showReleaseNotesPrompt();
 
-                Utils.logDebug(LocalizedConstants.extensionActivated);
+                Utils.logDebug('activated.');
                 self._initialized = true;
                 resolve(true);
             }).catch(err => {

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -421,7 +421,7 @@ export class ConnectionStore {
                     let connection = ConnInfo.fixupConnectionCredentials(element);
                     connections.push(connection);
                 } else {
-                    Utils.logDebug(LocalizedConstants.configMyConnectionsNoServerName + ' index (' + index + '): ' + element.toString());
+                    Utils.logDebug(`Missing server name in user preferences connection: index ( ${index} ): ${element.toString()}`);
                 }
             }
         }


### PR DESCRIPTION
- Fixes #867
- There is no benefit in using localized constants when logging to the debug console. It's not user visible, it is only useful when debugging the extension during development