### PR TITLE
Fix break in CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     fi
   - export BUILDMACHINE=true
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install xclip; fi
-  - npm install -g npm
+  - npm install -g npm@4
 install:
   - npm install -g --silent gulp-cli
   - npm install -g --silent xvfb-maybe@0.1.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
   - set BUILDMACHINE=true
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm
+  - npm install -g npm@4
   # show versions
   - npm --version
   - node --version


### PR DESCRIPTION
npm5 is breaking our CI builds, specifying 4 till we can upgrade to 5 safely.