### PR TITLE
add sqlGetSpaceUsed snippet

### DIFF
--- a/snippets/mssql.json
+++ b/snippets/mssql.json
@@ -241,7 +241,7 @@
 		],
 		"description": "List databases"
 	},
-	
+
 	"List columns": {
 		"prefix": "sqlListColumns",
 		"body": [
@@ -258,6 +258,41 @@
 			"WHERE tbl.table_type = 'base table' and tbl.table_name like '%${TableName}%'",
 			"GO"
 		],
-		"description": "Lists all the columns and their types of a table" 
+		"description": "Lists all the columns and their types of a table"
+	},
+
+	"Show space used by tables": {
+		"prefix": "sqlGetSpaceUsed",
+		"body": [
+			"-- Get the space used by table",
+			"SELECT TABL.name AS table_name,",
+			"INDX.name AS index_name,",
+			"SUM(PART.rows) AS rows_count,",
+			"SUM(ALOC.total_pages) AS total_pages,",
+			"SUM(ALOC.used_pages) AS used_pages,",
+			"SUM(ALOC.data_pages) AS data_pages,",
+			"(SUM(ALOC.total_pages)*8/1024) AS total_space_MB,",
+			"(SUM(ALOC.used_pages)*8/1024) AS used_space_MB,",
+			"(SUM(ALOC.data_pages)*8/1024) AS data_space_MB",
+			"FROM sys.Tables AS TABL",
+			"INNER JOIN sys.Indexes AS INDX",
+			"ON TABL.object_id = INDX.object_id",
+			"INNER JOIN sys.Partitions AS PART",
+			"ON INDX.object_id = PART.object_id",
+			"AND INDX.index_id = PART.index_id",
+			"INNER JOIN sys.Allocation_Units AS ALOC",
+			"ON PART.partition_id = ALOC.container_id",
+			"WHERE TABL.name LIKE '%${TableName}%'",
+			"AND INDX.object_id > 255",
+			"AND INDX.index_id <= 1",
+			"GROUP BY TABL.name, ",
+			"INDX.object_id,",
+			"INDX.index_id,",
+			"INDX.name",
+			"ORDER BY Object_Name(INDX.object_id),",
+			"(SUM(ALOC.total_pages)*8/1024) DESC",
+			"GO"
+		],
+		"description": "Get Space Used by Tables"
 	}
 }


### PR DESCRIPTION
This new snippet allows detailed view of tables, like as number of lines, pages and especially the size of each of them, including the indexes.

[getSpaceUsed.xlsx](https://github.com/Microsoft/vscode-mssql/files/1100469/getSpaceUsed.xlsx)
