### PR TITLE
Fix snippets

### DIFF
--- a/snippets/mssql.json
+++ b/snippets/mssql.json
@@ -20,17 +20,17 @@
 	"Create a new Database": {
 		"prefix": "sqlCreateDatabase",
 		"body": [
-			"-- Create a new database called '${DatabaseName}'",
+			"-- Create a new database called '${1:DatabaseName}'",
 			"-- Connect to the 'master' database to run this snippet",
 			"USE master",
 			"GO",
 			"-- Create the new database if it does not exist already",
 			"IF NOT EXISTS (",
-			"  SELECT name",
-			"   FROM sys.databases",
-			"   WHERE name = N'${DatabaseName}'",
+			"\tSELECT name",
+			"\t\tFROM sys.databases",
+			"\t\tWHERE name = N'${1:DatabaseName}'",
 			")",
-			"CREATE DATABASE ${DatabaseName}",
+			"CREATE DATABASE ${1:DatabaseName}",
 			"GO"
 		],
 		"description": "Create a new Database"
@@ -39,19 +39,19 @@
 	"Drop a Database": {
 		"prefix": "sqlDropDatabase",
 		"body": [
-			"-- Drop the database '${DatabaseName}'",
+			"-- Drop the database '${1:DatabaseName}'",
 			"-- Connect to the 'master' database to run this snippet",
 			"USE master",
 			"GO",
 			"-- Uncomment the ALTER DATABASE statement below to set the database to SINGLE_USER mode if the drop database command fails because the database is in use.",
-			"-- ALTER DATABASE ${DatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;",
+			"-- ALTER DATABASE ${1:DatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;",
 			"-- Drop the database if it exists",
 			"IF EXISTS (",
 			"  SELECT name",
 			"   FROM sys.databases",
-			"   WHERE name = N'${DatabaseName}'",
+			"   WHERE name = N'${1:DatabaseName}'",
 			")",
-			"DROP DATABASE ${DatabaseName}",
+			"DROP DATABASE ${1:DatabaseName}",
 			"GO"
 		],
 		"description": "Drop a Database"
@@ -60,18 +60,18 @@
 	"Create a new Table": {
 		"prefix": "sqlCreateTable",
 		"body": [
-			"-- Create a new table called '${TableName}' in schema '${SchemaName}'",
+			"-- Create a new table called '${1:TableName}' in schema '${2:SchemaName}'",
 			"-- Drop the table if it already exists",
-			"IF OBJECT_ID('${SchemaName}.${TableName}', 'U') IS NOT NULL",
-			"DROP TABLE ${SchemaName}.${TableName}",
+			"IF OBJECT_ID('${2:SchemaName}.${1:TableName}', 'U') IS NOT NULL",
+			"DROP TABLE ${2:SchemaName}.${1:TableName}",
 			"GO",
 			"-- Create the table in the specified schema",
-			"CREATE TABLE ${SchemaName}.${TableName}",
+			"CREATE TABLE ${2:SchemaName}.${1:TableName}",
 			"(",
-			"	${TableName}Id INT NOT NULL PRIMARY KEY, -- primary key column",
-			"	Column1 [NVARCHAR](50) NOT NULL,",
-			"	Column2 [NVARCHAR](50) NOT NULL",
-			"   -- specify more columns here",
+			"\t${1:TableName}Id INT NOT NULL PRIMARY KEY, -- primary key column",
+			"\t$3Column1 [NVARCHAR](50) NOT NULL,",
+			"\t$4Column2 [NVARCHAR](50) NOT NULL",
+			"\t-- specify more columns here",
 			");",
 			"GO"
 		],
@@ -81,16 +81,16 @@
 	"Drop a Table": {
 		"prefix": "sqlDropTable",
 		"body": [
-			"-- Drop the table '${TableName}' in schema '${SchemaName}'",
+			"-- Drop the table '${1:TableName}' in schema '${2:SchemaName}'",
 			"IF EXISTS (",
-			"  SELECT *",
-			"    FROM sys.tables",
-			"    JOIN sys.schemas",
-			"      ON sys.tables.schema_id = sys.schemas.schema_id",
-			"  WHERE sys.schemas.name = N'${SchemaName}'",
-			"     AND sys.tables.name = N'${TableName}'",
+			"\tSELECT *",
+			"\t\tFROM sys.tables",
+			"\t\tJOIN sys.schemas",
+			"\t\t\tON sys.tables.schema_id = sys.schemas.schema_id",
+			"\tWHERE sys.schemas.name = N'${2:SchemaName}'",
+			"\t\tAND sys.tables.name = N'${1:TableName}'",
 			")",
-			"  DROP TABLE ${SchemaName}.${TableName}",
+			"\tDROP TABLE ${2:SchemaName}.${1:TableName}",
 			"GO"
 		],
 		"description": "Drop a Table"
@@ -99,9 +99,9 @@
 	"Add a new column to a Table": {
 		"prefix": "sqlAddColumn",
 		"body": [
-			"-- Add a new column '$(NewColumnName)' to table '${TableName}' in schema '${SchemaName}'",
-			"ALTER TABLE ${SchemaName}.${TableName}",
-			"  ADD $(NewColumnName) /*new_column_name*/ int /*new_column_datatype*/ NULL /*new_column_nullability*/",
+			"-- Add a new column '${1:NewColumnName}' to table '${2:TableName}' in schema '${3:SchemaName}'",
+			"ALTER TABLE ${3:SchemaName}.${2:TableName}",
+			"\tADD ${1:NewColumnName} /*new_column_name*/ int /*new_column_datatype*/ NULL /*new_column_nullability*/",
 			"GO"
 		],
 		"description": "Add a new column to a Table"
@@ -110,9 +110,9 @@
 	"Drop a column from a Table": {
 		"prefix": "sqlDropColumn",
 		"body": [
-			"-- Drop '$(ColumnName)' from table '${TableName}' in schema '${SchemaName}'",
-			"ALTER TABLE ${SchemaName}.${TableName}",
-			"  DROP COLUMN $(ColumnName)",
+			"-- Drop '${1:ColumnName}' from table '${2:TableName}' in schema '${3:SchemaName}'",
+			"ALTER TABLE ${3:SchemaName}.${2:TableName}",
+			"\tDROP COLUMN ${1:ColumnName}",
 			"GO"
 		],
 		"description": "Add a new column to a Table"
@@ -121,9 +121,9 @@
 	"Select rows from a Table or a View": {
 		"prefix": "sqlSelect",
 		"body": [
-			"-- Select rows from a Table or View '${TableOrViewName}' in schema '${SchemaName}'",
-			"SELECT * FROM ${SchemaName}.${TableOrViewName}",
-			"WHERE </* add search conditions here */>",
+			"-- Select rows from a Table or View '${1:TableOrViewName}' in schema '${2:SchemaName}'",
+			"SELECT * FROM ${2:SchemaName}.${1:TableOrViewName}",
+			"WHERE $3\t/* add search conditions here */",
 			"GO"
 		],
 		"description": "Select rows from a Table or a View"
@@ -132,17 +132,17 @@
 	"Insert rows into a Table": {
 		"prefix": "sqlInsertRows",
 		"body": [
-			"-- Insert rows into table '${TableName}'",
-			"INSERT INTO ${TableName}",
+			"-- Insert rows into table '${1:TableName}'",
+			"INSERT INTO ${1:TableName}",
 			"( -- columns to insert data into",
-			" [Column1], [Column2], [Column3]",
+			" $2[Column1], [Column2], [Column3]",
 			")",
 			"VALUES",
 			"( -- first row: values for the columns in the list above",
-			" Column1_Value, Column2_Value, Column3_Value",
+			" $3Column1_Value, Column2_Value, Column3_Value",
 			"),",
 			"( -- second row: values for the columns in the list above",
-			" Column1_Value, Column2_Value, Column3_Value",
+			" $4Column1_Value, Column2_Value, Column3_Value",
 			")",
 			"-- add more rows here",
 			"GO"
@@ -153,9 +153,9 @@
 	"Delete rows from a Table": {
 		"prefix": "sqlDeleteRows",
 		"body": [
-			"-- Delete rows from table '${TableName}'",
-			"DELETE FROM ${TableName}",
-			"WHERE </* add search conditions here */>",
+			"-- Delete rows from table '${1:TableName}'",
+			"DELETE FROM ${1:TableName}",
+			"WHERE $2\t/* add search conditions here */",
 			"GO"
 		],
 		"description": "Delete rows from a Table"
@@ -164,13 +164,13 @@
 	"Update rows in a Table": {
 		"prefix": "sqlUpdateRows",
 		"body": [
-			"-- Update rows in table '${TableName}'",
-			"UPDATE ${TableName}",
+			"-- Update rows in table '${1:TableName}'",
+			"UPDATE ${1:TableName}",
 			"SET",
-			" [Colum1] = Colum1_Value,",
-			" [Colum2] = Colum2_Value",
-			"-- add more columns and values here",
-			"WHERE </* add search conditions here */>",
+			"\t$2[Colum1] = Colum1_Value,",
+			"\t$3[Colum2] = Colum2_Value",
+			"\t-- add more columns and values here",
+			"WHERE $4\t/* add search conditions here */",
 			"GO"
 		],
 		"description": "Update rows in a Table"
@@ -179,27 +179,27 @@
 	"Create a stored procedure": {
 		"prefix": "sqlCreateStoredProc",
 		"body": [
-			"-- Create a new stored procedure called '${StoredProcedureName}' in schema '$(SchemaName)'",
+			"-- Create a new stored procedure called '${1:StoredProcedureName}' in schema '${2:SchemaName}'",
 			"-- Drop the stored procedure if it already exists",
 			"IF EXISTS (",
 			"SELECT *",
-			"  FROM INFORMATION_SCHEMA.ROUTINES",
-			"WHERE SPECIFIC_SCHEMA = N'${SchemaName}'",
-			"  AND SPECIFIC_NAME = N'${StoredProcedureName}'",
+			"\tFROM INFORMATION_SCHEMA.ROUTINES",
+			"WHERE SPECIFIC_SCHEMA = N'${2:SchemaName}'",
+			"\tAND SPECIFIC_NAME = N'${1:StoredProcedureName}'",
 			")",
-			"DROP PROCEDURE ${SchemaName}.${StoredProcedureName}",
+			"DROP PROCEDURE ${2:SchemaName}.${1:StoredProcedureName}",
 			"GO",
 			"-- Create the stored procedure in the specified schema",
-			"CREATE PROCEDURE ${SchemaName}.${StoredProcedureName}",
-			"  @param1 /*parameter name*/ int /*datatype_for_param1*/ = 0 /*default_value_for_param1*/",
-			"  @param1 /*parameter name*/ int /*datatype_for_param1*/ = 0 /*default_value_for_param2*/",
+			"CREATE PROCEDURE ${2:SchemaName}.${1:StoredProcedureName}",
+			"\t$3@param1 /*parameter name*/ int /*datatype_for_param1*/ = 0, /*default_value_for_param1*/",
+			"\t$4@param2 /*parameter name*/ int /*datatype_for_param1*/ = 0 /*default_value_for_param2*/",
 			"-- add more stored procedure parameters here",
 			"AS",
-			"  -- body of the stored procedure",
-			"  SELECT @param1, @param2",
+			"\t-- body of the stored procedure",
+			"\tSELECT @param1, @param2",
 			"GO",
 			"-- example to execute the stored procedure we just created",
-			"EXECUTE ${SchemaName}.${StoredProcedureName} 1 /*value_for_param1*/, 2 /*value_for_param2*/",
+			"EXECUTE ${2:SchemaName}.${1:StoredProcedureName} 1 /*value_for_param1*/, 2 /*value_for_param2*/",
 			"GO"
 		],
 		"description": "Create a stored procedure"
@@ -208,14 +208,14 @@
 	"Drop a stored procedure": {
 		"prefix": "sqlDropStoredProc",
 		"body": [
-			"-- Drop the stored procedure called '${StoredProcedureName}' in schema '$(SchemaName)'",
+			"-- Drop the stored procedure called '${1:StoredProcedureName}' in schema '${2:SchemaName}'",
 			"IF EXISTS (",
 			"SELECT *",
-			"  FROM INFORMATION_SCHEMA.ROUTINES",
-			"WHERE SPECIFIC_SCHEMA = N'${SchemaName}'",
-			"  AND SPECIFIC_NAME = N'${StoredProcedureName}'",
+			"\tFROM INFORMATION_SCHEMA.ROUTINES",
+			"WHERE SPECIFIC_SCHEMA = N'${2:SchemaName}'",
+			"\tAND SPECIFIC_NAME = N'${1:StoredProcedureName}'",
 			")",
-			"DROP PROCEDURE ${SchemaName}.${StoredProcedureName}",
+			"DROP PROCEDURE ${2:SchemaName}.${1:StoredProcedureName}",
 			"GO"
 		],
 		"description": "Drop a stored procedure"
@@ -245,26 +245,26 @@
 	"List columns": {
 		"prefix": "sqlListColumns",
 		"body": [
-			"-- List columns and their types of all tables whose name like '${TableName}'",
+			"-- List columns in all tables whose name is like '${1:TableName}'",
 			"SELECT ",
-    			"TableName = tbl.table_schema + '.' + tbl.table_name, ",
-    			"ColumnName = col.column_name, ",
-    			"ColumnDataType = col.data_type",
+			"\tTableName = tbl.table_schema + '.' + tbl.table_name, ",
+			"\tColumnName = col.column_name, ",
+			"\tColumnDataType = col.data_type",
 			"FROM information_schema.tables tbl",
 			"INNER JOIN information_schema.columns col ",
-    			"ON col.table_name = tbl.table_name",
-			"AND col.table_schema = tbl.table_schema",
+			"\tON col.table_name = tbl.table_name",
+			"\tAND col.table_schema = tbl.table_schema",
 			"",
-			"WHERE tbl.table_type = 'base table' and tbl.table_name like '%${TableName}%'",
+			"WHERE tbl.table_type = 'base table' and tbl.table_name like '%${1:TableName}%'",
 			"GO"
 		],
-		"description": "Lists all the columns and their types of a table"
+		"description": "Lists all the columns and their types for tables matching a LIKE statement"
 	},
 
 	"Show space used by tables": {
 		"prefix": "sqlGetSpaceUsed",
 		"body": [
-			"-- Get the space used by table",
+			"-- Get the space used by table ${1:TableName}",
 			"SELECT TABL.name AS table_name,",
 			"INDX.name AS index_name,",
 			"SUM(PART.rows) AS rows_count,",
@@ -282,7 +282,7 @@
 			"AND INDX.index_id = PART.index_id",
 			"INNER JOIN sys.Allocation_Units AS ALOC",
 			"ON PART.partition_id = ALOC.container_id",
-			"WHERE TABL.name LIKE '%${TableName}%'",
+			"WHERE TABL.name LIKE '%${1:TableName}%'",
 			"AND INDX.object_id > 255",
 			"AND INDX.index_id <= 1",
 			"GROUP BY TABL.name, ",


### PR DESCRIPTION
- All snippets use official VSCode syntax with placeholders having a number
- Added tab stops so that after inserting placeholders, user can navigate to next logical location in the script
- Fixed a number of issues that meant  snippets did not compile by default including use of `(` instead of `{` and `<` brackets broke the snippet without adding value