### PR TITLE
Add ability to use Windows authentication when connecting to SQL Server from Mac/Linux 

### DIFF
--- a/KERBEROS_HELP.md
+++ b/KERBEROS_HELP.md
@@ -1,0 +1,95 @@
+In order to use Integrated Authentication (aka Windows Authentication) on macOS or Linux you will need to setup a Kerberos ticket linking your current user to a Windows domain account. A summary of key steps are included below.
+
+# Setup Kerberos on Mac
+
+## Requirements
+Access to a Windows domain-joined machine in order to query your Kerberos Domain Controller
+
+## Steps to set up Integrated Authentication
+
+### Step 1: Find Kerberos KDC (Key Distribution Center)
+- **Run on**: Windows command line
+- **Action**: `nltest /dsgetdc:DOMAIN.COMPANY.COM` (where “DOMAIN.COMPANY.COM” maps to your domain’s name)
+- **Sample Output**
+  ```
+  DC: \\co1-red-dc-33.domain.company.com
+  Address: \\2111:4444:2111:33:1111:ecff:ffff:3333
+  ...
+  The command completed successfully
+  ```
+- **Information to extract**
+  The DC name, in this case `co1-red-dc-33.domain.company.com`
+
+### Step 2: Configuring KDC in krb5.conf
+- **Run on**: MAC
+- **Action**: Edit the /etc/krb5.conf in an editor of your choice. Configure the following keys
+  ```
+  [libdefaults]
+    default_realm = DOMAIN.COMPANY.COM
+   
+  [realms]
+  DOMAIN.COMPANY.COM = {
+     kdc = co1-red-dc-28.domain.company.com
+  }
+  ```
+  Then save the krb5.conf file and exit
+
+  **Note** Domain must be in ALL CAPS
+
+### Step 3: Testing the Ticket Granting Ticket retrieval
+- **Run on**: Mac
+- **Action**:
+  - Use the command `kinit username@REDMOND.CORP.MICROSOFT.COM` to get a TGT from KDC. You will be prompted for your domain password.
+  - Use `klist` to see the available tickets. If the kinit was successful, you should see a ticket from krbtgt/DOMAIN.COMPANY.COM@ DOMAIN.COMPANY.COM.
+
+### Step 4: Connect in VSCode
+- Create a new connection profile
+- Choose `Integrated` as the authentication type
+- If all goes well and the steps above worked, you should be able to connect successfully!
+
+
+# Setup Kerberos on Linux
+
+### Step 0: Install krb5-user package
+- **Run on**: Linux
+- **Action**: `apt-get krb5-user`
+
+### Step 1: Find Kerberos KDC (Key Distribution Center)
+- **Run on**: Windows command line
+- **Action**: `nltest /dsgetdc:DOMAIN.COMPANY.COM` (where “DOMAIN.COMPANY.COM” maps to your domain’s name)
+- **Sample Output**
+  ```
+  DC: \\co1-red-dc-33.domain.company.com
+  Address: \\2111:4444:2111:33:1111:ecff:ffff:3333
+  ...
+  The command completed successfully
+  ```
+- **Information to extract**
+  The DC name, in this case `co1-red-dc-33.domain.company.com`
+
+### Step 2: Configuring KDC in krb5.conf
+- **Run on**: Linux
+- **Action**: Edit the /etc/krb5.conf in an editor of your choice. Configure the following keys
+  ```
+  [libdefaults]
+    default_realm = DOMAIN.COMPANY.COM
+   
+  [realms]
+  DOMAIN.COMPANY.COM = {
+     kdc = co1-red-dc-28.domain.company.com
+  }
+  ```
+  Then save the krb5.conf file and exit
+
+  **Note** Domain must be in ALL CAPS
+
+### Step 3: Testing the Ticket Granting Ticket retrieval
+- **Run on**: Linux
+- **Action**:
+  - Use the command `kinit username@REDMOND.CORP.MICROSOFT.COM` to get a TGT from KDC. You will be prompted for your domain password.
+  - Use `klist` to see the available tickets. If the kinit was successful, you should see a ticket from krbtgt/DOMAIN.COMPANY.COM@ DOMAIN.COMPANY.COM.
+
+### Step 4: Connect in VSCode
+- Create a new connection profile
+- Choose `Integrated` as the authentication type
+- If all goes well and the steps above worked, you should be able to connect successfully!

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -48,6 +48,7 @@ export const timeToWaitForLanguageModeChange = 10000.0;
 export const macOpenSslHelpLink = 'https://github.com/Microsoft/vscode-mssql/wiki/OpenSSL-Configuration';
 export const gettingStartedGuideLink = 'https://aka.ms/mssql-getting-started';
 export const changelogLink = 'https://aka.ms/vscode-mssql-changelog';
+export const integratedAuthHelpLink = 'https://aka.ms/vscode-mssql-integratedauth';
 export const sqlToolsServiceCrashLink = 'https://github.com/Microsoft/vscode-mssql/wiki/SqlToolsService-Known-Issues';
 
 // Configuration Constants

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -314,7 +314,16 @@ export default class ConnectionManager {
             }
         } else {
             PlatformInformation.GetCurrent().then( platformInfo => {
-                if (platformInfo.runtimeId === Runtime.OSX_10_11_64 &&
+                if (!platformInfo.isWindows() && result.errorMessage && result.errorMessage.includes('Kerberos')) {
+                    this.vscodeWrapper.showErrorMessage(
+                        Utils.formatString(LocalizedConstants.msgConnectionError2, result.errorMessage),
+                        LocalizedConstants.macOpenSslHelpButton)
+                    .then(action => {
+                        if (action && action === LocalizedConstants.macOpenSslHelpButton) {
+                            opener(Constants.integratedAuthHelpLink);
+                        }
+                     });
+                } else if (platformInfo.runtimeId === Runtime.OSX_10_11_64 &&
                 result.messages.indexOf('Unable to load DLL \'System.Security.Cryptography.Native\'') !== -1) {
                      this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.msgConnectionError2,
                      LocalizedConstants.macOpenSslErrorMessage), LocalizedConstants.macOpenSslHelpButton).then(action => {

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -278,13 +278,9 @@ export class ConnectionCredentials implements IConnectionCredentials {
 
     public static getAuthenticationTypesChoice(): INameValueChoice[] {
         let choices: INameValueChoice[] = [
-            { name: LocalizedConstants.authTypeSql, value: utils.authTypeToString(AuthenticationTypes.SqlLogin) }
-        ];
-        // In the case of win32 support integrated. For all others only SqlAuth supported
-        if ('win32' === os.platform()) {
-             choices.push({ name: LocalizedConstants.authTypeIntegrated, value: utils.authTypeToString(AuthenticationTypes.Integrated) });
-        }
-        // TODO When Azure Active Directory is supported, add this here
+            { name: LocalizedConstants.authTypeSql, value: utils.authTypeToString(AuthenticationTypes.SqlLogin) },
+            { name: LocalizedConstants.authTypeIntegrated, value: utils.authTypeToString(AuthenticationTypes.Integrated) }
+        ];        // TODO When Azure Active Directory is supported, add this here
 
         return choices;
     }

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -6,8 +6,6 @@ import { ConnectionStore } from './connectionStore';
 import * as utils from './utils';
 import { QuestionTypes, IQuestion, IPrompter, INameValueChoice } from '../prompts/question';
 
-import os = require('os');
-
 // Concrete implementation of the IConnectionCredentials interface
 export class ConnectionCredentials implements IConnectionCredentials {
     public server: string;

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -341,7 +341,7 @@ export class ConnectionUI {
     /**
      * Validate a connection profile by connecting to it, and save it if we are successful.
      */
-    private validateAndSaveProfile(profile: Interfaces.IConnectionProfile): Promise<Interfaces.IConnectionProfile> {
+    private validateAndSaveProfile(profile: Interfaces.IConnectionProfile): PromiseLike<Interfaces.IConnectionProfile> {
         const self = this;
         return self.connectionManager.connect(self.vscodeWrapper.activeTextEditorUri, profile).then(result => {
             if (result) {
@@ -456,7 +456,7 @@ export class ConnectionUI {
         return self._prompter.prompt(questions).then(answers => {
             if (answers && answers[confirm]) {
                 let profilePickItem = <IConnectionCredentialsQuickPickItem> answers[chooseProfile];
-                return profilePickItem.connectionCreds;
+                return <IConnectionProfile> profilePickItem.connectionCreds;
             } else {
                 return undefined;
             }

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -12,7 +12,6 @@ import VscodeWrapper from '../src/controllers/vscodeWrapper';
 
 import LocalizedConstants = require('../src/constants/localizedConstants');
 import assert = require('assert');
-import os = require('os');
 
 function createTestCredentials(): IConnectionCredentials {
     const creds: IConnectionCredentials = {
@@ -150,18 +149,13 @@ suite('Connection Profile tests', () => {
         // for now, just validates expected behavior on the platform tests are running on
         let authQuestion: IQuestion = profileQuestions[authTypeQuestionIndex];
         let authChoices = <INameValueChoice[]>authQuestion.choices;
-        if ('win32' === os.platform()) {
-            assert.strictEqual(authChoices.length, 2);
-            assert.strictEqual(authChoices[1].name, LocalizedConstants.authTypeIntegrated);
-            assert.strictEqual(authChoices[1].value, AuthenticationTypes[AuthenticationTypes.Integrated]);
+        assert.strictEqual(authChoices.length, 2);
+        assert.strictEqual(authChoices[1].name, LocalizedConstants.authTypeIntegrated);
+        assert.strictEqual(authChoices[1].value, AuthenticationTypes[AuthenticationTypes.Integrated]);
 
-            // And on a platform with multiple choices, should prompt for input
-            assert.strictEqual(authQuestion.shouldPrompt(answers), true);
-        } else {
-            assert.strictEqual(authChoices.length, 1);
-            // And on a platform with only 1 choice, should not prompt for input
-            assert.strictEqual(authQuestion.shouldPrompt(answers), false);
-        }
+        // And on a platform with multiple choices, should prompt for input
+        assert.strictEqual(authQuestion.shouldPrompt(answers), true);
+
         done();
     });
 


### PR DESCRIPTION
Fixes #356
- Removed block on Integrated auth on Mac & Linux
- Handle Kerberos error. Unfortunately we have to base it on having "Kerberos" in the error message since .Net Core is not sending a sensible error code yet
- Added a help doc on how to connect, and for the Kerberos error show a "Help" link just as we do for SSL
- Updated unit tests