### PR TITLE
Add disconnect option when changing databases

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -275,6 +275,15 @@
         <trans-unit id="testLocalizationConstant">
             <source xml:lang="en">test</source>
         </trans-unit>
+        <trans-unit id="disconnectOptionLabel">
+            <source xml:lang="en">Disconnect</source>
+        </trans-unit>
+        <trans-unit id="disconnectOptionDescription">
+            <source xml:lang="en">Close the current connection</source>
+        </trans-unit>
+        <trans-unit id="disconnectConfirmationMsg">
+            <source xml:lang="en">Are you sure you want to disconnect?</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -407,6 +407,8 @@ export default class ConnectionManager {
                         }).catch(err => {
                             reject(err);
                         });
+                    } else {
+                        resolve(false);
                     }
                 }).catch(err => {
                     reject(err);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -210,8 +210,7 @@ export class ConnectionUI {
             self.vscodeWrapper.showQuickPick<vscode.QuickPickItem>(pickListItems, pickListOptions).then( selection => {
                 if (selection === disconnectItem) {
                     self.handleDisconnectChoice().then(() => resolve(undefined), err => reject(err));
-                }
-                if (typeof selection !== 'undefined') {
+                } else if (typeof selection !== 'undefined') {
                     resolve((selection as Interfaces.IConnectionCredentialsQuickPickItem).connectionCreds);
                 } else {
                     resolve(undefined);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -178,7 +178,7 @@ export class ConnectionUI {
                                         databaseNames: Array<string>): Promise<Interfaces.IConnectionCredentials> {
         const self = this;
         return new Promise<Interfaces.IConnectionCredentials>((resolve, reject) => {
-            const pickListItems = databaseNames.map(name => {
+            const pickListItems: vscode.QuickPickItem[] = databaseNames.map(name => {
                 let newCredentials: Interfaces.IConnectionCredentials = <any>{};
                 Object.assign<Interfaces.IConnectionCredentials, Interfaces.IConnectionCredentials>(newCredentials, currentCredentials);
                 if (newCredentials['profileName']) {
@@ -195,18 +195,46 @@ export class ConnectionUI {
                 };
             });
 
+            // Add an option to disconnect from the current server
+            const disconnectItem: vscode.QuickPickItem = {
+                label: LocalizedConstants.disconnectOptionLabel,
+                description: LocalizedConstants.disconnectOptionDescription
+            };
+            pickListItems.push(disconnectItem);
+
             const pickListOptions: vscode.QuickPickOptions = {
                 placeHolder: LocalizedConstants.msgChooseDatabasePlaceholder
             };
 
             // show database picklist, and modify the current connection to switch the active database
-            self.vscodeWrapper.showQuickPick<Interfaces.IConnectionCredentialsQuickPickItem>(pickListItems, pickListOptions).then( selection => {
+            self.vscodeWrapper.showQuickPick<vscode.QuickPickItem>(pickListItems, pickListOptions).then( selection => {
+                if (selection === disconnectItem) {
+                    self.handleDisconnectChoice().then(() => resolve(undefined), err => reject(err));
+                }
                 if (typeof selection !== 'undefined') {
-                    resolve(selection.connectionCreds);
+                    resolve((selection as Interfaces.IConnectionCredentialsQuickPickItem).connectionCreds);
                 } else {
                     resolve(undefined);
                 }
             });
+        });
+    }
+
+    private handleDisconnectChoice(): Promise<void> {
+        const self = this;
+        return new Promise<void>((resolve, reject) => {
+            let question: IQuestion = {
+                type: QuestionTypes.confirm,
+                name: LocalizedConstants.disconnectConfirmationMsg,
+                message: LocalizedConstants.disconnectConfirmationMsg
+            };
+            self._prompter.promptSingle(question).then(result => {
+                if (result === true) {
+                    self.connectionManager.onDisconnect().then(() => resolve(), err => reject(err));
+                } else {
+                    resolve();
+                }
+            }, err => reject(err));
         });
     }
 

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -208,7 +208,7 @@ export class ConnectionUI {
 
             // show database picklist, and modify the current connection to switch the active database
             self.vscodeWrapper.showQuickPick<vscode.QuickPickItem>(pickListItems, pickListOptions).then( selection => {
-                if (selection.label === disconnectItem.label && selection.description === disconnectItem.description) {
+                if (selection === disconnectItem) {
                     self.handleDisconnectChoice().then(() => resolve(undefined), err => reject(err));
                 } else if (typeof selection !== 'undefined') {
                     resolve((selection as Interfaces.IConnectionCredentialsQuickPickItem).connectionCreds);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -208,7 +208,7 @@ export class ConnectionUI {
 
             // show database picklist, and modify the current connection to switch the active database
             self.vscodeWrapper.showQuickPick<vscode.QuickPickItem>(pickListItems, pickListOptions).then( selection => {
-                if (selection === disconnectItem) {
+                if (selection.label === disconnectItem.label && selection.description === disconnectItem.description) {
                     self.handleDisconnectChoice().then(() => resolve(undefined), err => reject(err));
                 } else if (typeof selection !== 'undefined') {
                     resolve((selection as Interfaces.IConnectionCredentialsQuickPickItem).connectionCreds);
@@ -227,7 +227,7 @@ export class ConnectionUI {
                 name: LocalizedConstants.disconnectConfirmationMsg,
                 message: LocalizedConstants.disconnectConfirmationMsg
             };
-            self._prompter.promptSingle(question).then(result => {
+            self._prompter.promptSingle<boolean>(question).then(result => {
                 if (result === true) {
                     self.connectionManager.onDisconnect().then(() => resolve(), err => reject(err));
                 } else {

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -346,8 +346,6 @@ suite('Per File Connection Tests', () => {
 
         let vscodeWrapperMock: TypeMoq.IMock<VscodeWrapper> = TypeMoq.Mock.ofType(VscodeWrapper);
         vscodeWrapperMock.callBase = true;
-        vscodeWrapperMock.setup(x => x.showQuickPick(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(options =>
-            Promise.resolve(options[options.findIndex(option => option.label === LocalizedConstants.disconnectOptionLabel)]));
         vscodeWrapperMock.setup(x => x.activeTextEditorUri).returns(() => testFile);
 
         manager.client = serviceClientMock.object;

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -354,7 +354,10 @@ suite('Per File Connection Tests', () => {
         manager.vscodeWrapper = vscodeWrapperMock.object;
         manager.connectionUI.vscodeWrapper = vscodeWrapperMock.object;
 
-        // Override the promptSingle method to automatically return true
+        // Override the database list prompt to select the disconnect option and the promptSingle method to automatically return true
+        manager.connectionUI.vscodeWrapper.showQuickPick = function(options: any[]): any {
+            return Promise.resolve(options.find(option => option.label === LocalizedConstants.disconnectOptionLabel));
+        };
         (manager.connectionUI as any)._prompter.promptSingle = function(_: any): Promise<boolean> { return Promise.resolve(true); };
 
         // Open a connection using the connection manager
@@ -374,7 +377,6 @@ suite('Per File Connection Tests', () => {
                 // Check that databases on the server were listed
                 serviceClientMock.verify(
                     x => x.sendRequest(TypeMoq.It.isValue(ConnectionContracts.ListDatabasesRequest.type), TypeMoq.It.isAny()), TypeMoq.Times.once());
-                vscodeWrapperMock.verify(x => x.showQuickPick(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 
                 // Check that the database was disconnected
                 assert.equal(manager.isConnected(testFile), false);


### PR DESCRIPTION
Closes #904 

This change adds an option to disconnect when clicking on the connection status in the bottom-right, as an alternative to changing the connected database. If you choose to disconnect, it will prompt for a confirmation before disconnecting.