### PR TITLE
Fix #807 Can't create SQL Profile

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "mssql",
-  "version": "0.3.0",
+  "version": "1.1.0",
   "dependencies": {
     "accepts": {
       "version": "1.3.3",
@@ -583,6 +583,11 @@
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "jsonc-parser": {
+      "version": "1.0.0",
+      "from": "jsonc-parser@latest",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-1.0.0.tgz"
     },
     "jsonfile": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "getmac": "1.2.1",
     "http-proxy-agent": "^1.0.0",
     "https-proxy-agent": "^1.0.0",
+    "jsonc-parser": "^1.0.0",
     "opener": "1.4.2",
     "pretty-data": "^0.40.0",
     "request": "^2.73.0",

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -6,6 +6,8 @@
 
 import fs = require('fs');
 import os = require('os');
+import { parse } from 'jsonc-parser';
+
 import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/localizedConstants';
 import * as Utils from '../models/utils';
@@ -209,7 +211,7 @@ export class ConnectionConfig implements IConnectionConfig {
                 let fileContents: string = fileBuffer.toString();
                 if (!Utils.isEmpty(fileContents)) {
                     try {
-                        let fileObject: any = commentJson.parse(fileContents);
+                        let fileObject: any = parse(fileContents);
                         return fileObject;
                     } catch (e) { // Error parsing JSON
                         this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.msgErrorReadingConfigFile, filename));

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -212,6 +212,9 @@ export class ConnectionConfig implements IConnectionConfig {
                 if (!Utils.isEmpty(fileContents)) {
                     try {
                         let fileObject: any = parse(fileContents);
+                        // TODO #930 handle case where mssql.connections section of the settings file is corrupt
+                        // the errors from parse only indicate if there were invalid symbols, numbers or properties which
+                        // isn't particularly useful so we'd need to check manually for missing required properties or other corruption.
                         return fileObject;
                     } catch (e) { // Error parsing JSON
                         this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.msgErrorReadingConfigFile, filename));

--- a/test/connectionconfig.test.ts
+++ b/test/connectionconfig.test.ts
@@ -7,14 +7,6 @@ import VscodeWrapper from '../src/controllers/vscodeWrapper';
 import assert = require('assert');
 import fs = require('fs');
 
-const corruptJson =
-`{
-    mssql.connections: [
-        {}
-        corrupt!@#$%
-    ]
-}`;
-
 const validJson =
 `
 {
@@ -36,22 +28,28 @@ const validJson =
 `;
 
 suite('ConnectionConfig tests', () => {
-    test('error message is shown when reading corrupt config file', () => {
-        let bufferMock = TypeMoq.Mock.ofType(Buffer, TypeMoq.MockBehavior.Loose, 0);
-        bufferMock.setup(x => x.toString()).returns(() => corruptJson);
+    // TODO #930 handle case where mssql.connections section of the settings file is corrupt
+    // test('error message is shown when reading corrupt config file', () => {
 
-        let fsMock = TypeMoq.Mock.ofInstance(fs);
-        fsMock.setup(x => x.readFileSync(TypeMoq.It.isAny())).returns(() => bufferMock.object);
+    //     const corruptJson =
+    //     `{
+    //         corrupt!@#$%
+    //     ]`;
+    //     let bufferMock = TypeMoq.Mock.ofType(Buffer, TypeMoq.MockBehavior.Loose, 0);
+    //     bufferMock.setup(x => x.toString()).returns(() => corruptJson);
 
-        let vscodeWrapperMock = TypeMoq.Mock.ofType(VscodeWrapper);
+    //     let fsMock = TypeMoq.Mock.ofInstance(fs);
+    //     fsMock.setup(x => x.readFileSync(TypeMoq.It.isAny())).returns(() => bufferMock.object);
 
-        // Given a connection config object that reads a corrupt json file
-        let config = new ConnectionConfig(fsMock.object, vscodeWrapperMock.object);
-        config.readAndParseSettingsFile('settings.json');
+    //     let vscodeWrapperMock = TypeMoq.Mock.ofType(VscodeWrapper);
 
-        // Verify that an error message was displayed to the user
-        vscodeWrapperMock.verify(x => x.showErrorMessage(TypeMoq.It.isAny()), TypeMoq.Times.once());
-    });
+    //     // Given a connection config object that reads a corrupt json file
+    //     let config = new ConnectionConfig(fsMock.object, vscodeWrapperMock.object);
+    //     config.readAndParseSettingsFile('settings.json');
+
+    //     // Verify that an error message was displayed to the user
+    //     vscodeWrapperMock.verify(x => x.showErrorMessage(TypeMoq.It.isAny()), TypeMoq.Times.once());
+    // });
 
     test('no error message is shown when reading valid config file', () => {
         let bufferMock = TypeMoq.Mock.ofType(Buffer, TypeMoq.MockBehavior.Loose, 0);


### PR DESCRIPTION
- Use the fault-tolerant jsonc-parser
- Removed invalid test expecting exception on JSON parse
- Created tracking issue to cover need to handle truly corrupted mssql.connections section



