### PR TITLE
Fix #891 Create Connection Profile Aborts Without Warning

### DIFF
--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -52,7 +52,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
                 }
         });
 
-        return prompter.prompt(questions).then(answers => {
+        return prompter.prompt(questions, true).then(answers => {
             if (answers && profile.isValidProfile()) {
                 return profile;
             }

--- a/src/prompts/adapter.ts
+++ b/src/prompts/adapter.ts
@@ -111,16 +111,16 @@ export default class CodeAdapter implements IPrompter {
         }
     }
 
-    public promptSingle<T>(question: IQuestion): Promise<T> {
+    public promptSingle<T>(question: IQuestion, ignoreFocusOut?: boolean): Promise<T> {
         let questions: IQuestion[] = [question];
-        return this.prompt(questions).then(answers => {
+        return this.prompt(questions, ignoreFocusOut).then(answers => {
             if (answers) {
                 return answers[question.name] || false;
             }
         });
     }
 
-    public prompt<T>(questions: IQuestion[]): Promise<{[key: string]: T}> {
+    public prompt<T>(questions: IQuestion[], ignoreFocusOut?: boolean): Promise<{[key: string]: T}> {
         let answers: {[key: string]: T} = {};
 
         // Collapse multiple questions into a set of prompt steps
@@ -128,7 +128,7 @@ export default class CodeAdapter implements IPrompter {
             this.fixQuestion(question);
 
             return promise.then(() => {
-                return PromptFactory.createPrompt(question);
+                return PromptFactory.createPrompt(question, ignoreFocusOut);
             }).then(prompt => {
                 // Original Code: uses jQuery patterns. Keeping for reference
                 // if (!question.when || question.when(answers) === true) {

--- a/src/prompts/checkbox.ts
+++ b/src/prompts/checkbox.ts
@@ -3,7 +3,7 @@
 // This code is originally from https://github.com/DonJayamanne/bowerVSCode
 // License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
 
-import {window, QuickPickOptions} from 'vscode';
+import { window } from 'vscode';
 import Prompt from './prompt';
 import EscapeException from '../utils/EscapeException';
 
@@ -11,8 +11,8 @@ const figures = require('figures');
 
 export default class CheckboxPrompt extends Prompt {
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
     }
 
     public render(): any {
@@ -22,9 +22,8 @@ export default class CheckboxPrompt extends Prompt {
             return result;
         }, {});
 
-        const options: QuickPickOptions = {
-            placeHolder: this._question.message
-        };
+        let options = this.defaultQuickPickOptions;
+        options.placeHolder = this._question.message;
 
         let quickPickOptions = Object.keys(choices);
         quickPickOptions.push(figures.tick);

--- a/src/prompts/confirm.ts
+++ b/src/prompts/confirm.ts
@@ -3,15 +3,15 @@
 // This code is originally from https://github.com/DonJayamanne/bowerVSCode
 // License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
 
-import {window, QuickPickOptions} from 'vscode';
+import { window } from 'vscode';
 import Prompt from './prompt';
 import LocalizedConstants = require('../constants/localizedConstants');
 import EscapeException from '../utils/EscapeException';
 
 export default class ConfirmPrompt extends Prompt {
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
     }
 
     public render(): any {
@@ -19,9 +19,8 @@ export default class ConfirmPrompt extends Prompt {
         choices[LocalizedConstants.msgYes] = true;
         choices[LocalizedConstants.msgNo] = false;
 
-        const options: QuickPickOptions = {
-            placeHolder: this._question.message
-        };
+        let options = this.defaultQuickPickOptions;
+        options.placeHolder = this._question.message;
 
         return window.showQuickPick(Object.keys(choices), options)
             .then(result => {

--- a/src/prompts/expand.ts
+++ b/src/prompts/expand.ts
@@ -12,8 +12,8 @@ const figures = require('figures');
 
 export default class ExpandPrompt extends Prompt {
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
     }
 
     public render(): any {
@@ -26,9 +26,8 @@ export default class ExpandPrompt extends Prompt {
     }
 
     private renderQuickPick(choices: vscode.QuickPickItem[]): any {
-        const options: vscode.QuickPickOptions = {
-            placeHolder: this._question.message
-        };
+        let options = this.defaultQuickPickOptions;
+        options.placeHolder = this._question.message;
 
         return vscode.window.showQuickPick(choices, options)
             .then(result => {
@@ -45,9 +44,8 @@ export default class ExpandPrompt extends Prompt {
             return result;
         }, {});
 
-        const options: vscode.QuickPickOptions = {
-            placeHolder: this._question.message
-        };
+        let options = this.defaultQuickPickOptions;
+        options.placeHolder = this._question.message;
 
         return vscode.window.showQuickPick(Object.keys(choiceMap), options)
             .then(result => {

--- a/src/prompts/factory.ts
+++ b/src/prompts/factory.ts
@@ -13,7 +13,7 @@ import ExpandPrompt from './expand';
 
 export default class PromptFactory {
 
-    public static createPrompt(question: any): Prompt {
+    public static createPrompt(question: any, ignoreFocusOut?: boolean): Prompt {
         /**
          * TODO:
          *   - folder
@@ -21,17 +21,17 @@ export default class PromptFactory {
         switch (question.type || 'input') {
             case 'string':
             case 'input':
-                return new InputPrompt(question);
+                return new InputPrompt(question, ignoreFocusOut);
             case 'password':
-                return new PasswordPrompt(question);
+                return new PasswordPrompt(question, ignoreFocusOut);
             case 'list':
-                return new ListPrompt(question);
+                return new ListPrompt(question, ignoreFocusOut);
             case 'confirm':
-                return new ConfirmPrompt(question);
+                return new ConfirmPrompt(question, ignoreFocusOut);
             case 'checkbox':
-                return new CheckboxPrompt(question);
+                return new CheckboxPrompt(question, ignoreFocusOut);
             case 'expand':
-                return new ExpandPrompt(question);
+                return new ExpandPrompt(question, ignoreFocusOut);
             default:
                 throw new Error(`Could not find a prompt for question type ${question.type}`);
         }

--- a/src/prompts/input.ts
+++ b/src/prompts/input.ts
@@ -13,12 +13,11 @@ export default class InputPrompt extends Prompt {
 
     protected _options: InputBoxOptions;
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
 
-        this._options = {
-            prompt: this._question.message
-        };
+        this._options = this.defaultInputBoxOptions;
+        this._options.prompt = this._question.message;
     }
 
     // Helper for callers to know the right type to get from the type factory

--- a/src/prompts/list.ts
+++ b/src/prompts/list.ts
@@ -3,14 +3,14 @@
 // This code is originally from https://github.com/DonJayamanne/bowerVSCode
 // License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
 
-import {window, QuickPickOptions} from 'vscode';
+import { window } from 'vscode';
 import Prompt from './prompt';
 import EscapeException from '../utils/EscapeException';
 
 export default class ListPrompt extends Prompt {
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
     }
 
     public render(): any {
@@ -19,9 +19,8 @@ export default class ListPrompt extends Prompt {
             return result;
         }, {});
 
-        const options: QuickPickOptions = {
-             placeHolder: this._question.message
-        };
+        let options = this.defaultQuickPickOptions;
+        options.placeHolder = this._question.message;
 
         return window.showQuickPick(Object.keys(choices), options)
             .then(result => {

--- a/src/prompts/password.ts
+++ b/src/prompts/password.ts
@@ -6,8 +6,8 @@ import InputPrompt from './input';
 
 export default class PasswordPrompt extends InputPrompt {
 
-    constructor(question: any) {
-        super(question);
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
 
         this._options.password = true;
     }

--- a/src/prompts/prompt.ts
+++ b/src/prompts/prompt.ts
@@ -3,15 +3,31 @@
 // This code is originally from https://github.com/DonJayamanne/bowerVSCode
 // License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
 
+import { InputBoxOptions, QuickPickOptions } from 'vscode';
+
 abstract class Prompt {
 
     protected _question: any;
+    protected _ignoreFocusOut?: boolean;
 
-    constructor(question: any) {
+    constructor(question: any, ignoreFocusOut?: boolean) {
         this._question = question;
+        this._ignoreFocusOut = ignoreFocusOut ? ignoreFocusOut : false;
     }
 
     public abstract render(): any;
+
+    protected get defaultQuickPickOptions(): QuickPickOptions {
+        return {
+            ignoreFocusOut: this._ignoreFocusOut
+        };
+    }
+
+    protected get defaultInputBoxOptions(): InputBoxOptions {
+        return {
+            ignoreFocusOut: this._ignoreFocusOut
+        };
+    }
 }
 
 export default Prompt;

--- a/src/prompts/question.ts
+++ b/src/prompts/question.ts
@@ -52,14 +52,14 @@ export interface IQuestionHandler {
 }
 
 export interface IPrompter {
-    promptSingle<T>(question: IQuestion): Promise<T>;
+    promptSingle<T>(question: IQuestion, ignoreFocusOut?: boolean): Promise<T>;
     /**
      * Prompts for multiple questions
      *
      * @returns {[questionId: string]: T} Map of question IDs to results, or undefined if
      * the user canceled the question session
      */
-    prompt<T>(questions: IQuestion[]): Promise<{[questionId: string]: T}>;
+    prompt<T>(questions: IQuestion[], ignoreFocusOut?: boolean): Promise<{[questionId: string]: T}>;
     promptCallback(questions: IQuestion[], callback: IPromptCallback): void;
 }
 

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -62,7 +62,7 @@ suite('Connection Profile tests', () => {
         let profileReturned: IConnectionProfile;
 
         // When createProfile is called and user cancels out
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .callback(questions => {
                     // Capture questions for verification
                     profileQuestions = questions;
@@ -104,7 +104,7 @@ suite('Connection Profile tests', () => {
         let profileReturned: IConnectionProfile;
 
         // When createProfile is called
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .callback(questions => {
                     // Capture questions for verification
                     profileQuestions = questions;
@@ -129,7 +129,7 @@ suite('Connection Profile tests', () => {
         let answers: {[key: string]: string} = {};
         let profileQuestions: IQuestion[];
         let profileReturned: IConnectionProfile;
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .callback(questions => {
                     // Capture questions for verification
                     profileQuestions = questions;
@@ -212,7 +212,7 @@ suite('Connection Profile tests', () => {
         connectionStoreMock.setup(x => x.saveProfile(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 
         let prompter: TypeMoq.IMock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .returns(questions => {
                     let answers: {[key: string]: string} = {};
                     answers[LocalizedConstants.serverPrompt] = 'my-server';
@@ -255,7 +255,7 @@ suite('Connection Profile tests', () => {
         connectionStoreMock.setup(x => x.saveProfile(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 
         let prompter: TypeMoq.IMock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .returns(questions => {
                     let answers: {[key: string]: string} = {};
                     answers[LocalizedConstants.serverPrompt] = 'my-server';
@@ -297,7 +297,7 @@ suite('Connection Profile tests', () => {
 
         // Set up the prompter to answer the server prompt with the connection string
         let prompter: TypeMoq.IMock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny())).returns(questions => {
+        prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(questions => {
             questions.filter(question => question.name === LocalizedConstants.serverPrompt)[0].onAnswered(answers[LocalizedConstants.serverPrompt]);
             questions.filter(question => question.name !== LocalizedConstants.serverPrompt && question.name !== LocalizedConstants.profileNamePrompt)
                 .forEach(question => {


### PR DESCRIPTION
- VSCode added an option that supports ignoring focusOut events so that prompts stay visible even on tabbing to other apps! Fixed and verified manually. Tests pass