### PR TITLE
Fix travis build for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ os:
   - linux
   - osx
 
+addons:
+  apt:
+    packages:
+      - libsecret-1-dev
+
 before_install:
   - export CHROME_BIN=chromium-browser
 # Set up chrome on osx

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -984,11 +984,6 @@
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
-    "vscode": {
-      "version": "1.1.4",
-      "from": "vscode@latest",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.4.tgz"
-    },
     "vscode-extension-telemetry": {
       "version": "0.0.5",
       "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -984,6 +984,11 @@
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
+    "vscode": {
+      "version": "1.1.4",
+      "from": "vscode@latest",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.4.tgz"
+    },
     "vscode-extension-telemetry": {
       "version": "0.0.5",
       "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",


### PR DESCRIPTION
According to https://github.com/Microsoft/vscode/issues/33998
the fix was adding libsecret-1-dev as dependency 