### PR TITLE
Fix package key missing warning and update SqlToolsService version

### DIFF
--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -80,6 +80,9 @@
         <trans-unit id="mssql.connection.workstationId">
             <source xml:lang="en">[Optional] Specify the name of the workstation connecting to SQL Server.</source>
         </trans-unit>
+        <trans-unit id="mssql.connection.applicationName">
+            <source xml:lang="en">[Optional] Specify the name of the application used for SQL Server to log (default: 'vscode-mssql').</source>
+        </trans-unit>
         <trans-unit id="mssql.connection.applicationIntent">
             <source xml:lang="en">[Optional] Declares the application workload type when connecting to SQL Server such as ReadWrite or ReadOnly. Refer to SQL Server AlwaysOn for more detail.</source>
         </trans-unit>

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,6 +25,7 @@
 "mssql.connection.connectRetryCount":"[Optional] Specify the number of attempts to restore connection.",
 "mssql.connection.connectRetryInterval":"[Optional] Specify the delay between attempts to restore connection.",
 "mssql.connection.workstationId":"[Optional] Specify the name of the workstation connecting to SQL Server.",
+"mssql.connection.applicationName":"[Optional] Specify the name of the application used for SQL Server to log (default: 'vscode-mssql').",
 "mssql.connection.applicationIntent":"[Optional] Declares the application workload type when connecting to SQL Server such as ReadWrite or ReadOnly. Refer to SQL Server AlwaysOn for more detail.",
 "mssql.connection.currentLanguage":"[Optional] Indicates the SQL Server language settings.",
 "mssql.connection.pooling":"[Optional] When set to 'true', the connection object is drawn from the appropriate pool, or if necessary, is created and added to the appropriate pool.",

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/0/C/B/0CBA32BE-E861-4C05-947D-228BC37799E0/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.1.0",
+        "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.1.0-alpha.35",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/0/C/B/0CBA32BE-E861-4C05-947D-228BC37799E0/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.1.0",
+        "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.1.0-alpha.35",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
- Fixes #954 through addition of full .Net Core 2.0 GA version of the SqlToolsService