### PR TITLE
Add language flavor to fix #978

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,15 @@
     "version": "0.1.0",
     "configurations": [
         {
+            "type": "node",
+            "request": "launch",
+            "name": "Gulp task",
+            "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+            "args": [
+                "ext:localization:xliff-to-package.nls"
+            ]
+        },
+        {
             "name": "Launch Extension",
             "type": "extensionHost",
             "request": "launch",

--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -335,6 +335,24 @@
         <trans-unit id="msgCannotSaveMultipleSelections">
             <source xml:lang="en">Save results command cannot be used with multiple selections.</source>
         </trans-unit>
+        <trans-unit id="mssqlProviderName">
+            <source xml:lang="en">MSSQL</source>
+        </trans-unit>
+        <trans-unit id="noneProviderName">
+            <source xml:lang="en">None</source>
+        </trans-unit>
+        <trans-unit id="chooseSqlLang">
+            <source xml:lang="en">Choose SQL Language</source>
+        </trans-unit>
+        <trans-unit id="flavorChooseLanguage">
+            <source xml:lang="en">Choose SQL Language</source>
+        </trans-unit>
+        <trans-unit id="flavorDescriptionMssql">
+            <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source>
+        </trans-unit>
+        <trans-unit id="flavorDescriptionNone">
+            <source xml:lang="en">Disable intellisense and syntax error checking on current document</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -23,6 +23,9 @@
         <trans-unit id="extension.chooseDatabase">
             <source xml:lang="en">Use Database</source>
         </trans-unit>
+        <trans-unit id="extension.chooseLanguageFlavor">
+            <source xml:lang="en">Choose SQL handler for this file</source>
+        </trans-unit>
         <trans-unit id="extension.showGettingStarted">
             <source xml:lang="en">Getting Started Guide</source>
         </trans-unit>

--- a/package.json
+++ b/package.json
@@ -193,6 +193,11 @@
         "category": "MS SQL"
       },
       {
+        "command": "extension.chooseLanguageFlavor",
+        "title": "%extension.chooseLanguageFlavor%",
+        "category": "MS SQL"
+      },
+      {
         "command": "extension.showGettingStarted",
         "title": "%extension.showGettingStarted%",
         "category": "MS SQL"

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
 "extension.disconnect":"Disconnect",
 "extension.manageProfiles":"Manage Connection Profiles",
 "extension.chooseDatabase":"Use Database",
+"extension.chooseLanguageFlavor":"Choose SQL handler for this file",
 "extension.showGettingStarted":"Getting Started Guide",
 "extension.newQuery":"New Query",
 "extension.rebuildIntelliSenseCache":"Refresh IntelliSense Cache",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,6 +2,8 @@
 export const languageId = 'sql';
 export const extensionName = 'mssql';
 export const extensionConfigSectionName = 'mssql';
+export const mssqlProviderName = 'MSSQL';
+export const noneProviderName = 'None';
 export const connectionApplicationName = 'vscode-mssql';
 export const outputChannelName = 'MSSQL';
 export const connectionConfigFilename = 'settings.json';
@@ -12,6 +14,7 @@ export const cmdCancelQuery = 'extension.cancelQuery';
 export const cmdConnect = 'extension.connect';
 export const cmdDisconnect = 'extension.disconnect';
 export const cmdChooseDatabase = 'extension.chooseDatabase';
+export const cmdChooseLanguageFlavor = 'extension.chooseLanguageFlavor';
 export const cmdShowReleaseNotes = 'extension.showReleaseNotes';
 export const cmdShowGettingStarted = 'extension.showGettingStarted';
 export const cmdNewQuery = 'extension.newQuery';

--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -29,6 +29,15 @@ export default class VscodeWrapper {
     }
 
     /**
+     * An [event](#Event) which fires when the [active editor](#window.activeTextEditor)
+     * has changed. *Note* that the event also fires when the active editor changes
+     * to `undefined`.
+     */
+    public get onDidChangeActiveTextEditor(): vscode.Event<vscode.TextEditor> {
+        return vscode.window.onDidChangeActiveTextEditor;
+    }
+
+    /**
      * get the current textDocument; any that are open?
      */
     public get textDocuments(): vscode.TextDocument[] {

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -44,13 +44,11 @@ interface IMessage {
  */
 class LanguageClientErrorHandler {
 
-    private vscodeWrapper: VscodeWrapper;
-
     /**
      * Creates an instance of LanguageClientErrorHandler.
      * @memberOf LanguageClientErrorHandler
      */
-    constructor() {
+    constructor(private vscodeWrapper?: VscodeWrapper) {
         if (!this.vscodeWrapper) {
             this.vscodeWrapper = new VscodeWrapper();
         }
@@ -113,7 +111,6 @@ export default class SqlToolsServiceClient {
 
     // VS Code Language Client
     private _client: LanguageClient = undefined;
-
     // getter method for the Language Client
     private get client(): LanguageClient {
         return this._client;
@@ -127,7 +124,8 @@ export default class SqlToolsServiceClient {
         private _config: IConfig,
         private _server: ServerProvider,
         private _logger: Logger,
-        private _statusView: StatusView) {
+        private _statusView: StatusView,
+        private _vscodeWrapper: VscodeWrapper) {
     }
 
     // gets or creates the singleton SQL Tools service client instance
@@ -142,8 +140,9 @@ export default class SqlToolsServiceClient {
             let downloadProvider = new ServiceDownloadProvider(config, logger, serverStatusView, httpClient,
             decompressProvider);
             let serviceProvider = new ServerProvider(downloadProvider, config, serverStatusView);
-            let statusView = new StatusView();
-            this._instance = new SqlToolsServiceClient(config, serviceProvider, logger, statusView);
+            let vscodeWrapper = new VscodeWrapper();
+            let statusView = new StatusView(vscodeWrapper);
+            this._instance = new SqlToolsServiceClient(config, serviceProvider, logger, statusView, vscodeWrapper);
         }
         return this._instance;
     }
@@ -281,7 +280,7 @@ export default class SqlToolsServiceClient {
             synchronize: {
                 configurationSection: 'mssql'
             },
-            errorHandler: new LanguageClientErrorHandler()
+            errorHandler: new LanguageClientErrorHandler(this._vscodeWrapper)
         };
 
         // cache the client instance for later use

--- a/src/models/contracts/languageService.ts
+++ b/src/models/contracts/languageService.ts
@@ -85,3 +85,30 @@ export class StatusChangeParams {
 
 
 // ------------------------------- </ Status Sent Event > ----------------------------------
+
+// ------------------------------- < Language Flavor Changed Event > ------------------------------------
+/**
+ * Language flavor change event parameters
+ */
+export class DidChangeLanguageFlavorParams {
+    /**
+     * URI identifying the text document
+     */
+    public uri: string;
+    /**
+     * text document's language
+     */
+    public language: string;
+    /**
+     * Sub-flavor for the langauge, e.g. 'MSSQL' for a SQL Server connection or 'Other' for any other SQL flavor
+     */
+    public  flavor: string;
+}
+
+/**
+ * Notification sent when the language flavor is changed
+ */
+export namespace LanguageFlavorChangedNotification {
+    export const type: NotificationType<DidChangeLanguageFlavorParams> = { get method(): string { return 'connection/languageflavorchanged'; } };
+}
+

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -23,6 +23,10 @@ enum ManageProfileTask {
     Remove
 }
 
+export interface ISqlProviderItem extends vscode.QuickPickItem {
+    providerId: string;
+}
+
 export class ConnectionUI {
     private _errorOutputChannel: vscode.OutputChannel;
 
@@ -86,6 +90,34 @@ export class ConnectionUI {
                     }
                 });
             }
+        });
+    }
+
+    public promptLanguageFlavor(): Promise<string> {
+        const self = this;
+        return new Promise<string>((resolve, reject) => {
+            let picklist: ISqlProviderItem[] = [
+                {
+                    label: LocalizedConstants.mssqlProviderName,
+                    description: LocalizedConstants.flavorDescriptionMssql,
+                    providerId: Constants.mssqlProviderName
+                },
+                {
+                    label: LocalizedConstants.noneProviderName,
+                    description: LocalizedConstants.flavorDescriptionNone,
+                    providerId: Constants.noneProviderName
+                }
+            ];
+            self.promptItemChoice({
+                placeHolder: LocalizedConstants.flavorChooseLanguage,
+                matchOnDescription: true
+            }, picklist).then(selection => {
+                if (selection) {
+                    resolve(selection.providerId);
+                } else {
+                    resolve(undefined);
+                }
+            });
         });
     }
 

--- a/test/serviceClient.test.ts
+++ b/test/serviceClient.test.ts
@@ -8,6 +8,7 @@ import StatusView from './../src/views/statusView';
 import * as LanguageServiceContracts from '../src/models/contracts/languageService';
 import { IConfig } from '../src/languageservice/interfaces';
 import ExtConfig from  '../src/configurations/extConfig';
+import VscodeWrapper from '../src/controllers/vscodeWrapper';
 
 interface IFixture {
     platformInfo: PlatformInformation;
@@ -21,11 +22,13 @@ suite('Service Client tests', () => {
     let testServiceProvider: TypeMoq.IMock<ServerProvider>;
     let logger = new Logger(text => console.log(text));
     let testStatusView: TypeMoq.IMock<StatusView>;
+    let vscodeWrapper: TypeMoq.IMock<VscodeWrapper>;
 
     setup(() => {
         testConfig = TypeMoq.Mock.ofType(ExtConfig, TypeMoq.MockBehavior.Loose);
         testServiceProvider = TypeMoq.Mock.ofType(ServerProvider, TypeMoq.MockBehavior.Strict);
         testStatusView = TypeMoq.Mock.ofType(StatusView);
+        vscodeWrapper = TypeMoq.Mock.ofType(VscodeWrapper);
     });
 
     function setupMocks(fixture: IFixture): void {
@@ -45,7 +48,7 @@ suite('Service Client tests', () => {
         };
 
         setupMocks(fixture);
-        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
 
         return serviceClient.initializeForPlatform(fixture.platformInfo, undefined).then( result => {
             assert.notEqual(result, undefined);
@@ -62,7 +65,7 @@ suite('Service Client tests', () => {
         };
 
         setupMocks(fixture);
-        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
 
         return serviceClient.initializeForPlatform(fixture.platformInfo, undefined).then( result => {
             assert.notEqual(result, undefined);
@@ -79,7 +82,7 @@ suite('Service Client tests', () => {
         };
 
         setupMocks(fixture);
-        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
 
         return serviceClient.initializeForPlatform(fixture.platformInfo, undefined).catch( error => {
             return assert.equal(error, 'Invalid Platform');
@@ -101,7 +104,7 @@ suite('Service Client tests', () => {
         testConfig.setup(x => x.useServiceVersion(TypeMoq.It.isAnyNumber())).callback(num => serviceVersion = num);
 
         setupMocks(fixture);
-        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
 
         return serviceClient.initializeForPlatform(fixture.platformInfo, undefined).then( result => {
             assert.equal(serviceVersion, 1);
@@ -128,7 +131,7 @@ suite('Service Client tests', () => {
         testConfig.setup(x => x.useServiceVersion(TypeMoq.It.isAnyNumber())).callback(num => serviceVersion = num);
 
         setupMocks(fixture);
-        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+        let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
 
         return serviceClient.initializeForPlatform(fixture.platformInfo, undefined).then( result => {
             assert.equal(serviceVersion, 0);
@@ -151,7 +154,7 @@ suite('Service Client tests', () => {
             const status = 'new status';
 
             setupMocks(fixture);
-            let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object);
+            let serviceClient = new SqlToolsServiceClient(testConfig.object, testServiceProvider.object, logger, testStatusView.object, vscodeWrapper.object);
             let statusChangeParams = new LanguageServiceContracts.StatusChangeParams();
             statusChangeParams.ownerUri = testFile;
             statusChangeParams.status = status;


### PR DESCRIPTION
Fixes #978: adds a new status indicator for Language Flavor so that users can choose `MSSQL` or `None` for provider type. If `None` then MSSQL intellisense and syntax checking are skipped.