### PR TITLE
Fix error where language flavor showed on new untitled docs

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -602,7 +602,7 @@ export default class MainController implements vscode.Disposable {
         }
         this._connectionMgr.onDidOpenTextDocument(doc);
 
-        if (this._vscodeWrapper.isEditingSqlFile) {
+        if (doc && doc.languageId === Constants.languageId) {
             this._statusview.languageFlavorChanged(doc.uri.toString(), Constants.mssqlProviderName);
         }
 

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -116,6 +116,7 @@ export default class StatusView implements vscode.Disposable {
         this.showStatusBarItem(fileUri, bar.statusConnection);
         bar.statusLanguageService.text = '';
         this.showStatusBarItem(fileUri, bar.statusLanguageService);
+        this.showStatusBarItem(fileUri, bar.statusLanguageFlavor);
     }
 
     public connecting(fileUri: string, connCreds: Interfaces.IConnectionCredentials): void {


### PR DESCRIPTION
- Incorrectly checked active editor instead of the doc passed into the onDidOpenTextDocument method