### PR TITLE
Display save dialog for serialization - part of multi-folder workspace support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   nodejs_version: "6.9.1"
   # Temporary Code version due to https://github.com/Microsoft/vscode-extension-vscode/issues/64
-  CODE_VERSION: 1.12.2
+  CODE_VERSION: 1.17.0
 
 
 # safelist

--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -311,6 +311,15 @@
         <trans-unit id="saveExcelLabel">
             <source xml:lang="en">Save as Excel</source>
         </trans-unit>
+        <trans-unit id="fileTypeCSVLabel">
+            <source xml:lang="en">CSV</source>
+        </trans-unit>
+        <trans-unit id="fileTypeJSONLabel">
+            <source xml:lang="en">JSON</source>
+        </trans-unit>
+        <trans-unit id="fileTypeExcelLabel">
+            <source xml:lang="en">Excel</source>
+        </trans-unit>
         <trans-unit id="resultPaneLabel">
             <source xml:lang="en">Results</source>
         </trans-unit>

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "MSSQL",
     "SQL Server",
     "Azure SQL Database",
-    "Azure SQL Data Warehouse",
-    "multi-root-ready"
+    "Azure SQL Data Warehouse"
   ],
   "activationEvents": [
     "onLanguage:sql",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
   "engines": {
-    "vscode": "^1.9.0"
+    "vscode": "^1.18.0"
   },
   "categories": [
     "Languages",
@@ -32,7 +32,8 @@
     "MSSQL",
     "SQL Server",
     "Azure SQL Database",
-    "Azure SQL Data Warehouse"
+    "Azure SQL Data Warehouse",
+    "multi-root-ready"
   ],
   "activationEvents": [
     "onLanguage:sql",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
   "engines": {
-    "vscode": "^1.18.0"
+    "vscode": "^1.17.0"
   },
   "categories": [
     "Languages",

--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -232,6 +232,16 @@ export default class VscodeWrapper {
     }
 
     /**
+     * Shows a file save dialog to the user which allows to select a file for saving-purposes.
+     *
+     * @param options Configures the behavior of the save dialog
+     * @return A promise that resolves to the selected resource or `undefined`.
+     */
+    public showSaveDialog(options: vscode.SaveDialogOptions): Thenable<vscode.Uri> {
+        return vscode.window.showSaveDialog(options);
+    }
+
+    /**
      * Show the given document in a text editor. A [column](#ViewColumn) can be provided
      * to control where the editor is being shown. Might change the [active editor](#window.activeTextEditor).
      *

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -98,7 +98,8 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             prod = false;
         }
         let mssqlConfig = this._vscodeWrapper.getConfiguration(Constants.extensionName);
-        let editorConfig = this._vscodeWrapper.getConfiguration('editor');
+        let editorConfig = vscode.workspace.getConfiguration('editor', vscode.Uri.parse(uri));
+        // // let editorConfig = this._vscodeWrapper.getConfiguration('editor');
         let extensionFontFamily = mssqlConfig.get<string>(Constants.extConfigResultFontFamily).split('\'').join('').split('"').join('');
         let extensionFontSize = mssqlConfig.get<number>(Constants.extConfigResultFontSize);
         let fontfamily = extensionFontFamily ?

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -98,8 +98,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             prod = false;
         }
         let mssqlConfig = this._vscodeWrapper.getConfiguration(Constants.extensionName);
-        let editorConfig = vscode.workspace.getConfiguration('editor', vscode.Uri.parse(uri));
-        // // let editorConfig = this._vscodeWrapper.getConfiguration('editor');
+        let editorConfig = this._vscodeWrapper.getConfiguration('editor');
         let extensionFontFamily = mssqlConfig.get<string>(Constants.extConfigResultFontFamily).split('\'').join('').split('"').join('');
         let extensionFontSize = mssqlConfig.get<number>(Constants.extConfigResultFontSize);
         let fontfamily = extensionFontFamily ?

--- a/test/saveResults.test.ts
+++ b/test/saveResults.test.ts
@@ -1,139 +1,60 @@
 import * as TypeMoq from 'typemoq';
 import assert = require('assert');
-import LocalizedConstants = require('../src/constants/localizedConstants');
 import Interfaces = require('../src/models/interfaces');
 import ResultsSerializer  from './../src/models/resultsSerializer';
 import { SaveResultsAsCsvRequestParams } from './../src/models/contracts';
 import SqlToolsServerClient from './../src/languageservice/serviceclient';
-import { IQuestion, IPrompter } from '../src/prompts/question';
-import { TestPrompter } from './stubs';
 import VscodeWrapper from './../src/controllers/vscodeWrapper';
+import { Uri } from 'vscode';
 import os = require('os');
 
 suite('save results tests', () => {
 
     const testFile = 'file:///my/test/file.sql';
-    let filePath = '';
+    let fileUri: Uri;
     let serverClient: TypeMoq.IMock<SqlToolsServerClient>;
-    let prompter: TypeMoq.IMock<IPrompter>;
     let vscodeWrapper: TypeMoq.IMock<VscodeWrapper>;
 
     setup(() => {
 
         serverClient = TypeMoq.Mock.ofType(SqlToolsServerClient, TypeMoq.MockBehavior.Strict);
-        prompter = TypeMoq.Mock.ofType(TestPrompter);
         vscodeWrapper = TypeMoq.Mock.ofType(VscodeWrapper);
         if (os.platform() === 'win32') {
-            filePath = 'c:\\test.csv';
+            fileUri = Uri.file('c:\\test.csv');
         } else {
-            filePath = '/test.csv';
+            fileUri = Uri.file('/test.csv');
         }
     });
 
 
-    test('check if filepath prompt displays and right value is set', () => {
-
-        let filePathQuestions: IQuestion[];
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
-
+    test('check if filepath prompt displays and right value is set', (done) => {
         // setup mock filepath prompt
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny())).callback(questions => {
-            filePathQuestions = questions;
-            })
-            .returns((questions: IQuestion[]) => Promise.resolve(answers));
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         // setup mock sql tools server client
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .callback((type, details: SaveResultsAsCsvRequestParams) => {
                     // check if filepath was set from answered prompt
-                    assert.equal(details.ownerUri, testFile);
-                    assert.equal(details.filePath, filePath);
+                    try {
+                        assert.equal(details.ownerUri, testFile);
+                        assert.equal(details.filePath, fileUri.fsPath);
+                        done();
+                    } catch (error) {
+                        done(error);
+                    }
             })
             .returns(() => {
                 // This will come back as null from the service layer, but tslinter doesn't like that
                 return Promise.resolve({messages: 'failure'});
             });
 
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
 
-        saveResults.onSaveResults(testFile, 0, 0, 'csv', undefined).then( () => {
-            assert.equal(filePathQuestions[0].name, LocalizedConstants.filepathPrompt );
-        });
+        saveResults.onSaveResults(testFile, 0, 0, 'csv', undefined);
 
     });
 
-    test('check if overwrite prompt displays and right value is set', () => {
-
-        let filePathQuestions: IQuestion[];
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
-        answers[LocalizedConstants.overwritePrompt] = true;
-
-        // setup mock filepath prompt
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny())).callback(questions => {
-            filePathQuestions = questions;
-            })
-            .returns((questions: IQuestion[]) => Promise.resolve(answers));
-
-        // setup mock sql tools server client
-        serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                                        .callback((type, details: SaveResultsAsCsvRequestParams) => {
-                                                // check if filepath was set from answered prompt
-                                                assert.equal(details.ownerUri, testFile);
-                                                assert.equal(details.filePath, filePath);
-                                        })
-                                        .returns(() => {
-                                            // This will come back as null from the service layer, but tslinter doesn't like that
-                                            return Promise.resolve({messages: 'failure'});
-                                        });
-
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
-
-        saveResults.onSaveResults(testFile, 0, 0, 'csv', undefined).then( () => {
-            assert.equal(filePathQuestions[0].name, LocalizedConstants.filepathPrompt );
-        });
-
-    });
-
-    test('check if filename resolves to absolute filepath with current directory', () => {
-
-        let answers = {};
-        let params: SaveResultsAsCsvRequestParams;
-        let filename = 'testfilename.csv';
-        let resolvedFilePath = '';
-        if (os.platform() === 'win32') {
-            resolvedFilePath = '\\my\\test\\testfilename.csv';
-        } else {
-            resolvedFilePath = '/my/test/testfilename.csv';
-        }
-        answers[LocalizedConstants.filepathPrompt] = filename;
+    function testSaveSuccess(format: string, done: () => void): Thenable<void> {
         // setup mocks
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
-                                        .returns((questions: IQuestion[]) => Promise.resolve(answers));
-
-        serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                                    .callback((type, details: SaveResultsAsCsvRequestParams) => {
-                                                              params = details;
-                                    })
-                                    .returns(() => {
-                                        // This will come back as null from the service layer, but tslinter doesn't like that
-                                        return Promise.resolve({messages: 'failure'});
-                                    });
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
-        return saveResults.onSaveResults(testFile, 0, 0, 'csv', undefined).then( () => {
-                                    // check if filename is resolved to full path
-                                    // resolvedpath = current directory + filename
-                                    assert.equal( params.filePath, resolvedFilePath);
-                                });
-    });
-
-    function testSaveSuccess(format: string): Thenable<void> {
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
-
-        // setup mocks
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
-                                    .returns((questions: IQuestion[]) => Promise.resolve(answers));
         vscodeWrapper.setup(x => x.showInformationMessage(TypeMoq.It.isAnyString()));
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
@@ -147,67 +68,64 @@ suite('save results tests', () => {
         vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                                     .returns(() => {
                                         // This will come back as null from the service layer, but tslinter doesn't like that
                                         return Promise.resolve({messages: undefined});
                                     });
 
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
         return saveResults.onSaveResults( testFile, 0, 0, format, undefined).then( () => {
                     // check if information message was displayed
                     vscodeWrapper.verify(x => x.showInformationMessage(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
+                    done();
         });
     }
 
-    function testSaveFailure(format: string): Thenable<void> {
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
+    function testSaveFailure(format: string, done: () => void): Thenable<void> {
 
         // setup mocks
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
-                                .returns((questions: IQuestion[]) => Promise.resolve(answers));
-        vscodeWrapper.setup(x => x.showErrorMessage(TypeMoq.It.isAnyString()));
+        vscodeWrapper.setup(x => x.showErrorMessage(TypeMoq.It.isAnyString())).callback(() => done());
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                                 .returns(() => {
                                     return Promise.resolve({messages: 'failure'});
                                 });
 
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
         return saveResults.onSaveResults( testFile, 0, 0, format, undefined).then( () => {
                     // check if error message was displayed
                     vscodeWrapper.verify(x => x.showErrorMessage(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
         });
     }
 
-    test('Save as CSV - test if information message is displayed on success', () => {
-        return testSaveSuccess('csv');
+    test('Save as CSV - test if information message is displayed on success', (done) => {
+        testSaveSuccess('csv', done);
     });
 
-    test('Save as CSV - test if error message is displayed on failure to save', () => {
-        return testSaveFailure('csv');
+    test('Save as CSV - test if error message is displayed on failure to save', (done) => {
+        testSaveFailure('csv', done);
     });
 
-    test('Save as JSON - test if information message is displayed on success', () => {
-        return testSaveSuccess('json');
+    test('Save as JSON - test if information message is displayed on success', (done) => {
+        testSaveSuccess('json', done);
     });
 
-    test('Save as JSON - test if error message is displayed on failure to save', () => {
-        return testSaveFailure('json');
+    test('Save as JSON - test if error message is displayed on failure to save', (done) => {
+        testSaveFailure('json', done);
     });
 
-    test('Save as Excel - test if information message is displayed on success', () => {
-        return testSaveSuccess('excel');
+    test('Save as Excel - test if information message is displayed on success', (done) => {
+        testSaveSuccess('excel', done);
     });
 
-    test('Save as Excel - test if error message is displayed on failure to save', () => {
-        return testSaveFailure('excel');
+    test('Save as Excel - test if error message is displayed on failure to save', (done) => {
+        testSaveFailure('excel', done);
     });
 
-    test('Save as with selection - test if selected range is passed in parameters', () => {
+    test('Save as with selection - test if selected range is passed in parameters', (done) => {
 
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
         let selection: Interfaces.ISlickRange[] = [{
             fromCell: 0,
             toCell: 1,
@@ -216,15 +134,14 @@ suite('save results tests', () => {
         }];
 
         // setup mocks
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
-                                    .returns((questions: IQuestion[]) => Promise.resolve(answers));
         vscodeWrapper.setup(x => x.showInformationMessage(TypeMoq.It.isAnyString()));
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
-        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).callback(() => done()).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                                     .callback((type, params: SaveResultsAsCsvRequestParams) => {
                                                             // check if right parameters were set from the selection
@@ -236,17 +153,15 @@ suite('save results tests', () => {
                                     })
                                     .returns(() => {
                                         // This will come back as null from the service layer, but tslinter doesn't like that
-                                        return Promise.resolve({messages: 'failure'});
+                                        return Promise.resolve({messages: undefined});
                                     });
 
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
-        return saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
+        saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
     });
 
-    test('Save as with selection - test case when right click on single cell - no selection is set in parameters', () => {
+    test('Save as with selection - test case when right click on single cell - no selection is set in parameters', (done) => {
 
-        let answers = {};
-        answers[LocalizedConstants.filepathPrompt] = filePath;
         let selection: Interfaces.ISlickRange[] = [{
             fromCell: 0,
             toCell: 0,
@@ -255,15 +170,14 @@ suite('save results tests', () => {
         }];
 
         // setup mocks
-        prompter.setup(x => x.prompt(TypeMoq.It.isAny()))
-                                    .returns((questions: IQuestion[]) => Promise.resolve(answers));
         vscodeWrapper.setup(x => x.showInformationMessage(TypeMoq.It.isAnyString()));
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
-        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).callback(() => done()).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                                     .callback((type, params: SaveResultsAsCsvRequestParams) => {
                                                             // Check if selection parameters were undefined in the request
@@ -277,10 +191,10 @@ suite('save results tests', () => {
                                     })
                                     .returns(() => {
                                         // This will come back as null from the service layer, but tslinter doesn't like that
-                                        return Promise.resolve({messages: 'failure'});
+                                        return Promise.resolve({messages: undefined});
                                     });
 
-        let saveResults = new ResultsSerializer(serverClient.object, prompter.object, vscodeWrapper.object);
-        return saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
+        saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
     });
 });

--- a/test/saveResults.test.ts
+++ b/test/saveResults.test.ts
@@ -53,7 +53,7 @@ suite('save results tests', () => {
 
     });
 
-    function testSaveSuccess(format: string, done: () => void): Thenable<void> {
+    function testSaveSuccess(format: string): Thenable<void> {
         // setup mocks
         vscodeWrapper.setup(x => x.showInformationMessage(TypeMoq.It.isAnyString()));
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
@@ -79,14 +79,13 @@ suite('save results tests', () => {
         return saveResults.onSaveResults( testFile, 0, 0, format, undefined).then( () => {
                     // check if information message was displayed
                     vscodeWrapper.verify(x => x.showInformationMessage(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
-                    done();
         });
     }
 
-    function testSaveFailure(format: string, done: () => void): Thenable<void> {
+    function testSaveFailure(format: string): Thenable<void> {
 
         // setup mocks
-        vscodeWrapper.setup(x => x.showErrorMessage(TypeMoq.It.isAnyString())).callback(() => done());
+        vscodeWrapper.setup(x => x.showErrorMessage(TypeMoq.It.isAnyString()));
         vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
         serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                                 .returns(() => {
@@ -100,31 +99,31 @@ suite('save results tests', () => {
         });
     }
 
-    test('Save as CSV - test if information message is displayed on success', (done) => {
-        testSaveSuccess('csv', done);
+    test('Save as CSV - test if information message is displayed on success', () => {
+        return testSaveSuccess('csv');
     });
 
-    test('Save as CSV - test if error message is displayed on failure to save', (done) => {
-        testSaveFailure('csv', done);
+    test('Save as CSV - test if error message is displayed on failure to save', () => {
+        return testSaveFailure('csv');
     });
 
-    test('Save as JSON - test if information message is displayed on success', (done) => {
-        testSaveSuccess('json', done);
+    test('Save as JSON - test if information message is displayed on success', () => {
+        return testSaveSuccess('json');
     });
 
-    test('Save as JSON - test if error message is displayed on failure to save', (done) => {
-        testSaveFailure('json', done);
+    test('Save as JSON - test if error message is displayed on failure to save', () => {
+        return testSaveFailure('json');
     });
 
-    test('Save as Excel - test if information message is displayed on success', (done) => {
-        testSaveSuccess('excel', done);
+    test('Save as Excel - test if information message is displayed on success', () => {
+        return testSaveSuccess('excel');
     });
 
-    test('Save as Excel - test if error message is displayed on failure to save', (done) => {
-        testSaveFailure('excel', done);
+    test('Save as Excel - test if error message is displayed on failure to save', () => {
+        return testSaveFailure('excel');
     });
 
-    test('Save as with selection - test if selected range is passed in parameters', (done) => {
+    test('Save as with selection - test if selected range is passed in parameters', () => {
 
         let selection: Interfaces.ISlickRange[] = [{
             fromCell: 0,
@@ -138,7 +137,7 @@ suite('save results tests', () => {
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
-        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).callback(() => done()).returns(() => {
+        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
         vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
@@ -157,10 +156,10 @@ suite('save results tests', () => {
                                     });
 
         let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
-        saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
+        return saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
     });
 
-    test('Save as with selection - test case when right click on single cell - no selection is set in parameters', (done) => {
+    test('Save as with selection - test case when right click on single cell - no selection is set in parameters', () => {
 
         let selection: Interfaces.ISlickRange[] = [{
             fromCell: 0,
@@ -174,7 +173,7 @@ suite('save results tests', () => {
         vscodeWrapper.setup(x => x.openTextDocument(TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
-        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).callback(() => done()).returns(() => {
+        vscodeWrapper.setup(x => x.showTextDocument(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
                                             return Promise.resolve(undefined);
                                         });
         vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(fileUri));
@@ -195,6 +194,6 @@ suite('save results tests', () => {
                                     });
 
         let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
-        saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
+        return saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
     });
 });

--- a/test/saveResults.test.ts
+++ b/test/saveResults.test.ts
@@ -196,4 +196,22 @@ suite('save results tests', () => {
         let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
         return saveResults.onSaveResults( testFile, 0, 0, 'csv', selection);
     });
+
+    test('canceling out of save file dialog cancels serialization', (done) => {
+        // setup mock filepath prompt
+        vscodeWrapper.setup(x => x.showSaveDialog(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
+        // setup mock sql tools server client
+        serverClient.setup(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()));
+
+        let saveResults = new ResultsSerializer(serverClient.object, vscodeWrapper.object);
+
+        saveResults.onSaveResults(testFile, 0, 0, 'csv', undefined).then(() => {
+            try {
+                serverClient.verify(x => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.never());
+                done();
+            } catch (error) {
+                done(error);
+            }
+        }, error => done(error));
+    });
 });

--- a/test/untitledSqlDocumentService.test.ts
+++ b/test/untitledSqlDocumentService.test.ts
@@ -16,9 +16,11 @@ suite('UntitledSqlDocumentService Tests', () => {
      function createTextDocumentObject(fileName: string = ''): vscode.TextDocument {
          return {
             uri: undefined,
+            eol: undefined,
             fileName: fileName,
             getText: undefined,
             getWordRangeAtPosition: undefined,
+            isClosed: undefined,
             isDirty: true,
             isUntitled: true,
             languageId: 'sql',


### PR DESCRIPTION
This is part of the work for multi-folder workspace support. During serialization we used our own dialogs to let the user choose where to save the file, and this relied on the now-deprecated `workspace.rootPath` property.

VS Code 1.17.0 introduces an API for displaying a file save dialog, which will be a better user experience than displaying text input dialogs, so this PR refactors the code to use that dialog.

This removes the dependency on `workspace.rootPath` because when the user is saving results for an untitled file we just let the dialog start in the default location and allow the user to navigate from there.

![screen shot 2017-11-01 at 3 54 40 pm](https://user-images.githubusercontent.com/3758704/32301920-3f6bc24a-bf1d-11e7-875d-de82e805d76a.png)
