### PR TITLE
Get editor configs at the resource level

### DIFF
--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -89,11 +89,19 @@ export default class VscodeWrapper {
     }
 
     /**
-     * Get the configuration for a extensionName; NOT YET IMPLEMENTED
+     * Get the configuration for a extensionName
      * @param extensionName The string name of the extension to get the configuration for
+     * @param resource The optional URI, as a URI object or a string, to use to get resource-scoped configurations
      */
-    public getConfiguration(extensionName: string): vscode.WorkspaceConfiguration {
-        return vscode.workspace.getConfiguration(extensionName);
+    public getConfiguration(extensionName: string, resource?: vscode.Uri | string): vscode.WorkspaceConfiguration {
+        if (typeof resource === 'string') {
+            try {
+                resource = this.parseUri(resource);
+            } catch (e) {
+                resource = undefined;
+            }
+        }
+        return vscode.workspace.getConfiguration(extensionName, resource as vscode.Uri);
     }
 
     /**

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -98,7 +98,7 @@ export class SqlOutputContentProvider implements vscode.TextDocumentContentProvi
             prod = false;
         }
         let mssqlConfig = this._vscodeWrapper.getConfiguration(Constants.extensionName);
-        let editorConfig = this._vscodeWrapper.getConfiguration('editor');
+        let editorConfig = this._vscodeWrapper.getConfiguration('editor', uri);
         let extensionFontFamily = mssqlConfig.get<string>(Constants.extConfigResultFontFamily).split('\'').join('').split('"').join('');
         let extensionFontSize = mssqlConfig.get<number>(Constants.extConfigResultFontSize);
         let fontfamily = extensionFontFamily ?


### PR DESCRIPTION
This is part of the work to support multi-folder workspaces.

VS Code's built in editor configs are now scoped at the resource (folder) level. This change modifies `vscodeWrapper` so that it is possible to get configs at the resource level and then uses it to get editor configs.

There are no other built in VS Code configs we use that need to be modified that I know of.

We will want to update many of the config options we contribute to be available at the folder level. I'll send another PR later for that change.