### PR TITLE
Change many configs to resource scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -427,7 +427,7 @@
               }
             }
           },
-          "scope": "resource"
+          "scope": "window"
         },
         "mssql.shortcuts": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -240,12 +240,14 @@
         "mssql.logDebugInfo": {
           "type": "boolean",
           "default": false,
-          "description": "%mssql.logDebugInfo%"
+          "description": "%mssql.logDebugInfo%",
+          "scope": "window"
         },
         "mssql.maxRecentConnections": {
           "type": "number",
           "default": 5,
-          "description": "%mssql.maxRecentConnections%"
+          "description": "%mssql.maxRecentConnections%",
+          "scope": "window"
         },
         "mssql.connections": {
           "type": "array",
@@ -424,7 +426,8 @@
                 "description": "%mssql.connection.emptyPasswordInput%"
               }
             }
-          }
+          },
+          "scope": "resource"
         },
         "mssql.shortcuts": {
           "type": "object",
@@ -442,42 +445,50 @@
             "event.saveAsJSON": "",
             "event.saveAsCSV": "",
             "event.saveAsExcel": ""
-          }
+          },
+          "scope": "resource"
         },
         "mssql.messagesDefaultOpen": {
           "type": "boolean",
           "description": "%mssql.messagesDefaultOpen%",
-          "default": true
+          "default": true,
+          "scope": "resource"
         },
         "mssql.resultsFontFamily": {
           "type": "string",
           "description": "%mssql.resultsFontFamily%",
-          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif"
+          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
+          "scope": "resource"
         },
         "mssql.resultsFontSize": {
           "type": "number",
           "description": "%mssql.resultsFontSize%",
-          "default": 13
+          "default": 13,
+          "scope": "resource"
         },
         "mssql.saveAsCsv.includeHeaders": {
           "type": "boolean",
           "description": "%mssql.saveAsCsv.includeHeaders%",
-          "default": true
+          "default": true,
+          "scope": "resource"
         },
         "mssql.copyIncludeHeaders": {
           "type": "boolean",
           "description": "%mssql.copyIncludeHeaders%",
-          "default": false
+          "default": false,
+          "scope": "resource"
         },
         "mssql.copyRemoveNewLine": {
           "type": "boolean",
           "description": "%mssql.copyRemoveNewLine%",
-          "default": true
+          "default": true,
+          "scope": "resource"
         },
         "mssql.showBatchTime": {
           "type": "boolean",
           "description": "%mssql.showBatchTime%",
-          "default": false
+          "default": false,
+          "scope": "resource"
         },
         "mssql.splitPaneSelection": {
           "type": "string",
@@ -487,12 +498,14 @@
             "next",
             "current",
             "end"
-          ]
+          ],
+          "scope": "resource"
         },
         "mssql.format.alignColumnDefinitionsInColumns": {
           "type": "boolean",
           "description": "%mssql.format.alignColumnDefinitionsInColumns%",
-          "default": false
+          "default": false,
+          "scope": "window"
         },
         "mssql.format.datatypeCasing": {
           "type": "string",
@@ -502,7 +515,8 @@
             "none",
             "uppercase",
             "lowercase"
-          ]
+          ],
+          "scope": "window"
         },
         "mssql.format.keywordCasing": {
           "type": "string",
@@ -512,52 +526,62 @@
             "none",
             "uppercase",
             "lowercase"
-          ]
+          ],
+          "scope": "window"
         },
         "mssql.format.placeCommasBeforeNextStatement": {
           "type": "boolean",
           "description": "%mssql.format.placeCommasBeforeNextStatement%",
-          "default": false
+          "default": false,
+          "scope": "window"
         },
         "mssql.format.placeSelectStatementReferencesOnNewLine": {
           "type": "boolean",
           "description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
-          "default": false
+          "default": false,
+          "scope": "window"
         },
         "mssql.applyLocalization": {
           "type": "boolean",
           "description": "%mssql.applyLocalization%",
-          "default": false
+          "default": false,
+          "scope": "window"
         },
         "mssql.query.displayBitAsNumber": {
           "type": "boolean",
           "default": true,
-          "description": "%mssql.query.displayBitAsNumber%"
+          "description": "%mssql.query.displayBitAsNumber%",
+          "scope": "window"
         },
         "mssql.intelliSense.enableIntelliSense": {
           "type": "boolean",
           "default": true,
-          "description": "%mssql.intelliSense.enableIntelliSense%"
+          "description": "%mssql.intelliSense.enableIntelliSense%",
+          "scope": "window"
         },
         "mssql.intelliSense.enableErrorChecking": {
           "type": "boolean",
           "default": true,
-          "description": "%mssql.intelliSense.enableErrorChecking%"
+          "description": "%mssql.intelliSense.enableErrorChecking%",
+          "scope": "window"
         },
         "mssql.intelliSense.enableSuggestions": {
           "type": "boolean",
           "default": true,
-          "description": "%mssql.intelliSense.enableSuggestions%"
+          "description": "%mssql.intelliSense.enableSuggestions%",
+          "scope": "window"
         },
         "mssql.intelliSense.enableQuickInfo": {
           "type": "boolean",
           "default": true,
-          "description": "%mssql.intelliSense.enableQuickInfo%"
+          "description": "%mssql.intelliSense.enableQuickInfo%",
+          "scope": "window"
         },
         "mssql.intelliSense.lowerCaseSuggestions": {
           "type": "boolean",
           "default": false,
-          "description": "%mssql.intelliSense.lowerCaseSuggestions%"
+          "description": "%mssql.intelliSense.lowerCaseSuggestions%",
+          "scope": "window"
         }
       }
     }

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -348,14 +348,14 @@ export default class QueryRunner {
             return includeHeaders;
         }
         // else get config option from vscode config
-        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this.uri);
         includeHeaders = config[Constants.copyIncludeHeaders];
         return !!includeHeaders;
     }
 
     private shouldRemoveNewLines(): boolean {
         // get config copyRemoveNewLine option from vscode config
-        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this.uri);
         let removeNewLines: boolean = config[Constants.configCopyRemoveNewLine];
         return removeNewLines;
     }
@@ -371,7 +371,7 @@ export default class QueryRunner {
 
     private sendBatchTimeMessage(batchId: number, executionTime: string): void {
         // get config copyRemoveNewLine option from vscode config
-        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this.uri);
         let showBatchTime: boolean = config[Constants.configShowBatchTime];
         if (showBatchTime) {
             let message: IResultMessage = {

--- a/src/models/resultsSerializer.ts
+++ b/src/models/resultsSerializer.ts
@@ -65,7 +65,7 @@ export default class ResultsSerializer {
 
     private getConfigForCsv(): Contracts.SaveResultsAsCsvRequestParams {
         // get save results config from vscode config
-        let config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this._uri);
         let saveConfig = config[Constants.configSaveAsCsv];
         let saveResultsParams = new Contracts.SaveResultsAsCsvRequestParams();
 
@@ -80,7 +80,7 @@ export default class ResultsSerializer {
 
     private getConfigForJson(): Contracts.SaveResultsAsJsonRequestParams {
         // get save results config from vscode config
-        let config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this._uri);
         let saveConfig = config[Constants.configSaveAsJson];
         let saveResultsParams = new Contracts.SaveResultsAsJsonRequestParams();
 
@@ -94,7 +94,7 @@ export default class ResultsSerializer {
         // get save results config from vscode config
         // Note: we are currently using the configSaveAsCsv setting since it has the option mssql.saveAsCsv.includeHeaders
         // and we want to have just 1 setting that lists this.
-        let config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, this._uri);
         let saveConfig = config[Constants.configSaveAsCsv];
         let saveResultsParams = new Contracts.SaveResultsAsExcelRequestParams();
 

--- a/src/views/htmlcontent/src/js/services/data.service.ts
+++ b/src/views/htmlcontent/src/js/services/data.service.ts
@@ -198,7 +198,9 @@ export class DataService {
             return Promise.resolve(this._config);
         } else {
             return new Promise<{[key: string]: string}>((resolve, reject) => {
-                self.http.get('/config').map((res): IResultsConfig => {
+                let url = '/config?'
+                    + '&uri=' + self.uri;
+                self.http.get(url).map((res): IResultsConfig => {
                     return res.json();
                 }).subscribe((result: IResultsConfig) => {
                     self._shortcuts = result.shortcuts;
@@ -216,7 +218,9 @@ export class DataService {
             return Promise.resolve(this._shortcuts);
         } else {
             return new Promise<any>((resolve, reject) => {
-                self.http.get('/config').map((res): IResultsConfig => {
+                let url = '/config?'
+                    + '&uri=' + self.uri;
+                self.http.get(url).map((res): IResultsConfig => {
                     return res.json();
                 }).subscribe((result) => {
                     self._shortcuts = result.shortcuts;

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -490,7 +490,7 @@ suite('Query Runner tests', () => {
 
     function setupWorkspaceConfig(configResult: {[key: string]: any}): void {
         let config = stubs.createWorkspaceConfiguration(configResult);
-        testVscodeWrapper.setup(x => x.getConfiguration(TypeMoq.It.isAny()))
+        testVscodeWrapper.setup(x => x.getConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
         .returns(x => {
             return config;
         });

--- a/test/saveResults.test.ts
+++ b/test/saveResults.test.ts
@@ -5,13 +5,13 @@ import ResultsSerializer  from './../src/models/resultsSerializer';
 import { SaveResultsAsCsvRequestParams } from './../src/models/contracts';
 import SqlToolsServerClient from './../src/languageservice/serviceclient';
 import VscodeWrapper from './../src/controllers/vscodeWrapper';
-import { Uri } from 'vscode';
+import * as vscode from 'vscode';
 import os = require('os');
 
 suite('save results tests', () => {
 
     const testFile = 'file:///my/test/file.sql';
-    let fileUri: Uri;
+    let fileUri: vscode.Uri;
     let serverClient: TypeMoq.IMock<SqlToolsServerClient>;
     let vscodeWrapper: TypeMoq.IMock<VscodeWrapper>;
 
@@ -19,10 +19,13 @@ suite('save results tests', () => {
 
         serverClient = TypeMoq.Mock.ofType(SqlToolsServerClient, TypeMoq.MockBehavior.Strict);
         vscodeWrapper = TypeMoq.Mock.ofType(VscodeWrapper);
+        vscodeWrapper.setup(x => x.getConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(extensionName => {
+            return vscode.workspace.getConfiguration(extensionName);
+        });
         if (os.platform() === 'win32') {
-            fileUri = Uri.file('c:\\test.csv');
+            fileUri = vscode.Uri.file('c:\\test.csv');
         } else {
-            fileUri = Uri.file('/test.csv');
+            fileUri = vscode.Uri.file('/test.csv');
         }
     });
 

--- a/test/sqlOutputContentProvider.test.ts
+++ b/test/sqlOutputContentProvider.test.ts
@@ -32,7 +32,7 @@ suite('SqlOutputProvider Tests', () => {
             let configResult: {[key: string]: any} = {};
             configResult[Constants.configSplitPaneSelection] = value;
             let config = stubs.createWorkspaceConfiguration(configResult);
-            vscodeWrapper.setup(x => x.getConfiguration(TypeMoq.It.isAny()))
+            vscodeWrapper.setup(x => x.getConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(x => {
                 return config;
             });
@@ -74,7 +74,7 @@ suite('SqlOutputProvider Tests', () => {
                 setSplitPaneSelectionConfig(c.config);
                 setCurrentEditorColumn(c.position);
 
-                let resultColumn = contentProvider.newResultPaneViewColumn();
+                let resultColumn = contentProvider.newResultPaneViewColumn('test_uri');
 
                 // Ensure each case properly outputs the result pane
                 assert.equal(resultColumn, c.expectedColumn);

--- a/test/webServiceRequestHandlers.test.ts
+++ b/test/webServiceRequestHandlers.test.ts
@@ -51,6 +51,7 @@ suite('Web Service Request Handler Tests', () => {
             startColumn: 0,
             startLine: 0
         };
+        queryRunner.setup(x => x.uri).returns(() => uri);
         contentProvider.runQuery(statusView.object, uri, querySelection, title);
         contentProvider.getResultsMap.get('tsqloutput:' + uri).queryRunner = queryRunner.object;
     });
@@ -117,7 +118,13 @@ suite('Web Service Request Handler Tests', () => {
     });
 
     test('ConfigRequestHandler properly handles request and renders content', done => {
-        let request = new stubs.ExpressRequest();
+        let testQuery = {
+            resultSetNo: 0,
+            uri: 'tsqloutput:test_uri',
+            batchIndex: 0,
+            format: 'test_format'
+        };
+        let request = new stubs.ExpressRequest(testQuery);
         // Run tested function
         contentProvider.configRequestHandler(request, result.object);
 


### PR DESCRIPTION
This PR changes many simple config settings to be available at the resource (folder) level instead of workspace level, as part of the changes to support multi-root workspaces.

With this change, users will continue to be able to set these settings at the folder level once VS Code's multi-root workspaces feature goes live. Without it, these settings could only be set as workspace or user configs.

There are still some settings left to move over, which will come in separate PRs, specifically (in the order that I plan to do them):
- format settings
- connection settings
- intellisense settings (maybe)