### PR TITLE
Use untitled file name as default when exporting results

### DIFF
--- a/src/models/resultsSerializer.ts
+++ b/src/models/resultsSerializer.ts
@@ -8,6 +8,7 @@ import {RequestType} from 'vscode-languageclient';
 import * as Utils from '../models/utils';
 import VscodeWrapper from '../controllers/vscodeWrapper';
 import Telemetry from '../models/telemetry';
+import * as path from 'path';
 
 let opener = require('opener');
 
@@ -39,9 +40,11 @@ export default class ResultsSerializer {
     }
 
     private promptForFilepath(format: string): Thenable<string> {
-        let defaultUri = vscode.Uri.parse(this._uri);
-        if (defaultUri.scheme === 'untitled') {
+        let defaultUri: vscode.Uri;
+        if (vscode.Uri.parse(this._uri).scheme === 'untitled') {
             defaultUri = undefined;
+        } else {
+            defaultUri = vscode.Uri.parse(path.dirname(this._uri));
         }
         let fileTypeFilter: { [name: string]: string[] } = {};
         if (format === 'csv') {


### PR DESCRIPTION
This fixes a bug in exporting query results that I introduced when I refactored the code to use VS Code's `showSaveDialog` api. The default file name used when saving used to match the name of the file that the query was executed from, which worked fine on Mac where the extension would subsequently be added, but did not work on Windows where it would attempt to overwrite the .sql file.

With this change, the save dialog opens to the folder containing the query file by default but does not set a file name.