### PR TITLE
Bump SQL Tools Service version to support special characters in paths

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/4/D/9/4D983AEF-AF2B-48AF-AB03-78C6DE276BA1/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.2.1",
+        "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.2.0-alpha.41",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
This bumps the SQL Tools Service version to include the fix for #1025 