### PR TITLE
Update release notes and config for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## Version 1.3.0
+* Release date: December 8, 2017
+* Release status: GA
+
+## What's new in this version
+* Fixed an issue where peek definition and go to definition failed for stored procedures.
+* Improved performance for peek definition and go to definition.
+* Added support for `GO N` syntax.
+* Fixed issue [#1025](https://github.com/Microsoft/vscode-mssql/issues/1025) where query execution would fail when executing from file paths containing special characters
+* Fixed issue [#785](https://github.com/Microsoft/vscode-mssql/issues/785) Inactive connection can't reconnect with out VS Code restart
+* A community-contributed fix for snippets that failed on databases with case-sensitive collations.
+
+
+### Contributions and "thank you"
+* Thank you to Stefán Jökull Sigurðarson for contributing the fix for snippets that failed with case-sensitive collations, which was ported here from the SQL Operations Studio repository.
+* We would like to thank everyone who contributed to localization for this update and encourage more people to join our [open source community localization effort](https://github.com/Microsoft/Localization/wiki).
+
 ## Version 1.2.1
 * Release date: November 8, 2017
 * Release status: GA

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ See [the SQL developer tutorial] to develop an app with C#, Java, Node.js, PHP, 
 
 <img src="https://github.com/Microsoft/vscode-mssql/raw/master/images/mssql-demo.gif" alt="demo" style="width:480px;"/>
 
+## What's new in 1.3.0
+* Fixed an issue where peek definition and go to definition failed for stored procedures.
+* Improved performance for peek definition and go to definition.
+* Added support for `GO N` syntax.
+* Fixed issue [#1025](https://github.com/Microsoft/vscode-mssql/issues/1025) where query execution would fail when executing from file paths containing special characters
+* A community-contributed fix for snippets that failed on databases with case-sensitive collations.
+
+
 ## What's new in 1.2.1
 * Support for multi-root workspaces in preparation for the feature's release in Visual Studio Code. When running with multi-root workspaces, users will be able to set many configuration options at the folder level, including connection configurations.
 * Exporting results as CSV, JSON, or Excel files now shows the operating system's save-as dialog instead of using text-based dialogs to name the saved file.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": false,

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.2.0-alpha.41",
+        "version": "1.2.0-alpha.45",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,6 +1,6 @@
 {
     "service": {
-        "downloadUrl": "http://download.microsoft.com/download/8/6/F/86FEE8EC-A1D4-4A43-A946-B6CA970BBCD7/microsoft.sqltools.servicelayer-{#fileName#}",
+        "downloadUrl": "https://download.microsoft.com/download/8/6/F/86FEE8EC-A1D4-4A43-A946-B6CA970BBCD7/microsoft.sqltools.servicelayer-{#fileName#}",
         "version": "1.3.0",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/4/D/9/4D983AEF-AF2B-48AF-AB03-78C6DE276BA1/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.2.1",
+        "downloadUrl": "http://download.microsoft.com/download/8/6/F/86FEE8EC-A1D4-4A43-A946-B6CA970BBCD7/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.3.0",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
Added release notes for 1.3.0.

I'll publish this version to the team as the release candidate. Meanwhile I will release 1.2.0-alpha.45 of SQL Tools Service to the download center and then update `production.config.json` to use it before publishing the release.