### PR TITLE
Remove call to deprecated vscode API

### DIFF
--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -300,15 +300,4 @@ export default class VscodeWrapper {
     public uriParse(value: string): vscode.Uri {
         return vscode.Uri.parse(value);
     }
-
-    /**
-     * The folder that is open in VS Code. `undefined` when no folder
-     * has been opened.
-     *
-     * @readonly
-     * @see vscode.workspace.rootPath
-     */
-    public get workspaceRootPath(): string {
-        return vscode.workspace.rootPath;
-    }
 }


### PR DESCRIPTION
Relevant guidance: https://github.com/Microsoft/vscode-wiki/blob/8aaafd483fc48f361a3e6f9e8feebd036600dc63/Extension-Authoring:-Adopting-Multi-Root-Workspace-APIs.md#do-i-need-to-do-anything