### PR TITLE
Fix copy/paste of unicode results on Mac

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -335,7 +335,15 @@ export default class QueryRunner {
                 p = p.then(tasks[i]);
             }
             p.then(() => {
+                let oldLang: string;
+                if (process.platform === 'darwin') {
+                    oldLang = process.env['LANG'];
+                    process.env['LANG'] = 'en_US.UTF-8';
+                }
                 ncp.copy(copyString, () => {
+                    if (process.platform === 'darwin') {
+                        process.env['LANG'] = oldLang;
+                    }
                     resolve();
                 });
             });

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -571,7 +571,7 @@ suite('Query Runner tests', () => {
             );
             queryRunner.uri = testuri;
             return queryRunner.copyResults(testRange, 0, 0).then(() => {
-                let pasteContents = ncp.paste();
+                let pasteContents = pasteCopiedString();
                 assert.equal(pasteContents, finalStringNoHeader);
             });
         });
@@ -594,7 +594,7 @@ suite('Query Runner tests', () => {
             // Call handleResult to ensure column header info is seeded
             queryRunner.handleQueryComplete(result);
             return queryRunner.copyResults(testRange, 0, 0).then(() => {
-                let pasteContents = ncp.paste();
+                let pasteContents = pasteCopiedString();
                 assert.equal(pasteContents, finalStringWithHeader);
             });
         });
@@ -619,7 +619,7 @@ suite('Query Runner tests', () => {
 
             // call copyResults with additional parameter indicating to include headers
             return queryRunner.copyResults(testRange, 0, 0, true).then(() => {
-                let pasteContents = ncp.paste();
+                let pasteContents = pasteCopiedString();
                 assert.equal(pasteContents, finalStringWithHeader);
             });
         });
@@ -644,7 +644,7 @@ suite('Query Runner tests', () => {
 
             // call copyResults with additional parameter indicating to not include headers
             return queryRunner.copyResults(testRange, 0, 0, false).then(() => {
-                let pasteContents = ncp.paste();
+                let pasteContents = pasteCopiedString();
                 assert.equal(pasteContents, finalStringNoHeader);
             });
         });
@@ -676,4 +676,17 @@ function setupStandardQueryNotificationHandlerMock(testQueryNotificationHandler:
         .callback((qr, u: string) => {
             assert.equal(u, standardUri);
         });
+}
+
+function pasteCopiedString(): string {
+    let oldLang: string;
+    if (process.platform === 'darwin') {
+        oldLang = process.env['LANG'];
+        process.env['LANG'] = 'en_US.UTF-8';
+    }
+    let pastedString = ncp.paste();
+    if (process.platform === 'darwin') {
+        process.env['LANG'] = oldLang;
+    }
+    return pastedString;
 }

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -504,7 +504,7 @@ suite('Query Runner tests', () => {
                             '3' + TAB + '4' + CLRF +
                             '5' + TAB + '6' + CLRF +
                             '7' + TAB + '8' + CLRF +
-                            '9' + TAB + '10';
+                            '9' + TAB + '10 ∞';
 
         const finalStringWithHeader = 'Col1' + TAB + 'Col2' + CLRF + finalStringNoHeader;
 
@@ -517,10 +517,11 @@ suite('Query Runner tests', () => {
                     [{isNull: false, displayValue: '3'}, {isNull: false, displayValue: '4'}],
                     [{isNull: false, displayValue: '5'}, {isNull: false, displayValue: '6'}],
                     [{isNull: false, displayValue: '7'}, {isNull: false, displayValue: '8'}],
-                    [{isNull: false, displayValue: '9'}, {isNull: false, displayValue: '10'}]
+                    [{isNull: false, displayValue: '9'}, {isNull: false, displayValue: '10 ∞'}]
                 ]
             }
         };
+        process.env['LANG'] = 'C';
 
         let testRange: ISlickRange[] = [{fromCell: 0, fromRow: 0, toCell: 1, toRow: 4}];
 


### PR DESCRIPTION
Copy/paste of unicode results can be broken on mac if the user's `LANG` environment variable isn't set to a locale that supports unicode. This has been reported by multiple users in #1059 and #1036