### PR TITLE
Update configs for 1.3.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": false,

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,19 +1,19 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/8/6/F/86FEE8EC-A1D4-4A43-A946-B6CA970BBCD7/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.3.0",
+        "downloadUrl": "https://download.microsoft.com/download/3/6/2/362408E3-F226-4B22-A67D-85A2544774B9/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.3.1",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.0.zip",
             "Windows_7_64": "win-x64-netcoreapp2.0.zip",
             "OSX_10_11_64": "osx-x64-netcoreapp2.0.tar.gz",
-            "CentOS_7": "centos-x64-netcoreapp2.0.tar.gz",
-            "Debian_8": "debian-x64-netcoreapp2.0.tar.gz",
-            "Fedora_23": "fedora-x64-netcoreapp2.0.tar.gz",
-            "OpenSUSE_13_2": "opensuse-x64-netcoreapp2.0.tar.gz",
-            "SLES_12_2": "opensuse-x64-netcoreapp2.0.tar.gz",
+            "CentOS_7": "rhel-x64-netcoreapp2.0.tar.gz",
+            "Debian_8": "rhel-x64-netcoreapp2.0.tar.gz",
+            "Fedora_23": "rhel-x64-netcoreapp2.0.tar.gz",
+            "OpenSUSE_13_2": "rhel-x64-netcoreapp2.0.tar.gz",
+            "SLES_12_2": "rhel-x64-netcoreapp2.0.tar.gz",
             "RHEL_7": "rhel-x64-netcoreapp2.0.tar.gz",
-            "Ubuntu_14": "ubuntu14-x64-netcoreapp2.0.tar.gz",
-            "Ubuntu_16": "ubuntu16-x64-netcoreapp2.0.tar.gz"
+            "Ubuntu_14": "rhel-x64-netcoreapp2.0.tar.gz",
+            "Ubuntu_16": "rhel-x64-netcoreapp2.0.tar.gz"
         },
         "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
         "executableFiles": ["MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer", "MicrosoftSqlToolsServiceLayer.dll"]


### PR DESCRIPTION
Update prod.config.json to set the 1.3.1 SQL Tools Service download location and mark this as version 1.3.1 of the extension