### PR TITLE
Add missing translations

### DIFF
--- a/localization/xliff/deu/constants/localizedConstants.deu.xlf
+++ b/localization/xliff/deu/constants/localizedConstants.deu.xlf
@@ -258,7 +258,7 @@
             <source xml:lang="en">Help</source><target>Hilfe</target>
         </trans-unit>
         <trans-unit id="macSierraRequiredErrorMessage">
-            <source xml:lang="en">macOS Sierra or newer is required to use this feature.</source>
+            <source xml:lang="en">macOS Sierra or newer is required to use this feature.</source><target>MacOS Sierra oder neuer ist erforderlich, um diese Funktion zu nutzen.</target>
         </trans-unit>
         <trans-unit id="gettingDefinitionMessage">
             <source xml:lang="en">Getting definition ...</source><target>Definition wird abgerufen...</target>
@@ -288,10 +288,10 @@
             <source xml:lang="en">Are you sure you want to disconnect?</source><target>Sind Sie sicher, dass Sie die Verbindung trennen möchten?</target>
         </trans-unit>
         <trans-unit id="elapsedBatchTime">
-            <source xml:lang="en">Batch execution time: {0}</source>
+            <source xml:lang="en">Batch execution time: {0}</source><target>Batch-Ausführungszeit: {0}</target>
         </trans-unit>
         <trans-unit id="noActiveEditorMsg">
-            <source xml:lang="en">A SQL editor must have focus before executing this command</source>
+            <source xml:lang="en">A SQL editor must have focus before executing this command</source><target>Ein SQL-Editor muss den Fokus haben vor der Ausführung dieses Befehls</target>
         </trans-unit>
         <trans-unit id="maximizeLabel">
             <source xml:lang="en">Maximize</source><target>Maximieren</target>
@@ -300,7 +300,7 @@
             <source xml:lang="en">Restore</source><target>Wiederherstellen</target>
         </trans-unit>
         <trans-unit id="saveCSVLabel">
-            <source xml:lang="en">Save as CSV</source>
+            <source xml:lang="en">Save as CSV</source><target>Als CSV speichern</target>
         </trans-unit>
         <trans-unit id="saveJSONLabel">
             <source xml:lang="en">Save as JSON</source><target>Als JSON speichern</target>
@@ -339,7 +339,7 @@
             <source xml:lang="en">Line {0}</source><target>Linie {0}</target>
         </trans-unit>
         <trans-unit id="elapsedTimeLabel">
-            <source xml:lang="en">Total execution time: {0}</source>
+            <source xml:lang="en">Total execution time: {0}</source><target>Gesamte Ausführungszeit: {0}</target>
         </trans-unit>
         <trans-unit id="msgCannotSaveMultipleSelections">
             <source xml:lang="en">Save results command cannot be used with multiple selections.</source><target>Der Befehl "Ergebnisse speichern" kann nicht mit Mehrfachauswahlen verwendet werden.</target>
@@ -351,10 +351,10 @@
             <source xml:lang="en">None</source><target>NONE</target>
         </trans-unit>
         <trans-unit id="chooseSqlLang">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>Wählen Sie SQL-Sprache</target>
         </trans-unit>
         <trans-unit id="flavorChooseLanguage">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>Wählen Sie SQL-Sprache</target>
         </trans-unit>
         <trans-unit id="flavorDescriptionMssql">
             <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source><target>Intellisense und Syntax-Fehlerüberprüfung im aktuellen Dokument verwenden</target>

--- a/localization/xliff/deu/localizedPackage.json.deu.xlf
+++ b/localization/xliff/deu/localizedPackage.json.deu.xlf
@@ -6,7 +6,7 @@
             <source xml:lang="en">Execute Query</source><target>Abfrage ausführen</target>
         </trans-unit>
         <trans-unit id="extension.runCurrentStatement">
-            <source xml:lang="en">Execute Current Statement</source>
+            <source xml:lang="en">Execute Current Statement</source><target>Aktuelle Anweisung ausführen</target>
         </trans-unit>
         <trans-unit id="extension.cancelQuery">
             <source xml:lang="en">Cancel Query</source><target>Abfrage abbrechen</target>
@@ -21,7 +21,7 @@
             <source xml:lang="en">Manage Connection Profiles</source><target>Verbindungsprofile verwalten</target>
         </trans-unit>
         <trans-unit id="extension.chooseDatabase">
-            <source xml:lang="en">Use Database</source>
+            <source xml:lang="en">Use Database</source><target>Datenbank verwenden</target>
         </trans-unit>
         <trans-unit id="extension.chooseLanguageFlavor">
             <source xml:lang="en">Choose SQL handler for this file</source><target>Wählen Sie den SQL-Handler für diese Datei</target>
@@ -33,7 +33,7 @@
             <source xml:lang="en">New Query</source><target>Neue Abfrage</target>
         </trans-unit>
         <trans-unit id="extension.rebuildIntelliSenseCache">
-            <source xml:lang="en">Refresh IntelliSense Cache</source>
+            <source xml:lang="en">Refresh IntelliSense Cache</source><target>IntelliSense Cache aktualisieren</target>
         </trans-unit>
         <trans-unit id="mssql.logDebugInfo">
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -&gt; Toggle Developer Tools)</source><target>[Optional] Protokolliere die Debugausgaben mit der VS Code Konsole (Hilfe -&gt; Entwicklertools umschalten)</target>
@@ -90,7 +90,7 @@
             <source xml:lang="en">[Optional] Declares the application workload type when connecting to SQL Server such as ReadWrite or ReadOnly. Refer to SQL Server AlwaysOn for more detail.</source><target>[Optional] Gibt den Anwendungstyp bei der Verbindung mit SQL Server an, z. B. ReadWrite oder ReadOnly. Mehr Details finden Sie unter SQL Server AlwaysOn.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.currentLanguage">
-            <source xml:lang="en">[Optional] Indicates the SQL Server language settings.</source>
+            <source xml:lang="en">[Optional] Indicates the SQL Server language settings.</source><target>[Optional] Zeigt die SQL Server-Spracheinstellungen.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.pooling">
             <source xml:lang="en">[Optional] When set to 'true', the connection object is drawn from the appropriate pool, or if necessary, is created and added to the appropriate pool.</source><target>[Optional] Bei "Ja" wird das Verbindungs-Objekt ist aus dem entsprechenden Pool entnommen oder bei Bedarf erstellt und dem entsprechenden Pool hinzugefügt.</target>
@@ -153,10 +153,10 @@
             <source xml:lang="en">[Optional] When true, column headers are included when saving results as CSV</source><target>[Optional] Bei "Ja" werden die Spaltenüberschriften beim Speichern der Ergebnisse als CSV mit ausgegeben</target>
         </trans-unit>
         <trans-unit id="mssql.copyIncludeHeaders">
-            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
+            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source><target>[Optional] Konfigurations-Optionen für das Kopieren von Ergebnissen aus der Ergebnisansicht</target>
         </trans-unit>
         <trans-unit id="mssql.copyRemoveNewLine">
-            <source xml:lang="en">[Optional] Configuration options for copying multi-line results from the Results View</source>
+            <source xml:lang="en">[Optional] Configuration options for copying multi-line results from the Results View</source><target>[Optional] Konfigurations-Optionen für das Kopieren von mehrzeiligen Ergebnisse aus der Ergebnisansicht</target>
         </trans-unit>
         <trans-unit id="mssql.showBatchTime">
             <source xml:lang="en">[Optional] Should execution time be shown for individual batches</source><target>[Optional] Soll die Ausführungszeit für einzelne Aufrufe angezeigt werden</target>

--- a/localization/xliff/esn/constants/localizedConstants.esn.xlf
+++ b/localization/xliff/esn/constants/localizedConstants.esn.xlf
@@ -285,28 +285,28 @@
             <source xml:lang="en">Close the current connection</source><target>Cerrar la conexión actual</target>
         </trans-unit>
         <trans-unit id="disconnectConfirmationMsg">
-            <source xml:lang="en">Are you sure you want to disconnect?</source>
+            <source xml:lang="en">Are you sure you want to disconnect?</source><target>¿Está seguro de que desea desconectar?</target>
         </trans-unit>
         <trans-unit id="elapsedBatchTime">
-            <source xml:lang="en">Batch execution time: {0}</source>
+            <source xml:lang="en">Batch execution time: {0}</source><target>Tiempo de ejecución por lotes: {0}</target>
         </trans-unit>
         <trans-unit id="noActiveEditorMsg">
             <source xml:lang="en">A SQL editor must have focus before executing this command</source><target>Un editor de SQL debe tener foco antes de ejecutar este comando</target>
         </trans-unit>
         <trans-unit id="maximizeLabel">
-            <source xml:lang="en">Maximize</source>
+            <source xml:lang="en">Maximize</source><target>Maximizar</target>
         </trans-unit>
         <trans-unit id="restoreLabel">
-            <source xml:lang="en">Restore</source>
+            <source xml:lang="en">Restore</source><target>Restaurar</target>
         </trans-unit>
         <trans-unit id="saveCSVLabel">
-            <source xml:lang="en">Save as CSV</source>
+            <source xml:lang="en">Save as CSV</source><target>Guardar como CSV</target>
         </trans-unit>
         <trans-unit id="saveJSONLabel">
             <source xml:lang="en">Save as JSON</source><target>Guardar como JSON</target>
         </trans-unit>
         <trans-unit id="saveExcelLabel">
-            <source xml:lang="en">Save as Excel</source>
+            <source xml:lang="en">Save as Excel</source><target>Guardar como Excel</target>
         </trans-unit>
         <trans-unit id="fileTypeCSVLabel">
             <source xml:lang="en">CSV</source><target>CSV</target>
@@ -321,7 +321,7 @@
             <source xml:lang="en">Results</source><target>Resultados</target>
         </trans-unit>
         <trans-unit id="selectAll">
-            <source xml:lang="en">Select all</source>
+            <source xml:lang="en">Select all</source><target>Seleccionar todo</target>
         </trans-unit>
         <trans-unit id="copyLabel">
             <source xml:lang="en">Copy</source><target>Copiar</target>
@@ -351,7 +351,7 @@
             <source xml:lang="en">None</source><target>NONE</target>
         </trans-unit>
         <trans-unit id="chooseSqlLang">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>Elegir lenguaje SQL</target>
         </trans-unit>
         <trans-unit id="flavorChooseLanguage">
             <source xml:lang="en">Choose SQL Language</source><target>Elegir lenguaje SQL</target>

--- a/localization/xliff/esn/localizedPackage.json.esn.xlf
+++ b/localization/xliff/esn/localizedPackage.json.esn.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" original="extension.i18ntest.JSON" source-language="en" target-language="es">
     <body>
         <trans-unit id="extension.runQuery">
-            <source xml:lang="en">Execute Query</source>
+            <source xml:lang="en">Execute Query</source><target>Ejecutar la consulta</target>
         </trans-unit>
         <trans-unit id="extension.runCurrentStatement">
             <source xml:lang="en">Execute Current Statement</source><target>Ejecutar la instrucción actual</target>
@@ -21,7 +21,7 @@
             <source xml:lang="en">Manage Connection Profiles</source><target>Administrar perfiles de conexión</target>
         </trans-unit>
         <trans-unit id="extension.chooseDatabase">
-            <source xml:lang="en">Use Database</source>
+            <source xml:lang="en">Use Database</source><target>Utilizar base de datos</target>
         </trans-unit>
         <trans-unit id="extension.chooseLanguageFlavor">
             <source xml:lang="en">Choose SQL handler for this file</source><target>Seleccione el manejador SQL para este archivo</target>
@@ -33,7 +33,7 @@
             <source xml:lang="en">New Query</source><target>Nueva consulta</target>
         </trans-unit>
         <trans-unit id="extension.rebuildIntelliSenseCache">
-            <source xml:lang="en">Refresh IntelliSense Cache</source>
+            <source xml:lang="en">Refresh IntelliSense Cache</source><target>Actualizar Cache de IntelliSense</target>
         </trans-unit>
         <trans-unit id="mssql.logDebugInfo">
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -&gt; Toggle Developer Tools)</source><target>[Opcional] Registrar los resultados de depuración a la consola de VS Code (ayuda-&gt; Interruptor de herramientas de desarrollo)</target>
@@ -60,7 +60,7 @@
             <source xml:lang="en">[Optional] Specify the SQL Server authentication type.</source><target>Especifica el tipo de autenticación para SQL Server.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.port">
-            <source xml:lang="en">[Optional] Specify the port number to connect to.</source>
+            <source xml:lang="en">[Optional] Specify the port number to connect to.</source><target>[Opcional] Especificar el número de puerto para conectarse.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.encrypt">
             <source xml:lang="en">[Optional] When set to 'true', SQL Server uses SSL encryption for data sent between the client and the server if the server has a certificate installed. Set 'true' for Azure SQL Database connection.</source><target>[Opcional] Cuando está establecido en 'true', SQL Server utiliza encriptación SSL para los datos enviados entre el cliente y el servidor si el servidor tiene un certificado instalado. Establecer 'true' para la conexión de base de datos de SQL Azure.</target>
@@ -75,7 +75,7 @@
             <source xml:lang="en">[Optional] Specify the length of time in seconds to wait for a connection to the server before it times out. The default timeout value for Azure SQL Database is 30.</source><target>[Opcional] Especificar la cantidad de tiempo en segundos durante la que se espera una conexión al servidor antes de que caduque el tiempo de espera. El valor de tiempo de espera predeterminado para la base de datos de SQL Azure es 30.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.connectRetryCount">
-            <source xml:lang="en">[Optional] Specify the number of attempts to restore connection.</source>
+            <source xml:lang="en">[Optional] Specify the number of attempts to restore connection.</source><target>[Opcional] Especificar el número de intentos para restablecer la conexión.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.connectRetryInterval">
             <source xml:lang="en">[Optional] Specify the delay between attempts to restore connection.</source><target>[Opcional] Especifique el retardo entre intentos de restablecer la conexión.</target>
@@ -120,7 +120,7 @@
             <source xml:lang="en">[Optional] When set to 'true', multiple result sets can be returned and read from on connection.</source><target>[Opcional] Cuando se establece en 'true', se pueden devolver y leer múltiples conjuntos de resultados a través de la conexión.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.packetSize">
-            <source xml:lang="en">[Optional] Specify the size in bytes of the network packets to communicate with SQL Server.</source>
+            <source xml:lang="en">[Optional] Specify the size in bytes of the network packets to communicate with SQL Server.</source><target>[Opcional] Especifique el tamaño en bytes de los paquetes de red para comunicarse con SQL Server.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.typeSystemVersion">
             <source xml:lang="en">[Optional] Indicates which server type the provider will expose through the DataReader.</source><target>[Opcional] Indica qué tipo de servidor expondrá el proveedor a través del DataReader.</target>
@@ -138,7 +138,7 @@
             <source xml:lang="en">[Optional] Indicates whether this profile has an empty password explicitly set</source><target>[Opcional] Indica si este perfil tiene una contraseña vacía establecida explícitamente</target>
         </trans-unit>
         <trans-unit id="mssql.shortcuts">
-            <source xml:lang="en">Shortcuts related to the results window</source>
+            <source xml:lang="en">Shortcuts related to the results window</source><target>Accesos directos relacionados con la ventana de resultados</target>
         </trans-unit>
         <trans-unit id="mssql.messagesDefaultOpen">
             <source xml:lang="en">True for the messages pane to be open by default; false for closed</source><target>True para que el panel de mensajes esté abierto de forma predeterminada; false para que esté cerrado</target>
@@ -186,7 +186,7 @@
             <source xml:lang="en">Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'</source><target>¿Se deben mostrar las columnas BIT como números (1 o 0)? Si es false, las columnas BIT se mostrarán como 'true' o 'false'</target>
         </trans-unit>
         <trans-unit id="mssql.intelliSense.enableIntelliSense">
-            <source xml:lang="en">Should IntelliSense be enabled</source>
+            <source xml:lang="en">Should IntelliSense be enabled</source><target>Debe habilitar IntelliSense</target>
         </trans-unit>
         <trans-unit id="mssql.intelliSense.enableErrorChecking">
             <source xml:lang="en">Should IntelliSense error checking be enabled</source><target>Debe habilitar la comprobación de errores de IntelliSense </target>

--- a/localization/xliff/fra/localizedPackage.json.fra.xlf
+++ b/localization/xliff/fra/localizedPackage.json.fra.xlf
@@ -33,7 +33,7 @@
             <source xml:lang="en">New Query</source><target>Nouvelle requête</target>
         </trans-unit>
         <trans-unit id="extension.rebuildIntelliSenseCache">
-            <source xml:lang="en">Refresh IntelliSense Cache</source>
+            <source xml:lang="en">Refresh IntelliSense Cache</source><target>Actualiser le Cache IntelliSense</target>
         </trans-unit>
         <trans-unit id="mssql.logDebugInfo">
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -&gt; Toggle Developer Tools)</source><target>[Facultatif] Loguer la sortie de débogage dans la console de VS Code (Aide -&gt; Activer/Désactiver les outils de développement)</target>

--- a/localization/xliff/ita/constants/localizedConstants.ita.xlf
+++ b/localization/xliff/ita/constants/localizedConstants.ita.xlf
@@ -222,7 +222,7 @@
             <source xml:lang="en">Error: Unable to connect using the connection information provided. Retry profile creation?</source><target>Errore: Impossibile connettersi utilizzando le informazioni di connessione fornite. Ritentare la creazione del profilo?</target>
         </trans-unit>
         <trans-unit id="msgPromptRetryConnectionDifferentCredentials">
-            <source xml:lang="en">Error: Login failed. Retry using different credentials?</source>
+            <source xml:lang="en">Error: Login failed. Retry using different credentials?</source><target>Errore: Accesso non riuscito. Riprovare utilizzando credenziali diverse?</target>
         </trans-unit>
         <trans-unit id="retryLabel">
             <source xml:lang="en">Retry</source><target>Riprova</target>
@@ -351,10 +351,10 @@
             <source xml:lang="en">None</source><target>Nessuno</target>
         </trans-unit>
         <trans-unit id="chooseSqlLang">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>Scegli il Linguaggio SQL</target>
         </trans-unit>
         <trans-unit id="flavorChooseLanguage">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>Scegli il Linguaggio SQL</target>
         </trans-unit>
         <trans-unit id="flavorDescriptionMssql">
             <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source><target>Utilizza intellisense e il controllo degli errori di sintassi T-SQL nel documento corrente</target>

--- a/localization/xliff/ita/localizedPackage.json.ita.xlf
+++ b/localization/xliff/ita/localizedPackage.json.ita.xlf
@@ -60,7 +60,7 @@
             <source xml:lang="en">[Optional] Specify the SQL Server authentication type.</source><target>[Facoltativo] Specifica il tipo di autenticazione di SQL Server.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.port">
-            <source xml:lang="en">[Optional] Specify the port number to connect to.</source>
+            <source xml:lang="en">[Optional] Specify the port number to connect to.</source><target>[Facoltativo] Specificare il numero di porta a cui connettersi.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.encrypt">
             <source xml:lang="en">[Optional] When set to 'true', SQL Server uses SSL encryption for data sent between the client and the server if the server has a certificate installed. Set 'true' for Azure SQL Database connection.</source><target>[Facoltativo] Quando impostato a 'true', SQL Server utilizza la crittografia SSL per i dati inviati tra il client e il server se il server ha un certificato installato. Impostare a 'true' per le connessioni a Azure SQL Database.</target>
@@ -153,7 +153,7 @@
             <source xml:lang="en">[Optional] When true, column headers are included when saving results as CSV</source><target>[Facoltativo] Quando è 'true', le intestazioni di colonna sono incluse quando si salvano i risultati come file CSV</target>
         </trans-unit>
         <trans-unit id="mssql.copyIncludeHeaders">
-            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
+            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source><target>[Facoltativo] Opzioni di configurazione per copiare i risultati dalla vista dei risultati</target>
         </trans-unit>
         <trans-unit id="mssql.copyRemoveNewLine">
             <source xml:lang="en">[Optional] Configuration options for copying multi-line results from the Results View</source><target>[Facoltativo] Opzioni di configurazione per la copia di risultati multi linea dalla vista dei risultati</target>

--- a/localization/xliff/jpn/constants/localizedConstants.jpn.xlf
+++ b/localization/xliff/jpn/constants/localizedConstants.jpn.xlf
@@ -282,7 +282,7 @@
             <source xml:lang="en">Disconnect</source><target>切断</target>
         </trans-unit>
         <trans-unit id="disconnectOptionDescription">
-            <source xml:lang="en">Close the current connection</source>
+            <source xml:lang="en">Close the current connection</source><target>現在の接続を閉じる</target>
         </trans-unit>
         <trans-unit id="disconnectConfirmationMsg">
             <source xml:lang="en">Are you sure you want to disconnect?</source><target>切断してよろしいですか?</target>
@@ -297,7 +297,7 @@
             <source xml:lang="en">Maximize</source><target>最大化</target>
         </trans-unit>
         <trans-unit id="restoreLabel">
-            <source xml:lang="en">Restore</source>
+            <source xml:lang="en">Restore</source><target>復元</target>
         </trans-unit>
         <trans-unit id="saveCSVLabel">
             <source xml:lang="en">Save as CSV</source><target>CSV として保存</target>

--- a/localization/xliff/jpn/localizedPackage.json.jpn.xlf
+++ b/localization/xliff/jpn/localizedPackage.json.jpn.xlf
@@ -39,10 +39,10 @@
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -&gt; Toggle Developer Tools)</source><target>[オプション]VS Codeコンソールにデバッグ出力を記録 (ヘルプ -&gt; 開発者ツールの切り替え)</target>
         </trans-unit>
         <trans-unit id="mssql.maxRecentConnections">
-            <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+            <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source><target>接続リストに格納する最近使用された接続の最大数。</target>
         </trans-unit>
         <trans-unit id="mssql.connections">
-            <source xml:lang="en">Connection profiles defined in 'User Settings' are shown under 'MS SQL: Connect' command in the command palette.</source>
+            <source xml:lang="en">Connection profiles defined in 'User Settings' are shown under 'MS SQL: Connect' command in the command palette.</source><target>「ユーザー設定」で定義されている接続プロファイルの下に表示される 'MS SQL: Connect' コマンド パレットのコマンド。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.server">
             <source xml:lang="en"><![CDATA[[Required] Specify the server name to connect to. Use 'hostname\\instance' or '<server>.database.windows.net' for Azure SQL Database.]]></source><target>[必須]接続先のサーバー名を指定します。'hostname\\instance' または Azure SQL データベースに対しては'&lt;server&gt;. database.windows.net' を使用します。</target>
@@ -105,13 +105,13 @@
             <source xml:lang="en">[Optional] Specify the minimum amount of time in seconds for this connection to live in the pool before being removed/deleted.</source><target>[オプション]この接続を削除する前に、この接続がプールに生存する最小値を秒単位で指定します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.replication">
-            <source xml:lang="en">[Optional] Used by SQL Server in replication.</source>
+            <source xml:lang="en">[Optional] Used by SQL Server in replication.</source><target>[オプション]SQL Server レプリケーションで使用。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.attachDbFilename">
-            <source xml:lang="en">[Optional] Specify the name of the primary file, including the full path name, of an attachable database.</source>
+            <source xml:lang="en">[Optional] Specify the name of the primary file, including the full path name, of an attachable database.</source><target>[オプション]アタッチ可能なデータベースの完全なパス名を含む、プライマリ ファイルの名前を指定します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.failoverPartner">
-            <source xml:lang="en">[Optional] Specify the name or network address of the instance of SQL Server that acts as a failover partner.</source>
+            <source xml:lang="en">[Optional] Specify the name or network address of the instance of SQL Server that acts as a failover partner.</source><target>[オプション]フェールオーバー パートナーとして動作する SQL Server のインスタンスの名前またはネットワーク アドレスを指定します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.multiSubnetFailover">
             <source xml:lang="en">[Optional] When set to 'true', the detection and connection to the active server is faster if AlwaysOn Availability Group is configured on different subnets.</source><target>[オプション] 'true' に設定すると、AlwaysOn 可用性グループが異なるサブネット上に構成されている場合にアクティブなサーバーの検出と接続が高速になります。</target>
@@ -123,10 +123,10 @@
             <source xml:lang="en">[Optional] Specify the size in bytes of the network packets to communicate with SQL Server.</source><target>[オプション]SQL Server との通信に使われるネットワーク パケットのバイト単位のサイズを指定します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.typeSystemVersion">
-            <source xml:lang="en">[Optional] Indicates which server type the provider will expose through the DataReader.</source>
+            <source xml:lang="en">[Optional] Indicates which server type the provider will expose through the DataReader.</source><target>[オプション]プロバイダーは、DataReader を通じて公開されるサーバーの種類を示します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.connectionString">
-            <source xml:lang="en">[Optional] The ADO.NET connection string to use for the connection. Overrides any other options given in this connection.</source>
+            <source xml:lang="en">[Optional] The ADO.NET connection string to use for the connection. Overrides any other options given in this connection.</source><target>[オプション]接続に使用する ADO.NET 接続文字列。この接続に指定された他のオプションよりも優先されます。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.profileName">
             <source xml:lang="en">[Optional] Specify a custom name for this connection profile to easily browse and search in the command palette of Visual Studio Code.</source><target>[オプション]Visual Studio Codeのコマンドパレットで簡単に参照し探すことができるように、この接続プロファイルにカスタムの名前を指定します。</target>
@@ -135,31 +135,31 @@
             <source xml:lang="en">[Optional] When set to 'true', the password for SQL Server authentication is saved in the secure store of your operating system such as KeyChain in MacOS or Secure Store in Windows.</source><target>[オプション] 'true' に設定すると、SQL server 認証に使われるパスワードは MacOS のキーチェーンやWindowsのセキュリティストアといった、オペレーティング システムのセキュリティで保護された場所に保存します。</target>
         </trans-unit>
         <trans-unit id="mssql.connection.emptyPasswordInput">
-            <source xml:lang="en">[Optional] Indicates whether this profile has an empty password explicitly set</source>
+            <source xml:lang="en">[Optional] Indicates whether this profile has an empty password explicitly set</source><target>[オプション]このプロファイルが空のパスワードを明示的に設定するかどうかを示します</target>
         </trans-unit>
         <trans-unit id="mssql.shortcuts">
-            <source xml:lang="en">Shortcuts related to the results window</source>
+            <source xml:lang="en">Shortcuts related to the results window</source><target>[結果] ウィンドウに関連するショートカット</target>
         </trans-unit>
         <trans-unit id="mssql.messagesDefaultOpen">
             <source xml:lang="en">True for the messages pane to be open by default; false for closed</source><target>既定で開いているメッセージ ウィンドウの場合は true。閉じている場合はfalse。</target>
         </trans-unit>
         <trans-unit id="mssql.resultsFontFamily">
-            <source xml:lang="en">Set the font family for the results grid; set to blank to use the editor font</source>
+            <source xml:lang="en">Set the font family for the results grid; set to blank to use the editor font</source><target>結果グリッドのフォント ファミリを設定します。エディターのフォントを使用する空白に設定します。</target>
         </trans-unit>
         <trans-unit id="mssql.resultsFontSize">
-            <source xml:lang="en">Set the font size for the results grid; set to blank to use the editor size</source>
+            <source xml:lang="en">Set the font size for the results grid; set to blank to use the editor size</source><target>結果グリッドのフォント サイズを設定します。エディターのサイズを使用する空白に設定します。</target>
         </trans-unit>
         <trans-unit id="mssql.saveAsCsv.includeHeaders">
             <source xml:lang="en">[Optional] When true, column headers are included when saving results as CSV</source><target>[オプション] true の場合、CSV として結果を保存する際に列ヘッダーが含まれます。</target>
         </trans-unit>
         <trans-unit id="mssql.copyIncludeHeaders">
-            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
+            <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source><target>[オプション]結果を結果ビューからコピーするための構成オプション</target>
         </trans-unit>
         <trans-unit id="mssql.copyRemoveNewLine">
-            <source xml:lang="en">[Optional] Configuration options for copying multi-line results from the Results View</source>
+            <source xml:lang="en">[Optional] Configuration options for copying multi-line results from the Results View</source><target>[オプション]複数行の結果を結果ビューからコピーするための構成オプション</target>
         </trans-unit>
         <trans-unit id="mssql.showBatchTime">
-            <source xml:lang="en">[Optional] Should execution time be shown for individual batches</source>
+            <source xml:lang="en">[Optional] Should execution time be shown for individual batches</source><target>[オプション]各バッチの実行時間を表示するか</target>
         </trans-unit>
         <trans-unit id="mssql.splitPaneSelection">
             <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source><target>[オプション]どの列が新しい結果ウィンドウで開く必要があるかの設定オプション</target>
@@ -180,10 +180,10 @@
             <source xml:lang="en">Should references to objects in a select statements be split into separate lines? E.g. for 'SELECT C1, C2 FROM T1' both C1 and C2 will be on separate lines</source><target>例えば 'SELECT C1, C2 FROM T1'の場合に C1 と C2 の両方を別々 の行にするように、Select ステートメント内のオブジェクトへの参照を別々の行に分割するか? </target>
         </trans-unit>
         <trans-unit id="mssql.applyLocalization">
-            <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
+            <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source><target>[オプション](有効にする設定の VSCode を再起動する必要があります) VSCode の構成されているロケールにローカライズするための構成オプション</target>
         </trans-unit>
         <trans-unit id="mssql.query.displayBitAsNumber">
-            <source xml:lang="en">Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'</source>
+            <source xml:lang="en">Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'</source><target>ビット列を数値 (1 または 0) として表示しますか?False の場合、ビット列が 'true' または 'false' として表示されます。</target>
         </trans-unit>
         <trans-unit id="mssql.intelliSense.enableIntelliSense">
             <source xml:lang="en">Should IntelliSense be enabled</source><target>IntelliSense を有効にするか</target>

--- a/localization/xliff/kor/constants/localizedConstants.kor.xlf
+++ b/localization/xliff/kor/constants/localizedConstants.kor.xlf
@@ -288,25 +288,25 @@
             <source xml:lang="en">Are you sure you want to disconnect?</source><target>정말로 연결을 해제하시겠습니까?</target>
         </trans-unit>
         <trans-unit id="elapsedBatchTime">
-            <source xml:lang="en">Batch execution time: {0}</source>
+            <source xml:lang="en">Batch execution time: {0}</source><target>일괄 처리 실행 시간: {0}</target>
         </trans-unit>
         <trans-unit id="noActiveEditorMsg">
             <source xml:lang="en">A SQL editor must have focus before executing this command</source><target>이 명령을 실행하기 전에 SQL 편집기에 포커스가 있어야 합니다.</target>
         </trans-unit>
         <trans-unit id="maximizeLabel">
-            <source xml:lang="en">Maximize</source>
+            <source xml:lang="en">Maximize</source><target>최대화</target>
         </trans-unit>
         <trans-unit id="restoreLabel">
             <source xml:lang="en">Restore</source><target>복원</target>
         </trans-unit>
         <trans-unit id="saveCSVLabel">
-            <source xml:lang="en">Save as CSV</source>
+            <source xml:lang="en">Save as CSV</source><target>CSV로 저장</target>
         </trans-unit>
         <trans-unit id="saveJSONLabel">
             <source xml:lang="en">Save as JSON</source><target>JSON으로 저장</target>
         </trans-unit>
         <trans-unit id="saveExcelLabel">
-            <source xml:lang="en">Save as Excel</source>
+            <source xml:lang="en">Save as Excel</source><target>Excel로 저장</target>
         </trans-unit>
         <trans-unit id="fileTypeCSVLabel">
             <source xml:lang="en">CSV</source><target>CSV</target>
@@ -321,7 +321,7 @@
             <source xml:lang="en">Results</source><target>결과</target>
         </trans-unit>
         <trans-unit id="selectAll">
-            <source xml:lang="en">Select all</source>
+            <source xml:lang="en">Select all</source><target>모두 선택</target>
         </trans-unit>
         <trans-unit id="copyLabel">
             <source xml:lang="en">Copy</source><target>복사</target>
@@ -339,7 +339,7 @@
             <source xml:lang="en">Line {0}</source><target>줄 {0}</target>
         </trans-unit>
         <trans-unit id="elapsedTimeLabel">
-            <source xml:lang="en">Total execution time: {0}</source>
+            <source xml:lang="en">Total execution time: {0}</source><target>총 실행 시간: {0}</target>
         </trans-unit>
         <trans-unit id="msgCannotSaveMultipleSelections">
             <source xml:lang="en">Save results command cannot be used with multiple selections.</source><target>결과 저장 명령은 다중 선택을 사용할 수 없습니다.</target>
@@ -351,10 +351,10 @@
             <source xml:lang="en">None</source><target>None</target>
         </trans-unit>
         <trans-unit id="chooseSqlLang">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>SQL 언어 선택</target>
         </trans-unit>
         <trans-unit id="flavorChooseLanguage">
-            <source xml:lang="en">Choose SQL Language</source>
+            <source xml:lang="en">Choose SQL Language</source><target>SQL 언어 선택</target>
         </trans-unit>
         <trans-unit id="flavorDescriptionMssql">
             <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source><target>현재 문서에서 T-SQL intellisense와 구문 오류 확인을 사용</target>

--- a/localization/xliff/kor/localizedPackage.json.kor.xlf
+++ b/localization/xliff/kor/localizedPackage.json.kor.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" original="extension.i18ntest.JSON" source-language="en" target-language="ko">
     <body>
         <trans-unit id="extension.runQuery">
-            <source xml:lang="en">Execute Query</source>
+            <source xml:lang="en">Execute Query</source><target>쿼리 실행</target>
         </trans-unit>
         <trans-unit id="extension.runCurrentStatement">
-            <source xml:lang="en">Execute Current Statement</source>
+            <source xml:lang="en">Execute Current Statement</source><target>현재 문을 실행합니다</target>
         </trans-unit>
         <trans-unit id="extension.cancelQuery">
-            <source xml:lang="en">Cancel Query</source>
+            <source xml:lang="en">Cancel Query</source><target>쿼리 취소</target>
         </trans-unit>
         <trans-unit id="extension.connect">
             <source xml:lang="en">Connect</source><target>연결</target>
@@ -27,19 +27,19 @@
             <source xml:lang="en">Choose SQL handler for this file</source><target>이 파일에 대한 SQL 핸들러를 선택하십시오</target>
         </trans-unit>
         <trans-unit id="extension.showGettingStarted">
-            <source xml:lang="en">Getting Started Guide</source>
+            <source xml:lang="en">Getting Started Guide</source><target>가이드 시작</target>
         </trans-unit>
         <trans-unit id="extension.newQuery">
             <source xml:lang="en">New Query</source><target>새 쿼리</target>
         </trans-unit>
         <trans-unit id="extension.rebuildIntelliSenseCache">
-            <source xml:lang="en">Refresh IntelliSense Cache</source>
+            <source xml:lang="en">Refresh IntelliSense Cache</source><target>IntelliSense 캐시를 새로 고침</target>
         </trans-unit>
         <trans-unit id="mssql.logDebugInfo">
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -&gt; Toggle Developer Tools)</source><target>[옵션] VS Code 콘솔로 디버그 결과를 기록 (도움말 -&gt; 개발자 도구 설정/해제)</target>
         </trans-unit>
         <trans-unit id="mssql.maxRecentConnections">
-            <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source>
+            <source xml:lang="en">The maximum number of recently used connections to store in the connection list.</source><target>최근에 사용한 연결을 연결 목록에 저장할 최대 수입니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connections">
             <source xml:lang="en">Connection profiles defined in 'User Settings' are shown under 'MS SQL: Connect' command in the command palette.</source><target>'사용자 설정'에 정의 된 연결 프로필은 명령 팔레트의 'MS SQL: Connect' 명령 내에서 확인할 수 있습니다.</target>
@@ -57,10 +57,10 @@
             <source xml:lang="en">[Optional] Specify the password for SQL Server authentication. If password is not specified or already saved, when you connect, you will be asked again.</source><target>[옵션] SQL Server 인증을 위한 암호를 지정 합니다. 연결할 때 암호가 지정되지 않거나 저장되어 있지 않으면 다시 요청 될 것입니다</target>
         </trans-unit>
         <trans-unit id="mssql.connection.authenticationType">
-            <source xml:lang="en">[Optional] Specify the SQL Server authentication type.</source>
+            <source xml:lang="en">[Optional] Specify the SQL Server authentication type.</source><target>[옵션] SQL Server 인증 유형을 지정합니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.port">
-            <source xml:lang="en">[Optional] Specify the port number to connect to.</source>
+            <source xml:lang="en">[Optional] Specify the port number to connect to.</source><target>[옵션] 연결할 포트 번호를 지정 합니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.encrypt">
             <source xml:lang="en">[Optional] When set to 'true', SQL Server uses SSL encryption for data sent between the client and the server if the server has a certificate installed. Set 'true' for Azure SQL Database connection.</source><target>[옵션] 'true'로 설정되면, 서버에 인증서가 설치되어 있을 때  클라이언트와 서버 간에 데이터 전송에  SSL 암호화를 사용합니다. Azure SQL 데이터베이스 연결에 대해서는 'true'로 설정하십시오.</target>
@@ -90,7 +90,7 @@
             <source xml:lang="en">[Optional] Declares the application workload type when connecting to SQL Server such as ReadWrite or ReadOnly. Refer to SQL Server AlwaysOn for more detail.</source><target>[옵션] SQL Server에 연결할 때 ReadWrite 또는 ReadOnly와 같은 응용 프로그램 작업 유형을 선언 합니다. 자세한 내용은 SQL Server AlwaysOn를 참조하십시오.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.currentLanguage">
-            <source xml:lang="en">[Optional] Indicates the SQL Server language settings.</source>
+            <source xml:lang="en">[Optional] Indicates the SQL Server language settings.</source><target>[옵션] SQL Server 언어 설정을 나타냅니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.pooling">
             <source xml:lang="en">[Optional] When set to 'true', the connection object is drawn from the appropriate pool, or if necessary, is created and added to the appropriate pool.</source><target>[옵션] 'true'로 설정되면, 연결 개체를 적절한 풀에서 가져오거나, 필요한 경우 새로 만들어지거나 적절한 풀에 추가됩니다.</target>
@@ -105,7 +105,7 @@
             <source xml:lang="en">[Optional] Specify the minimum amount of time in seconds for this connection to live in the pool before being removed/deleted.</source><target>[옵션] 연결이 풀에서 제거/삭제되기 전 생존하는 최소 시간을 초 단위로 지정합니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.replication">
-            <source xml:lang="en">[Optional] Used by SQL Server in replication.</source>
+            <source xml:lang="en">[Optional] Used by SQL Server in replication.</source><target>[옵션] SQL Server 복제에 사용합니다.</target>
         </trans-unit>
         <trans-unit id="mssql.connection.attachDbFilename">
             <source xml:lang="en">[Optional] Specify the name of the primary file, including the full path name, of an attachable database.</source><target>[옵션] 연결 가능한 데이터베이스의 전체 경로명을 포함한 primary 파일 이름을 지정합니다.</target>
@@ -162,7 +162,7 @@
             <source xml:lang="en">[Optional] Should execution time be shown for individual batches</source><target>[옵션] 개별 일괄 처리에 대한 실행시간 표시 여부</target>
         </trans-unit>
         <trans-unit id="mssql.splitPaneSelection">
-            <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
+            <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source><target>[옵션] 구성 옵션을 열에 대 한 새로운 결과 창에서 열립니다</target>
         </trans-unit>
         <trans-unit id="mssql.format.alignColumnDefinitionsInColumns">
             <source xml:lang="en">Should column definitions be aligned?</source><target>열 정의에 대한 정렬 여부</target>


### PR DESCRIPTION
Some translations accidentally got removed in the April update because of the switch to the new localization platform. The problem has been fixed now so this PR puts them back