### PR TITLE
[Discussion] [Live Share] Restrict language services to local files

### DIFF
--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -276,7 +276,10 @@ export default class SqlToolsServiceClient {
     private createLanguageClient(serverOptions: ServerOptions): LanguageClient {
         // Options to control the language client
         let clientOptions: LanguageClientOptions = {
-            documentSelector: ['sql'],
+            documentSelector: [
+                { language: 'sql', scheme: 'file' },
+                { language: 'sql', scheme: 'untitled' }
+            ],
             synchronize: {
                 configurationSection: 'mssql'
             },


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](http://aka.ms/vsls) adding support for "guests" to receive remote language services for SQL files, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*