### PR TITLE
New Feature: support to all versions of Linux Deepin, based on Debian distro.

### DIFF
--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -26,8 +26,7 @@ export enum Runtime {
     SLES_12_2 = <any>'SLES_12_2',
     RHEL_7 = <any>'RHEL_7',
     Ubuntu_14 = <any>'Ubuntu_14',
-    Ubuntu_16 = <any>'Ubuntu_16',
-    deepin = <any>'deepin'
+    Ubuntu_16 = <any>'Ubuntu_16'
 }
 
 export function getRuntimeDisplayName(runtime: Runtime): string {
@@ -41,7 +40,6 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
         case Runtime.CentOS_7:
             return 'CentOS';
         case Runtime.Debian_8:
-        case Runtime.deepin:
             return 'Debian';
         case Runtime.Fedora_23:
             return 'Fedora';

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -26,7 +26,8 @@ export enum Runtime {
     SLES_12_2 = <any>'SLES_12_2',
     RHEL_7 = <any>'RHEL_7',
     Ubuntu_14 = <any>'Ubuntu_14',
-    Ubuntu_16 = <any>'Ubuntu_16'
+    Ubuntu_16 = <any>'Ubuntu_16',
+    deepin = <any>'deepin'
 }
 
 export function getRuntimeDisplayName(runtime: Runtime): string {
@@ -40,6 +41,7 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
         case Runtime.CentOS_7:
             return 'CentOS';
         case Runtime.Debian_8:
+        case Runtime.deepin:
             return 'Debian';
         case Runtime.Fedora_23:
             return 'Fedora';
@@ -304,6 +306,7 @@ export class PlatformInformation {
             case 'rhel':
                 return Runtime.RHEL_7;
             case 'debian':
+            case 'deepin':
                 return Runtime.Debian_8;
             case 'galliumos':
                 if (distributionVersion.startsWith('2.0')) {


### PR DESCRIPTION
### Hi lovers of Visual Studio Code and Microsoft SQL Server!

I add a new feature to support the extention service of __SQLToolService__ to __Linux Deepin__ to all versions. __Linux Deepin__ is based on __Linux Debian__, and the new lines of code is added to support this OS system and can install __SQLToolService__ on __Linux Deepin__. I test this in two Computers and works everything with __mssql__ extention.

Let me know if you agree or not.

Please sorry for my bad english.