### PR TITLE
chore: TSQL Formatter Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tqsl-formmater-issue.md
+++ b/.github/ISSUE_TEMPLATE/tqsl-formmater-issue.md
@@ -1,0 +1,35 @@
+---
+name: TQSL Formmater Issue
+about: This is the template for any TSQL Formatter issues
+
+---
+
+**Problem Summary**
+
+    MSSQL Extension Version: <0.3.0>
+    VSCode Version: <1.9.0>
+    OS Version:
+
+**Formatter Settings**
+```
+datatypeCasing: "none" / "uppercase" / "lowercase",
+keywordCasing: "none" / "uppercase" / "lowercase",
+alignColumnDefinitionsInColumns: false,
+placeCommasBeforeNextStatement: false,
+placeSelectStatementReferencesOnNewLine" false,
+```
+
+**Input Text** - place unformatted SQL below
+```sql
+
+```
+
+**Actual Output** - place formatted SQL (that doesn't work as expected) below
+```sql
+
+```
+
+**Expected Output** - place formatted SQL as you'd expect it to look below
+```sql
+
+```


### PR DESCRIPTION
Closes #704 based on the new issue template system https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/
The old `issue_template.md` could also be moved/migrated to the bug_template.md format.
Feel free to redo this youself using the Settings page if you prefer to do it all at once.