### PR TITLE
Combine grid selections when copying/exporting results

### DIFF
--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -470,13 +470,15 @@ export class AppComponent implements OnInit, AfterViewChecked {
 
     openContextMenu(event: {x: number, y: number}, batchId, resultId, index): void {
         let selection = this.slickgrids.toArray()[index].getSelectedRanges();
-        if (selection.length > 1) {
-            selection = this.tryCombineSelections(selection);
-        }
+        selection = this.tryCombineSelections(selection);
         this.contextMenu.show(event.x, event.y, batchId, resultId, index, selection);
     }
 
     private tryCombineSelections(selections: ISlickRange[]): ISlickRange[] {
+        if (!selections || selections.length === 0) {
+            return selections;
+        }
+
         // If the selections combine into a single continuous selection, this will be the selection
         let unifiedSelection: ISlickRange = {
             fromCell: selections.map(range => range.fromCell).reduce((min, next) => next < min ? next : min),

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -475,7 +475,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
     }
 
     private tryCombineSelections(selections: ISlickRange[]): ISlickRange[] {
-        if (!selections || selections.length === 0) {
+        if (!selections || selections.length === 0 || selections.length === 1) {
             return selections;
         }
 

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -180,12 +180,14 @@ export class AppComponent implements OnInit, AfterViewChecked {
             } else {
                 let activeGrid = this.activeGrid;
                 let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
+                selection = this.tryCombineSelections(selection);
                 this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId, this.renderedDataSets[activeGrid].resultId);
             }
         },
         'event.copyWithHeaders': () => {
             let activeGrid = this.activeGrid;
             let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
+            selection = this.tryCombineSelections(selection);
             this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId,
                 this.renderedDataSets[activeGrid].resultId, true);
         },
@@ -492,9 +494,9 @@ export class AppComponent implements OnInit, AfterViewChecked {
         });
         for (let row = unifiedSelection.fromRow; row <= unifiedSelection.toRow; row++) {
             for (let column = unifiedSelection.fromCell; column <= unifiedSelection.toCell; column++) {
-                // If some cell in the combined selection isn't actually selected, return undefined as the selection
+                // If some cell in the combined selection isn't actually selected, return the original selections
                 if (!verifiers.some(verifier => verifier([row, column]))) {
-                    return undefined;
+                    return selections;
                 }
             }
         }

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -508,6 +508,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
         let batchId = this.renderedDataSets[activeGrid].batchId;
         let resultId = this.renderedDataSets[activeGrid].resultId;
         let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
+        selection = this.tryCombineSelections(selection);
         this.dataService.sendSaveRequest(batchId, resultId, format, selection);
     }
 

--- a/src/views/htmlcontent/src/js/components/contextmenu.component.ts
+++ b/src/views/htmlcontent/src/js/components/contextmenu.component.ts
@@ -82,7 +82,7 @@ export class ContextMenu implements OnInit {
         this.resultId = resultId;
         this.index = index;
         this.selection = selection;
-        this.isDisabled = selection === undefined || selection.length > 1;
+        this.isDisabled = (selection.length > 1);
         this.position = { x: x, y: y};
         this.visible = true;
     }

--- a/src/views/htmlcontent/src/js/components/contextmenu.component.ts
+++ b/src/views/htmlcontent/src/js/components/contextmenu.component.ts
@@ -82,7 +82,7 @@ export class ContextMenu implements OnInit {
         this.resultId = resultId;
         this.index = index;
         this.selection = selection;
-        this.isDisabled = (selection.length > 1);
+        this.isDisabled = selection === undefined || selection.length > 1;
         this.position = { x: x, y: y};
         this.visible = true;
     }

--- a/src/views/htmlcontent/test/app.component.spec.ts
+++ b/src/views/htmlcontent/test/app.component.spec.ts
@@ -462,6 +462,38 @@ describe('AppComponent', function (): void {
             expect(contextmenu.show).toHaveBeenCalledWith(20, 20, 0, 0, 0, []);
         });
 
+        it('should combine selections when opening the context menu', () => {
+            let range1: ISlickRange = {
+                fromCell: 0,
+                fromRow: 0,
+                toCell: 10,
+                toRow: 10
+            };
+            let range2: ISlickRange = {
+                fromCell: range1.fromCell,
+                fromRow: 11,
+                toCell: range1.toCell,
+                toRow: 100
+            };
+            let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
+            dataService.sendWSEvent(messageBatchStart);
+            dataService.sendWSEvent(resultSetSmall);
+            dataService.sendWSEvent(messageResultSet);
+            dataService.sendWSEvent(completeEvent);
+            fixture.detectChanges();
+            let contextmenu = comp.contextMenu;
+            let slickgrid = comp.slickgrids.toArray()[0];
+            spyOn(contextmenu, 'show');
+            spyOn(slickgrid, 'getSelectedRanges').and.returnValue([range1, range2]);
+            slickgrid.contextMenu.emit({x: 20, y: 20});
+            expect(contextmenu.show).toHaveBeenCalledWith(20, 20, 0, 0, 0, [{
+                fromCell: range1.fromCell,
+                fromRow: range1.fromRow,
+                toCell: range1.toCell,
+                toRow: range2.toRow
+            } as ISlickRange]);
+        });
+
         it('should open messages context menu when event is fired', () => {
             let dataService = <MockDataService> fixture.componentRef.injector.get(DataService);
             dataService.sendWSEvent(messageBatchStart);


### PR DESCRIPTION
This updates the logic when opening the right click context menu for grids so that all selections on the grid get combined into a single large selection if possible.

This partially addresses #1101 where it wasn't possible to select multiple columns or rows that were next to each other and then copy or export the values.

In order to fully address it we would also have to update our serialization code to handle non-contiguous columns and rows, which will be more complicated and can be done in a separate PR.