### PR TITLE
Update query results to use VS Code's new web view API

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.format.placeCommasBeforeNextStatement": false,
     "mssql.format.placeSelectStatementReferencesOnNewLine": false,
     "mssql.applyLocalization": false,
-    "mssql.query.displayBitAsNumber": true
+    "mssql.query.displayBitAsNumber": true,
+    "mssql.persistQueryResultTabs": false
 }
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   nodejs_version: "6.9.1"
   # Temporary Code version due to https://github.com/Microsoft/vscode-extension-vscode/issues/64
-  CODE_VERSION: 1.17.0
+  CODE_VERSION: 1.23.0
 
 
 # safelist

--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -200,6 +200,9 @@
         <trans-unit id="mssql.intelliSense.lowerCaseSuggestions">
             <source xml:lang="en">Should IntelliSense suggestions be lowercase</source>
         </trans-unit>
+        <trans-unit id="mssql.persistQueryResultTabs">
+            <source xml:lang="en">Should query result selections and scroll positions be saved when switching tabs (may impact performance)</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/package.json
+++ b/package.json
@@ -583,6 +583,12 @@
           "default": false,
           "description": "%mssql.intelliSense.lowerCaseSuggestions%",
           "scope": "window"
+        },
+        "mssql.persistQueryResultTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.persistQueryResultTabs%",
+          "scope": "window"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.23.0"
   },
   "categories": [
     "Languages",

--- a/package.nls.json
+++ b/package.nls.json
@@ -64,5 +64,6 @@
 "mssql.intelliSense.enableErrorChecking":"Should IntelliSense error checking be enabled",
 "mssql.intelliSense.enableSuggestions":"Should IntelliSense suggestions be enabled",
 "mssql.intelliSense.enableQuickInfo":"Should IntelliSense quick info be enabled",
-"mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase"
+"mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase",
+"mssql.persistQueryResultTabs":"Should query result selections and scroll positions be saved when switching tabs (may impact performance)"
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -78,6 +78,7 @@ export const sqlToolsServiceDownloadUrlConfigKey = 'downloadUrl';
 export const extConfigResultFontFamily = 'resultsFontFamily';
 export const extConfigResultFontSize = 'resultsFontSize';
 export const configApplyLocalization = 'applyLocalization';
+export const configPersistQueryResultTabs = 'persistQueryResultTabs';
 
 // ToolsService Constants
 export const serviceInstallingTo = 'Installing SQL tools service to';

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -155,8 +155,6 @@ export default class MainController implements vscode.Disposable {
 
                 // Init content provider for results pane
                 self._outputContentProvider = new SqlOutputContentProvider(self._context, self._statusview);
-                let registration = vscode.workspace.registerTextDocumentContentProvider(SqlOutputContentProvider.providerName, self._outputContentProvider);
-                self._context.subscriptions.push(registration);
 
                 // Init connection manager and connection MRU
                 self._connectionMgr = new ConnectionManager(self._context, self._statusview, self._prompter);

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -1,7 +1,6 @@
 'use strict';
 import { EventEmitter } from 'events';
 
-import * as vscode from 'vscode';
 import StatusView from '../views/statusView';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import {QueryNotificationHandler} from './queryNotificationHandler';
@@ -398,11 +397,11 @@ export default class QueryRunner {
      * Sets a selection range in the editor for this query
      * @param selection The selection range to select
      */
-    public setEditorSelection(selection: ISelectionData, editorColumn?: vscode.ViewColumn): Thenable<void> {
+    public setEditorSelection(selection: ISelectionData): Thenable<void> {
         const self = this;
         return new Promise<void>((resolve, reject) => {
             self._vscodeWrapper.openTextDocument(self._vscodeWrapper.parseUri(self.uri)).then((doc) => {
-                self._vscodeWrapper.showTextDocument(doc, editorColumn).then((editor) => {
+                self._vscodeWrapper.showTextDocument(doc).then((editor) => {
                     editor.selection = self._vscodeWrapper.selection(
                                     self._vscodeWrapper.position(selection.startLine, selection.startColumn),
                                     self._vscodeWrapper.position(selection.endLine, selection.endColumn));

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { EventEmitter } from 'events';
 
+import * as vscode from 'vscode';
 import StatusView from '../views/statusView';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import {QueryNotificationHandler} from './queryNotificationHandler';
@@ -397,11 +398,11 @@ export default class QueryRunner {
      * Sets a selection range in the editor for this query
      * @param selection The selection range to select
      */
-    public setEditorSelection(selection: ISelectionData): Thenable<void> {
+    public setEditorSelection(selection: ISelectionData, editorColumn?: vscode.ViewColumn): Thenable<void> {
         const self = this;
         return new Promise<void>((resolve, reject) => {
             self._vscodeWrapper.openTextDocument(self._vscodeWrapper.parseUri(self.uri)).then((doc) => {
-                self._vscodeWrapper.showTextDocument(doc).then((editor) => {
+                self._vscodeWrapper.showTextDocument(doc, editorColumn).then((editor) => {
                     editor.selection = self._vscodeWrapper.selection(
                                     self._vscodeWrapper.position(selection.startLine, selection.startColumn),
                                     self._vscodeWrapper.position(selection.endLine, selection.endColumn));

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -343,11 +343,14 @@ export class SqlOutputContentProvider {
         // Wrapper tells us where the new results pane should be placed
         let resultPaneColumn = this.newResultPaneViewColumn(queryUri);
 
+        let config = this._vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, queryUri);
+        let retainContextWhenHidden = config[Constants.configPersistQueryResultTabs];
+
         // Check if the results window already exists
         let panel = this._resultsPanes.get(resultsUri);
         if (!panel) {
             panel = vscode.window.createWebviewPanel(resultsUri, paneTitle, resultPaneColumn, {
-                retainContextWhenHidden: true,
+                retainContextWhenHidden: retainContextWhenHidden,
                 enableScripts: true
             });
             this._resultsPanes.set(resultsUri, panel);

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -190,9 +190,7 @@ export class SqlOutputContentProvider {
             endLine: parseInt(req.query.endLine, 10),
             endColumn: parseInt(req.query.endColumn, 10)
         };
-        let activeEditor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === uri);
-        let editorColumn = activeEditor ? activeEditor.viewColumn : undefined;
-        this._queryResultsMap.get(uri).queryRunner.setEditorSelection(selection, editorColumn).then(() => {
+        this._queryResultsMap.get(uri).queryRunner.setEditorSelection(selection).then(() => {
             res.status = 200;
             res.send();
         });

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -35,6 +35,7 @@ class TestTextEditor implements vscode.TextEditor {
     selections: vscode.Selection[];
     options: vscode.TextEditorOptions;
     viewColumn: vscode.ViewColumn;
+    visibleRanges: vscode.Range[];
 
     edit(callback: (editBuilder: vscode.TextEditorEdit) => void): Thenable<boolean> { return undefined; };
     setDecorations(decorationType: vscode.TextEditorDecorationType, rangesOrOptions: vscode.Range[] | vscode.DecorationOptions[]): void { return undefined; };


### PR DESCRIPTION
Updates the query result display to use VS Code's new web view API. The major benefit of this is that users' selections and scroll positions will no longer be lost when switching between tabs.

Closes #1109 