### PR TITLE
Try to find existing editor when clicking on batch link

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { EventEmitter } from 'events';
 
+import * as vscode from 'vscode';
 import StatusView from '../views/statusView';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import {QueryNotificationHandler} from './queryNotificationHandler';
@@ -400,8 +401,15 @@ export default class QueryRunner {
     public setEditorSelection(selection: ISelectionData): Thenable<void> {
         const self = this;
         return new Promise<void>((resolve, reject) => {
+            let column = vscode.ViewColumn.One;
+            let visibleEditors = self._vscodeWrapper.visibleEditors;
+            visibleEditors.forEach(editor => {
+                if (editor.document.uri.toString() === self.uri) {
+                    column = editor.viewColumn;
+                }
+            });
             self._vscodeWrapper.openTextDocument(self._vscodeWrapper.parseUri(self.uri)).then((doc) => {
-                self._vscodeWrapper.showTextDocument(doc).then((editor) => {
+                self._vscodeWrapper.showTextDocument(doc, column).then((editor) => {
                     editor.selection = self._vscodeWrapper.selection(
                                     self._vscodeWrapper.position(selection.startLine, selection.startColumn),
                                     self._vscodeWrapper.position(selection.endLine, selection.endColumn));

--- a/test/queryRunner.test.ts
+++ b/test/queryRunner.test.ts
@@ -713,7 +713,7 @@ suite('Query Runner tests', () => {
                     done(err);
                 }
             }, err => done(err));
-        })
+        });
     });
 });
 


### PR DESCRIPTION
The next release of VS Code will change the `showTextDocument` API to open in the active column by default instead of the first column, which breaks our batch link behavior. This PR fixes it by continuing to use column 1 as the default (since the user's query will usually be in column 1) and searching the other columns in case the user's query is visible in another column.