### PR TITLE
Bump version to 1.4.0 and update readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## Version 1.3.2
+* Release date: TBD
+* Release status: Pending
+
+## What's new in 1.3.2
+* Updated to .NET Core 2.1 to address [issues where some Mac users encountered connection errors](https://github.com/Microsoft/vscode-mssql/issues/1090)
+* Added support for Deepin Linux
+* Updated query results display to use VS Code's new webview API
+* Added a new experimental setting "mssql.persistQueryResultTabs" which when set to true will save your scroll position and active selection when switching between query result tabs
+  * Note that this option is false by default because it [may cause high memory usage](https://code.visualstudio.com/docs/extensions/webview#_retaincontextwhenhidden
+  * If you use this option and have feedback on it please share it on our [GitHub page](https://github.com/Microsoft/vscode-mssql/issues/916).
+
+
+### Contributions and "thank you"
+We would like to thank all our users who raised issues, and in particular the following users who helped contribute features or localization of the tool:
+* [@ChristianGrimberg](https://github.com/ChristianGrimberg) for adding support for Deepin Linux
+* [@nschonni](https://github.com/nschonni) for closing issue [#704](https://github.com/Microsoft/vscode-mssql/issues/704) by adding a new TSQL formatter issue template
+* We would like to thank everyone who contributed to localization for this update and encourage more people to join our [open source community localization effort](https://github.com/Microsoft/Localization/wiki).
+
 ## Version 1.3.1
 * Release date: April 10, 2018
 * Release status: GA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
-## Version 1.3.2
+## Version 1.4.0
 * Release date: TBD
 * Release status: Pending
 
-## What's new in 1.3.2
+## What's new in 1.4.0
 * Updated to .NET Core 2.1 to address [issues where some Mac users encountered connection errors](https://github.com/Microsoft/vscode-mssql/issues/1090)
 * Added support for Deepin Linux
 * Updated query results display to use VS Code's new webview API

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [the SQL developer tutorial] to develop an app with C#, Java, Node.js, PHP, 
 
 <img src="https://github.com/Microsoft/vscode-mssql/raw/master/images/mssql-demo.gif" alt="demo" style="width:480px;"/>
 
-## What's new in 1.3.2
+## What's new in 1.4.0
 * Updated to .NET Core 2.1 to address [issues where some Mac users encountered connection errors](https://github.com/Microsoft/vscode-mssql/issues/1090)
 * Added support for Deepin Linux
 * Updated query results display to use VS Code's new webview API
@@ -242,7 +242,7 @@ See [customize options] and [manage connection profiles] for more details.
 ```
 
 ## Change Log
-The current version is ```1.3.2```. See the [change log] for a detailed list of changes in each version.
+The current version is ```1.4.0```. See the [change log] for a detailed list of changes in each version.
 
 ## Supported Operating Systems
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ See [the SQL developer tutorial] to develop an app with C#, Java, Node.js, PHP, 
 
 <img src="https://github.com/Microsoft/vscode-mssql/raw/master/images/mssql-demo.gif" alt="demo" style="width:480px;"/>
 
+## What's new in 1.3.2
+* Updated to .NET Core 2.1 to address [issues where some Mac users encountered connection errors](https://github.com/Microsoft/vscode-mssql/issues/1090)
+* Added support for Deepin Linux
+* Updated query results display to use VS Code's new webview API
+* Added a new experimental setting "mssql.persistQueryResultTabs" which when set to true will save your scroll position and active selection when switching between query result tabs
+  * Note that this option is false by default because it [may cause high memory usage](https://code.visualstudio.com/docs/extensions/webview#_retaincontextwhenhidden
+  * If you use this option and have feedback on it please share it on our [GitHub page](https://github.com/Microsoft/vscode-mssql/issues/916).
+
+
+### Contributions and "thank you"
+We would like to thank all our users who raised issues, and in particular the following users who helped contribute features or localization of the tool:
+* [@ChristianGrimberg](https://github.com/ChristianGrimberg) for adding support for Deepin Linux
+* [@nschonni](https://github.com/nschonni) for closing issue [#704](https://github.com/Microsoft/vscode-mssql/issues/704) by adding a new TSQL formatter issue template
+* We would like to thank everyone who contributed to localization for this update and encourage more people to join our [open source community localization effort](https://github.com/Microsoft/Localization/wiki).
+
 ## What's new in 1.3.1
 * Fixed issue [#1036](https://github.com/Microsoft/vscode-mssql/issues/1036) where copy/pasting Unicode text can fail on Mac depending on the active locale environment variable
 * Fixed issue [#1066](https://github.com/Microsoft/vscode-mssql/issues/1066) RAND() function using GO N produces the same result
@@ -227,7 +242,7 @@ See [customize options] and [manage connection profiles] for more details.
 ```
 
 ## Change Log
-The current version is ```1.1```. See the [change log] for a detailed list of changes in each version.
+The current version is ```1.3.2```. See the [change log] for a detailed list of changes in each version.
 
 ## Supported Operating Systems
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mssql",
   "displayName": "mssql",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
   "publisher": "ms-mssql",
   "preview": false,
@@ -68,7 +68,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-tslint": "^6.0.2",
+    "gulp-tslint": "^6.1.3",
     "gulp-typescript": "^3.1.4",
     "gulp-uglify": "^2.0.0",
     "istanbul": "^0.4.5",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://download.microsoft.com/download/3/2/9/32995640-2B4A-4C47-8764-287485C733DB/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.3.2",
+        "version": "1.4.0",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.1.zip",
             "Windows_7_64": "win-x64-netcoreapp2.1.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,19 +1,19 @@
 {
     "service": {
-        "downloadUrl": "https://download.microsoft.com/download/3/6/2/362408E3-F226-4B22-A67D-85A2544774B9/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.3.1",
+        "downloadUrl": "https://download.microsoft.com/download/3/2/9/32995640-2B4A-4C47-8764-287485C733DB/microsoft.sqltools.servicelayer-{#fileName#}",
+        "version": "1.3.2",
         "downloadFileNames": {
-            "Windows_7_86": "win-x86-netcoreapp2.0.zip",
-            "Windows_7_64": "win-x64-netcoreapp2.0.zip",
-            "OSX_10_11_64": "osx-x64-netcoreapp2.0.tar.gz",
-            "CentOS_7": "rhel-x64-netcoreapp2.0.tar.gz",
-            "Debian_8": "rhel-x64-netcoreapp2.0.tar.gz",
-            "Fedora_23": "rhel-x64-netcoreapp2.0.tar.gz",
-            "OpenSUSE_13_2": "rhel-x64-netcoreapp2.0.tar.gz",
-            "SLES_12_2": "rhel-x64-netcoreapp2.0.tar.gz",
-            "RHEL_7": "rhel-x64-netcoreapp2.0.tar.gz",
-            "Ubuntu_14": "rhel-x64-netcoreapp2.0.tar.gz",
-            "Ubuntu_16": "rhel-x64-netcoreapp2.0.tar.gz"
+            "Windows_7_86": "win-x86-netcoreapp2.1.zip",
+            "Windows_7_64": "win-x64-netcoreapp2.1.zip",
+            "OSX_10_11_64": "osx-x64-netcoreapp2.1.tar.gz",
+            "CentOS_7": "rhel-x64-netcoreapp2.1.tar.gz",
+            "Debian_8": "rhel-x64-netcoreapp2.1.tar.gz",
+            "Fedora_23": "rhel-x64-netcoreapp2.1.tar.gz",
+            "OpenSUSE_13_2": "rhel-x64-netcoreapp2.1.tar.gz",
+            "SLES_12_2": "rhel-x64-netcoreapp2.1.tar.gz",
+            "RHEL_7": "rhel-x64-netcoreapp2.1.tar.gz",
+            "Ubuntu_14": "rhel-x64-netcoreapp2.1.tar.gz",
+            "Ubuntu_16": "rhel-x64-netcoreapp2.1.tar.gz"
         },
         "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
         "executableFiles": ["MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer", "MicrosoftSqlToolsServiceLayer.dll"]


### PR DESCRIPTION
Update to version 1.4.0 by
- updating the version in `package.json`
- adding release notes to the readme and change log
- updating the SQL Tools Service production URL

I also changed the version of `gulp-tslint` to fix a bug with it that I ran into