### PR TITLE
Enable save as buttons with combined selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
 ## Version 1.4.0
-* Release date: TBD
-* Release status: Pending
+* Release date: June 28, 2018
+* Release status: GA
 
 ## What's new in 1.4.0
 * Updated to .NET Core 2.1 to address [issues where some Mac users encountered connection errors](https://github.com/Microsoft/vscode-mssql/issues/1090)

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -231,6 +231,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
             hoverText: () => { return Constants.saveCSVLabel; },
             functionality: (batchId, resultId, index) => {
                 let selection = this.slickgrids.toArray()[index].getSelectedRanges();
+                selection = this.tryCombineSelections(selection);
                 if (selection.length <= 1) {
                     this.handleContextClick({type: 'savecsv', batchId: batchId, resultId: resultId, index: index, selection: selection});
                 } else {
@@ -244,6 +245,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
             hoverText: () => { return Constants.saveJSONLabel; },
             functionality: (batchId, resultId, index) => {
                 let selection = this.slickgrids.toArray()[index].getSelectedRanges();
+                selection = this.tryCombineSelections(selection);
                 if (selection.length <= 1) {
                     this.handleContextClick({type: 'savejson', batchId: batchId, resultId: resultId, index: index, selection: selection});
                 } else {
@@ -257,6 +259,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
             hoverText: () => { return Constants.saveExcelLabel; },
             functionality: (batchId, resultId, index) => {
                 let selection = this.slickgrids.toArray()[index].getSelectedRanges();
+                selection = this.tryCombineSelections(selection);
                 if (selection.length <= 1) {
                     this.handleContextClick({type: 'saveexcel', batchId: batchId, resultId: resultId, index: index, selection: selection});
                 } else {


### PR DESCRIPTION
The save as csv/json/excel buttons were previously disabled when the user had multiple selections that could be combined into one selection, even though saving the results worked fine when using the right click context menu. 