### PR TITLE
Added support for specifying delimiter while exporting query results as CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See [customize options] and [manage connection profiles] for more details.
     "mssql.messagesDefaultOpen": true,
     "mssql.logDebugInfo": false,
     "mssql.saveAsCSV.includeHeaders": true,
+    "mssql.saveAsCSV.delimiter": ",",
     "mssql.intelliSense.enableIntelliSense": true,
     "mssql.intelliSense.enableErrorChecking": true,
     "mssql.intelliSense.enableSuggestions": true,

--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -152,6 +152,9 @@
         <trans-unit id="mssql.saveAsCsv.includeHeaders">
             <source xml:lang="en">[Optional] When true, column headers are included when saving results as CSV</source>
         </trans-unit>
+        <trans-unit id="mssql.saveAsCsv.delimiter">
+            <source xml:lang="en">[Optional] Delimiter for separating data items when saving results as CSV</source>
+        </trans-unit>
         <trans-unit id="mssql.copyIncludeHeaders">
             <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         </trans-unit>

--- a/package.json
+++ b/package.json
@@ -473,6 +473,12 @@
           "default": true,
           "scope": "resource"
         },
+        "mssql.saveAsCsv.delimiter": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.delimiter%",
+          "default": true,
+          "scope": "resource"
+        },
         "mssql.copyIncludeHeaders": {
           "type": "boolean",
           "description": "%mssql.copyIncludeHeaders%",

--- a/package.json
+++ b/package.json
@@ -476,7 +476,7 @@
         "mssql.saveAsCsv.delimiter": {
           "type": "string",
           "description": "%mssql.saveAsCsv.delimiter%",
-          "default": true,
+          "default": ",",
           "scope": "resource"
         },
         "mssql.copyIncludeHeaders": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -49,6 +49,7 @@
 "mssql.resultsFontFamily":"Set the font family for the results grid; set to blank to use the editor font",
 "mssql.resultsFontSize":"Set the font size for the results grid; set to blank to use the editor size",
 "mssql.saveAsCsv.includeHeaders":"[Optional] When true, column headers are included when saving results as CSV",
+"mssql.saveAsCsv.delimiter":"[Optional] Delimiter for separating data items when saving results as CSV",
 "mssql.copyIncludeHeaders":"[Optional] Configuration options for copying results from the Results View",
 "mssql.copyRemoveNewLine":"[Optional] Configuration options for copying multi-line results from the Results View",
 "mssql.showBatchTime":"[Optional] Should execution time be shown for individual batches",

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "1.4.0-alpha.41",
+        "version": "v1.5.0-alpha.7",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.1.zip",
             "Windows_7_64": "win-x64-netcoreapp2.1.zip",

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "v1.5.0-alpha.7",
+        "version": "1.5.0-alpha.7",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-netcoreapp2.1.zip",
             "Windows_7_64": "win-x64-netcoreapp2.1.zip",

--- a/src/models/contracts.ts
+++ b/src/models/contracts.ts
@@ -1,4 +1,4 @@
-import {RequestType} from 'vscode-languageclient';
+import { RequestType } from 'vscode-languageclient';
 
 // --------------------------------- < Version Request > -------------------------------------------------
 
@@ -67,6 +67,7 @@ export class SaveResultsRequestParams {
 
 export class SaveResultsAsCsvRequestParams extends SaveResultsRequestParams {
     includeHeaders: boolean = true;
+    delimiter: string = ',';
 }
 
 export class SaveResultsAsJsonRequestParams extends SaveResultsRequestParams {

--- a/src/models/resultsSerializer.ts
+++ b/src/models/resultsSerializer.ts
@@ -2,13 +2,13 @@ import vscode = require('vscode');
 import Constants = require('../constants/constants');
 import LocalizedConstants = require('../constants/localizedConstants');
 import Interfaces = require('./interfaces');
+import * as path from 'path';
+import { RequestType } from 'vscode-languageclient';
+import VscodeWrapper from '../controllers/vscodeWrapper';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import * as Contracts from '../models/contracts';
-import {RequestType} from 'vscode-languageclient';
-import * as Utils from '../models/utils';
-import VscodeWrapper from '../controllers/vscodeWrapper';
 import Telemetry from '../models/telemetry';
-import * as path from 'path';
+import * as Utils from '../models/utils';
 
 let opener = require('opener');
 
@@ -76,6 +76,9 @@ export default class ResultsSerializer {
         if (saveConfig) {
             if (saveConfig.includeHeaders !== undefined) {
                 saveResultsParams.includeHeaders = saveConfig.includeHeaders;
+            }
+            if (saveConfig.delimiter !== undefined) {
+                saveResultsParams.delimiter = saveConfig.delimiter;
             }
         }
         return saveResultsParams;


### PR DESCRIPTION
The delimiter can be added in extension config:
Example:
"mssql.saveAsCsv": {
        "delimiter": '|'
 }
This is used in separating data items in export to CSV. Closes #1078 