### PR TITLE
Adding support for antergos platform

### DIFF
--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -261,6 +261,7 @@ export class PlatformInformation {
     private static getRuntimeIdHelper(distributionName: string, distributionVersion: string): Runtime {
         switch (distributionName) {
             case 'arch':
+            case 'antergos':
                 // NOTE: currently Arch Linux seems to be compatible enough with Ubuntu 16 that this works,
                 // though in the future this may need to change as Arch follows a rolling release model.
                 return Runtime.Ubuntu_16;


### PR DESCRIPTION
Hi.

I'm using Antergos Linux:
```sh
cat /etc/os-release

NAME="Antergos Linux"
PRETTY_NAME="Antergos Linux"
ID=antergos
ID_LIKE=archlinux
ANSI_COLOR="0;36"
HOME_URL="https://antergos.com/"
SUPPORT_URL="https://forum.antergos.com/"
BUG_REPORT_URL="https://github.com/antergos"
```

and I'm getting the `The platform is not supported` error.

After doing this change and installing the extension from VSIX I've been able to use it.