### PR TITLE
Use correct tag for gulp package

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "coveralls": "^2.11.15",
     "decache": "^4.1.0",
     "del": "^2.2.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#v4.0.0",
     "gulp-clean-css": "^2.0.13",
     "gulp-concat": "^2.6.0",
     "gulp-filter": "^5.0.0",
@@ -619,6 +619,6 @@
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "install-packages": "npm install github:gulpjs/gulp#4.0 && npm install gulp-install && gulp --gulpfile install.js install"
+    "install-packages": "npm install github:gulpjs/gulp#v4.0.0 && npm install gulp-install && gulp --gulpfile install.js install"
   }
 }

--- a/src/views/htmlcontent/tsconfig.json
+++ b/src/views/htmlcontent/tsconfig.json
@@ -5,6 +5,7 @@
         "module": "commonjs",
         "sourceMap": true,
         "rootDir": ".",
-        "target": "ES6"
+        "target": "ES6",
+        "types": []
     }
 }

--- a/tasks/htmltasks.js
+++ b/tasks/htmltasks.js
@@ -30,7 +30,8 @@ gulp.task('html:lint', () => {
 gulp.task('html:compile-src', () => {
   return gulp
     .src([config.paths.html.root + '/src/js/**/*.ts',
-    config.paths.html.root + '/typings/**/*.d.ts'])
+    config.paths.html.root + '/typings/**/*.d.ts',
+    '!../../../../node_modules/@types/**/node_modules/**/index.d.ts'])
     .pipe(srcmap.init())
     .pipe(tsProject())
     .pipe(srcmap.write('.', {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "sourceMap": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "typeRoots":["./typings"]
     },
     "exclude": [
         "node_modules",

--- a/typings/globals/index.d.ts
+++ b/typings/globals/index.d.ts
@@ -1,0 +1,2 @@
+// this is an empty file to suppress the error "Cannot find type definition file for 'globals'.". The file in the index.d.ts in the
+// parent folder holds the references to 'istanbul' and 'underscore'


### PR DESCRIPTION
For new machine setup, running `npm install` errors because the tag used for the gulp package in package.json does not exist (4.0). The error was like this:

```
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but npm-shrinkwrap.json was generated for lockfileVersion@0. I'll try to do my best with it!
npm WARN deprecated postinstall-build@2.1.3: postinstall-build's behavior is now built into npm! You should migrate off of postinstall-build and use the new `prepare` lifecycle script with npm 5.0.0 or greater.
npm ERR! code 1
npm ERR! Command failed: C:\Program Files\Git\cmd\git.EXE checkout 4.0
npm ERR! error: pathspec '4.0' did not match any file(s) known to git.
npm ERR!

```

**The change uses the tag "v4.0.0" which exists in the gulp repo here:** [https://github.com/gulpjs/gulp/releases/tag/v4.0.0](https://github.com/gulpjs/gulp/releases/tag/v4.0.0). 

I have no idea, though, how this worked previously, maybe there was another tag "4.0" that was  removed? or NPM versions handles discovering the tags differently?