### PR TITLE
Set default runtime to Ubuntu_16

### DIFF
--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -286,7 +286,7 @@ export class PlatformInformation {
 
                 break;
             case 'linuxmint':
-                if (distributionVersion.startsWith('18')) {
+                if (distributionVersion.startsWith('18') || distributionVersion.startsWith('19')) {
                     // Linux Mint 18 is binary compatible with Ubuntu 16.04
                     return Runtime.Ubuntu_16;
                 }
@@ -313,10 +313,10 @@ export class PlatformInformation {
                 }
                 break;
             default:
-                return Runtime.UnknownRuntime;
+                return Runtime.Ubuntu_16;
         }
 
-        return Runtime.UnknownVersion;
+        return Runtime.Ubuntu_16;
     }
 }
 

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -121,10 +121,10 @@ suite('Platform Tests', () => {
         expect(platformInfo.runtimeId).to.equal( undefined);
     });
 
-    test('Compute no RID for fake distro with no ID_LIKE', () => {
+    test('Compute default (Ubuntu_16) RID for fake distro with no ID_LIKE', () => {
         const platformInfo = new PlatformInformation('linux', 'x86_64', distro_unknown_no_id_like());
 
-        expect(platformInfo.runtimeId).to.equal( undefined);
+        expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_16.toString());
     });
 });
 


### PR DESCRIPTION
Uses Ubuntu_16 as the default runtime, matching the changes we've made for Azure Data Studio's [service downloader](https://github.com/anthonydresser/service-downloader/blob/master/src/platform.ts). Going forward we'll also want to look at simplifying the logic since we only make a single Linux tools service build now, as Kevin mentioned at https://github.com/Microsoft/vscode-mssql/issues/1153

This will fix #1153.