### PR TITLE
Fix for Microsoft/vscode-mssql#1178 by replacing all whitespace with non-breaking spaces

### DIFF
--- a/src/views/htmlcontent/src/js/utils.ts
+++ b/src/views/htmlcontent/src/js/utils.ts
@@ -19,15 +19,17 @@ export function isNumber(val: any): boolean {
 
 /**
  * Converts <, >, &, ", ', and any characters that are outside \u00A0 to numeric HTML entity values
- * like &#123;
+ * like &#123;. Also converts whitespace to &nbsp; to ensure all spaces are respected.
  * (Adapted from http://stackoverflow.com/a/18750001)
  * @param str String to convert
  * @return String with characters replaced.
  */
 export function htmlEntities(str: string): string {
-    return typeof(str) === 'string'
-        ? str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => { return `&#${i.charCodeAt(0)};`; })
-        : undefined;
+    if (typeof(str) !== 'string') { return undefined; }
+
+    let newStr = str.replace(/[\u00A0-\u9999<>\&"']/gim, (i) => { return `&#${i.charCodeAt(0)};`; });
+    newStr = newStr.replace(/\s/g, '&nbsp;');
+    return newStr;
 }
 
 /**

--- a/src/views/htmlcontent/test/utils.spec.ts
+++ b/src/views/htmlcontent/test/utils.spec.ts
@@ -26,6 +26,13 @@ describe('Utility Tests', () => {
             });
         });
 
+        it( 'Does encode all spaces to non-breaking spaces', () => {
+            [' ', '  ', '   '].forEach(item => {
+                let expectedValue = '&nbsp;'.repeat(item.length);
+                expect(Utils.htmlEntities(item)).toEqual(expectedValue);
+            });
+        });
+
         it('Does not attempt encoding if the value is null or undefined', () => {
             // We're explicitly checking null b/c this is what comes back from the service
             [null, undefined].forEach((item) => {                       // tslint:disable-line:no-null-keyword


### PR DESCRIPTION
This PR includes a small change to the HTMLEntities utility that ensures that all whitespace is replaced with non-breaking spaces. This fixes #1178 by ensuring all spaces are displayed in a cell. There is also a unit test, and I have validated that this continues to work as expected for copy/paste.

<img width="902" alt="screen shot 2019-01-12 at 3 15 36 pm" src="https://user-images.githubusercontent.com/585878/51078081-d910f100-167d-11e9-96ce-41c8cac7b6d5.png">
