### PR TITLE
Move rulesDirectory from JSON to tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ require('./tasks/htmltasks')
 require('./tasks/packagetasks')
 
 gulp.task('ext:lint', () => {
+    // !! If updating this make sure to check if you need to update the TSA Scan task in ADO !!
     var program = tslint.Linter.createProgram('tsconfig.json');
     return gulp.src([
         config.paths.project.root + '/src/**/*.ts',
@@ -33,7 +34,8 @@ gulp.task('ext:lint', () => {
     ])
     .pipe((gulpTsLint({
         program,
-        formatter: "verbose"
+        formatter: "verbose",
+        rulesDirectory: "node_modules/tslint-microsoft-contrib"
     })))
     .pipe(gulpTsLint.report());
 });

--- a/tasks/htmltasks.js
+++ b/tasks/htmltasks.js
@@ -18,6 +18,7 @@ var tslint = require('tslint');
 var min = (argv.min === undefined) ? false : true;
 
 gulp.task('html:lint', () => {
+    // !! If updating this make sure to check if you need to update the TSA Scan task in ADO !!
     var program = tslint.Linter.createProgram(config.paths.html.root + '/tsconfig.json');
     return gulp.src([
         config.paths.html.root + '/src/**/*.ts',
@@ -25,9 +26,10 @@ gulp.task('html:lint', () => {
     ])
     .pipe((gulpTsLint({
         program,
-        formatter: "verbose"
+        formatter: "verbose",
+        rulesDirectory: "node_modules/tslint-microsoft-contrib"
     })))
-    .pipe(gulpTsLint.report());
+    .pipe(gulpTsLint.report())
 });
 
 // Compile TypeScript to JS

--- a/tslint.mssdl.required.json
+++ b/tslint.mssdl.required.json
@@ -1,5 +1,4 @@
 {
-  "rulesDirectory": "node_modules/tslint-microsoft-contrib",
   "rules": {
     "no-banned-terms": true,
     "no-delete-expression": true,


### PR DESCRIPTION
This is so TSA scans can use the same JSON file (they use a different node_modules location for the additional rules package)