### PR TITLE
Fixed bug: In high contrast mode, Color contrast ratio for CTRL+ALT+R is 4.4:1 which is less than 7:1

### DIFF
--- a/src/views/htmlcontent/src/css/color-theme-dark.css
+++ b/src/views/htmlcontent/src/css/color-theme-dark.css
@@ -103,5 +103,5 @@ slick-grid.active .grid .slick-cell.selected {
 }
 
 .shortCut {
-  color: grey;
+  color: rgb(255, 255, 255);
 }

--- a/src/views/htmlcontent/src/css/color-theme-dark.css
+++ b/src/views/htmlcontent/src/css/color-theme-dark.css
@@ -103,5 +103,5 @@ slick-grid.active .grid .slick-cell.selected {
 }
 
 .shortCut {
-  color: rgb(255, 255, 255);
+  color: var(--color-content);
 }


### PR DESCRIPTION
This resolve https://github.com/microsoft/vscode-mssql/issues/1234
In the dark theme, the font color for the shortcut strings should be white like other label string so that it fulfills >= 7:1 contrast ratio requirement.

Before fix:
![image](https://user-images.githubusercontent.com/19577035/62329775-bacce000-b46b-11e9-9ebe-831dd18b3f57.png)


After fix: 
![image](https://user-images.githubusercontent.com/19577035/62329392-9fada080-b46a-11e9-80cc-63b8a081188e.png)
