### PR TITLE
Fixed tab switching without retaining context

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,10 @@
         {
           "command": "extension.disconnectObjectExplorerNode",
           "when": "enablePreviewFeatures && viewItem != null"
+        },
+        {
+          "command": "extension.toggleSqlCmd",
+          "when": "editorFocus"
         }
       ]
     },

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -417,7 +417,7 @@ export default class MainController implements vscode.Disposable {
      */
     public onNewConnection(): Promise<boolean> {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
-            this._connectionMgr.onNewConnection().then((result) => {
+            return this._connectionMgr.onNewConnection().then((result) => {
                 if (result) {
                     if (this._previewEnabled) {
                         this._objectExplorerProvider.objectExplorerExists = false;
@@ -521,6 +521,10 @@ export default class MainController implements vscode.Disposable {
 
             let editor = self._vscodeWrapper.activeTextEditor;
             let uri = self._vscodeWrapper.activeTextEditorUri;
+            if (!self._connectionMgr.isConnected(uri)) {
+                // create new connection
+                await self.onNewConnection();
+            }
             let title = path.basename(editor.document.fileName);
             let querySelection: ISelectionData;
             // Calculate the selection if we have a selection, otherwise we'll treat null as

--- a/src/controllers/webviewController.ts
+++ b/src/controllers/webviewController.ts
@@ -70,6 +70,17 @@ export class WebviewPanelController implements vscode.Disposable {
         this._panel.webview.html = formattedHTML;
     }
 
+    public dispose(): void {
+        this._disposables.forEach(d => d.dispose());
+        this._isDisposed = true;
+    }
+
+    public revealToForeground(): void {
+        this._panel.reveal();
+    }
+
+    /** Getters */
+
     /**
      * Property indicating whether the tab is active
      */
@@ -77,11 +88,10 @@ export class WebviewPanelController implements vscode.Disposable {
         return this._isActive;
     }
 
-    public dispose(): void {
-        this._disposables.forEach(d => d.dispose());
-        this._isDisposed = true;
-    }
-
+    /**
+     * Property indicating whether the panel controller
+     * is disposed or not
+     */
     public get isDisposed(): boolean {
         return this._isDisposed;
     }

--- a/src/controllers/webviewController.ts
+++ b/src/controllers/webviewController.ts
@@ -34,7 +34,7 @@ export class WebviewPanelController implements vscode.Disposable {
         uri: string,
         title: string,
         serverProxy: IServerProxy,
-        private baseUri: string,
+        private baseUri: string
     ) {
         const config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName, vscode.Uri.parse(uri));
         const retainContextWhenHidden = config[Constants.configPersistQueryResultTabs];

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -299,7 +299,7 @@ export class SqlOutputContentProvider {
         if (panelController.isActive && queryRunner.hasCompleted) {
             return queryRunner.refreshQueryTab();
         }
-        return;
+        return false;
     }
 
     private setRunnerDeletionTimeout(uri: string): NodeJS.Timer {

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -153,9 +153,10 @@ export class SqlOutputContentProvider {
                 this.saveResultsRequestHandler(uri, batchId, resultId, format, selection),
             setEditorSelection: (selection: ISelectionData) => this.editorSelectionRequestHandler(uri, selection),
             showError: (message: string) => this.showErrorRequestHandler(message),
-            showWarning: (message: string) => this.showWarningRequestHandler(message)
+            showWarning: (message: string) => this.showWarningRequestHandler(message),
+            sendReadyEvent: () => this.sendReadyEvent(uri)
         };
-        const controller = new WebviewPanelController(uri, title, proxy, this.context.extensionPath, queryRunner);
+        const controller = new WebviewPanelController(uri, title, proxy, this.context.extensionPath);
         this._panels.set(uri, controller);
         await controller.init();
     }
@@ -280,6 +281,19 @@ export class SqlOutputContentProvider {
             if (doc.uri.toString() === key) {
                 value.timeout = this.setRunnerDeletionTimeout(key);
             }
+        }
+    }
+
+    /**
+     * Ready event sent by the angular app
+     * @param uri
+     */
+    private async sendReadyEvent(uri: string): Promise<boolean> {
+        // in case of a tab switch
+        const panelController = this._panels.get(uri);
+        const queryRunner = this.getQueryRunner(uri);
+        if (panelController.isActive && queryRunner.hasCompleted) {
+            return queryRunner.refreshQueryTab();
         }
     }
 

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -299,6 +299,7 @@ export class SqlOutputContentProvider {
         if (panelController.isActive && queryRunner.hasCompleted) {
             return queryRunner.refreshQueryTab();
         }
+        return;
     }
 
     private setRunnerDeletionTimeout(uri: string): NodeJS.Timer {

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -101,6 +101,10 @@ export class SqlOutputContentProvider {
         await this.runQueryCallback(statusView ? statusView : this._statusView, uri, title,
             (queryRunner) => {
                 if (queryRunner) {
+                    // if the panel isn't active, bring it to foreground
+                    if (!this._panels.get(uri).isActive) {
+                        this._panels.get(uri).revealToForeground();
+                    }
                     queryRunner.runQuery(selection);
                 }
             });

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -20,7 +20,7 @@ export interface IServerProxy {
     showWarning(message: string): void;
     showError(message: string): void;
     getLocalizedTexts(): Promise<{ [key: string]: any }>;
-    sendReadyEvent(uri: string);
+    sendReadyEvent(uri: string): Promise<boolean>;
 }
 
 export interface IMessageProtocol {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -20,6 +20,7 @@ export interface IServerProxy {
     showWarning(message: string): void;
     showError(message: string): void;
     getLocalizedTexts(): Promise<{ [key: string]: any }>;
+    sendReadyEvent(uri: string);
 }
 
 export interface IMessageProtocol {

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -418,6 +418,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
                     break;
             }
         });
+        this.dataService.sendReadyEvent(this.uri);
     }
 
     ngAfterViewChecked(): void {

--- a/src/views/htmlcontent/src/js/services/data.service.ts
+++ b/src/views/htmlcontent/src/js/services/data.service.ts
@@ -80,6 +80,14 @@ export class DataService {
     }
 
     /**
+     * send ready event to server to show that
+     * the angular app has loaded
+     */
+    sendReadyEvent(uri: string): void {
+        this._proxy.sendReadyEvent(uri);
+    }
+
+    /**
      * send request to get all the localized texts
      */
     getLocalizedTextsRequest():  Promise<{ [key: string]: any }> {

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -152,6 +152,7 @@ export default class StatusView implements vscode.Disposable {
         bar.statusConnection.text = ConnInfo.getConnectionDisplayString(connCreds);
         bar.statusConnection.tooltip = ConnInfo.getTooltip(connCreds, serverInfo);
         this.showStatusBarItem(fileUri, bar.statusConnection);
+        this.sqlCmdModeChanged(fileUri, false);
     }
 
     public connectError(fileUri: string, credentials: Interfaces.IConnectionCredentials, error: ConnectionContracts.ConnectionCompleteParams): void {
@@ -283,6 +284,7 @@ export default class StatusView implements vscode.Disposable {
                 this.showStatusBarItem(fileUri, bar.statusLanguageFlavor);
                 this.showStatusBarItem(fileUri, bar.statusConnection);
                 this.showStatusBarItem(fileUri, bar.statusLanguageService);
+                this.showStatusBarItem(fileUri, bar.sqlCmdMode);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1326 and  https://github.com/microsoft/vscode-mssql/issues/1324 and 
https://github.com/microsoft/vscode-mssql/issues/1321

without using the "retainContextWhenHidden" property 

The issue was that sometimes the `WebviewPanel` changed state event occurred before the angular app was loaded and hence the query runner events weren't being listened to, by angular, to show the results on the canvas.

Fixed the issue by sending a ready event from angular when `ngOnInit()` is called. When a `WebviewPanel` is not active, the `WebviewPanel'`s `Webview` is disposed and thus the angular app is built every time. Thus, `ngOnInit()` will only be called the very first time or if the tab was switched (`WebviewPanel` is not active).