### PR TITLE
bring results of respective editor when query is run

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,10 @@
         {
           "command": "extension.disconnectObjectExplorerNode",
           "when": "enablePreviewFeatures && viewItem != null"
+        },
+        {
+          "command": "extension.toggleSqlCmd",
+          "when": "editorFocus"
         }
       ]
     },

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -417,7 +417,7 @@ export default class MainController implements vscode.Disposable {
      */
     public onNewConnection(): Promise<boolean> {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
-            this._connectionMgr.onNewConnection().then((result) => {
+            return this._connectionMgr.onNewConnection().then((result) => {
                 if (result) {
                     if (this._previewEnabled) {
                         this._objectExplorerProvider.objectExplorerExists = false;
@@ -521,6 +521,10 @@ export default class MainController implements vscode.Disposable {
 
             let editor = self._vscodeWrapper.activeTextEditor;
             let uri = self._vscodeWrapper.activeTextEditorUri;
+            if (!self._connectionMgr.isConnected(uri)) {
+                // create new connection
+                await self.onNewConnection();
+            }
             let title = path.basename(editor.document.fileName);
             let querySelection: ISelectionData;
             // Calculate the selection if we have a selection, otherwise we'll treat null as

--- a/src/controllers/webviewController.ts
+++ b/src/controllers/webviewController.ts
@@ -70,6 +70,17 @@ export class WebviewPanelController implements vscode.Disposable {
         this._panel.webview.html = formattedHTML;
     }
 
+    public dispose(): void {
+        this._disposables.forEach(d => d.dispose());
+        this._isDisposed = true;
+    }
+
+    public revealToForeground(): void {
+        this._panel.reveal();
+    }
+
+    /** Getters */
+
     /**
      * Property indicating whether the tab is active
      */
@@ -77,11 +88,10 @@ export class WebviewPanelController implements vscode.Disposable {
         return this._isActive;
     }
 
-    public dispose(): void {
-        this._disposables.forEach(d => d.dispose());
-        this._isDisposed = true;
-    }
-
+    /**
+     * Property indicating whether the panel controller
+     * is disposed or not
+     */
     public get isDisposed(): boolean {
         return this._isDisposed;
     }

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -101,6 +101,10 @@ export class SqlOutputContentProvider {
         await this.runQueryCallback(statusView ? statusView : this._statusView, uri, title,
             (queryRunner) => {
                 if (queryRunner) {
+                    // if the panel isn't active, bring it to foreground
+                    if (!this._panels.get(uri).isActive) {
+                        this._panels.get(uri).revealToForeground();
+                    }
                     queryRunner.runQuery(selection);
                 }
             });

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -152,6 +152,7 @@ export default class StatusView implements vscode.Disposable {
         bar.statusConnection.text = ConnInfo.getConnectionDisplayString(connCreds);
         bar.statusConnection.tooltip = ConnInfo.getTooltip(connCreds, serverInfo);
         this.showStatusBarItem(fileUri, bar.statusConnection);
+        this.sqlCmdModeChanged(fileUri, false);
     }
 
     public connectError(fileUri: string, credentials: Interfaces.IConnectionCredentials, error: ConnectionContracts.ConnectionCompleteParams): void {
@@ -283,6 +284,7 @@ export default class StatusView implements vscode.Disposable {
                 this.showStatusBarItem(fileUri, bar.statusLanguageFlavor);
                 this.showStatusBarItem(fileUri, bar.statusConnection);
                 this.showStatusBarItem(fileUri, bar.statusLanguageService);
+                this.showStatusBarItem(fileUri, bar.sqlCmdMode);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1332

Addresses https://github.com/microsoft/vscode-mssql/issues/1319 by showing the "Toggle SQLCMD Mode" only when editor has focus, and thus not being confusing any more. Then there are 3 cases -
1. Editor file is .sql and connected - command runs
2. Editor file is .sql and not connected - editor asks to connect to run command
3. Editor file is not .sql - show info message that a .sql file is required to run the command

Fixes https://github.com/microsoft/vscode-mssql/issues/1327