### PR TITLE
Check for ready event when switching tabs

### DIFF
--- a/src/controllers/webviewController.ts
+++ b/src/controllers/webviewController.ts
@@ -10,7 +10,6 @@ import { readFile as fsreadFile } from 'fs';
 import { promisify } from 'util';
 import * as ejs from 'ejs';
 import * as path from 'path';
-import QueryRunner from './queryRunner';
 
 function readFile(filePath: string): Promise<Buffer> {
     return promisify(fsreadFile)(filePath);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -72,7 +72,11 @@ class MessageProxy implements Disposable {
                 // first message
                 if (message === 'ready') {
                     // sanity check
-                    this.disposables.push(self.protocol.onMessage(val => self.onReceive(val)));
+                    this.disposables.push(self.protocol.onMessage((val) => {
+                        if (val !== 'ready') {
+                            self.onReceive(val);
+                        }
+                    }));
                     first.dispose();
                     self.ready.resolve();
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1349

Check for `ready` event when switching tabs. Since the protocol already exists when the tab is switched, we know it's already ready.