### PR TITLE
Check for default db when making a new query

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -160,7 +160,8 @@ export default class MainController implements vscode.Disposable {
                         Constants.cmdObjectExplorerNewQuery, async (treeNodeInfo: TreeNodeInfo) => {
                     const connectionCredentials = treeNodeInfo.connectionCredentials;
                     const databaseName = self.getDatabaseName(treeNodeInfo);
-                    if (databaseName !== connectionCredentials.database) {
+                    if (databaseName !== connectionCredentials.database &&
+                        databaseName !== LocalizedConstants.defaultDatabaseLabel) {
                         connectionCredentials.database = databaseName;
                     }
                     await self.onNewQuery(treeNodeInfo);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1370

Don't change the database name if the database name is `<default>`