### PR TITLE
Reprompt pass if wrong password

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -19,7 +19,7 @@ import CodeAdapter from '../prompts/adapter';
 import Telemetry from '../models/telemetry';
 import VscodeWrapper from './vscodeWrapper';
 import UntitledSqlDocumentService from './untitledSqlDocumentService';
-import { ISelectionData, IConnectionProfile } from './../models/interfaces';
+import { ISelectionData, IConnectionProfile, IConnectionCredentials } from './../models/interfaces';
 import * as path from 'path';
 import fs = require('fs');
 import { ObjectExplorerProvider } from '../objectExplorer/objectExplorerProvider';
@@ -205,9 +205,14 @@ export default class MainController implements vscode.Disposable {
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                         Constants.cmdObjectExplorerNodeSignIn, async (node: AccountSignInTreeNode) => {
-                    this._objectExplorerProvider.signInNodeServer(node.parentNode);
-                    const profile = <IConnectionProfile>node.parentNode.connectionCredentials;
-                    return this.connectionManager.connectionUI.promptForRetryCreateProfile(profile);
+                    let profile = <IConnectionProfile>node.parentNode.connectionCredentials;
+                    profile = await self.connectionManager.connectionUI.promptForRetryCreateProfile(profile);
+                    if (profile) {
+                        node.parentNode.connectionCredentials = <IConnectionCredentials>profile;
+                        self._objectExplorerProvider.updateNode(node.parentNode);
+                        self._objectExplorerProvider.signInNodeServer(node.parentNode);
+                        return self._objectExplorerProvider.refresh(undefined);
+                    }
                 }));
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -206,7 +206,8 @@ export default class MainController implements vscode.Disposable {
                     vscode.commands.registerCommand(
                         Constants.cmdObjectExplorerNodeSignIn, async (node: AccountSignInTreeNode) => {
                     this._objectExplorerProvider.signInNodeServer(node.parentNode);
-                    return this._objectExplorerProvider.refresh(undefined);
+                    const profile = <IConnectionProfile>node.parentNode.connectionCredentials;
+                    return this.connectionManager.connectionUI.promptForRetryCreateProfile(profile);
                 }));
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(

--- a/src/objectExplorer/objectExplorerProvider.ts
+++ b/src/objectExplorer/objectExplorerProvider.ts
@@ -58,7 +58,11 @@ export class ObjectExplorerProvider implements vscode.TreeDataProvider<any> {
     }
 
     public signInNodeServer(node: TreeNodeInfo): void {
-        return this._objectExplorerService.signInNodeServer(node);
+        this._objectExplorerService.signInNodeServer(node);
+    }
+
+    public updateNode(node: TreeNodeInfo): void {
+        this._objectExplorerService.updateNode(node);
     }
 
     /** Getters */

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -89,7 +89,10 @@ export class ObjectExplorerService {
                 }
                 return promise.resolve(self._currentNode);
             } else {
-                // failure
+                // create session failure
+                if (self._currentNode.connectionCredentials.password) {
+                    self._currentNode.connectionCredentials.password = '';
+                }
                 self.updateNode(self._currentNode);
                 self._currentNode = undefined;
                 let error = LocalizedConstants.connectErrorLabel;

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -90,6 +90,9 @@ export class ObjectExplorerService {
                 return promise.resolve(self._currentNode);
             } else {
                 // create session failure
+                if (self._currentNode.connectionCredentials.password) {
+                    self._currentNode.connectionCredentials.password = '';
+                }
                 self.updateNode(self._currentNode);
                 self._currentNode = undefined;
                 let error = LocalizedConstants.connectErrorLabel;
@@ -144,7 +147,7 @@ export class ObjectExplorerService {
         return response;
     }
 
-    private updateNode(node: TreeNodeInfo): void {
+    public updateNode(node: TreeNodeInfo): void {
         for (let rootTreeNode of this._rootTreeNodeArray) {
             if (rootTreeNode.connectionCredentials === node.connectionCredentials &&
                 rootTreeNode.label === node.label) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -90,9 +90,6 @@ export class ObjectExplorerService {
                 return promise.resolve(self._currentNode);
             } else {
                 // create session failure
-                if (self._currentNode.connectionCredentials.password) {
-                    self._currentNode.connectionCredentials.password = '';
-                }
                 self.updateNode(self._currentNode);
                 self._currentNode = undefined;
                 let error = LocalizedConstants.connectErrorLabel;

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -490,7 +490,7 @@ export class ConnectionUI {
         return ConnectionProfile.createProfile(this._prompter);
     }
 
-    private promptForRetryCreateProfile(profile: IConnectionProfile): PromiseLike<IConnectionProfile> {
+    public promptForRetryCreateProfile(profile: IConnectionProfile): PromiseLike<IConnectionProfile> {
         // Ask if the user would like to fix the profile
         return this._vscodeWrapper.showErrorMessage(LocalizedConstants.msgPromptRetryCreateProfile, LocalizedConstants.retryLabel).then(result => {
             if (result === LocalizedConstants.retryLabel) {


### PR DESCRIPTION
Reset the node password when there's a create session failure so clicking on `Sign In` re-prompts for password.

Fixes https://github.com/microsoft/vscode-mssql/issues/1343