### PR TITLE
Connect the node when adding connection

### DIFF
--- a/coverconfig.json
+++ b/coverconfig.json
@@ -1,8 +1,8 @@
 {
     "enabled": false,
     "relativeSourcePath": "../src",
-    "relativeCoverageDir": "../../coverage",
-    "ignorePatterns": ["**/node_modules/**", "**/libs/**", "**/lib/**", "**/htmlcontent/**/*.js", "**/*.bundle.js"],
+    "relativeCoverageDir": "../coverage",
+    "ignorePatterns": ["**/node_modules/**", "**/libs/**", "**/lib/**", "**/htmlcontent/**/*.js", "**/*.bundle.js", "**/out/**"],
     "includePid": false,
     "reports": ["json"],
     "verbose": false

--- a/coverconfig.json
+++ b/coverconfig.json
@@ -1,8 +1,8 @@
 {
     "enabled": false,
     "relativeSourcePath": "../src",
-    "relativeCoverageDir": "../coverage",
-    "ignorePatterns": ["**/node_modules/**", "**/libs/**", "**/lib/**", "**/htmlcontent/**/*.js", "**/*.bundle.js", "**/out/**"],
+    "relativeCoverageDir": "../../coverage",
+    "ignorePatterns": ["**/node_modules/**", "**/libs/**", "**/lib/**", "**/htmlcontent/**/*.js", "**/*.bundle.js"],
     "includePid": false,
     "reports": ["json"],
     "verbose": false

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -160,7 +160,8 @@ export default class MainController implements vscode.Disposable {
                         Constants.cmdObjectExplorerNewQuery, async (treeNodeInfo: TreeNodeInfo) => {
                     const connectionCredentials = treeNodeInfo.connectionCredentials;
                     const databaseName = self.getDatabaseName(treeNodeInfo);
-                    if (databaseName !== connectionCredentials.database) {
+                    if (databaseName !== connectionCredentials.database &&
+                        databaseName !== LocalizedConstants.defaultDatabaseLabel) {
                         connectionCredentials.database = databaseName;
                     }
                     await self.onNewQuery(treeNodeInfo);

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -405,8 +405,6 @@ export default class MainController implements vscode.Disposable {
         if (this.canRunCommand()) {
             Telemetry.sendTelemetryEvent('ManageProfiles');
             await this._connectionMgr.onManageProfiles();
-            this._objectExplorerProvider.refresh(undefined);
-            return;
         }
     }
 

--- a/test/mainController.test.ts
+++ b/test/mainController.test.ts
@@ -205,7 +205,7 @@ suite('MainController Tests', () => {
     test('onNewQuery should call the new query and new connection' , () => {
 
         untitledSqlDocumentService.setup(x => x.newQuery()).returns(() => Promise.resolve(TypeMoq.It.isAny()));
-        connectionManager.setup(x => x.onNewConnection()).returns(() => Promise.resolve(TypeMoq.It.isAny()));
+        connectionManager.setup(x => x.onNewConnection()).returns(() => Promise.resolve(undefined));
 
         return mainController.onNewQuery(undefined).then(result => {
             untitledSqlDocumentService.verify(x => x.newQuery(), TypeMoq.Times.once());


### PR DESCRIPTION
The nodes are in a connected state when added from a command (`Add Object Explorer`/ `New Connection`/ `New Query`)  etc. 

However, when a connection is added manually by editing the settings file, the node isn't automatically connected because a connection isn't made for it. It will be added in a disconnected state.

Fixes https://github.com/microsoft/vscode-mssql/issues/1365