### PR TITLE
Added short cut for oe

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,6 +381,11 @@
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "workbench.view.extension.objectExplorer",
+        "key": "ctrl+alt+d",
+        "mac": "cmd+alt+d"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1395

Wanted to take Ctrl+Shift+D like ADS, but that's already taken by Disconnect, which existed in the previous version, so I don't want to override it. 