### PR TITLE
Also check for save password for same connection

### DIFF
--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -254,7 +254,9 @@ export function isSameConnection(conn: interfaces.IConnectionCredentials, expect
         expectedConn.server === conn.server
         && isSameDatabase(expectedConn.database, conn.database)
         && isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType)
-        && expectedConn.user === conn.user;
+        && expectedConn.user === conn.user
+        && (<interfaces.IConnectionProfile>conn).savePassword ===
+        (<interfaces.IConnectionProfile>expectedConn).savePassword;
 }
 
 /**


### PR DESCRIPTION
Check for `savePassword` option as well when comparing 2 connections. Fixes UX problems when 2 same connections are made with different values of `savePassword` 