### PR TITLE
Fix bug with new nodes when DB is changed

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -186,7 +186,7 @@ export default class MainController implements vscode.Disposable {
                     Constants.cmdScriptSelect, async (node: TreeNodeInfo) => {
                     let actionPromise = new Promise<boolean>(async (resolve, reject) => {
                         const nodeUri = ObjectExplorerUtils.getNodeUri(node);
-                        let connectionCreds = node.connectionCredentials;
+                        let connectionCreds = Object.assign({}, node.connectionCredentials);
                         const databaseName = ObjectExplorerUtils.getDatabaseName(node);
                         // if not connected or different database
                         if (!this.connectionManager.isConnected(nodeUri) ||

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -154,7 +154,7 @@ export default class MainController implements vscode.Disposable {
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                         Constants.cmdObjectExplorerNewQuery, async (treeNodeInfo: TreeNodeInfo) => {
-                    const connectionCredentials = treeNodeInfo.connectionCredentials;
+                    const connectionCredentials = Object.assign({}, treeNodeInfo.connectionCredentials);
                     const databaseName = ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
                     if (databaseName !== connectionCredentials.database &&
                         databaseName !== LocalizedConstants.defaultDatabaseLabel) {


### PR DESCRIPTION
Instead of changing node credentials, make a connection with an object so that a new node isn't made when we connect to a new database.