### PR TITLE
Fix UX for create session issue

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -321,13 +321,19 @@ export default class MainController implements vscode.Disposable {
      */
     private async createObjectExplorerSession(connectionCredentials?: IConnectionCredentials): Promise<void> {
         let createSessionPromise = new Deferred<TreeNodeInfo>();
-        await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
-        const newNode = await createSessionPromise;
-        this._objectExplorerProvider.refresh(undefined);
-        let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
-        await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
-        await expandSessionPromise;
-        this._objectExplorerProvider.refresh(undefined);
+        try {
+            await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
+            const newNode = await createSessionPromise;
+            if (newNode) {
+                this._objectExplorerProvider.refresh(undefined);
+                let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
+                await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
+                await expandSessionPromise;
+                this._objectExplorerProvider.refresh(undefined);
+            }
+        } catch (err) {
+            throw err;
+        }
     }
 
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -322,14 +322,16 @@ export default class MainController implements vscode.Disposable {
      */
     private async createObjectExplorerSession(connectionCredentials?: IConnectionCredentials): Promise<void> {
         let createSessionPromise = new Deferred<TreeNodeInfo>();
-        await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
-        const newNode = await createSessionPromise;
-        if (newNode) {
-            this._objectExplorerProvider.refresh(undefined);
-            let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
-            await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
-            await expandSessionPromise;
-            this._objectExplorerProvider.refresh(undefined);
+        const sessionId = await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
+        if (sessionId) {
+            const newNode = await createSessionPromise;
+            if (newNode) {
+                this._objectExplorerProvider.refresh(undefined);
+                let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
+                await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
+                await expandSessionPromise;
+                this._objectExplorerProvider.refresh(undefined);
+            }
         }
     }
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -232,6 +232,7 @@ export default class MainController implements vscode.Disposable {
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                         Constants.cmdConnectObjectExplorerNode, async (node: ConnectTreeNode) => {
+                        self._objectExplorerProvider.currentNode = node.parentNode;
                         await self.createObjectExplorerSession(node.parentNode.connectionCredentials);
                 }));
                 this._context.subscriptions.push(
@@ -321,18 +322,14 @@ export default class MainController implements vscode.Disposable {
      */
     private async createObjectExplorerSession(connectionCredentials?: IConnectionCredentials): Promise<void> {
         let createSessionPromise = new Deferred<TreeNodeInfo>();
-        try {
-            await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
-            const newNode = await createSessionPromise;
-            if (newNode) {
-                this._objectExplorerProvider.refresh(undefined);
-                let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
-                await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
-                await expandSessionPromise;
-                this._objectExplorerProvider.refresh(undefined);
-            }
-        } catch (err) {
-            throw err;
+        await this._objectExplorerProvider.createSession(createSessionPromise, connectionCredentials);
+        const newNode = await createSessionPromise;
+        if (newNode) {
+            this._objectExplorerProvider.refresh(undefined);
+            let expandSessionPromise = new Deferred<TreeNodeInfo[]>();
+            await this._objectExplorerProvider.expandNode(newNode, newNode.sessionId, expandSessionPromise);
+            await expandSessionPromise;
+            this._objectExplorerProvider.refresh(undefined);
         }
     }
 

--- a/src/objectExplorer/objectExplorerProvider.ts
+++ b/src/objectExplorer/objectExplorerProvider.ts
@@ -98,4 +98,8 @@ export class ObjectExplorerProvider implements vscode.TreeDataProvider<any> {
     public set objectExplorerService(value: ObjectExplorerService) {
         this._objectExplorerService = value;
     }
+
+    public set currentNode(node: TreeNodeInfo) {
+        this._objectExplorerService.currentNode = node;
+    }
 }

--- a/src/objectExplorer/objectExplorerProvider.ts
+++ b/src/objectExplorer/objectExplorerProvider.ts
@@ -37,7 +37,7 @@ export class ObjectExplorerProvider implements vscode.TreeDataProvider<any> {
         }
     }
 
-    async createSession(promise: Deferred<TreeNodeInfo>, connectionCredentials?: IConnectionCredentials): Promise<void> {
+    async createSession(promise: Deferred<TreeNodeInfo>, connectionCredentials?: IConnectionCredentials): Promise<string> {
         return this._objectExplorerService.createSession(promise, connectionCredentials);
     }
 

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -267,14 +267,22 @@ export class ObjectExplorerService {
                 } else {
                     // start node session
                     let promise = new Deferred<TreeNodeInfo>();
-                    await this.createSession(promise, element.connectionCredentials);
-                    let node = await promise;
-                    // If node create session failed
-                    if (!node) {
+                    try {
+                        await this.createSession(promise, element.connectionCredentials);
+                        let node = await promise;
+                        // if password failed
+                        if (!node) {
+                            const connectNode = new ConnectTreeNode(element);
+                            this._treeNodeToChildrenMap.set(element, [connectNode]);
+                            return [connectNode];
+                        }
+                    } catch (err) {
+                        // If node create session failed
                         const signInNode = new AccountSignInTreeNode(element);
                         this._treeNodeToChildrenMap.set(element, [signInNode]);
                         return [signInNode];
                     }
+
                     // otherwise expand the node by refreshing the root
                     // to add connected context key
                     this._objectExplorerProvider.refresh(undefined);
@@ -341,6 +349,8 @@ export class ObjectExplorerService {
                 this._sessionIdToPromiseMap.set(response.sessionId, promise);
                 return;
             }
+        } else {
+            return Promise.reject();
         }
     }
 

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -479,4 +479,11 @@ export class ObjectExplorerService {
         const connections = this._rootTreeNodeArray.map(node => node.connectionCredentials);
         return connections;
     }
+
+    /**
+     * Setters
+     */
+    public set currentNode(node: TreeNodeInfo) {
+        this._currentNode = node;
+    }
 }

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -350,6 +350,7 @@ export class ObjectExplorerService {
                 return;
             }
         } else {
+            // no connection was made
             return Promise.reject();
         }
     }

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -317,7 +317,7 @@ export class ObjectExplorerService {
      * OE out of
      * @param connectionCredentials Connection Credentials for a node
      */
-    public async createSession(promise: Deferred<vscode.TreeItem>, connectionCredentials?: IConnectionCredentials): Promise<string> {
+    public async createSession(promise: Deferred<vscode.TreeItem | undefined>, connectionCredentials?: IConnectionCredentials): Promise<string> {
         if (!connectionCredentials) {
             const connectionUI = this._connectionManager.connectionUI;
             connectionCredentials = await connectionUI.showConnections(false);
@@ -351,6 +351,7 @@ export class ObjectExplorerService {
             }
         } else {
             // no connection was made
+            promise.resolve(undefined);
             return undefined;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1431.

`ObjectExplorerService.createSession` now rejects if there were no credentials i.e. if connection prompt failed. After that the deferred promise resolves a node if the `createSession` was successful in the notification handler. 

Also shows the correct node for just prompting password in the case where savePassword is false. (instead of retry creating the profile, which is shown when connection prompt failed)