### PR TITLE
Fix query options

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -425,7 +425,7 @@ export default class QueryRunner {
 
 
     public async toggleSqlCmd(): Promise<boolean> {
-        const queryExecuteOptions: QueryExecutionOptions = { options: new Map<string, any>() };
+        const queryExecuteOptions: QueryExecutionOptions = { options: {} };
         queryExecuteOptions.options['isSqlCmdMode'] = !this.isSqlCmd;
         const queryExecuteOptionsParams: QueryExecutionOptionsParams = {
             ownerUri: this.uri,

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -128,6 +128,7 @@ export class QueryExecutionOptionsParams {
     options: QueryExecutionOptions;
 }
 
-export class QueryExecutionOptions {
-    options: Map<string, any>;
+// tslint:disable-next-line:interface-name
+export interface QueryExecutionOptions {
+    [option: string]: any;
 }


### PR DESCRIPTION
Fix the way we send options, by using an object instead of incorrectly using a `Map`