### PR TITLE
update coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/Microsoft/vscode-mssql?svg=true&retina=true&branch=master)](https://ci.appveyor.com/project/kburtram/vscode-mssql)
+[![Build Status](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_apis/build/status/VSCode-MSSQL?branchName=master)](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/latest?definitionId=70&branchName=master)
 [![Coverage Status](https://coveralls.io/repos/github/Microsoft/vscode-mssql/badge.svg?branch=master)](https://coveralls.io/github/Microsoft/vscode-mssql?branch=master)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-blue.svg)](https://gitter.im/Microsoft/mssql)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_apis/build/status/VSCode-MSSQL?branchName=master)](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/latest?definitionId=70&branchName=master)
-[![Coverage Status](https://coveralls.io/repos/github/Microsoft/vscode-mssql/badge.svg?branch=master)](https://coveralls.io/github/Microsoft/vscode-mssql?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/microsoft/vscode-mssql/badge.svg?branch=master)](https://coveralls.io/github/microsoft/vscode-mssql?branch=master)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-blue.svg)](https://gitter.im/Microsoft/mssql)
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,8 @@ test_script:
 after_test:
   - gulp cover:clean
   - gulp cover:enableconfig
-  - gulp cover:combine-json
   - node ./node_modules/vscode/bin/test
+  - gulp cover:combine-json
   - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   nodejs_version: "6.9.1"
   # Temporary Code version due to https://github.com/Microsoft/vscode-extension-vscode/issues/64
   CODE_VERSION: 1.33.0
+  COVERALLS_SERVICE_NAME: "VSCode-MSSQL"
   COVERALLS_REPO_TOKEN:
     secure: 9VOgkRYij4Ga9kqUvcfo0XVoJ5AoCir4npEDA2f0gwromo25QZd+pT0QgObjCJSC
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,8 @@ test_script:
 
 coverage_script:
   - gulp cover:jenkins
+
+publish_script:
   - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
   # Temporary Code version due to https://github.com/Microsoft/vscode-extension-vscode/issues/64
   CODE_VERSION: 1.33.0
   COVERALLS_REPO_TOKEN:
-    secure: yDAV24iOuk28iTfIZX9+U4LB7UGtNG8pHY4mCP9eVxl0aQK/Yu2fDesgaj3utsyE
+    secure: 9VOgkRYij4Ga9kqUvcfo0XVoJ5AoCir4npEDA2f0gwromo25QZd+pT0QgObjCJSC
 
 
 # safelist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,10 @@ build_script:
   - gulp build
 
 test_script:
-  - node ./node_modules/vscode/bin/test
-
-after_test:
   - gulp cover:clean
   - gulp cover:enableconfig
   - gulp cover:combine-json
+  - node ./node_modules/vscode/bin/test
   - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,9 @@ build_script:
   - gulp build
 
 test_script:
+  - node ./node_modules/vscode/bin/test
+
+after_test:
   - gulp cover:clean
   - gulp cover:enableconfig
   - gulp cover:combine-json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,9 @@ test_script:
   - node ./node_modules/vscode/bin/test
 
 after_test:
-  - gulp cover:jenkins
+  - gulp cover:clean
+  - gulp cover:enableconfig
+  - gulp cover:combine-json
   - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,10 +32,8 @@ build_script:
 test_script:
   - node ./node_modules/vscode/bin/test
 
-coverage_script:
+after_test:
   - gulp cover:jenkins
-
-publish_script:
   - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   nodejs_version: "6.9.1"
   # Temporary Code version due to https://github.com/Microsoft/vscode-extension-vscode/issues/64
   CODE_VERSION: 1.33.0
+  COVERALLS_REPO_TOKEN:
+    secure: yDAV24iOuk28iTfIZX9+U4LB7UGtNG8pHY4mCP9eVxl0aQK/Yu2fDesgaj3utsyE
 
 
 # safelist
@@ -29,6 +31,10 @@ build_script:
 
 test_script:
   - node ./node_modules/vscode/bin/test
+
+coverage_script:
+  - gulp cover:jenkins
+  - ./node_modules/.bin/coveralls < coverage/lcov.info
 
 on_finish:
   - ps: scripts\upload.ps1


### PR DESCRIPTION
Update coveralls to use appveyor and use azure pipelines badge. The existing code coverage badge is incorrect (from Travis CI) which we disabled long time ago.