### PR TITLE
Use correct database for new query when called from OE

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -166,6 +166,7 @@ export default class MainController implements vscode.Disposable {
                     } else if (databaseName === LocalizedConstants.defaultDatabaseLabel) {
                         connectionCredentials.database = '';
                     }
+                    treeNodeInfo.connectionCredentials = connectionCredentials;
                     await self.onNewQuery(treeNodeInfo);
                 }));
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1435

Database connections are now different from server connections (https://github.com/microsoft/vscode-mssql/commit/16045d2be75e5f773a0cc928cf0f361204a0be40), so we won't have the issue of getting a new node for a database connection when starting a new query