### PR TITLE
Check for ip address from firewall result

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -389,7 +389,7 @@ export default class ConnectionManager {
                 Utils.showErrorMsg(Utils.formatString(LocalizedConstants.msgConnectionError, result.errorNumber, result.errorMessage));
                 // check whether it's a firewall rule error
                 let firewallResult = await this.firewallService.handleFirewallRule(result.errorNumber, result.errorMessage);
-                if (firewallResult) {
+                if (firewallResult.result && firewallResult.ipAddress) {
                     this._failedUriToFirewallIpMap.set(fileUri, firewallResult.ipAddress);
                 }
             }

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -112,13 +112,14 @@ export class ObjectExplorerService {
                 // handle session failure because of firewall issue
                 if (ObjectExplorerUtils.isFirewallError(result.errorMessage)) {
                     let handleFirewallResult = await self._connectionManager.firewallService.handleFirewallRule(Constants.errorFirewallRule, result.errorMessage);
-                    const nodeUri = ObjectExplorerUtils.getNodeUri(self._currentNode);
-                    const profile = <IConnectionProfile>self._currentNode.connectionCredentials;
-                    self.updateNode(self._currentNode);
-                    self._currentNode = undefined;
-                    self._connectionManager.connectionUI.handleFirewallError(nodeUri, profile, handleFirewallResult.ipAddress);
+                    if (handleFirewallResult.result && handleFirewallResult.ipAddress) {
+                        const nodeUri = ObjectExplorerUtils.getNodeUri(self._currentNode);
+                        const profile = <IConnectionProfile>self._currentNode.connectionCredentials;
+                        self.updateNode(self._currentNode);
+                        self._currentNode = undefined;
+                        self._connectionManager.connectionUI.handleFirewallError(nodeUri, profile, handleFirewallResult.ipAddress);
+                    }
                 }
-
                 if (promise) {
                     return promise.resolve(undefined);
                 }


### PR DESCRIPTION
Found a bug in my own testing for firewall rules. Check explicitly if result was true and if we get an ipAddress back