### PR TITLE
Fixed intellisense bug

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -788,8 +788,8 @@ export default class ConnectionManager {
         return this.connectionUI.removeProfile();
     }
 
-    public onDidCloseTextDocument(doc: vscode.TextDocument): void {
-        let docUri: string = doc.uri.toString();
+    public async onDidCloseTextDocument(doc: vscode.TextDocument): Promise<void> {
+        let docUri: string = doc.uri.toString(true);
 
         // If this file isn't connected, then don't do anything
         if (!this.isConnected(docUri)) {
@@ -797,17 +797,17 @@ export default class ConnectionManager {
         }
 
         // Disconnect the document's connection when we close it
-        this.disconnect(docUri);
+        await this.disconnect(docUri);
     }
 
     public onDidOpenTextDocument(doc: vscode.TextDocument): void {
-        let uri = doc.uri.toString();
+        let uri = doc.uri.toString(true);
         if (doc.languageId === 'sql' && typeof(this._connections[uri]) === 'undefined') {
             this.statusView.notConnected(uri);
         }
     }
 
-    public transferFileConnection(oldFileUri: string, newFileUri: string): void {
+    public async transferFileConnection(oldFileUri: string, newFileUri: string): Promise<void> {
         // Is the new file connected or the old file not connected?
         if (!this.isConnected(oldFileUri) || this.isConnected(newFileUri)) {
             return;
@@ -815,11 +815,10 @@ export default class ConnectionManager {
 
         // Connect the saved uri and disconnect the untitled uri on successful connection
         let creds: Interfaces.IConnectionCredentials = this._connections[oldFileUri].credentials;
-        this.connect(newFileUri, creds).then(result => {
-            if (result) {
-                this.disconnect(oldFileUri);
-            }
-        });
+        let result = await this.connect(newFileUri, creds)
+        if (result) {
+            await this.disconnect(oldFileUri);
+        }
     }
 
     private getIsServerLinux(osVersion: string): string {

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -507,7 +507,7 @@ export default class QueryRunner {
      * @param selection The selection range to select
      */
     public async setEditorSelection(selection: ISelectionData): Promise<void> {
-        const docExists = this._vscodeWrapper.textDocuments.find(textDoc => textDoc.uri.toString() === this.uri);
+        const docExists = this._vscodeWrapper.textDocuments.find(textDoc => textDoc.uri.toString(true) === this.uri);
         if (docExists) {
             let column = vscode.ViewColumn.One;
             const doc = await this._vscodeWrapper.openTextDocument(this._vscodeWrapper.parseUri(this.uri));

--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -63,7 +63,7 @@ export default class VscodeWrapper {
     public get activeTextEditorUri(): string {
         if (typeof vscode.window.activeTextEditor !== 'undefined' &&
             typeof vscode.window.activeTextEditor.document !== 'undefined') {
-            return vscode.window.activeTextEditor.document.uri.toString();
+            return vscode.window.activeTextEditor.document.uri.toString(true);
         }
         return undefined;
     }

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -312,17 +312,11 @@ export default class SqlToolsServiceClient {
     }
 
     private createResourceClient(resourcePath: string): LanguageClient {
-        // Options to control the language client
-        let clientOptions: LanguageClientOptions = {
-            // documentSelector: ['sql'],
-            // synchronize: {
-            //     configurationSection: 'mssql'
-            // },
-            // errorHandler: new LanguageClientErrorHandler(this._vscodeWrapper)
-        };
         // add resource provider path here
         let serverOptions = this.generateResourceServiceServerOptions(resourcePath);
-        let client = new LanguageClient(Constants.resourceServiceName, serverOptions, clientOptions);
+        // client options are undefined since we don't want to send language events to the
+        // server, since it's handled by the main client
+        let client = new LanguageClient(Constants.resourceServiceName, serverOptions, undefined);
         return client;
     }
 

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -314,11 +314,11 @@ export default class SqlToolsServiceClient {
     private createResourceClient(resourcePath: string): LanguageClient {
         // Options to control the language client
         let clientOptions: LanguageClientOptions = {
-            documentSelector: ['sql'],
-            synchronize: {
-                configurationSection: 'mssql'
-            },
-            errorHandler: new LanguageClientErrorHandler(this._vscodeWrapper)
+            // documentSelector: ['sql'],
+            // synchronize: {
+            //     configurationSection: 'mssql'
+            // },
+            // errorHandler: new LanguageClientErrorHandler(this._vscodeWrapper)
         };
         // add resource provider path here
         let serverOptions = this.generateResourceServiceServerOptions(resourcePath);

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -278,12 +278,12 @@ export class SqlOutputContentProvider {
     public onDidCloseTextDocument(doc: vscode.TextDocument): void {
         for (let [key, value] of this._queryResultsMap.entries()) {
             // closed text document related to a results window we are holding
-            if (doc.uri.toString() === value.queryRunner.uri) {
+            if (doc.uri.toString(true) === value.queryRunner.uri) {
                 value.flaggedForDeletion = true;
             }
 
             // "closed" a results window we are holding
-            if (doc.uri.toString() === key) {
+            if (doc.uri.toString(true) === key) {
                 value.timeout = this.setRunnerDeletionTimeout(key);
             }
         }

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -117,7 +117,7 @@ export function getActiveTextEditor(): vscode.TextEditor {
 export function getActiveTextEditorUri(): string {
     if (typeof vscode.window.activeTextEditor !== 'undefined' &&
         typeof vscode.window.activeTextEditor.document !== 'undefined') {
-        return vscode.window.activeTextEditor.document.uri.toString();
+        return vscode.window.activeTextEditor.document.uri.toString(true);
     }
     return '';
 }

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -278,7 +278,7 @@ export default class StatusView implements vscode.Disposable {
         if (typeof editor !== 'undefined') {
             // Hide the most recently shown status bar
             this.hideLastShownStatusBar();
-            const fileUri = editor.document.uri.toString();
+            const fileUri = editor.document.uri.toString(true);
             const bar = this._statusBars[fileUri];
             if (bar) {
                 this.showStatusBarItem(fileUri, bar.statusLanguageFlavor);
@@ -291,7 +291,7 @@ export default class StatusView implements vscode.Disposable {
 
     private onDidCloseTextDocument(doc: vscode.TextDocument): void {
         // Remove the status bar associated with the document
-        this.destroyStatusBar(doc.uri.toString());
+        this.destroyStatusBar(doc.uri.toString(true));
     }
 
     private showStatusBarItem(fileUri: string, statusBarItem: vscode.StatusBarItem): void {


### PR DESCRIPTION
Fixed intellisense stopped working after saving file - https://github.com/microsoft/vscode-mssql/issues/1453

1. `doc.uri.toString(true)` disables encoding when given a parameter `true`, so the connection URI would be the same as the file URI.
2. Remove `sql` from the `Resource Provider Language Client`, because it was sending double language changes to the server along with the actual `Sql Tools Service Client`.