### PR TITLE
Fix menu order to match ADS

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,17 +203,17 @@
         {
           "command": "mssql.removeObjectExplorerNode",
           "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
-          "group": "MS_SQL@3"
+          "group": "MS_SQL@4"
         },
         {
           "command": "mssql.refreshObjectExplorerNode",
           "when": "view == objectExplorer && viewItem != disconnectedServer",
-          "group": "MS_SQL@2"
+          "group": "MS_SQL@10"
         },
         {
           "command": "mssql.disconnectObjectExplorerNode",
           "when": "view == objectExplorer && viewItem == Server",
-          "group": "MS_SQL@4"
+          "group": "MS_SQL@3"
         },
         {
           "command": "mssql.scriptSelect",
@@ -223,22 +223,22 @@
         {
           "command": "mssql.scriptCreate",
           "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/",
-          "group": "MS_SQL@1"
+          "group": "MS_SQL@2"
         },
         {
           "command": "mssql.scriptDelete",
           "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/",
-          "group": "MS_SQL@1"
+          "group": "MS_SQL@3"
         },
         {
           "command": "mssql.scriptExecute",
           "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
-          "group": "MS_SQL@1"
+          "group": "MS_SQL@5"
         },
         {
           "command": "mssql.scriptAlter",
           "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
-          "group": "MS_SQL@1"
+          "group": "MS_SQL@4"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1533

Comparing ADS (Top) vs Extension (Bottom) context menus

1. ADS menu for server
![ads-server](https://user-images.githubusercontent.com/6411451/70569321-933f0000-1b4e-11ea-9f82-807ac48391b8.jpg)

Extension menu for server
![extension-server](https://user-images.githubusercontent.com/6411451/70569332-99cd7780-1b4e-11ea-854e-4b23da995f5e.jpg)

2. ADS menu for tables
![ads-table](https://user-images.githubusercontent.com/6411451/70569350-a225b280-1b4e-11ea-95c5-822ecd269486.jpg)

Extension menu for table
![extension-table](https://user-images.githubusercontent.com/6411451/70569362-a8b42a00-1b4e-11ea-935a-8b7f3f2262ed.jpg)

3. ADS menu for stored procedures
![ads-storedProcedure](https://user-images.githubusercontent.com/6411451/70569552-02b4ef80-1b4f-11ea-940e-97724a00b7b4.jpg)

Extension menu for stored procedures
![extension-storedProcedure](https://user-images.githubusercontent.com/6411451/70569703-4b6ca880-1b4f-11ea-95db-9cfa296ebf15.jpg)

