### PR TITLE
Fixes in Query Results

### DIFF
--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -4,8 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 /** Disable selection in html **/
-.results.vertBox.scrollable {
+.fullsize.vertBox {
   user-select: none;
+}
+
+/** Add the ability to select messages using the cursor **/
+.scrollable.messages {
+  cursor: text;
+  user-select: text;
 }
 
 /** Light Theme **/

--- a/src/views/htmlcontent/src/css/styles.css
+++ b/src/views/htmlcontent/src/css/styles.css
@@ -61,6 +61,11 @@
 }
 
 /* messages */
+
+table#messageTable td.errorMessage {
+  color: var(--color-error);
+}
+
 table {
   font-weight: inherit;
   font-size: inherit;

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -107,7 +107,7 @@ const template = `
             </tbody>
         </table>
     </div>
-    <div id="resizeHandle" [class.hidden]="!resizing" [style.top]="resizeHandleTop"></div>
+    <div id="resizeHandle" [class.hidden]="!resizing" [style.top.px]="resizeHandleTop"></div>
 </div>
 `;
 // tslint:enable:max-line-length
@@ -782,11 +782,14 @@ export class AppComponent implements OnInit, AfterViewChecked {
      */
     keyEvent(e: KeyboardEvent): void {
         const self = this;
+        e.preventDefault();
+        e.stopImmediatePropagation();
         let eString = this.shortcuts.buildEventString(e);
         this.shortcuts.getEvent(eString).then((result) => {
             if (result) {
                 let eventName = <string> result;
                 self.shortcutfunc[eventName]();
+                e.preventDefault();
                 e.stopImmediatePropagation();
             }
         });

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -117,7 +117,7 @@ const template = `
  */
 @Component({
     selector: 'my-app',
-    host: { '(window:keydown)': 'keyEvent($event)', '(window:gridnav)': 'keyEvent($event)' },
+    host: { '(window:keydown)': 'keyEvent($event)', '(window:gridnav)': 'keyEvent($event)', '(window:keyup)' : 'keyUpEvent($event)' },
     template: template,
     providers: [DataService, ShortcutService],
     styles: [`
@@ -782,14 +782,29 @@ export class AppComponent implements OnInit, AfterViewChecked {
      */
     keyEvent(e: KeyboardEvent): void {
         const self = this;
-        e.preventDefault();
-        e.stopImmediatePropagation();
         let eString = this.shortcuts.buildEventString(e);
         this.shortcuts.getEvent(eString).then((result) => {
             if (result) {
                 let eventName = <string> result;
                 self.shortcutfunc[eventName]();
-                e.preventDefault();
+                e.stopImmediatePropagation();
+            }
+        });
+    }
+
+    /**
+     * Helper to deselect messages when Ctrl + A is pressed
+     * inside the grid
+    */
+    keyUpEvent(e: KeyboardEvent): void {
+        let eString = this.shortcuts.buildEventString(e);
+        this.shortcuts.getEvent(eString).then((result) => {
+            if (result) {
+                let eventName = <string> result;
+                if (eventName === 'event.selectAll') {
+                    window.getSelection().empty();
+                    rangy.getSelection().removeAllRanges();
+                }
                 e.stopImmediatePropagation();
             }
         });

--- a/src/views/htmlcontent/src/js/components/messagescontextmenu.component.ts
+++ b/src/views/htmlcontent/src/js/components/messagescontextmenu.component.ts
@@ -13,7 +13,7 @@ import { IRange } from '../../../../../models/interfaces';
  */
 
 const template = `
-<ul class="contextMenu" style="position:absolute" [class.hidden]="!visible" [style.top]="position.y" [style.left]="position.x">
+<ul class="contextMenu" style="position:absolute" [class.hidden]="!visible" [style.top.px]="position.y" [style.left.px]="position.x">
     <li id="copy" (click)="handleContextActionClick('copySelection')" [class.disabled]="isDisabled"> {{Constants.copyLabel}}
         <span style="float: right; color: lightgrey; padding-left: 10px">{{keys['event.copySelection']}}</span>
     </li>


### PR DESCRIPTION
- [x] Fixes https://github.com/microsoft/vscode-mssql/issues/1535 - Ctrl + A selects outside grid
- [x] Fixes https://github.com/microsoft/vscode-mssql/issues/1536 - Result window header shouldn't be selectable
- [x] Fixes https://github.com/microsoft/vscode-mssql/issues/1541 - Query execution messages aren't shown in red
- [x] Fixes https://github.com/microsoft/vscode-mssql/issues/1495 - Redrag handler is not drawn correctly
- [x] Fixes another bug I found where the context menu to copy messages was drawn incorrectly