### PR TITLE
Remove extra step for activating the extension

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -236,9 +236,6 @@
         <trans-unit id="msgPromptRetryFirewallRuleNotSignedIn">
             <source xml:lang="en">Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.</source>
         </trans-unit>
-        <trans-unit id="msgPromptRetryFirewallRuleNotActivated">
-            <source xml:lang="en">Your client IP address does not have access to the server. Activate the Azure Account extension and sign in to an Azure account and create a new firewall rule to enable access.</source>
-        </trans-unit>
         <trans-unit id="msgPromptRetryFirewallRuleSignedIn">
             <source xml:lang="en">Account signed In. Create new firewall rule? </source>
         </trans-unit>
@@ -265,9 +262,6 @@
         </trans-unit>
         <trans-unit id="downloadAndInstallLabel">
             <source xml:lang="en">Download and Install</source>
-        </trans-unit>
-        <trans-unit id="activateLabel">
-            <source xml:lang="en">Activate</source>
         </trans-unit>
         <trans-unit id="createFirewallRuleLabel">
             <source xml:lang="en">Create Firewall Rule</source>

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -529,7 +529,7 @@ export class ConnectionUI {
     }
 
     /**
-     * Save a connection profile using the connection store.
+     * Save a connection profile using the connection store
      */
     private saveProfile(profile: IConnectionProfile): Promise<IConnectionProfile> {
         return this._connectionStore.saveProfile(profile);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -507,17 +507,8 @@ export class ConnectionUI {
         } else {
             // If the extension exists but not active
             if (this._vscodeWrapper.azureAccountExtension) {
-                // Prompt user to activate the extension
-                let selection = await this._vscodeWrapper.showInformationMessage(LocalizedConstants.msgPromptRetryFirewallRuleNotActivated,
-                    LocalizedConstants.activateLabel);
-                if (selection === LocalizedConstants.activateLabel) {
-                    let activated = await this._vscodeWrapper.azureAccountExtension.activate();
-                    if (activated) {
-                        this.showAzureExtensionActivated();
-                        return this.handleFirewallError(uri, profile, ipAddress);
-                    }
-                }
-                return false;
+                await this._vscodeWrapper.azureAccountExtension.activate();
+                return this.handleExtensionActivation();
             } else {
                 // Show recommendation to download the azure account extension
                 const selection = await this._vscodeWrapper.showInformationMessage(LocalizedConstants.msgPromptRetryFirewallRuleExtNotInstalled,
@@ -528,7 +519,7 @@ export class ConnectionUI {
                         // Activate the Azure Account extension and call the function again
                         if (this._vscodeWrapper.azureAccountExtension) {
                             await this._vscodeWrapper.azureAccountExtension.activate();
-                            await this.showAzureExtensionActivated();
+                            await this.handleExtensionActivation();
                         }
                     });
                 }
@@ -582,7 +573,7 @@ export class ConnectionUI {
         });
     }
 
-    private async showAzureExtensionActivated(): Promise<boolean> {
+    private async handleExtensionActivation(): Promise<boolean> {
         if (!this._vscodeWrapper.isAccountSignedIn) {
             const result = await this._vscodeWrapper.showInformationMessage(LocalizedConstants.msgPromptAzureExtensionActivatedNotSignedIn,
                 LocalizedConstants.signInLabel);
@@ -591,7 +582,6 @@ export class ConnectionUI {
             }
             return false;
         } else {
-            await this._vscodeWrapper.showInformationMessage(LocalizedConstants.msgPromptAzureExtensionActivatedSignedIn);
             return true;
         }
     }


### PR DESCRIPTION
Show the `Create Firewall Rule` dialog directly and remove the `Activation` UX dialog from the Firewall feature.