### PR TITLE
Match null styling to ADS

### DIFF
--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -206,7 +206,7 @@
 
   .vscode-light .grid .slick-cell.selected .grid-cell-value-container.missing-value,
   .vscode-dark .grid .slick-cell.selected .grid-cell-value-container.missing-value,
-  .vscode-high-contrast .slick-cell.selected .grid .grid-cell-value-container.missing-value {
+  .vscode-high-contrast .grid .slick-cell.selected .grid-cell-value-container.missing-value {
       color: var(--color-content);
       font-style: italic;
   }

--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -185,19 +185,30 @@
 
   /* grid styling */
 
+  .vscode-light slick-grid.active .grid .slick-cell.active,
   .vscode-dark slick-grid.active .grid .slick-cell.active,
   .vscode-high-contrast slick-grid.active .grid .slick-cell.active {
     border: dotted 1px var(--color-cell-border-active);
   }
 
+  .vscode-light slick-grid.active .grid .slick-cell.selected,
   .vscode-dark slick-grid.active .grid .slick-cell.selected,
   .vscode-high-contrast slick-grid.active .grid .slick-cell.selected {
     background-color: var(--color-cell-bg-grid-selected);
   }
 
-  .vscode-dark .grid .slick-cell.selected .grid-cell-value-container.missing-value,
-  .vscode-high-contrast .grid .slick-cell.selected .grid-cell-value-container.missing-value {
+  .vscode-light .grid .grid-cell-value-container.missing-value,
+  .vscode-dark .grid .grid-cell-value-container.missing-value,
+  .vscode-high-contrast .grid .grid-cell-value-container.missing-value {
       color: var(--color-content);
+      font-style: italic;
+  }
+
+  .vscode-light .grid .slick-cell.selected .grid-cell-value-container.missing-value,
+  .vscode-dark .grid .slick-cell.selected .grid-cell-value-container.missing-value,
+  .vscode-high-contrast .slick-cell.selected .grid .grid-cell-value-container.missing-value {
+      color: var(--color-content);
+      font-style: italic;
   }
 
   .vscode-dark .boxRow.content.horzBox.slickgrid,


### PR DESCRIPTION
Match the styling for `NULL` cells to ADS 

Fixes https://github.com/microsoft/vscode-mssql/issues/1565