### PR TITLE
Fix  expanding 2 nodes at once

### DIFF
--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -135,6 +135,7 @@ export class ObjectExplorerService {
                 const credentials = self._sessionIdToConnectionCredentialsMap.get(result.sessionId);
                 const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
                     self._currentNode, credentials));
+                self._currentNode = self._rootTreeNodeArray.find(n => n.nodePath === result.nodePath);
                 self._treeNodeToChildrenMap.set(self._currentNode, children);
                 const expandParams: ExpandParams = {
                     sessionId: result.sessionId,

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -133,9 +133,9 @@ export class ObjectExplorerService {
         const handler = (result: ExpandResponse) => {
             if (result && result.nodes) {
                 const credentials = self._sessionIdToConnectionCredentialsMap.get(result.sessionId);
-                const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
-                    self._currentNode, credentials));
                 let parentNode = self._rootTreeNodeArray.find(n => n.nodePath === result.nodePath);
+                const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
+                    parentNode, credentials));
                 self._treeNodeToChildrenMap.set(parentNode, children);
                 const expandParams: ExpandParams = {
                     sessionId: result.sessionId,

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -135,8 +135,8 @@ export class ObjectExplorerService {
                 const credentials = self._sessionIdToConnectionCredentialsMap.get(result.sessionId);
                 const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
                     self._currentNode, credentials));
-                self._currentNode = self._rootTreeNodeArray.find(n => n.nodePath === result.nodePath);
-                self._treeNodeToChildrenMap.set(self._currentNode, children);
+                let parentNode = self._rootTreeNodeArray.find(n => n.nodePath === result.nodePath);
+                self._treeNodeToChildrenMap.set(parentNode, children);
                 const expandParams: ExpandParams = {
                     sessionId: result.sessionId,
                     nodePath: result.nodePath


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1555. 

There was a race condition where `self._currentNode` wasn't being set before we got the notification about the children. Explicitly look for parent now.