### PR TITLE
Proper fix for race condition in expanding nodes

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -223,32 +223,32 @@ export default class MainController implements vscode.Disposable {
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                     Constants.cmdScriptSelect, async (node: TreeNodeInfo) => {
-                        this.scriptNode(node, ScriptOperation.Select, true);
+                        await this.scriptNode(node, ScriptOperation.Select, true);
                     }));
 
                 // Script as Create
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                     Constants.cmdScriptCreate, async (node: TreeNodeInfo) =>
-                    this.scriptNode(node, ScriptOperation.Create)));
+                    await this.scriptNode(node, ScriptOperation.Create)));
 
                 // Script as Drop
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                     Constants.cmdScriptDelete, async (node: TreeNodeInfo) =>
-                    this.scriptNode(node, ScriptOperation.Delete)));
+                    await this.scriptNode(node, ScriptOperation.Delete)));
 
                 // Script as Execute
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                     Constants.cmdScriptExecute, async (node: TreeNodeInfo) =>
-                    this.scriptNode(node, ScriptOperation.Execute)));
+                    await this.scriptNode(node, ScriptOperation.Execute)));
 
                 // Script as Alter
                 this._context.subscriptions.push(
                     vscode.commands.registerCommand(
                     Constants.cmdScriptAlter, async (node: TreeNodeInfo) =>
-                    this.scriptNode(node, ScriptOperation.Alter)));
+                    await this.scriptNode(node, ScriptOperation.Alter)));
 
                 // Add handlers for VS Code generated commands
                 this._vscodeWrapper.onDidCloseTextDocument(async (params) => await this.onDidCloseTextDocument(params));

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -130,7 +130,7 @@ export class ObjectExplorerService {
         return handler;
     }
 
-    private getParentFromExpandParams(params: ExpandParams): TreeNodeInfo {
+    private getParentFromExpandParams(params: ExpandParams): TreeNodeInfo | undefined {
         for (let key of this._expandParamsToTreeNodeInfoMap.keys()) {
             if (key.sessionId === params.sessionId &&
                 key.nodePath === params.nodePath) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -32,6 +32,7 @@ export class ObjectExplorerService {
     private _nodePathToNodeLabelMap: Map<string, string>;
     private _rootTreeNodeArray: Array<TreeNodeInfo>;
     private _sessionIdToConnectionCredentialsMap: Map<string, IConnectionCredentials>;
+    private _expandParamsToTreeNodeInfoMap: Map<ExpandParams, TreeNodeInfo>;
 
     // Deferred promise maps
     private _sessionIdToPromiseMap: Map<string, Deferred<vscode.TreeItem>>;
@@ -46,6 +47,7 @@ export class ObjectExplorerService {
         this._nodePathToNodeLabelMap = new Map<string, string>();
         this._sessionIdToPromiseMap = new Map<string, Deferred<vscode.TreeItem>>();
         this._expandParamsToPromiseMap = new Map<ExpandParams, Deferred<TreeNodeInfo[]>>();
+        this._expandParamsToTreeNodeInfoMap = new Map<ExpandParams, TreeNodeInfo>();
 
         this._client.onNotification(CreateSessionCompleteNotification.type,
             this.handleSessionCreatedNotification());
@@ -128,24 +130,36 @@ export class ObjectExplorerService {
         return handler;
     }
 
+    private getParentFromExpandParams(params: ExpandParams): TreeNodeInfo {
+        for (let key of this._expandParamsToTreeNodeInfoMap.keys()) {
+            if (key.sessionId === params.sessionId &&
+                key.nodePath === params.nodePath) {
+                return this._expandParamsToTreeNodeInfoMap.get(key);
+            }
+        }
+        return undefined;
+    }
+
     private handleExpandSessionNotification(): NotificationHandler<ExpandResponse> {
         const self = this;
         const handler = (result: ExpandResponse) => {
             if (result && result.nodes) {
                 const credentials = self._sessionIdToConnectionCredentialsMap.get(result.sessionId);
-                const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
-                    self._currentNode, credentials));
-                self._treeNodeToChildrenMap.set(self._currentNode, children);
                 const expandParams: ExpandParams = {
                     sessionId: result.sessionId,
                     nodePath: result.nodePath
                 };
+                const parentNode = self.getParentFromExpandParams(expandParams);
+                const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
+                    parentNode, credentials));
+                self._treeNodeToChildrenMap.set(parentNode, children);
                 for (let key of self._expandParamsToPromiseMap.keys()) {
                     if (key.sessionId === expandParams.sessionId &&
                         key.nodePath === expandParams.nodePath) {
                         let promise = self._expandParamsToPromiseMap.get(key);
                         promise.resolve(children);
                         self._expandParamsToPromiseMap.delete(key);
+                        self._expandParamsToTreeNodeInfoMap.delete(key);
                         return;
                     }
                 }
@@ -160,12 +174,14 @@ export class ObjectExplorerService {
             nodePath: node.nodePath
         };
         this._expandParamsToPromiseMap.set(expandParams, promise);
+        this._expandParamsToTreeNodeInfoMap.set(expandParams, node);
         const response = await this._connectionManager.client.sendRequest(ExpandRequest.type, expandParams);
         if (response) {
             this._currentNode = node;
             return response;
         } else {
             this._expandParamsToPromiseMap.delete(expandParams);
+            this._expandParamsToTreeNodeInfoMap.delete(expandParams);
             promise.resolve(undefined);
             return undefined;
         }
@@ -241,6 +257,7 @@ export class ObjectExplorerService {
             if (key.sessionId === node.sessionId &&
                 key.nodePath === node.nodePath) {
                 this._expandParamsToPromiseMap.delete(key);
+                this._expandParamsToTreeNodeInfoMap.delete(key);
             }
         }
     }

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -133,10 +133,9 @@ export class ObjectExplorerService {
         const handler = (result: ExpandResponse) => {
             if (result && result.nodes) {
                 const credentials = self._sessionIdToConnectionCredentialsMap.get(result.sessionId);
-                let parentNode = self._rootTreeNodeArray.find(n => n.nodePath === result.nodePath);
                 const children = result.nodes.map(node => TreeNodeInfo.fromNodeInfo(node, result.sessionId,
-                    parentNode, credentials));
-                self._treeNodeToChildrenMap.set(parentNode, children);
+                    self._currentNode, credentials));
+                self._treeNodeToChildrenMap.set(self._currentNode, children);
                 const expandParams: ExpandParams = {
                     sessionId: result.sessionId,
                     nodePath: result.nodePath


### PR DESCRIPTION
I realized that https://github.com/microsoft/vscode-mssql/pull/1568 was not a correct fix for this bug - https://github.com/microsoft/vscode-mssql/issues/1555.

This is a proper fix. The fix above was incorrect because it only looked for parents in the server nodes. I didn't realize I didn't `await` any of those scripting operations and hence was getting a race condition. 
