### PR TITLE
Improve query perf

### DIFF
--- a/src/controllers/webviewController.ts
+++ b/src/controllers/webviewController.ts
@@ -72,6 +72,7 @@ export class WebviewPanelController implements vscode.Disposable {
             }
         }));
         this.proxy = createProxy(createMessageProtocol(this._panel.webview), serverProxy, false);
+        this._disposables.push(this.proxy);
     }
 
     /**

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -164,7 +164,8 @@ export class SqlOutputContentProvider {
             setEditorSelection: (selection: ISelectionData) => this.editorSelectionRequestHandler(uri, selection),
             showError: (message: string) => this.showErrorRequestHandler(message),
             showWarning: (message: string) => this.showWarningRequestHandler(message),
-            sendReadyEvent: async () => await this.sendReadyEvent(uri)
+            sendReadyEvent: async () => await this.sendReadyEvent(uri),
+            dispose: () => this._panels.delete(uri)
         };
         const controller = new WebviewPanelController(this._vscodeWrapper, uri, title, proxy, this.context.extensionPath, this._statusView);
         this._panels.set(uri, controller);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -6,11 +6,11 @@
 import { Event, Disposable } from 'vscode';
 import { ISlickRange, IResultsConfig, ResultSetSubset, ISelectionData } from './models/interfaces';
 
-export interface IWebviewProxy {
+export interface IWebviewProxy extends Disposable {
     sendEvent(type: string, arg: any): void;
 }
 
-export interface IServerProxy {
+export interface IServerProxy extends Disposable {
     getRows(batchId: number, resultId: number, rowStart: number, numberOfRows: number): Promise<ResultSetSubset>;
     saveResults(batchId: number, resultId: number, format: string, selection: ISlickRange[]): void;
     openLink(content: string, columnName: string, linkType: string): void;
@@ -131,7 +131,7 @@ function isResponseMessage(val: any): val is IResponse {
 
 export function createProxy(protocol: IMessageProtocol, handler: IServerProxy, isClient: boolean): IWebviewProxy;
 export function createProxy(protocol: IMessageProtocol, handler: IWebviewProxy, isClient: boolean): IServerProxy;
-export function createProxy(protocol: IMessageProtocol, handler: any, isClient: boolean): any {
+export function createProxy(protocol: IMessageProtocol, handler: any, isClient: boolean): Disposable {
     const messageProxy = new MessageProxy(protocol, handler, isClient);
     let proxy = {
         get: (target: any, name: string) => {

--- a/src/views/htmlcontent/src/js/services/data.service.ts
+++ b/src/views/htmlcontent/src/js/services/data.service.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { Subject } from 'rxjs/Subject';
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { ISlickRange } from 'angular2-slickgrid';
 import { QueryEvent, ResultSetSubset, ISelectionData } from './../../../../../models/interfaces';
 import * as Constants from './../constants';
@@ -34,7 +34,7 @@ function createMessageProtocol(): IMessageProtocol {
  */
 
 @Injectable()
-export class DataService {
+export class DataService implements OnDestroy {
     private _shortcuts;
     private _config;
     private _proxy: IServerProxy;
@@ -42,7 +42,8 @@ export class DataService {
 
     constructor() {
         this._proxy = createProxy(createMessageProtocol(), {
-            sendEvent: (type, args) => this.sendEvent(type, args)
+            sendEvent: (type, args) => this.sendEvent(type, args),
+            dispose: () => void(0)
         }, true);
 
         this.getLocalizedTextsRequest().then(result => {
@@ -52,7 +53,12 @@ export class DataService {
         });
     }
 
-   private sendEvent(type: string, arg: any): void {
+    ngOnDestroy(): void {
+        this.dataEventObs.dispose();
+        this._proxy.dispose();
+    }
+
+    private sendEvent(type: string, arg: any): void {
         this.dataEventObs.next({ type, data: arg });
     }
 


### PR DESCRIPTION
Improved perf on closing and re-opening queries.

The following images show the JS profiler with the same queries opened and closed. 

1. Without changes
![nochange](https://user-images.githubusercontent.com/6411451/73103039-fdfe8d80-3ea7-11ea-95ce-7f224a1b6a86.JPG)

2. With changes
![changes](https://user-images.githubusercontent.com/6411451/73103053-03f46e80-3ea8-11ea-9e7f-0fba238619ee.JPG)
