### PR TITLE
Improved tree logic and added ability to copy object names

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,6 +338,10 @@
         {
           "command": "mssql.pauseQueryHistoryCapture",
           "when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
+        },
+        {
+          "command": "mssql.copyObjectName",
+          "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
         }
       ]
     },
@@ -506,6 +510,11 @@
         "command": "mssql.commandPaletteQueryHistory",
         "title": "%mssql.commandPaletteQueryHistory%",
         "group": "MS SQL"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "title": "%mssql.copyObjectName%",
+        "group": "MS SQL"
       }
     ],
     "keybindings": [
@@ -531,6 +540,12 @@
         "command": "workbench.view.extension.objectExplorer",
         "key": "ctrl+alt+d",
         "mac": "cmd+alt+d"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "key": "f2",
+        "mac": "f2",
+        "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -537,8 +537,8 @@
       },
       {
         "command": "mssql.copyObjectName",
-        "key": "f2",
-        "mac": "f2",
+        "key": "ctrl+c",
+        "mac": "cmd+c",
         "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
       }
     ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -29,6 +29,7 @@
 "mssql.newQuery":"New Query",
 "mssql.objectExplorerNewQuery":"New Query",
 "mssql.toggleSqlCmd":"Toggle SQLCMD Mode",
+"mssql.copyObjectName":"Copy Object Name",
 "mssql.rebuildIntelliSenseCache":"Refresh IntelliSense Cache",
 "mssql.logDebugInfo":"[Optional] Log debug output to the VS Code console (Help -> Toggle Developer Tools)",
 "mssql.maxRecentConnections":"The maximum number of recently used connections to store in the connection list.",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -51,6 +51,7 @@ export const cmdScriptDelete = 'mssql.scriptDelete';
 export const cmdScriptExecute = 'mssql.scriptExecute';
 export const cmdScriptAlter = 'mssql.scriptAlter';
 export const cmdToggleSqlCmd = 'mssql.toggleSqlCmd';
+export const cmdCopyObjectName = 'mssql.copyObjectName';
 export const cmdOpenExtension = 'extension.open';
 export const cmdLoadCompletionExtension = 'mssql.loadCompletionExtension';
 export const cmdAzureSignIn = 'azure-account.login';

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -17,6 +17,7 @@ export const connectionConfigFilename = 'settings.json';
 export const connectionsArrayName = 'connections';
 export const disconnectedServerLabel = 'disconnectedServer';
 export const serverLabel = 'Server';
+export const folderLabel = 'Folder';
 export const cmdRunQuery = 'mssql.runQuery';
 export const cmdRunCurrentStatement = 'mssql.runCurrentStatement';
 export const cmdCancelQuery = 'mssql.cancelQuery';

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -384,7 +384,7 @@ export default class MainController implements vscode.Disposable {
             Constants.cmdScriptAlter, async (node: TreeNodeInfo) =>
             await this.scriptNode(node, ScriptOperation.Alter)));
 
-        // Copy object name keybinding
+        // Copy object name command
         this._context.subscriptions.push(
             vscode.commands.registerCommand(Constants.cmdCopyObjectName, async () => {
                 let node = this._objectExplorerProvider.currentNode;
@@ -396,11 +396,14 @@ export default class MainController implements vscode.Disposable {
                         await this._vscodeWrapper.clipboardWriteText(node.label);
                 } else {
                     let scriptingObject = this._scriptingService.getObjectFromNode(node);
+                    const escapedName = Utils.escapeClosingBrackets(scriptingObject.name);
                     if (scriptingObject.schema) {
                         let database = ObjectExplorerUtils.getDatabaseName(node);
-                        await this._vscodeWrapper.clipboardWriteText(`[${database}].${scriptingObject.schema}.[${scriptingObject.name}]`);
+                        const databaseName = Utils.escapeClosingBrackets(database);
+                        const escapedSchema = Utils.escapeClosingBrackets(scriptingObject.schema);
+                        await this._vscodeWrapper.clipboardWriteText(`[${databaseName}].${escapedSchema}.[${escapedName}]`);
                     } else {
-                        await this._vscodeWrapper.clipboardWriteText(`[${scriptingObject.name}]`);
+                        await this._vscodeWrapper.clipboardWriteText(`[${escapedName}]`);
                     }
                 }
             }));

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -273,12 +273,12 @@ export default class MainController implements vscode.Disposable {
         this._context.subscriptions.push(treeView);
 
         // Sets the correct current node on any node selection
-        treeView.onDidChangeSelection((e: vscode.TreeViewSelectionChangeEvent<TreeNodeInfo>) => {
+        this._context.subscriptions.push(treeView.onDidChangeSelection((e: vscode.TreeViewSelectionChangeEvent<TreeNodeInfo>) => {
             const selections: TreeNodeInfo[] = e.selection;
             if (selections && selections.length > 0) {
                 self._objectExplorerProvider.currentNode = selections[0];
             }
-        });
+        }));
 
         // Add Object Explorer Node
         this.registerCommand(Constants.cmdAddObjectExplorer);
@@ -389,8 +389,11 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(Constants.cmdCopyObjectName, async () => {
                 let node = this._objectExplorerProvider.currentNode;
                 // Folder node
-                if (node.contextValue === 'Folder') {
+                if (node.contextValue === Constants.folderLabel) {
                     return;
+                } else if (node.contextValue === Constants.serverLabel ||
+                    node.contextValue === Constants.disconnectedServerLabel) {
+                        await this._vscodeWrapper.clipboardWriteText(node.label);
                 } else {
                     let scriptingObject = this._scriptingService.getObjectFromNode(node);
                     if (scriptingObject.schema) {

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -173,6 +173,10 @@ export function authTypeToString(value: AuthenticationTypes): string {
     return AuthenticationTypes[value];
 }
 
+export function escapeClosingBrackets(str: string): string {
+    return str.replace(']', ']]');
+}
+
 /**
  * Format a string. Behaves like C#'s string.Format() function.
  */


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1594.

Behavior: Pressing `F2` will copy a string with `[databaseName].[schemaName].[objectName]` if the object metadata has a `schema`, otherwise copies `[objectName]`. It doesn't do anything when `F2` is pressed on a `Folder` (matching SSMS behavior).  

Pressing `F2` on every node starting from the `Server` node to the last selected `Column` node in the screenshot and pasting the results has the following results: 

![Capture](https://user-images.githubusercontent.com/6411451/75080571-37371700-54c1-11ea-931a-993c6bad0f36.JPG)

Also improves the logic for setting `currentNode`. Instead of using the `registerTreeDataProvider` function, create a `TreeView` instead, which gives more functionality on the tree. Set the `currentNode` whenever a node is clicked instead of setting it from the service. This removes any potential race conditions from the service side.

