### PR TITLE
Fix refresh mechanism to not use current node

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -316,10 +316,11 @@ export default class MainController implements vscode.Disposable {
         }));
 
         // Refresh Object Explorer Node
-        this.registerCommand(Constants.cmdRefreshObjectExplorerNode);
-        this._event.on(Constants.cmdRefreshObjectExplorerNode, () => {
-            return this._objectExplorerProvider.refreshNode(this._objectExplorerProvider.currentNode);
-        });
+        this._context.subscriptions.push(
+            vscode.commands.registerCommand(
+                Constants.cmdRefreshObjectExplorerNode, async (treeNodeInfo: TreeNodeInfo) => {
+                await this._objectExplorerProvider.refreshNode(treeNodeInfo);
+        }));
 
         // Sign In into Object Explorer Node
         this._context.subscriptions.push(

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -467,8 +467,11 @@ export class ObjectExplorerService {
             sessionId: node.sessionId,
             nodePath: node.nodePath
         };
-        await this._connectionManager.client.sendRequest(RefreshRequest.type, refreshParams);
-        return this._objectExplorerProvider.refresh(undefined);
+        let response = await this._connectionManager.client.sendRequest(RefreshRequest.type, refreshParams);
+        if (response) {
+            this._treeNodeToChildrenMap.delete(node);
+        }
+        return this._objectExplorerProvider.refresh(node);
     }
 
     public signInNodeServer(node: TreeNodeInfo): void {


### PR DESCRIPTION
Remove the old `currentNode` mechanism to refresh a node, and use the node directly when right clicking. 

Fixes https://github.com/microsoft/vscode-mssql/issues/1606