### PR TITLE
fix: string highlighting containing escaped characters

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -654,7 +654,7 @@
 					<key>comment</key>
 					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
 					<key>match</key>
-					<string>(N)?(')[^']*(')</string>
+					<string>(N)?(')(?:[^'\\]|\\.)*(')</string>
 					<key>name</key>
 					<string>string.quoted.single.sql</string>
 				</dict>
@@ -706,7 +706,7 @@
 					<key>comment</key>
 					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
 					<key>match</key>
-					<string>(`)[^`\\]*(`)</string>
+					<string>(`)(?:[^`\\]|\\.)*(`)</string>
 					<key>name</key>
 					<string>string.quoted.other.backtick.sql</string>
 				</dict>
@@ -758,7 +758,7 @@
 					<key>comment</key>
 					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
 					<key>match</key>
-					<string>(")[^"#]*(")</string>
+					<string>(")(?:[^"#\\]|\\.)*(")</string>
 					<key>name</key>
 					<string>string.quoted.double.sql</string>
 				</dict>


### PR DESCRIPTION
Issue : When a string enclose by single quote contains an escaped single quote, the higlight of the string stop at the escaped single quote and not at the end of the string (show below).

![image](https://user-images.githubusercontent.com/37904498/75870429-3da38800-5e0b-11ea-9c59-a7a1ddbbb4c3.png)
