### PR TITLE
Query history for non refreshed queries

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -292,7 +292,7 @@ export default class QueryRunner {
         this._statusView.executedQuery(uri);
         this._isExecuting = false;
         this._hasCompleted = true;
-        this.eventEmitter.emit('complete', Utils.parseNumAsTimeString(this._totalElapsedMilliseconds), true);
+        this.eventEmitter.emit('complete', Utils.parseNumAsTimeString(this._totalElapsedMilliseconds), true, true);
         return true;
     }
 

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -215,8 +215,11 @@ export class SqlOutputContentProvider {
             queryRunner.eventEmitter.on('message', (message) => {
                 this._panels.get(uri).proxy.sendEvent('message', message);
             });
-            queryRunner.eventEmitter.on('complete', (totalMilliseconds, hasError) => {
-                this._vscodeWrapper.executeCommand(Constants.cmdRefreshQueryHistory, uri, hasError);
+            queryRunner.eventEmitter.on('complete', (totalMilliseconds, hasError, isRefresh?) => {
+                if (!isRefresh) {
+                    // only update query history with new queries
+                    this._vscodeWrapper.executeCommand(Constants.cmdRefreshQueryHistory, uri, hasError);
+                }
                 this._panels.get(uri).proxy.sendEvent('complete', totalMilliseconds);
             });
             this._queryResultsMap.set(uri, new QueryRunnerState(queryRunner));


### PR DESCRIPTION
This PR fixes an issue where when you switched (refreshed) a tab, it would appear on the query history tree.