### PR TITLE
make SQL plist parseable xml

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -16,7 +16,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>((?<!@)@)\b(\w+)\b</string>
+			<string>((?&lt;!@)@)\b(\w+)\b</string>
 			<key>name</key>
 			<string>text.variable</string>
 		</dict>
@@ -351,7 +351,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?<!@)@@(?i)\b(cursor_rows|connections|cpu_busy|datefirst|dbts|error|fetch_status|identity|idle|io_busy|langid|language|lock_timeout|max_connections|max_precision|nestlevel|options|packet_errors|pack_received|pack_sent|procid|remserver|rowcount|servername|servicename|spid|textsize|timeticks|total_errors|total_read|total_write|trancount|version)\b</string>
+			<string>(?&lt;!@)@@(?i)\b(cursor_rows|connections|cpu_busy|datefirst|dbts|error|fetch_status|identity|idle|io_busy|langid|language|lock_timeout|max_connections|max_precision|nestlevel|options|packet_errors|pack_received|pack_sent|procid|remserver|rowcount|servername|servicename|spid|textsize|timeticks|total_errors|total_read|total_write|trancount|version)\b</string>
 			<key>name</key>
 			<string>support.function.globalvar.sql</string>
 		</dict>


### PR DESCRIPTION
without this I was getting the following:

```pycon
>>> with open('SQL.plist', 'rb') as f:
...     contents = f.read()
... 
>>> import plistlib
>>> plistlib.loads(contents)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/plistlib.py", line 1024, in loads
    fp, fmt=fmt, use_builtin_types=use_builtin_types, dict_type=dict_type)
  File "/usr/lib/python3.6/plistlib.py", line 1015, in load
    return p.parse(fp)
  File "/usr/lib/python3.6/plistlib.py", line 325, in parse
    self.parser.ParseFile(fileobj)
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 19, column 16
```