### PR TITLE
Fix build and upgrade vscode API

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.45.0"
   },
   "categories": [
     "Programming Languages",
@@ -74,7 +74,7 @@
     "@types/mocha": "^5.2.7",
     "@types/tmp": "0.0.28",
     "@types/underscore": "1.8.3",
-    "@types/vscode": "^1.43.0",
+    "@types/vscode": "^1.45.0",
     "assert": "^1.4.1",
     "chai": "^3.5.0",
     "coveralls": "^3.0.2",

--- a/src/queryHistory/queryHistoryProvider.ts
+++ b/src/queryHistory/queryHistoryProvider.ts
@@ -43,7 +43,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<any> {
 
     clearAll(): void {
         this._queryHistoryNodes = [new EmptyHistoryNode()];
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire(undefined);
     }
 
     refresh(ownerUri: string, timeStamp: Date, hasError): void {
@@ -70,7 +70,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<any> {
         if (this._queryHistoryNodes.length > this._queryHistoryLimit) {
             this._queryHistoryNodes.shift();
         }
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire(undefined);
     }
 
     getTreeItem(node: QueryHistoryNode): QueryHistoryNode {
@@ -145,7 +145,7 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<any> {
             return historyNode === node;
         });
         this._queryHistoryNodes.splice(index, 1);
-        this._onDidChangeTreeData.fire();
+        this._onDidChangeTreeData.fire(undefined);
     }
 
     /**

--- a/test/firewallService.test.ts
+++ b/test/firewallService.test.ts
@@ -45,6 +45,7 @@ suite('Firewall Service Tests', () => {
             isActive: true,
             packageJSON: undefined,
             activate: undefined,
+            extensionUri: undefined,
             exports: {
                 sessions: [mockSession]
             }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -29,6 +29,7 @@ class TestExtensionContext implements vscode.ExtensionContext {
     storagePath: string;
     globalStoragePath: string;
     logPath: string;
+    extensionUri: vscode.Uri = vscode.Uri.parse('test_uri');
 
     asAbsolutePath(relativePath: string): string {
         return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,10 +115,10 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.3.tgz#d3cb512dd3dde32b2bbba4be0ca68bd3dad4a1f5"
   integrity sha512-DP70788BXjp9+CKArXOUlNkZaXa+rHonDpbqH3/74ez16dLL5z2/bMT37etbln5J+H9M07NbRUyduDIoTM2tnw==
 
-"@types/vscode@^1.43.0":
-  version "1.43.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.43.0.tgz#22276e60034c693b33117f1068ffaac0e89522db"
-  integrity sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==
+"@types/vscode@^1.45.0":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.45.0.tgz#8a07e740aa1ca7264da8cb17be87b733836d6c01"
+  integrity sha512-b0Gyir7sPBCqiKLygAhn/AYVfzWD+SMPkWltBrIuPEyTOxSU1wVApWY/FcxYO2EWTRacoubTl4+gvZf86RkecA==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
The VSCode API changed one of it's function parameters to be non-optional, causing the builds to break. This isn't VSCode's fault that we always break for minor engine upgrades since their APIs are always backwards compatible, but it's because we use a wrapper around VSCode's API for testing and any addition to the VSCode API breaks the wrapper. 