### PR TITLE
refreshAccess, getHomeTenant, hydrateAccoount, and interface changes

### DIFF
--- a/lib/adal-aad-node/src/engine/AzureAuth.ts
+++ b/lib/adal-aad-node/src/engine/AzureAuth.ts
@@ -1,7 +1,12 @@
 import { ProviderSettings, SecureStorageProvider, Tenant, AADResource, LoginResponse, Deferred, AzureAccount, Logger, MessageDisplayer } from "../models";
 import { AzureAuthError } from "../errors/AzureAuthError";
- 
+import { ProviderResources } from "../models/provider";
+import { AccessToken, Token, TokenClaims } from "../models/auth";
+
+
 export abstract class AzureAuth {
+	public static ACCOUNT_VERSION = '2.0';
+
     protected readonly commonTenant: Tenant = {
         id: 'common',
         displayName: 'common'
@@ -68,9 +73,9 @@ export abstract class AzureAuth {
 			return await this.hydrateAccount(tokenResult, this.getTokenClaims(tokenResult.token));
 		} catch (ex) {
 			if (ex instanceof AzureAuthError) {
-				vscode.window.showErrorMessage(ex.getPrintableString());
+				this.messageDisplayer.displayErrorMessage(ex.getPrintableString());
 			}
-			Logger.error(ex);
+			this.logger.error(ex);
 			account.isStale = true;
 			return account;
 		}

--- a/lib/adal-aad-node/src/models/account.ts
+++ b/lib/adal-aad-node/src/models/account.ts
@@ -1,13 +1,50 @@
 export interface AzureAccount {
-
+    key: AccountKey;
+    properties: AzureAccountProperties;
+    isStale: boolean;
+    delete?: boolean;
 }
 
 export interface AccountKey {
     id: string;
     providerId: string;
+    accountVersion?: string;
 }
 
 export interface Tenant {
     id: string;
     displayName: string;
+    userId?: string;
+    tenantCategory?: string;
+}
+
+export enum AzureAuthType {
+    AuthCodeGrant = 0,
+    DeviceCode = 1
+}
+
+interface AzureAccountProperties {
+    /**
+     * Auth type of azure used to authenticate this account.
+     */
+    azureAuthType?: AzureAuthType;
+
+    providerSettings: AzureAccountProviderMetadata;
+    /**
+     * Whether or not the account is a Microsoft account
+     */
+    isMsAccount: boolean;
+
+    /**
+     * A list of tenants (aka directories) that the account belongs to
+     */
+    tenants: Tenant[];
+
+}
+
+interface AzureAccountProviderMetadata {
+    id: string;
+    displayName: string;
+    args?: any;
+    settings?: {};
 }

--- a/lib/adal-aad-node/src/models/auth.ts
+++ b/lib/adal-aad-node/src/models/auth.ts
@@ -31,6 +31,13 @@ export interface AccessToken extends TokenKey {
 	token: string;
 }
 
+export interface Token extends AccessToken {
+	/**
+	 * TokenType
+	 */
+	tokenType: string;
+}
+
 export interface RefreshToken extends TokenKey {
 	/**
 	 * Refresh Token


### PR DESCRIPTION
![Screen Shot 2020-07-27 at 7 36 09 PM](https://user-images.githubusercontent.com/18150417/88602261-6dfcf480-d040-11ea-9bc6-53089e30bfa8.png)
`this.getTokenClaims(tokenResult.token)` gives this error and I'm not sure how to resolve that one
also, line 67 will need to be changed once we fix `getAccountSecurityToken`
but otherwise everything else should be good.