### PR TITLE
Fix download paths for release build

### DIFF
--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -3,17 +3,17 @@
         "downloadUrl": "https://download.microsoft.com/download/9/6/7/96792b35-04b8-4ef0-8d38-c634ef975e3b/microsoft.sqltools.servicelayer-{#fileName#}",
         "version": "1.10.0",
         "downloadFileNames": {
-            "Windows_7_86": "win-x86-netcoreapp2.2.zip",
-            "Windows_7_64": "win-x64-netcoreapp2.2.zip",
-            "OSX_10_11_64": "osx-x64-netcoreapp2.2.tar.gz",
-            "CentOS_7": "rhel-x64-netcoreapp2.2.tar.gz",
-            "Debian_8": "rhel-x64-netcoreapp2.2.tar.gz",
-            "Fedora_23": "rhel-x64-netcoreapp2.2.tar.gz",
-            "OpenSUSE_13_2": "rhel-x64-netcoreapp2.2.tar.gz",
-            "SLES_12_2": "rhel-x64-netcoreapp2.2.tar.gz",
-            "RHEL_7": "rhel-x64-netcoreapp2.2.tar.gz",
-            "Ubuntu_14": "rhel-x64-netcoreapp2.2.tar.gz",
-            "Ubuntu_16": "rhel-x64-netcoreapp2.2.tar.gz"
+            "Windows_7_86": "win-x86-netcoreapp3.1.zip",
+            "Windows_7_64": "win-x64-netcoreapp3.1.zip",
+            "OSX_10_11_64": "osx-x64-netcoreapp3.1.tar.gz",
+            "CentOS_7": "rhel-x64-netcoreapp3.1.tar.gz",
+            "Debian_8": "rhel-x64-netcoreapp3.1.tar.gz",
+            "Fedora_23": "rhel-x64-netcoreapp3.1.tar.gz",
+            "OpenSUSE_13_2": "rhel-x64-netcoreapp3.1.tar.gz",
+            "SLES_12_2": "rhel-x64-netcoreapp3.1.tar.gz",
+            "RHEL_7": "rhel-x64-netcoreapp3.1.tar.gz",
+            "Ubuntu_14": "rhel-x64-netcoreapp3.1.tar.gz",
+            "Ubuntu_16": "rhel-x64-netcoreapp3.1.tar.gz"
         },
         "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
         "executableFiles": ["MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer", "MicrosoftSqlToolsServiceLayer.dll"]


### PR DESCRIPTION
The previous build was still using the .Net 2.2 SDK paths