### PR TITLE
Fix case sensitiveness issues for AzureAuthError & AzureAuth

### DIFF
--- a/lib/ads-adal-library/src/engine/AzureAuth.ts
+++ b/lib/ads-adal-library/src/engine/AzureAuth.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { ProviderSettings, SecureStorageProvider, Tenant, AADResource, LoginResponse, Deferred, AzureAccount, Logger, MessageDisplayer, ErrorLookup, CachingProvider, RefreshTokenPostData, AuthorizationCodePostData, TokenPostData, AccountKey, StringLookup, DeviceCodeStartPostData, DeviceCodeCheckPostData, AzureAuthType, AccountType, UserInteraction } from '../models';
-import { AzureAuthError } from '../errors/azureAuthError';
+import { AzureAuthError } from '../errors/AzureAuthError';
 import { ErrorCodes }  from '../errors/errors';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { AccessToken, Token, TokenClaims, RefreshToken, OAuthTokenResponse } from '../models/auth';

--- a/lib/ads-adal-library/src/engine/AzureCodeGrant.ts
+++ b/lib/ads-adal-library/src/engine/AzureCodeGrant.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import { AzureAuth } from './azureAuth';
+import { AzureAuth } from './AzureAuth';
 import { AzureAuthType, ProviderSettings, SecureStorageProvider, CachingProvider, Logger, MessageDisplayer, ErrorLookup, StringLookup, AADResource, LoginResponse, Tenant, Deferred, AuthorizationCodePostData, OAuthTokenResponse, AuthRequest, UserInteraction } from '../models';
 import * as crypto from 'crypto';
 import * as qs from 'qs';
-import { AzureAuthError } from '../errors/azureAuthError';
+import { AzureAuthError } from '../errors/AzureAuthError';
 import { ErrorCodes } from '../errors/errors';
 
 export class AzureCodeGrant extends AzureAuth {

--- a/lib/ads-adal-library/src/engine/AzureDeviceCode.ts
+++ b/lib/ads-adal-library/src/engine/AzureDeviceCode.ts
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import { AzureAuth } from './azureAuth';
+import { AzureAuth } from './AzureAuth';
 import { ProviderSettings, SecureStorageProvider, CachingProvider, Logger, MessageDisplayer, ErrorLookup, StringLookup, AzureAuthType, Tenant, AADResource, LoginResponse, DeviceCodeStartPostData, Deferred, DeviceCodeCheckPostData, AuthRequest, UserInteraction } from '../models';
-import { AzureAuthError } from '../errors/azureAuthError';
+import { AzureAuthError } from '../errors/AzureAuthError';
 import { ErrorCodes } from '../errors/errors';
 
 export class AzureDeviceCode extends AzureAuth {


### PR DESCRIPTION
The issue was found when I was trying to install vscode-mssql extension for code-server - https://hub.docker.com/r/codercom/code-server
There were errors like
**cannot find module ./errors/azureAuthError**
**cannot find module ./azureAuth** 