### PR TITLE
Update brew command

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -70,7 +70,7 @@ steps:
 
 - script: |
    brew update
-   brew cask install visual-studio-code
+   brew install --cask visual-studio-code
   displayName: 'Install VS Code for testing'
 
 - task: Gulp@0

--- a/lib/ads-adal-library/package.json
+++ b/lib/ads-adal-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ads-adal-library",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "ADAL NodeJS authentication library",
   "main": "dist/index.js",
   "repository": "git://github.com/microsoft/vscode-mssql.git",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
   },
   "dependencies": {
-    "ads-adal-library": "1.0.10",
+    "ads-adal-library": "1.0.12",
     "core-js": "^2.4.1",
     "decompress-zip": "^0.2.2",
     "tar": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -112,10 +112,10 @@
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
   },
   "dependencies": {
+    "@types/node": "^14.14.16",
     "ads-adal-library": "1.0.12",
     "core-js": "^2.4.1",
     "decompress-zip": "^0.2.2",
-    "tar": "^6.0.1",
     "ejs": "^2.6.2",
     "error-ex": "^1.3.0",
     "figures": "^1.4.0",
@@ -131,6 +131,7 @@
     "rangy": "^1.3.0",
     "reflect-metadata": "0.1.12",
     "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+    "tar": "^6.0.1",
     "tmp": "^0.0.28",
     "underscore": "^1.8.3",
     "vscode-languageclient": "5.2.1",


### PR DESCRIPTION
The "Install VS Code for testing" build step was throwing an error: `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.` so I updated the brew command.

`brew cask install`-> `brew install --cask`