### PR TITLE
Syntax highlighting: correct capture groups for `string.quoted.single`

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -640,12 +640,12 @@
 				<dict>
 					<key>captures</key>
 					<dict>
-						<key>1</key>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.begin.sql</string>
 						</dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.end.sql</string>


### PR DESCRIPTION
Currently, the opening `'` of `string.quoted.single` receives scope `punctuation.definition.string.end.sql`, and the closing `'` receives no punctuation scope. This results in incorrect highlighting for themes that use separate colors for string delimiters/punctuation. The reason for the discrepancy is that there is an additional capture group `(N)?` at the start of the pattern, which was not counted. This PR increments the capture group numbers so that the punctuation will receive the correct scope.