### PR TITLE
Adding patterns for hash comments

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -510,6 +510,22 @@
 					<string>(?!\G)</string>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>begin</key>
+							<string>#</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.comment.sql</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>\n</string>
+							<key>name</key>
+							<string>comment.line.hash.sql</string>
+						</dict>
 					</array>
 				</dict>
 				<dict>


### PR DESCRIPTION
The SQL syntax highlighting in VSCode recognises the whitespace leading up to a hash as proceeding a comment, but doesn't recognise the comment itself:

![image](https://user-images.githubusercontent.com/150152/121384248-5ffa4e80-c948-11eb-8dec-b7a7f41edeb6.png)

This seems to be because the patterns array is empty which is fixed in this PR.
