### PR TITLE
Add DacFx service

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('ext:compile-src', (done) => {
     return gulp.src([
                 config.paths.project.root + '/src/**/*.ts',
                 config.paths.project.root + '/src/**/*.js',
-                '!' + config.paths.project.root + '/typings/**/*.ts',
+                config.paths.project.root + '/typings/**/*.d.ts',
                 '!' + config.paths.project.root + '/src/views/htmlcontent/**/*'])
                 .pipe(srcmap.init())
                 .pipe(tsProject())

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -31,6 +31,7 @@ import { ObjectExplorerUtils } from '../objectExplorer/objectExplorerUtils';
 import { ScriptOperation } from '../models/contracts/scripting/scriptingRequest';
 import { QueryHistoryProvider } from '../queryHistory/queryHistoryProvider';
 import { QueryHistoryNode } from '../queryHistory/queryHistoryNode';
+import { DacFxService } from '../dacFxService/dacFxService';
 
 /**
  * The main controller class that initializes the extension
@@ -53,6 +54,7 @@ export default class MainController implements vscode.Disposable {
     private _queryHistoryProvider: QueryHistoryProvider;
     private _scriptingService: ScriptingService;
     private _queryHistoryRegistered: boolean = false;
+    public dacFxService: DacFxService;
 
     /**
      * The main controller constructor
@@ -143,6 +145,8 @@ export default class MainController implements vscode.Disposable {
             this.initializeObjectExplorer();
 
             this.initializeQueryHistory();
+
+            this.dacFxService = new DacFxService(SqlToolsServerClient.instance);
 
             // Add handlers for VS Code generated commands
             this._vscodeWrapper.onDidCloseTextDocument(async (params) => await this.onDidCloseTextDocument(params));

--- a/src/dacFxService/dacFxService.ts
+++ b/src/dacFxService/dacFxService.ts
@@ -1,0 +1,143 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import SqlToolsServiceClient from '../languageservice/serviceclient';
+import * as dacFxContracts from '../models/contracts/dacFx/dacFxContracts';
+import * as mssql from 'vscode-mssql';
+
+export class DacFxService {
+
+    constructor(
+        private _client: SqlToolsServiceClient) { }
+
+    public exportBacpac(
+        databaseName: string,
+        packageFilePath: string,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+        const params: mssql.ExportParams = {
+            databaseName: databaseName,
+            packageFilePath: packageFilePath,
+            ownerUri: ownerUri,
+            taskExecutionMode: taskExecutionMode
+        };
+        return this._client.sendRequest(dacFxContracts.ExportRequest.type, params);
+    }
+
+    public importBacpac(
+        packageFilePath: string,
+        databaseName: string,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+        const params: mssql.ImportParams = {
+            packageFilePath: packageFilePath,
+            databaseName: databaseName,
+            ownerUri: ownerUri,
+            taskExecutionMode: taskExecutionMode
+        };
+        return this._client.sendRequest(dacFxContracts.ImportRequest.type, params);
+    }
+
+    public extractDacpac(
+        databaseName: string,
+        packageFilePath: string,
+        applicationName: string,
+        applicationVersion: string,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+        const params: mssql.ExtractParams = {
+            databaseName: databaseName,
+            packageFilePath: packageFilePath,
+            applicationName: applicationName,
+            applicationVersion: applicationVersion,
+            ownerUri: ownerUri,
+            extractTarget: mssql.ExtractTarget.dacpac,
+            taskExecutionMode: taskExecutionMode };
+        return this._client.sendRequest(dacFxContracts.ExtractRequest.type, params);
+    }
+
+    public createProjectFromDatabase(
+        databaseName: string,
+        targetFilePath: string,
+        applicationName: string,
+        applicationVersion: string,
+        ownerUri: string,
+        extractTarget: mssql.ExtractTarget,
+        taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+        const params: mssql.ExtractParams = {
+            databaseName: databaseName,
+            packageFilePath: targetFilePath,
+            applicationName: applicationName,
+            applicationVersion: applicationVersion,
+            ownerUri: ownerUri,
+            extractTarget: extractTarget,
+            taskExecutionMode: taskExecutionMode };
+        return this._client.sendRequest(dacFxContracts.ExtractRequest.type, params);
+    }
+
+    public deployDacpac(
+        packageFilePath: string,
+        targetDatabaseName: string,
+        upgradeExisting: boolean,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode,
+        sqlCommandVariableValues?: Record<string, string>,
+        deploymentOptions?: mssql.DeploymentOptions): Thenable<mssql.DacFxResult> {
+        const params: mssql.DeployParams = {
+            packageFilePath: packageFilePath,
+            databaseName: targetDatabaseName,
+            upgradeExisting: upgradeExisting,
+            sqlCommandVariableValues: sqlCommandVariableValues,
+            deploymentOptions: deploymentOptions,
+            ownerUri: ownerUri,
+            taskExecutionMode: taskExecutionMode };
+        return this._client.sendRequest(dacFxContracts.DeployRequest.type, params);
+    }
+
+    public generateDeployScript(
+        packageFilePath: string,
+        targetDatabaseName: string,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode,
+        sqlCommandVariableValues?: Record<string, string>,
+        deploymentOptions?: mssql.DeploymentOptions): Thenable<mssql.DacFxResult> {
+        const params: mssql.GenerateDeployScriptParams = {
+            packageFilePath: packageFilePath,
+            databaseName: targetDatabaseName,
+            sqlCommandVariableValues: sqlCommandVariableValues,
+            deploymentOptions: deploymentOptions,
+            ownerUri: ownerUri,
+            taskExecutionMode: taskExecutionMode
+        };
+        return this._client.sendRequest(dacFxContracts.GenerateDeployScriptRequest.type, params);
+    }
+
+    public generateDeployPlan(
+        packageFilePath: string,
+        targetDatabaseName: string,
+        ownerUri: string,
+        taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> {
+        const params: mssql.GenerateDeployPlanParams = {
+            packageFilePath: packageFilePath,
+            databaseName: targetDatabaseName,
+            ownerUri: ownerUri,
+            taskExecutionMode: taskExecutionMode
+        };
+        return this._client.sendRequest(dacFxContracts.GenerateDeployPlanRequest.type, params);
+    }
+
+    public getOptionsFromProfile(profilePath: string): Thenable<mssql.DacFxOptionsResult> {
+        const params: mssql.GetOptionsFromProfileParams = { profilePath: profilePath };
+        return this._client.sendRequest(dacFxContracts.GetOptionsFromProfileRequest.type, params);
+    }
+
+    public validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<mssql.ValidateStreamingJobResult> {
+        const params: mssql.ValidateStreamingJobParams = {
+            packageFilePath: packageFilePath,
+            createStreamingJobTsql: createStreamingJobTsql
+        };
+        return this._client.sendRequest(dacFxContracts.ValidateStreamingJobRequest.type, params);
+    }
+}

--- a/src/models/contracts/dacFx/dacFxContracts.ts
+++ b/src/models/contracts/dacFx/dacFxContracts.ts
@@ -1,0 +1,39 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RequestType } from 'vscode-languageclient';
+import * as mssql from 'vscode-mssql';
+
+export namespace ExportRequest {
+    export const type = new RequestType<mssql.ExportParams, mssql.DacFxResult, void, void>('dacfx/export');
+}
+
+export namespace ImportRequest {
+    export const type = new RequestType<mssql.ImportParams, mssql.DacFxResult, void, void>('dacfx/import');
+}
+
+export namespace ExtractRequest {
+    export const type = new RequestType<mssql.ExtractParams, mssql.DacFxResult, void, void>('dacfx/extract');
+}
+
+export namespace DeployRequest {
+    export const type = new RequestType<mssql.DeployParams, mssql.DacFxResult, void, void>('dacfx/deploy');
+}
+
+export namespace GenerateDeployScriptRequest {
+    export const type = new RequestType<mssql.GenerateDeployScriptParams, mssql.DacFxResult, void, void>('dacfx/generateDeploymentScript');
+}
+
+export namespace GenerateDeployPlanRequest {
+    export const type = new RequestType<mssql.GenerateDeployPlanParams, mssql.GenerateDeployPlanResult, void, void>('dacfx/generateDeployPlan');
+}
+
+export namespace GetOptionsFromProfileRequest {
+    export const type = new RequestType<mssql.GetOptionsFromProfileParams, mssql.DacFxOptionsResult, void, void>('dacfx/getOptionsFromProfile');
+}
+
+export namespace ValidateStreamingJobRequest {
+    export const type = new RequestType<mssql.ValidateStreamingJobParams, mssql.ValidateStreamingJobResult, void, void>('dacfx/validateStreamingJob');
+}

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode-mssql' {
+    /**
+     * Covers defining what the vscode-mssql extension exports to other extensions
+     *
+     * IMPORTANT: THIS IS NOT A HARD DEFINITION unlike vscode; therefore no enums or classes should be defined here
+     * (const enums get evaluated when typescript -> javascript so those are fine)
+     */
+
+
+    export const enum extension {
+        name = 'ms-mssql.mssql'
+    }
+
+    /**
+    * The APIs provided by Mssql extension
+    */
+    export interface IExtension {
+
+        readonly dacFx: IDacFxService;
+    }
+
+    export const enum ExtractTarget {
+        dacpac = 0,
+        file = 1,
+        flat = 2,
+        objectType = 3,
+        schema = 4,
+        schemaObjectType = 5
+    }
+
+    export interface IDacFxService {
+        exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+        importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+        extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+        createProjectFromDatabase(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: ExtractTarget, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+        deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
+        generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
+        generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
+        getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
+        validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
+    }
+
+    export const enum TaskExecutionMode {
+        execute = 0,
+        script = 1,
+        executeAndScript = 2
+    }
+
+    export interface DeploymentOptions {
+        ignoreTableOptions: boolean;
+        ignoreSemicolonBetweenStatements: boolean;
+        ignoreRouteLifetime: boolean;
+        ignoreRoleMembership: boolean;
+        ignoreQuotedIdentifiers: boolean;
+        ignorePermissions: boolean;
+        ignorePartitionSchemes: boolean;
+        ignoreObjectPlacementOnPartitionScheme: boolean;
+        ignoreNotForReplication: boolean;
+        ignoreLoginSids: boolean;
+        ignoreLockHintsOnIndexes: boolean;
+        ignoreKeywordCasing: boolean;
+        ignoreIndexPadding: boolean;
+        ignoreIndexOptions: boolean;
+        ignoreIncrement: boolean;
+        ignoreIdentitySeed: boolean;
+        ignoreUserSettingsObjects: boolean;
+        ignoreFullTextCatalogFilePath: boolean;
+        ignoreWhitespace: boolean;
+        ignoreWithNocheckOnForeignKeys: boolean;
+        verifyCollationCompatibility: boolean;
+        unmodifiableObjectWarnings: boolean;
+        treatVerificationErrorsAsWarnings: boolean;
+        scriptRefreshModule: boolean;
+        scriptNewConstraintValidation: boolean;
+        scriptFileSize: boolean;
+        scriptDeployStateChecks: boolean;
+        scriptDatabaseOptions: boolean;
+        scriptDatabaseCompatibility: boolean;
+        scriptDatabaseCollation: boolean;
+        runDeploymentPlanExecutors: boolean;
+        registerDataTierApplication: boolean;
+        populateFilesOnFileGroups: boolean;
+        noAlterStatementsToChangeClrTypes: boolean;
+        includeTransactionalScripts: boolean;
+        includeCompositeObjects: boolean;
+        allowUnsafeRowLevelSecurityDataMovement: boolean;
+        ignoreWithNocheckOnCheckConstraints: boolean;
+        ignoreFillFactor: boolean;
+        ignoreFileSize: boolean;
+        ignoreFilegroupPlacement: boolean;
+        doNotAlterReplicatedObjects: boolean;
+        doNotAlterChangeDataCaptureObjects: boolean;
+        disableAndReenableDdlTriggers: boolean;
+        deployDatabaseInSingleUserMode: boolean;
+        createNewDatabase: boolean;
+        compareUsingTargetCollation: boolean;
+        commentOutSetVarDeclarations: boolean;
+        blockWhenDriftDetected: boolean;
+        blockOnPossibleDataLoss: boolean;
+        backupDatabaseBeforeChanges: boolean;
+        allowIncompatiblePlatform: boolean;
+        allowDropBlockingAssemblies: boolean;
+        dropConstraintsNotInSource: boolean;
+        dropDmlTriggersNotInSource: boolean;
+        dropExtendedPropertiesNotInSource: boolean;
+        dropIndexesNotInSource: boolean;
+        ignoreFileAndLogFilePath: boolean;
+        ignoreExtendedProperties: boolean;
+        ignoreDmlTriggerState: boolean;
+        ignoreDmlTriggerOrder: boolean;
+        ignoreDefaultSchema: boolean;
+        ignoreDdlTriggerState: boolean;
+        ignoreDdlTriggerOrder: boolean;
+        ignoreCryptographicProviderFilePath: boolean;
+        verifyDeployment: boolean;
+        ignoreComments: boolean;
+        ignoreColumnCollation: boolean;
+        ignoreAuthorizer: boolean;
+        ignoreAnsiNulls: boolean;
+        generateSmartDefaults: boolean;
+        dropStatisticsNotInSource: boolean;
+        dropRoleMembersNotInSource: boolean;
+        dropPermissionsNotInSource: boolean;
+        dropObjectsNotInSource: boolean;
+        ignoreColumnOrder: boolean;
+        doNotDropObjectTypes: SchemaObjectType[];
+        excludeObjectTypes: SchemaObjectType[];
+    }
+
+    /**
+     * Values from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs
+     */
+    export const enum SchemaObjectType {
+        Aggregates = 0,
+        ApplicationRoles = 1,
+        Assemblies = 2,
+        AssemblyFiles = 3,
+        AsymmetricKeys = 4,
+        BrokerPriorities = 5,
+        Certificates = 6,
+        ColumnEncryptionKeys = 7,
+        ColumnMasterKeys = 8,
+        Contracts = 9,
+        DatabaseOptions = 10,
+        DatabaseRoles = 11,
+        DatabaseTriggers = 12,
+        Defaults = 13,
+        ExtendedProperties = 14,
+        ExternalDataSources = 15,
+        ExternalFileFormats = 16,
+        ExternalTables = 17,
+        Filegroups = 18,
+        Files = 19,
+        FileTables = 20,
+        FullTextCatalogs = 21,
+        FullTextStoplists = 22,
+        MessageTypes = 23,
+        PartitionFunctions = 24,
+        PartitionSchemes = 25,
+        Permissions = 26,
+        Queues = 27,
+        RemoteServiceBindings = 28,
+        RoleMembership = 29,
+        Rules = 30,
+        ScalarValuedFunctions = 31,
+        SearchPropertyLists = 32,
+        SecurityPolicies = 33,
+        Sequences = 34,
+        Services = 35,
+        Signatures = 36,
+        StoredProcedures = 37,
+        SymmetricKeys = 38,
+        Synonyms = 39,
+        Tables = 40,
+        TableValuedFunctions = 41,
+        UserDefinedDataTypes = 42,
+        UserDefinedTableTypes = 43,
+        ClrUserDefinedTypes = 44,
+        Users = 45,
+        Views = 46,
+        XmlSchemaCollections = 47,
+        Audits = 48,
+        Credentials = 49,
+        CryptographicProviders = 50,
+        DatabaseAuditSpecifications = 51,
+        DatabaseEncryptionKeys = 52,
+        DatabaseScopedCredentials = 53,
+        Endpoints = 54,
+        ErrorMessages = 55,
+        EventNotifications = 56,
+        EventSessions = 57,
+        LinkedServerLogins = 58,
+        LinkedServers = 59,
+        Logins = 60,
+        MasterKeys = 61,
+        Routes = 62,
+        ServerAuditSpecifications = 63,
+        ServerRoleMembership = 64,
+        ServerRoles = 65,
+        ServerTriggers = 66,
+        ExternalStreams = 67,
+        ExternalStreamingJobs = 68
+    }
+
+    /**
+     * ResultStatus from d.ts
+     */
+    export interface ResultStatus {
+        success: boolean;
+        errorMessage: string;
+    }
+
+    export interface DacFxResult extends ResultStatus {
+        operationId: string;
+    }
+
+    export interface GenerateDeployPlanResult extends DacFxResult {
+        report: string;
+    }
+
+    export interface DacFxOptionsResult extends ResultStatus {
+        deploymentOptions: DeploymentOptions;
+    }
+
+    export interface ValidateStreamingJobResult extends ResultStatus { }
+
+    export interface ExportParams {
+        databaseName: string;
+        packageFilePath: string;
+        ownerUri: string;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface ImportParams {
+        packageFilePath: string;
+        databaseName: string;
+        ownerUri: string;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface ExtractParams {
+        databaseName: string;
+        packageFilePath: string;
+        applicationName: string;
+        applicationVersion: string;
+        ownerUri: string;
+        extractTarget?: ExtractTarget;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface DeployParams {
+        packageFilePath: string;
+        databaseName: string;
+        upgradeExisting: boolean;
+        sqlCommandVariableValues?: Record<string, string>;
+        deploymentOptions?: DeploymentOptions;
+        ownerUri: string;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface GenerateDeployScriptParams {
+        packageFilePath: string;
+        databaseName: string;
+        sqlCommandVariableValues?: Record<string, string>;
+        deploymentOptions?: DeploymentOptions;
+        ownerUri: string;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface GenerateDeployPlanParams {
+        packageFilePath: string;
+        databaseName: string;
+        ownerUri: string;
+        taskExecutionMode: TaskExecutionMode;
+    }
+
+    export interface GetOptionsFromProfileParams {
+        profilePath: string;
+    }
+
+    export interface ValidateStreamingJobParams {
+        packageFilePath: string;
+        createStreamingJobTsql: string;
+    }
+
+}


### PR DESCRIPTION
This is for SQL Proj extension support. All the functionality is already in SQL Tools Service, this is just adding the wrapper code to expose it (and export it for use by other extensions, similar to what we do in the ADS MSSQL extension)