### PR TITLE
Expose listDatabases API

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -524,7 +524,7 @@ export default class ConnectionManager {
         const connectionPromise = new Deferred<boolean>();
         this.connect(uri, connectionInfo, connectionPromise);
         await connectionPromise;
-        let listParams = new ConnectionContracts.ListDatabasesParams();
+        const listParams = new ConnectionContracts.ListDatabasesParams();
         listParams.ownerUri = uri;
         const result = await this.client.sendRequest(ConnectionContracts.ListDatabasesRequest.type, listParams);
         return result.databaseNames;

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -336,7 +336,6 @@ export default class ConnectionManager {
                 if (result.connectionSummary && result.connectionSummary.databaseName) {
                     newCredentials.database = result.connectionSummary.databaseName;
                 }
-
                 self.handleConnectionSuccess(fileUri, connection, newCredentials, result);
                 mruConnection = connection.credentials;
                 const promise = self._uriToConnectionPromiseMap.get(result.ownerUri);
@@ -509,6 +508,26 @@ export default class ConnectionManager {
         } else {
             return false;
         }
+    }
+
+    /**
+     * Creates a new connection and gets the list of databases from that connection.
+     * @param connectionInfo The connection info to query databases for.
+     * @returns The list of databases retrieved from the connection
+     * @throws If an error occurs while connecting, this will be displayed to the user
+     */
+    public async listDatabases(connectionInfo: IConnectionInfo): Promise<string[]> {
+        // Currently we're creating a new connection each time, this could be updated to take
+        // in a URI as well for re-using connections, but that case isn't something we need now
+        // so just leaving it simpler like this.
+        const uri = Utils.generateQueryUri().toString();
+        const connectionPromise = new Deferred<boolean>();
+        this.connect(uri, connectionInfo, connectionPromise);
+        await connectionPromise;
+        let listParams = new ConnectionContracts.ListDatabasesParams();
+        listParams.ownerUri = uri;
+        const result = await this.client.sendRequest(ConnectionContracts.ListDatabasesRequest.type, listParams);
+        return result.databaseNames;
     }
 
     public async changeDatabase(newDatabaseCredentials: IConnectionInfo): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import Constants = require('./constants/constants');
 import * as LocalizedConstants from './constants/localizedConstants';
 import MainController from './controllers/mainController';
 import VscodeWrapper from './controllers/vscodeWrapper';
-import { IExtension } from 'vscode-mssql';
+import { IConnectionInfo, IExtension } from 'vscode-mssql';
 
 let controller: MainController = undefined;
 
@@ -29,8 +29,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     vscode.commands.registerCommand('mssql.getControllerForTests', () => controller);
     await controller.activate();
     return {
-        promptForConnection: () => {
-            return controller.connectionManager.connectionUI.promptForConnection();
+        promptForConnection: (ignoreFocusOut?: boolean) => {
+            return controller.connectionManager.connectionUI.promptForConnection(ignoreFocusOut);
+        },
+        listDatabases: (connectionInfo: IConnectionInfo) => {
+            return controller.connectionManager.listDatabases(connectionInfo);
         },
         dacFx: controller.dacFxService
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,8 +29,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     vscode.commands.registerCommand('mssql.getControllerForTests', () => controller);
     await controller.activate();
     return {
-        promptForConnection: (ignoreFocusOut?: boolean) => {
-            return controller.connectionManager.connectionUI.promptForConnection(ignoreFocusOut);
+        promptForConnection: () => {
+            return controller.connectionManager.connectionUI.promptForConnection();
         },
         listDatabases: (connectionInfo: IConnectionInfo) => {
             return controller.connectionManager.listDatabases(connectionInfo);

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -485,3 +485,15 @@ export function limitStringSize(input: string, forCommandPalette: boolean = fals
     }
     return input;
 }
+
+let uriIndex = 0;
+/**
+ * Generates a URI intended for use when running queries if a file connection isn't present (such
+ * as when running ad-hoc queries).
+ */
+export function generateQueryUri(scheme = 'vscode-mssql-adhoc'): vscode.Uri {
+    return vscode.Uri.from({
+        scheme: scheme,
+        authority: `Query${uriIndex++}`
+    });
+}

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -87,13 +87,12 @@ export class ConnectionUI {
      * Return the ConnectionInfo for the user's choice
      * @returns The connection picked or created.
      */
-    public async promptForConnection(ignoreFocusOut = false): Promise<IConnectionInfo | undefined> {
+    public async promptForConnection(): Promise<IConnectionInfo | undefined> {
         let picklist = this._connectionStore.getPickListItems();
         // We have recent connections - show them in a picklist
         const selection = await this.promptItemChoice({
             placeHolder: LocalizedConstants.recentConnectionsPlaceholder,
-            matchOnDescription: true,
-            ignoreFocusOut
+            matchOnDescription: true
         }, picklist);
         if (selection) {
             return this.handleSelectedConnection(selection);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -21,7 +21,9 @@ import { AccountStore } from '../azure/accountStore';
 import { AzureController } from '../azure/azureController';
 import { IAccount } from '../models/contracts/azure/accountInterfaces';
 import providerSettings from '../azure/providerSettings';
+import * as ConnectionContracts from '../models/contracts/connection';
 import { IConnectionInfo } from 'vscode-mssql';
+import { Deferred } from '../protocol';
 
 /**
  * The different tasks for managing connection profiles.
@@ -85,12 +87,13 @@ export class ConnectionUI {
      * Return the ConnectionInfo for the user's choice
      * @returns The connection picked or created.
      */
-    public async promptForConnection(): Promise<IConnectionInfo | undefined> {
+    public async promptForConnection(ignoreFocusOut = false): Promise<IConnectionInfo | undefined> {
         let picklist = this._connectionStore.getPickListItems();
         // We have recent connections - show them in a picklist
         const selection = await this.promptItemChoice({
             placeHolder: LocalizedConstants.recentConnectionsPlaceholder,
-            matchOnDescription: true
+            matchOnDescription: true,
+            ignoreFocusOut
         }, picklist);
         if (selection) {
             return this.handleSelectedConnection(selection);

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -28,9 +28,8 @@ declare module 'vscode-mssql' {
 
         /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
-         * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
-        promptForConnection(ignoreFocusOut?: boolean): Promise<IConnectionInfo | undefined>;
+        promptForConnection(): Promise<IConnectionInfo | undefined>;
 
         /**
          * Lists the databases for a given connection. An error is thrown and displayed to the user if an

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -25,10 +25,19 @@ declare module 'vscode-mssql' {
          * Service for accessing DacFx functionality
          */
         readonly dacFx: IDacFxService;
+
         /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
+         * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
-        promptForConnection(): Promise<IConnectionInfo | undefined>
+        promptForConnection(ignoreFocusOut?: boolean): Promise<IConnectionInfo | undefined>;
+
+        /**
+         * Lists the databases for a given connection. An error is thrown and displayed to the user if an
+         * error occurs while connecting
+         * @param connection The connection to list the databases for
+         */
+        listDatabases(connection: IConnectionInfo): Promise<string[]>;
     }
 
     /**
@@ -76,7 +85,7 @@ declare module 'vscode-mssql' {
         authenticationType: string;
 
         /**
-         * Gets or sets the azure account token to use
+         * Gets or sets the azure account token to use.
          */
         azureAccountToken: string;
 
@@ -189,7 +198,7 @@ declare module 'vscode-mssql' {
         typeSystemVersion: string;
 
         /**
-         * Gets or sets the connection string to use for this connection
+         * Gets or sets the connection string to use for this connection.
          */
         connectionString: string;
     }


### PR DESCRIPTION
Another thing to be used by the sql-database-projects extension.

We create a new connection because it's possible that a connection is being used that isn't actually associated with an editor - so we wouldn't have a URI for it already we could use.

As mentioned in the comment, a possible improvement if we wanted to make this as generic and re-usable as possible would be to optionally take in a URI instead so that we could re-use connections. But given the specific use case of this and the pooling nature of sqlclient I don't think this is a scenario we have to be too concerned about so am going with this for the time being until we need otherwise. 