### PR TITLE
Allow ignoreFocusOut when prompting for connection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,8 +29,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     vscode.commands.registerCommand('mssql.getControllerForTests', () => controller);
     await controller.activate();
     return {
-        promptForConnection: () => {
-            return controller.connectionManager.connectionUI.promptForConnection();
+        promptForConnection: (ignoreFocusOut?: boolean) => {
+            return controller.connectionManager.connectionUI.promptForConnection(ignoreFocusOut);
         },
         dacFx: controller.dacFxService
     };

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -83,14 +83,16 @@ export class ConnectionUI {
     /**
      * Helper to let user choose a connection from a picklist, or to create a new connection.
      * Return the ConnectionInfo for the user's choice
+     * @param ignoreFocusOut Whether to ignoreFocusOut on the quickpick prompt
      * @returns The connection picked or created.
      */
-    public async promptForConnection(): Promise<IConnectionInfo | undefined> {
+    public async promptForConnection(ignoreFocusOut = false): Promise<IConnectionInfo | undefined> {
         let picklist = this._connectionStore.getPickListItems();
         // We have recent connections - show them in a picklist
         const selection = await this.promptItemChoice({
             placeHolder: LocalizedConstants.recentConnectionsPlaceholder,
-            matchOnDescription: true
+            matchOnDescription: true,
+            ignoreFocusOut
         }, picklist);
         if (selection) {
             return this.handleSelectedConnection(selection);

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -27,8 +27,9 @@ declare module 'vscode-mssql' {
         readonly dacFx: IDacFxService;
         /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
+         * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
-        promptForConnection(): Promise<IConnectionInfo | undefined>
+        promptForConnection(ignoreFocusOut?: boolean): Promise<IConnectionInfo | undefined>;
     }
 
     /**


### PR DESCRIPTION
Enhancement so that this prompt can behave like the other ones in the sql-database-projects extension