### PR TITLE
Export Schema Compare service API

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -31,8 +31,9 @@ import { ObjectExplorerUtils } from '../objectExplorer/objectExplorerUtils';
 import { ScriptOperation } from '../models/contracts/scripting/scriptingRequest';
 import { QueryHistoryProvider } from '../queryHistory/queryHistoryProvider';
 import { QueryHistoryNode } from '../queryHistory/queryHistoryNode';
-import { DacFxService } from '../dacFxService/dacFxService';
+import { DacFxService } from '../services/dacFxService';
 import { IConnectionInfo } from 'vscode-mssql';
+import { SchemaCompareService } from '../services/schemaCompareService';
 
 /**
  * The main controller class that initializes the extension
@@ -56,6 +57,7 @@ export default class MainController implements vscode.Disposable {
     private _scriptingService: ScriptingService;
     private _queryHistoryRegistered: boolean = false;
     public dacFxService: DacFxService;
+    public schemaCompareService: SchemaCompareService;
 
     /**
      * The main controller constructor
@@ -148,6 +150,7 @@ export default class MainController implements vscode.Disposable {
             this.initializeQueryHistory();
 
             this.dacFxService = new DacFxService(SqlToolsServerClient.instance);
+            this.schemaCompareService = new SchemaCompareService(SqlToolsServerClient.instance);
 
             // Add handlers for VS Code generated commands
             this._vscodeWrapper.onDidCloseTextDocument(async (params) => await this.onDidCloseTextDocument(params));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         listDatabases: (connectionInfo: IConnectionInfo) => {
             return controller.connectionManager.listDatabases(connectionInfo);
         },
-        dacFx: controller.dacFxService
+        dacFx: controller.dacFxService,
+        schemaCompare: controller.schemaCompareService
     };
 }
 

--- a/src/models/contracts/schemaCompare/schemaCompareContracts.ts
+++ b/src/models/contracts/schemaCompare/schemaCompareContracts.ts
@@ -1,0 +1,11 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RequestType } from 'vscode-languageclient';
+import * as mssql from 'vscode-mssql';
+
+export namespace SchemaCompareGetDefaultOptionsRequest {
+    export const type = new RequestType<mssql.SchemaCompareGetOptionsParams, mssql.SchemaCompareOptionsResult, void, void>('schemaCompare/getDefaultOptions');
+}

--- a/src/services/dacFxService.ts
+++ b/src/services/dacFxService.ts
@@ -7,7 +7,7 @@ import SqlToolsServiceClient from '../languageservice/serviceclient';
 import * as dacFxContracts from '../models/contracts/dacFx/dacFxContracts';
 import * as mssql from 'vscode-mssql';
 
-export class DacFxService {
+export class DacFxService implements mssql.IDacFxService {
 
     constructor(
         private _client: SqlToolsServiceClient) { }

--- a/src/services/schemaCompareService.ts
+++ b/src/services/schemaCompareService.ts
@@ -1,0 +1,19 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import SqlToolsServiceClient from '../languageservice/serviceclient';
+import * as schemaCompareContracts from '../models/contracts/schemaCompare/schemaCompareContracts';
+import * as mssql from 'vscode-mssql';
+
+export class SchemaCompareService implements mssql.ISchemaCompareService {
+
+    constructor(
+        private _client: SqlToolsServiceClient) { }
+
+    public schemaCompareGetDefaultOptions(): Thenable<mssql.SchemaCompareOptionsResult> {
+        const params: mssql.SchemaCompareGetOptionsParams = {};
+        return this._client.sendRequest(schemaCompareContracts.SchemaCompareGetDefaultOptionsRequest.type, params);
+    }
+}

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -27,6 +27,11 @@ declare module 'vscode-mssql' {
         readonly dacFx: IDacFxService;
 
         /**
+         * Service for accessing SchemaCompare functionality
+         */
+        readonly schemaCompare: ISchemaCompareService;
+
+        /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
          * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
@@ -210,6 +215,10 @@ declare module 'vscode-mssql' {
         objectType = 3,
         schema = 4,
         schemaObjectType = 5
+    }
+
+    export interface ISchemaCompareService {
+        schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
     }
 
     export interface IDacFxService {
@@ -465,6 +474,12 @@ declare module 'vscode-mssql' {
     export interface ValidateStreamingJobParams {
         packageFilePath: string;
         createStreamingJobTsql: string;
+    }
+
+    export interface SchemaCompareGetOptionsParams { }
+
+    export interface SchemaCompareOptionsResult extends ResultStatus {
+        defaultDeploymentOptions: DeploymentOptions;
     }
 
 }


### PR DESCRIPTION
Just the one function we need right now - doing actual schema compare in the extension is out of scope for my changes so keeping this scoped to just the stuff I need. 