### PR TITLE
Export connect API and have listDatabases use existing URI

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -516,16 +516,9 @@ export default class ConnectionManager {
      * @returns The list of databases retrieved from the connection
      * @throws If an error occurs while connecting, this will be displayed to the user
      */
-    public async listDatabases(connectionInfo: IConnectionInfo): Promise<string[]> {
-        // Currently we're creating a new connection each time, this could be updated to take
-        // in a URI as well for re-using connections, but that case isn't something we need now
-        // so just leaving it simpler like this.
-        const uri = Utils.generateQueryUri().toString();
-        const connectionPromise = new Deferred<boolean>();
-        this.connect(uri, connectionInfo, connectionPromise);
-        await connectionPromise;
+    public async listDatabases(connectionUri: string): Promise<string[]> {
         const listParams = new ConnectionContracts.ListDatabasesParams();
-        listParams.ownerUri = uri;
+        listParams.ownerUri = connectionUri;
         const result = await this.client.sendRequest(ConnectionContracts.ListDatabasesRequest.type, listParams);
         return result.databaseNames;
     }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -511,10 +511,9 @@ export default class ConnectionManager {
     }
 
     /**
-     * Creates a new connection and gets the list of databases from that connection.
-     * @param connectionInfo The connection info to query databases for.
+     * Retrieves the list of databases for the connection specified by the given URI.
+     * @param connectionUri The URI of the connection to list the databases for
      * @returns The list of databases retrieved from the connection
-     * @throws If an error occurs while connecting, this will be displayed to the user
      */
     public async listDatabases(connectionUri: string): Promise<string[]> {
         const listParams = new ConnectionContracts.ListDatabasesParams();

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -48,6 +48,7 @@ declare module 'vscode-mssql' {
         /**
          * Lists the databases for a given connection. Must be given an already-opened connection to succeed.
          * @param connectionUri The URI of the connection to list the databases for.
+         * @returns The list of database names
          */
         listDatabases(connectionUri: string): Promise<string[]>;
     }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -38,11 +38,18 @@ declare module 'vscode-mssql' {
         promptForConnection(ignoreFocusOut?: boolean): Promise<IConnectionInfo | undefined>;
 
         /**
-         * Lists the databases for a given connection. An error is thrown and displayed to the user if an
-         * error occurs while connecting
-         * @param connection The connection to list the databases for
+         * Attempts to create a new connection for the given connection info. An error is thrown and displayed
+         * to the user if an error occurs while connecting.
+         * @param connectionInfo The connection info
+         * @returns The URI associated with this connection
          */
-        listDatabases(connection: IConnectionInfo): Promise<string[]>;
+        connect(connectionInfo: IConnectionInfo): Promise<string>;
+
+        /**
+         * Lists the databases for a given connection. Must be given an already-opened connection to succeed.
+         * @param connectionUri The URI of the connection to list the databases for.
+         */
+        listDatabases(connectionUri: string): Promise<string[]>;
     }
 
     /**


### PR DESCRIPTION
Turns out that we need a connection URI later on for the actual deployment - so I added and exported the API for doing that. I also modified listDatabases to take in a URI instead to reduce the number of duplicate connections being made. 