### PR TITLE
Add SqlTaskService

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -488,6 +488,36 @@
         <trans-unit id="azureSignInToAzureCloudDescription">
             <source xml:lang="en">Sign in to your Azure subscription in one of the sovereign clouds.</source>
         </trans-unit>
+        <trans-unit id="taskStatusWithName">
+            <source xml:lang="en">{0}: {1}</source>
+        </trans-unit>
+        <trans-unit id="taskStatusWithMessage">
+            <source xml:lang="en">{1}. {2}</source>
+        </trans-unit>
+        <trans-unit id="taskStatusWithNameAndMessage">
+            <source xml:lang="en">{0}: {1}. {2}</source>
+        </trans-unit>
+        <trans-unit id="failed">
+            <source xml:lang="en">Failed</source>
+        </trans-unit>
+        <trans-unit id="succeeded">
+            <source xml:lang="en">Succeeded</source>
+        </trans-unit>
+        <trans-unit id="succeededWithWarning">
+            <source xml:lang="en">Succeeded with warning</source>
+        </trans-unit>
+        <trans-unit id="canceled">
+            <source xml:lang="en">Canceled</source>
+        </trans-unit>
+        <trans-unit id="inProgress">
+            <source xml:lang="en">In progress</source>
+        </trans-unit>
+        <trans-unit id="canceling">
+            <source xml:lang="en">Canceling</source>
+        </trans-unit>
+        <trans-unit id="notStarted">
+            <source xml:lang="en">Not started</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -34,6 +34,7 @@ import { QueryHistoryNode } from '../queryHistory/queryHistoryNode';
 import { DacFxService } from '../services/dacFxService';
 import { IConnectionInfo } from 'vscode-mssql';
 import { SchemaCompareService } from '../services/schemaCompareService';
+import { SqlTasksService } from '../services/sqlTasksService';
 
 /**
  * The main controller class that initializes the extension
@@ -56,6 +57,7 @@ export default class MainController implements vscode.Disposable {
     private _queryHistoryProvider: QueryHistoryProvider;
     private _scriptingService: ScriptingService;
     private _queryHistoryRegistered: boolean = false;
+    private _sqlTasksService: SqlTasksService;
     public dacFxService: DacFxService;
     public schemaCompareService: SchemaCompareService;
 
@@ -149,6 +151,7 @@ export default class MainController implements vscode.Disposable {
 
             this.initializeQueryHistory();
 
+            this._sqlTasksService = new SqlTasksService(SqlToolsServerClient.instance);
             this.dacFxService = new DacFxService(SqlToolsServerClient.instance);
             this.schemaCompareService = new SchemaCompareService(SqlToolsServerClient.instance);
 

--- a/src/services/sqlTasksService.ts
+++ b/src/services/sqlTasksService.ts
@@ -65,8 +65,7 @@ export class SqlTasksService {
 
     private _activeTasks = new Map<string, ActiveTaskInfo>();
 
-    constructor(
-        private _client: SqlToolsServiceClient) {
+    constructor(private _client: SqlToolsServiceClient) {
         this._client.onNotification(TaskCreatedNotification.type, taskInfo => this.handleTaskCreatedNotification(taskInfo));
         this._client.onNotification(TaskStatusChangedNotification.type, taskProgressInfo => this.handleTaskChangedNotification(taskProgressInfo));
     }
@@ -124,7 +123,7 @@ export class SqlTasksService {
             const taskMessage = taskProgressInfo.message && taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase() ?
                 utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, taskProgressInfo.message) :
                 utils.formatString(localizedConstants.taskStatusWithName, taskInfo.taskInfo.name, taskStatusString);
-            vscode.window.showInformationMessage(taskMessage);
+            showCompletionMessage(taskProgressInfo.status, taskMessage);
         } else {
             // Task is still ongoing so just update the progress notification with the latest status
 
@@ -149,6 +148,25 @@ function isTaskCompleted(taskStatus: TaskStatus): boolean {
         taskStatus === TaskStatus.Failed ||
         taskStatus === TaskStatus.Succeeded ||
         taskStatus === TaskStatus.SucceededWithWarning;
+}
+
+/**
+ * Shows a message for a task with a different type of toast notification being used for
+ * different status types.
+ *  Failed - Error notification
+ *  Canceled or SucceededWithWarning - Warning notification
+ *  All others - Information notification
+ * @param taskStatus The status of the task we're showing the message for
+ * @param message The message to show
+ */
+function showCompletionMessage(taskStatus: TaskStatus, message: string): void {
+    if (taskStatus === TaskStatus.Failed) {
+        vscode.window.showErrorMessage(message);
+    } else if (taskStatus === TaskStatus.Canceled || taskStatus === TaskStatus.SucceededWithWarning) {
+        vscode.window.showWarningMessage(message);
+    } else {
+        vscode.window.showInformationMessage(message);
+    }
 }
 
 /**

--- a/src/services/sqlTasksService.ts
+++ b/src/services/sqlTasksService.ts
@@ -1,0 +1,175 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+import SqlToolsServiceClient from '../languageservice/serviceclient';
+import { NotificationType } from 'vscode-languageclient';
+import { TaskExecutionMode } from 'vscode-mssql';
+import { Deferred } from '../protocol';
+import * as utils from '../models/utils';
+import * as localizedConstants from '../constants/localizedConstants';
+
+export enum TaskStatus {
+    NotStarted = 0,
+    InProgress = 1,
+    Succeeded = 2,
+    SucceededWithWarning = 3,
+    Failed = 4,
+    Canceled = 5,
+    Canceling = 6
+}
+
+// tslint:disable: interface-name
+export interface TaskProgressInfo {
+    taskId: string;
+    status: TaskStatus;
+    message: string;
+    script?: string | undefined;
+}
+
+
+export interface TaskInfo {
+    taskId: string;
+    status: TaskStatus;
+    taskExecutionMode: TaskExecutionMode;
+    serverName: string;
+    databaseName: string;
+    name: string;
+    description: string;
+    providerName: string;
+    isCancelable: boolean;
+}
+
+export namespace TaskStatusChangedNotification {
+    export const type = new NotificationType<TaskProgressInfo, void>('tasks/statuschanged');
+}
+
+export namespace TaskCreatedNotification {
+    export const type = new NotificationType<TaskInfo, void>('tasks/newtaskcreated');
+}
+
+type ActiveTaskInfo = {
+    taskInfo: TaskInfo,
+    progressCallback: ProgressCallback,
+    completionPromise: Deferred<void>
+};
+type ProgressCallback = (value: { message?: string; increment?: number }) => void;
+
+/**
+ * A simple service that hooks into the SQL Task Service feature provided by SQL Tools Service. This handles detecting when
+ * new tasks are started and displaying a progress notification for those tasks while they're running.
+ */
+export class SqlTasksService {
+
+    private _activeTasks = new Map<string, ActiveTaskInfo>();
+
+    constructor(
+        private _client: SqlToolsServiceClient) {
+        this._client.onNotification(TaskCreatedNotification.type, taskInfo => this.handleTaskCreatedNotification(taskInfo));
+        this._client.onNotification(TaskStatusChangedNotification.type, taskProgressInfo => this.handleTaskChangedNotification(taskProgressInfo));
+    }
+
+    /**
+     * Handles a new task being created. This will start up a progress notification toast for the task and set up
+     * callbacks to update the status of that task as it runs.
+     * @param taskInfo The info for the new task that was created
+     */
+    private handleTaskCreatedNotification(taskInfo: TaskInfo): void {
+        const newTaskInfo: ActiveTaskInfo = {
+            taskInfo,
+            progressCallback: () => { return; },
+            completionPromise: new Deferred<void>()
+        };
+
+        vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: taskInfo.name,
+                cancellable: false
+            },
+            async (progress, _token): Promise<void> => {
+                newTaskInfo.progressCallback = value => progress.report(value);
+                await newTaskInfo.completionPromise;
+            }
+        );
+        this._activeTasks.set(taskInfo.taskId, newTaskInfo);
+    }
+
+    /**
+     * Handles an update to an existing task, updating the current progress notification as needed with any new
+     * status/messages. If the task is completed then completes the progress notification and displays a final toast
+     * informing the user that the task was completed.
+     * @param taskProgressInfo The progress info for the task
+     */
+    private handleTaskChangedNotification(taskProgressInfo: TaskProgressInfo): void {
+        const taskInfo = this._activeTasks.get(taskProgressInfo.taskId);
+        if (!taskInfo) {
+            console.warn(`Status update for unknown task ${taskProgressInfo.taskId}`!);
+            return;
+        }
+        const taskStatusString = toTaskStatusDisplayString(taskProgressInfo.status);
+        if (isTaskCompleted(taskProgressInfo.status)) {
+            // Task is completed, complete the progress notification and display a final toast informing the
+            // user of the final status.
+            this._activeTasks.delete(taskProgressInfo.taskId);
+            taskInfo.completionPromise.resolve();
+            // Only include the message if it isn't the same as the task status string we already have - some (but not all) task status
+            // notifications include this string as the message
+            const taskMessage = taskProgressInfo.message && taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase() ?
+                utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, taskProgressInfo.message) :
+                utils.formatString(localizedConstants.taskStatusWithName, taskInfo.taskInfo.name, taskStatusString);
+            vscode.window.showInformationMessage(taskMessage);
+        } else {
+            // Task is still ongoing so just update the progress notification with the latest status
+
+            // The progress notification already has the name, so we just need to update the message with the latest status info.
+            // Only include the message if it isn't the same as the task status string we already have - some (but not all) task status
+            // notifications include this string as the message
+            const taskMessage = taskProgressInfo.message && taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase() ?
+                utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, taskProgressInfo.message) :
+                taskStatusString;
+            taskInfo.progressCallback({ message: taskMessage });
+        }
+    }
+}
+
+/**
+ * Determines whether a particular TaskStatus indicates that the task is completed.
+ * @param taskStatus The task status to check
+ * @returns true if the task is considered completed, false if not
+ */
+function isTaskCompleted(taskStatus: TaskStatus): boolean {
+    return taskStatus === TaskStatus.Canceled ||
+        taskStatus === TaskStatus.Failed ||
+        taskStatus === TaskStatus.Succeeded ||
+        taskStatus === TaskStatus.SucceededWithWarning;
+}
+
+/**
+ * Gets the string to display for the specified task status
+ * @param taskStatus The task status to get the display string for
+ * @returns The display string for the task status, or the task status directly as a string if we don't have a mapping
+ */
+function toTaskStatusDisplayString(taskStatus: TaskStatus): string {
+    switch (taskStatus) {
+        case TaskStatus.Canceled:
+            return localizedConstants.canceled;
+        case TaskStatus.Failed:
+            return localizedConstants.failed;
+        case TaskStatus.Succeeded:
+            return localizedConstants.succeeded;
+        case TaskStatus.SucceededWithWarning:
+            return localizedConstants.succeededWithWarning;
+        case TaskStatus.InProgress:
+            return localizedConstants.inProgress;
+        case TaskStatus.Canceling:
+            return localizedConstants.canceling;
+        case TaskStatus.NotStarted:
+            return localizedConstants.notStarted;
+        default:
+            console.warn(`Don't have display string for task status ${taskStatus}`);
+            return (<any>taskStatus).toString(); // Typescript warns that we can never get here because we've used all the enum values so cast to any
+    }
+}

--- a/src/services/sqlTasksService.ts
+++ b/src/services/sqlTasksService.ts
@@ -77,6 +77,10 @@ export class SqlTasksService {
      * @param taskInfo The info for the new task that was created
      */
     private handleTaskCreatedNotification(taskInfo: TaskInfo): void {
+        // Default to no-op for the progressCallback since we don't have the progress callback from the notification yet. There's
+        // potential here for a race condition in which the first update comes in before this callback is updated - if that starts
+        // happening then we'd want to look into keeping track of the latest update message to display as soon as the progress
+        // callback is set such that we update the notification correctly.
         const newTaskInfo: ActiveTaskInfo = {
             taskInfo,
             progressCallback: () => { return; },


### PR DESCRIPTION
Hooks into the SQL Task feature and displays notifications for ongoing tasks. The primary use for this currently is for the SQL DB Project to display the publish/generate script tasks but I made this generic enough to display progress for any tasks that are ongoing.

Currently it doesn't support other features such as canceling tasks or dealing with child tasks - those can be added later on as needed.

I'm testing it with the project scenarios outlined above, but it's fairly likely that if other features decide to use this that there will be oddities with the display strings. I noticed some weirdness with ordering of events - for example I'm getting a status of completed, followed by a status of in-progress with a message of "Completed" followed then by another one with status of completed except that one has a duration. I'll investigate those if they end up causing problems, but my intention here is just to get the basic framework working for at least the mainline scenarios and then fixing up further issues as we discover them. 

![VsCodeTasks](https://user-images.githubusercontent.com/28519865/126827042-5d7eaced-2fdc-4c71-bca9-14d19edb77c0.gif)
