### PR TITLE
Export getDatabaseName for tree item action handlers

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -169,7 +169,7 @@ export default class MainController implements vscode.Disposable {
      */
     public async scriptNode(node: TreeNodeInfo, operation: ScriptOperation, executeScript: boolean = false): Promise<void> {
         const nodeUri = ObjectExplorerUtils.getNodeUri(node);
-        let connectionCreds = Object.assign({}, node.connectionCredentials);
+        let connectionCreds = Object.assign({}, node.connectionInfo);
         const databaseName = ObjectExplorerUtils.getDatabaseName(node);
         // if not connected or different database
         if (!this.connectionManager.isConnected(nodeUri) ||
@@ -310,7 +310,7 @@ export default class MainController implements vscode.Disposable {
         this._context.subscriptions.push(
             vscode.commands.registerCommand(
                 Constants.cmdObjectExplorerNewQuery, async (treeNodeInfo: TreeNodeInfo) => {
-            const connectionCredentials = Object.assign({}, treeNodeInfo.connectionCredentials);
+            const connectionCredentials = Object.assign({}, treeNodeInfo.connectionInfo);
             const databaseName = ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
             if (databaseName !== connectionCredentials.database &&
                 databaseName !== LocalizedConstants.defaultDatabaseLabel) {
@@ -318,7 +318,7 @@ export default class MainController implements vscode.Disposable {
             } else if (databaseName === LocalizedConstants.defaultDatabaseLabel) {
                 connectionCredentials.database = '';
             }
-            treeNodeInfo.connectionCredentials = connectionCredentials;
+            treeNodeInfo.connectionInfo = connectionCredentials;
             await self.onNewQuery(treeNodeInfo);
         }));
 
@@ -327,7 +327,7 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdRemoveObjectExplorerNode, async (treeNodeInfo: TreeNodeInfo) => {
             await this._objectExplorerProvider.removeObjectExplorerNode(treeNodeInfo);
-            let profile = <IConnectionProfile>treeNodeInfo.connectionCredentials;
+            let profile = <IConnectionProfile>treeNodeInfo.connectionInfo;
             await this._connectionMgr.connectionStore.removeProfile(profile, false);
             return this._objectExplorerProvider.refresh(undefined);
         }));
@@ -343,10 +343,10 @@ export default class MainController implements vscode.Disposable {
         this._context.subscriptions.push(
             vscode.commands.registerCommand(
                 Constants.cmdObjectExplorerNodeSignIn, async (node: AccountSignInTreeNode) => {
-            let profile = <IConnectionProfile>node.parentNode.connectionCredentials;
+            let profile = <IConnectionProfile>node.parentNode.connectionInfo;
             profile = await self.connectionManager.connectionUI.promptForRetryCreateProfile(profile);
             if (profile) {
-                node.parentNode.connectionCredentials = <IConnectionInfo>profile;
+                node.parentNode.connectionInfo = <IConnectionInfo>profile;
                 self._objectExplorerProvider.updateNode(node.parentNode);
                 self._objectExplorerProvider.signInNodeServer(node.parentNode);
                 return self._objectExplorerProvider.refresh(undefined);
@@ -357,7 +357,7 @@ export default class MainController implements vscode.Disposable {
         this._context.subscriptions.push(
             vscode.commands.registerCommand(
                 Constants.cmdConnectObjectExplorerNode, async (node: ConnectTreeNode) => {
-                await self.createObjectExplorerSession(node.parentNode.connectionCredentials);
+                await self.createObjectExplorerSession(node.parentNode.connectionInfo);
         }));
 
         // Disconnect Object Explorer Node
@@ -858,11 +858,11 @@ export default class MainController implements vscode.Disposable {
             const uri = editor.document.uri.toString(true);
             if (node) {
                 // connect to the node if the command came from the context
-                const connectionCreds = node.connectionCredentials;
+                const connectionCreds = node.connectionInfo;
                 // if the node isn't connected
                 if (!node.sessionId) {
                     // connect it first
-                    await this.createObjectExplorerSession(node.connectionCredentials);
+                    await this.createObjectExplorerSession(node.connectionInfo);
                 }
                 this._statusview.languageFlavorChanged(uri, Constants.mssqlProviderName);
                 // connection string based credential

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
-import vscode = require('vscode');
+import * as vscode from 'vscode';
+import * as vscodeMssql from 'vscode-mssql';
 import Constants = require('./constants/constants');
 import * as LocalizedConstants from './constants/localizedConstants';
 import MainController from './controllers/mainController';
@@ -12,6 +13,7 @@ import VscodeWrapper from './controllers/vscodeWrapper';
 import { IConnectionInfo, IExtension } from 'vscode-mssql';
 import { Deferred } from './protocol';
 import * as utils from './models/utils';
+import { ObjectExplorerUtils } from './objectExplorer/objectExplorerUtils';
 
 let controller: MainController = undefined;
 
@@ -52,6 +54,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         },
         listDatabases: (connectionUri: string) => {
             return controller.connectionManager.listDatabases(connectionUri);
+        },
+        getDatabaseNameFromTreeNode: (node: vscodeMssql.ITreeNodeInfo) => {
+            return ObjectExplorerUtils.getDatabaseName(node);
         },
         dacFx: controller.dacFxService,
         schemaCompare: controller.schemaCompareService

--- a/src/metadata/metadataService.ts
+++ b/src/metadata/metadataService.ts
@@ -5,7 +5,8 @@
 
 import SqlToolsServiceClient from '../languageservice/serviceclient';
 import ConnectionManager from '../controllers/connectionManager';
-import { MetadataQueryParams, MetadataQueryRequest, ObjectMetadata } from '../models/contracts/metadata/metadataRequest';
+import { MetadataQueryParams, MetadataQueryRequest } from '../models/contracts/metadata/metadataRequest';
+import { ObjectMetadata } from 'vscode-mssql';
 
 export class MetadataService {
 

--- a/src/models/contracts/metadata/metadataRequest.ts
+++ b/src/models/contracts/metadata/metadataRequest.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RequestType } from 'vscode-languageclient';
-
+import * as vscodeMssql from 'vscode-mssql';
 
 export class MetadataQueryParams {
     /**
@@ -13,28 +13,8 @@ export class MetadataQueryParams {
     public ownerUri: string;
 }
 
-export enum MetadataType {
-    Table = 0,
-    View = 1,
-    SProc = 2,
-    Function = 3
-}
-
-// tslint:disable-next-line:interface-name
-export interface ObjectMetadata {
-    metadataType: MetadataType;
-
-    metadataTypeName: string;
-
-    urn: string;
-
-    name: string;
-
-    schema: string;
-}
-
 export class MetadataQueryResult {
-    public metadata: ObjectMetadata[];
+    public metadata: vscodeMssql.ObjectMetadata[];
 }
 
 

--- a/src/models/contracts/objectExplorer/nodeInfo.ts
+++ b/src/models/contracts/objectExplorer/nodeInfo.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { ObjectMetadata } from '../metadata/metadataRequest';
+import { ObjectMetadata } from 'vscode-mssql';
 
 /**
  * Information describing a Node in the Object Explorer tree.

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -79,9 +79,9 @@ export class ObjectExplorerService {
                 // set connection and other things
                 let node: TreeNodeInfo;
                 if (self._currentNode && (self._currentNode.sessionId === result.sessionId)) {
-                    nodeLabel = !nodeLabel ? self.createNodeLabel(self._currentNode.connectionCredentials) : nodeLabel;
+                    nodeLabel = !nodeLabel ? self.createNodeLabel(self._currentNode.connectionInfo) : nodeLabel;
                     node = TreeNodeInfo.fromNodeInfo(result.rootNode, result.sessionId,
-                        undefined, self._currentNode.connectionCredentials, nodeLabel, Constants.serverLabel);
+                        undefined, self._currentNode.connectionInfo, nodeLabel, Constants.serverLabel);
                 } else {
                     nodeLabel = !nodeLabel ? self.createNodeLabel(nodeConnection) : nodeLabel;
                     node = TreeNodeInfo.fromNodeInfo(result.rootNode, result.sessionId,
@@ -91,7 +91,7 @@ export class ObjectExplorerService {
                 const nodeUri = ObjectExplorerUtils.getNodeUri(node);
                 if (!this._connectionManager.isConnected(nodeUri) &&
                     !this._connectionManager.isConnecting(nodeUri)) {
-                    const profile = <IConnectionProfile>node.connectionCredentials;
+                    const profile = <IConnectionProfile>node.connectionInfo;
                     await this._connectionManager.connect(nodeUri, profile);
                 }
 
@@ -105,8 +105,8 @@ export class ObjectExplorerService {
                 return promise.resolve(node);
             } else {
                 // create session failure
-                if (self._currentNode.connectionCredentials?.password) {
-                    self._currentNode.connectionCredentials.password = '';
+                if (self._currentNode.connectionInfo?.password) {
+                    self._currentNode.connectionInfo.password = '';
                 }
                 let error = LocalizedConstants.connectErrorLabel;
                 if (result.errorMessage) {
@@ -121,7 +121,7 @@ export class ObjectExplorerService {
                     (Constants.errorFirewallRule, result.errorMessage);
                     if (handleFirewallResult.result && handleFirewallResult.ipAddress) {
                         const nodeUri = ObjectExplorerUtils.getNodeUri(self._currentNode);
-                        const profile = <IConnectionProfile>self._currentNode.connectionCredentials;
+                        const profile = <IConnectionProfile>self._currentNode.connectionInfo;
                         self.updateNode(self._currentNode);
                         self._connectionManager.connectionUI.handleFirewallError(nodeUri, profile, handleFirewallResult.ipAddress);
                     }
@@ -193,7 +193,7 @@ export class ObjectExplorerService {
 
     public updateNode(node: TreeNodeInfo): void {
         for (let rootTreeNode of this._rootTreeNodeArray) {
-            if (Utils.isSameConnection(node.connectionCredentials, rootTreeNode.connectionCredentials) &&
+            if (Utils.isSameConnection(node.connectionInfo, rootTreeNode.connectionInfo) &&
                 rootTreeNode.label === node.label) {
                     const index = this._rootTreeNodeArray.indexOf(rootTreeNode);
                     delete this._rootTreeNodeArray[index];
@@ -327,12 +327,12 @@ export class ObjectExplorerService {
                 } else {
                     // start node session
                     let promise = new Deferred<TreeNodeInfo>();
-                    const sessionId = await this.createSession(promise, element.connectionCredentials);
+                    const sessionId = await this.createSession(promise, element.connectionInfo);
                     if (sessionId) {
                         let node = await promise;
                         // if the server was found but connection failed
                         if (!node) {
-                            let profile = element.connectionCredentials as IConnectionProfile;
+                            let profile = element.connectionInfo as IConnectionProfile;
                             let password = await this._connectionManager.connectionStore.lookupPassword(profile);
                             if (password) {
                                 return this.createSignInNode(element);
@@ -484,14 +484,14 @@ export class ObjectExplorerService {
             node.nodeType = Constants.disconnectedServerLabel;
             node.contextValue = Constants.disconnectedServerLabel;
             node.sessionId = undefined;
-            if (!(<IConnectionProfile>node.connectionCredentials).savePassword) {
-                node.connectionCredentials.password = '';
+            if (!(<IConnectionProfile>node.connectionInfo).savePassword) {
+                node.connectionInfo.password = '';
             }
             const label = typeof node.label === 'string' ? node.label : node.label.label;
             // make a new node to show disconnected behavior
             let disconnectedNode = new TreeNodeInfo(label, Constants.disconnectedServerLabel,
                 node.collapsibleState, node.nodePath, node.nodeStatus, Constants.disconnectedServerLabel,
-                undefined, node.connectionCredentials, node.parentNode);
+                undefined, node.connectionInfo, node.parentNode);
 
             this.updateNode(disconnectedNode);
             this._currentNode = disconnectedNode;
@@ -504,7 +504,7 @@ export class ObjectExplorerService {
     public async removeConnectionNodes(connections: IConnectionInfo[]): Promise<void> {
         for (let conn of connections) {
             for (let node of this._rootTreeNodeArray) {
-                if (Utils.isSameConnection(node.connectionCredentials, conn)) {
+                if (Utils.isSameConnection(node.connectionInfo, conn)) {
                     await this.removeObjectExplorerNode(node);
                 }
             }
@@ -592,7 +592,7 @@ export class ObjectExplorerService {
     }
 
     public get rootNodeConnections(): IConnectionInfo[] {
-        const connections = this._rootTreeNodeArray.map(node => node.connectionCredentials);
+        const connections = this._rootTreeNodeArray.map(node => node.connectionInfo);
         return connections;
     }
 

--- a/src/objectExplorer/treeNodeInfo.ts
+++ b/src/objectExplorer/treeNodeInfo.ts
@@ -7,10 +7,9 @@ import * as vscode from 'vscode';
 import { NodeInfo } from '../models/contracts/objectExplorer/nodeInfo';
 import { ObjectExplorerUtils } from './objectExplorerUtils';
 import Constants = require('../constants/constants');
-import { ObjectMetadata } from '../models/contracts/metadata/metadataRequest';
-import { IConnectionInfo } from 'vscode-mssql';
+import { IConnectionInfo, ITreeNodeInfo, ObjectMetadata } from 'vscode-mssql';
 
-export class TreeNodeInfo extends vscode.TreeItem {
+export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
 
     private _nodePath: string;
     private _nodeStatus: string;
@@ -20,7 +19,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
     private _errorMessage: string;
     private _sessionId: string;
     private _parentNode: TreeNodeInfo;
-    private _connectionCredentials: IConnectionInfo;
+    private _connectionInfo: IConnectionInfo;
     private _metadata: ObjectMetadata;
 
     constructor(
@@ -31,7 +30,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
         nodeStatus: string,
         nodeType: string,
         sessionId: string,
-        connectionCredentials: IConnectionInfo,
+        connectionInfo: IConnectionInfo,
         parentNode: TreeNodeInfo,
         objectMetadata?: ObjectMetadata
     ) {
@@ -42,7 +41,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
         this._nodeType = nodeType;
         this._sessionId = sessionId;
         this._parentNode = parentNode;
-        this._connectionCredentials = connectionCredentials;
+        this._connectionInfo = connectionInfo;
         this._metadata = objectMetadata;
         this.iconPath = ObjectExplorerUtils.iconPath(this.nodeType);
     }
@@ -51,7 +50,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
         nodeInfo: NodeInfo,
         sessionId: string,
         parentNode: TreeNodeInfo,
-        connectionCredentials: IConnectionInfo,
+        connectionInfo: IConnectionInfo,
         label?: string,
         nodeType?: string): TreeNodeInfo {
         let type = nodeType ? nodeType : nodeInfo.nodeType;
@@ -60,7 +59,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
             (type === Constants.serverLabel ? vscode.TreeItemCollapsibleState.Expanded :
             vscode.TreeItemCollapsibleState.Collapsed),
             nodeInfo.nodePath, nodeInfo.nodeStatus,
-            type, sessionId, connectionCredentials, parentNode, nodeInfo.metadata);
+            type, sessionId, connectionInfo, parentNode, nodeInfo.metadata);
         return treeNodeInfo;
     }
 
@@ -97,8 +96,8 @@ export class TreeNodeInfo extends vscode.TreeItem {
         return this._parentNode;
     }
 
-    public get connectionCredentials(): IConnectionInfo {
-        return this._connectionCredentials;
+    public get connectionInfo(): IConnectionInfo {
+        return this._connectionInfo;
     }
 
     public get metadata(): ObjectMetadata {
@@ -138,7 +137,7 @@ export class TreeNodeInfo extends vscode.TreeItem {
         this._parentNode = value;
     }
 
-    public set connectionCredentials(value: IConnectionInfo) {
-        this._connectionCredentials = value;
+    public set connectionInfo(value: IConnectionInfo) {
+        this._connectionInfo = value;
     }
 }

--- a/src/scripting/scriptingService.ts
+++ b/src/scripting/scriptingService.ts
@@ -60,7 +60,7 @@ export class ScriptingService {
      */
     public createScriptingParams(node: TreeNodeInfo, uri: string, operation: ScriptOperation): IScriptingParams {
         const scriptingObject = this.getObjectFromNode(node);
-        let serverInfo = this._connectionManager.getServerInfo(node.connectionCredentials);
+        let serverInfo = this._connectionManager.getServerInfo(node.connectionInfo);
         let scriptCreateDropOption: string;
         switch (operation) {
             case (ScriptOperation.Select):

--- a/test/objectExplorerProvider.test.ts
+++ b/test/objectExplorerProvider.test.ts
@@ -233,8 +233,8 @@ suite('Object Explorer Node Types Test', () => {
         expect(treeNode.isLeaf, 'Node should not be a leaf').is.equal(false);
         treeNode.parentNode = treeNode.parentNode;
         expect(treeNode.parentNode, 'Parent node should be equal to expected value').is.equal(undefined);
-        treeNode.connectionCredentials = treeNode.connectionCredentials;
-        expect(treeNode.connectionCredentials, 'Connection credentials should be equal to expected value').is.equal(undefined);
+        treeNode.connectionInfo = treeNode.connectionInfo;
+        expect(treeNode.connectionInfo, 'Connection credentials should be equal to expected value').is.equal(undefined);
     });
 
     test('Test fromNodeInfo function', () => {
@@ -259,7 +259,7 @@ suite('Object Explorer Node Types Test', () => {
         treeNodeInfo.isLeaf = nodeInfo.isLeaf;
         expect(treeNodeInfo.isLeaf, 'Node should not be a leaf').is.equal(nodeInfo.isLeaf);
         expect(treeNodeInfo.parentNode, 'Parent node should be equal to expected value').is.equal(undefined);
-        expect(treeNodeInfo.connectionCredentials, 'Connection credentials should be equal to expected value').is.equal(undefined);
+        expect(treeNodeInfo.connectionInfo, 'Connection credentials should be equal to expected value').is.equal(undefined);
         expect(treeNodeInfo.errorMessage, 'Error message should be equal to expected value').is.equal('test_error');
         expect(treeNodeInfo.metadata, 'Node metadata should be the same as nodeInfo metadata').is.equal(nodeInfo.metadata);
     });

--- a/test/objectExplorerUtils.test.ts
+++ b/test/objectExplorerUtils.test.ts
@@ -8,7 +8,7 @@ import { expect, assert } from 'chai';
 import Constants = require('../src/constants/constants');
 import { TreeNodeInfo } from '../src/objectExplorer/treeNodeInfo';
 import { ConnectionProfile } from '../src/models/connectionProfile';
-import { ObjectMetadata } from '../src/models/contracts/metadata/metadataRequest';
+import { ObjectMetadata } from 'vscode-mssql';
 
 suite('Object Explorer Utils Tests', () => {
 

--- a/test/scriptingService.test.ts
+++ b/test/scriptingService.test.ts
@@ -10,8 +10,8 @@ import { ScriptingService } from '../src/scripting/scriptingService';
 import { ScriptingRequest, IScriptingObject, IScriptingResult, ScriptOperation } from '../src/models/contracts/scripting/scriptingRequest';
 import { TreeNodeInfo } from '../src/objectExplorer/treeNodeInfo';
 import { ServerInfo } from '../src/models/contracts/connection';
-import { ObjectMetadata, MetadataType } from '../src/models/contracts/metadata/metadataRequest';
 import { assert } from 'chai';
+import { MetadataType, ObjectMetadata } from 'vscode-mssql';
 
 suite('Scripting Service Tests', () => {
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 declare module 'vscode-mssql' {
+
+    import * as vscode from 'vscode';
+
     /**
      * Covers defining what the vscode-mssql extension exports to other extensions
      *
@@ -51,6 +54,9 @@ declare module 'vscode-mssql' {
          * @returns The list of database names
          */
         listDatabases(connectionUri: string): Promise<string[]>;
+
+        getDatabaseNameFromTreeNode(node: ITreeNodeInfo): string;
+
     }
 
     /**
@@ -490,4 +496,30 @@ declare module 'vscode-mssql' {
         defaultDeploymentOptions: DeploymentOptions;
     }
 
+    export interface ITreeNodeInfo extends vscode.TreeItem {
+        readonly connectionInfo: IConnectionInfo;
+        nodeType: string;
+        metadata: ObjectMetadata;
+        parentNode: ITreeNodeInfo;
+    }
+
+    export const enum MetadataType {
+        Table = 0,
+        View = 1,
+        SProc = 2,
+        Function = 3
+    }
+
+    // tslint:disable-next-line:interface-name
+    export interface ObjectMetadata {
+        metadataType: MetadataType;
+
+        metadataTypeName: string;
+
+        urn: string;
+
+        name: string;
+
+        schema: string;
+    }
 }


### PR DESCRIPTION
This will be used by SQL Database Project - that is contributing commands to the view item context and so needs to have the typings for the tree node.

The getDatabaseName export is so that extensions can use the same logic to get the actual database name for a given node.