### PR TITLE
Add AzureFunctionsService to expose AddSqlBinding

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "3.0.0-release.115",
+        "version": "3.0.0-release.118",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-net5.0.zip",
             "Windows_7_64": "win-x64-net5.0.zip",

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -34,6 +34,7 @@ import { DacFxService } from '../services/dacFxService';
 import { IConnectionInfo } from 'vscode-mssql';
 import { SchemaCompareService } from '../services/schemaCompareService';
 import { SqlTasksService } from '../services/sqlTasksService';
+import { AzureFunctionsService } from '../services/azureFunctionsService';
 
 /**
  * The main controller class that initializes the extension
@@ -59,6 +60,7 @@ export default class MainController implements vscode.Disposable {
     private _sqlTasksService: SqlTasksService;
     public dacFxService: DacFxService;
     public schemaCompareService: SchemaCompareService;
+    public azureFunctionsService: AzureFunctionsService;
 
     /**
      * The main controller constructor
@@ -153,6 +155,7 @@ export default class MainController implements vscode.Disposable {
             this._sqlTasksService = new SqlTasksService(SqlToolsServerClient.instance, this._untitledSqlDocumentService);
             this.dacFxService = new DacFxService(SqlToolsServerClient.instance);
             this.schemaCompareService = new SchemaCompareService(SqlToolsServerClient.instance);
+            this.azureFunctionsService = new AzureFunctionsService(SqlToolsServerClient.instance);
 
             // Add handlers for VS Code generated commands
             this._vscodeWrapper.onDidCloseTextDocument(async (params) => await this.onDidCloseTextDocument(params));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
             return ObjectExplorerUtils.getDatabaseName(node);
         },
         dacFx: controller.dacFxService,
-        schemaCompare: controller.schemaCompareService
+        schemaCompare: controller.schemaCompareService,
+        azureFunctions: controller.azureFunctionsService
     };
 }
 

--- a/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
+++ b/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
@@ -1,0 +1,11 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RequestType } from 'vscode-languageclient';
+import * as mssql from 'vscode-mssql';
+
+export namespace AddSqlBindingRequest {
+    export const type = new RequestType<mssql.AddSqlBindingParams, mssql.ResultStatus, void, void>('azureFunctions/sqlBinding');
+}

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -1,0 +1,33 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import SqlToolsServiceClient from '../languageservice/serviceclient';
+import * as mssql from 'vscode-mssql';
+import * as azureFunctionsContracts from '../models/contracts/azureFunctions/azureFunctionsContracts';
+
+export const hostFileName: string = 'host.json';
+
+export class AzureFunctionsService implements mssql.IAzureFunctionsService {
+
+    constructor(private _client: SqlToolsServiceClient) { }
+
+    addSqlBinding(
+        bindingType: mssql.BindingType,
+        filePath: string,
+        functionName: string,
+        objectName: string,
+        connectionStringSetting: string
+    ): Thenable<mssql.ResultStatus> {
+        const params: mssql.AddSqlBindingParams = {
+            bindingType: bindingType,
+            filePath: filePath,
+            functionName: functionName,
+            objectName: objectName,
+            connectionStringSetting: connectionStringSetting
+        };
+
+        return this._client.sendRequest(azureFunctionsContracts.AddSqlBindingRequest.type, params);
+    }
+}

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -35,6 +35,11 @@ declare module 'vscode-mssql' {
         readonly schemaCompare: ISchemaCompareService;
 
         /**
+         * Service for accessing AzureFunctions functionality
+         */
+        readonly azureFunctions: IAzureFunctionsService;
+
+        /**
          * Prompts the user to select an existing connection or create a new one, and then returns the result
          * @param ignoreFocusOut Whether the quickpick prompt ignores focus out (default false)
          */
@@ -245,6 +250,10 @@ declare module 'vscode-mssql' {
         generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
         getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
         validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
+    }
+
+    export interface IAzureFunctionsService {
+        addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Thenable<ResultStatus>;
     }
 
     export const enum TaskExecutionMode {
@@ -520,5 +529,27 @@ declare module 'vscode-mssql' {
         name: string;
 
         schema: string;
+    }
+
+
+    export const enum BindingType {
+        input,
+        output
+    }
+
+    export interface AddSqlBindingParams {
+        filePath: string;
+        functionName: string;
+        objectName: string;
+        bindingType: BindingType;
+        connectionStringSetting: string;
+    }
+
+    export interface GetAzureFunctionsParams {
+        filePath: string;
+    }
+
+    export interface GetAzureFunctionsResult extends ResultStatus {
+        azureFunctions: string[];
     }
 }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -531,7 +531,6 @@ declare module 'vscode-mssql' {
         schema: string;
     }
 
-
     export const enum BindingType {
         input,
         output
@@ -543,13 +542,5 @@ declare module 'vscode-mssql' {
         objectName: string;
         bindingType: BindingType;
         connectionStringSetting: string;
-    }
-
-    export interface GetAzureFunctionsParams {
-        filePath: string;
-    }
-
-    export interface GetAzureFunctionsResult extends ResultStatus {
-        azureFunctions: string[];
     }
 }


### PR DESCRIPTION
This exposes the AddSqlBinding functionality added in https://github.com/microsoft/sqltoolsservice/pull/1224 so that it can be used by the Sql Database Projects extension.

how it will be used in Sql Database Projects:
![addSqlBinding](https://user-images.githubusercontent.com/31145923/128439916-2565a59c-d2de-4e73-a986-0819c981406d.gif)
