### PR TITLE
Export SQL Tools Service install path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { IConnectionInfo, IExtension } from 'vscode-mssql';
 import { Deferred } from './protocol';
 import * as utils from './models/utils';
 import { ObjectExplorerUtils } from './objectExplorer/objectExplorerUtils';
+import SqlToolsServerClient from './languageservice/serviceclient';
 
 let controller: MainController = undefined;
 
@@ -32,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     vscode.commands.registerCommand('mssql.getControllerForTests', () => controller);
     await controller.activate();
     return {
+        sqlToolsServicePath: SqlToolsServerClient.instance.sqlToolsServicePath,
         promptForConnection: (ignoreFocusOut?: boolean) => {
             return controller.connectionManager.connectionUI.promptForConnection(ignoreFocusOut);
         },

--- a/src/languageservice/serviceInstallerUtil.ts
+++ b/src/languageservice/serviceInstallerUtil.ts
@@ -74,37 +74,3 @@ export function installService(runtime: Runtime): Promise<String> {
         return serverProvider.getOrDownloadServer(runtime);
     }
 }
-
-/*
-* Returns the install folder path for given platform.
-*/
-export function getServiceInstallDirectory(runtime: Runtime): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-        if (runtime === undefined) {
-            PlatformInformation.getCurrent().then( platformInfo => {
-                if (platformInfo.isValidRuntime()) {
-                    resolve(downloadProvider.getInstallDirectory(platformInfo.runtimeId));
-                } else {
-                    reject('unsupported runtime');
-                }
-            }).catch( error => {
-                reject(error);
-            });
-        } else {
-            resolve(downloadProvider.getInstallDirectory(runtime));
-        }
-    });
-
-}
-
-/*
-* Returns the path to the root folder of service install location.
-*/
-export function getServiceInstallDirectoryRoot(): string {
-    let directoryPath: string = downloadProvider.getInstallDirectoryRoot();
-    directoryPath = directoryPath.replace('\\{#version#}\\{#platform#}', '');
-    directoryPath = directoryPath.replace('/{#version#}/{#platform#}', '');
-    return directoryPath;
-}
-
-

--- a/src/languageservice/serviceInstallerUtil.ts
+++ b/src/languageservice/serviceInstallerUtil.ts
@@ -74,3 +74,36 @@ export function installService(runtime: Runtime): Promise<String> {
         return serverProvider.getOrDownloadServer(runtime);
     }
 }
+
+/*
+* Returns the install folder path for given platform.
+*/
+export function getServiceInstallDirectory(runtime: Runtime): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        if (runtime === undefined) {
+            PlatformInformation.getCurrent().then( platformInfo => {
+                if (platformInfo.isValidRuntime()) {
+                    resolve(downloadProvider.getInstallDirectory(platformInfo.runtimeId));
+                } else {
+                    reject('unsupported runtime');
+                }
+            }).catch( error => {
+                reject(error);
+            });
+        } else {
+            resolve(downloadProvider.getInstallDirectory(runtime));
+        }
+    });
+
+}
+
+/*
+* Returns the path to the root folder of service install location.
+*/
+export function getServiceInstallDirectoryRoot(): string {
+    let directoryPath: string = downloadProvider.getInstallDirectoryRoot();
+    directoryPath = directoryPath.replace('\\{#version#}\\{#platform#}', '');
+    directoryPath = directoryPath.replace('/{#version#}/{#platform#}', '');
+    return directoryPath;
+}
+

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -103,6 +103,14 @@ class LanguageClientErrorHandler {
 // The Service Client class handles communication with the VS Code LanguageClient
 export default class SqlToolsServiceClient {
 
+    private _sqlToolsServicePath: string | undefined = undefined;
+    /**
+     * Path to the root of the SQL Tools Service folder
+     */
+    public get sqlToolsServicePath(): string | undefined {
+        return this._sqlToolsServicePath;
+    }
+
     private _logPath: string;
 
     // singleton instance
@@ -189,10 +197,12 @@ export default class SqlToolsServiceClient {
                             _channel.show();
                         }
                         let installedServerPath = await this._server.downloadServerFiles(platformInfo.runtimeId);
+                        this._sqlToolsServicePath = path.dirname(installedServerPath);
                         this.initializeLanguageClient(installedServerPath, context, platformInfo.isWindows());
                         await this._client.onReady();
                         resolve(new ServerInitializationResult(true, true, installedServerPath));
                     } else {
+                        this._sqlToolsServicePath = path.dirname(serverPath);
                         this.initializeLanguageClient(serverPath, context, platformInfo.isWindows());
                         await this._client.onReady();
                         resolve(new ServerInitializationResult(false, true, serverPath));

--- a/test/serviceInstallerUtils.test.ts
+++ b/test/serviceInstallerUtils.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assert } from 'chai';
-import { StubStatusView, StubLogger, installService } from '../src/languageservice/serviceInstallerUtil';
+import { StubStatusView, StubLogger, getServiceInstallDirectoryRoot, installService } from '../src/languageservice/serviceInstallerUtil';
 
 function setupConsole(): string[] {
     let logs = [];
@@ -97,11 +97,21 @@ suite('Stub Logger tests', () => {
 });
 
 suite('Test Service Installer Util functions', () => {
+
+    test('Test getServiceInstallDirectoryRoot function', () => {
+        let path = getServiceInstallDirectoryRoot();
+        assert.isNotNull(path, 'Service install directory root should not be null');
+    });
+
+    // test('Test getgetServiceInstallDirectory function', async () => {
+    //     let dir = await getServiceInstallDirectory(undefined);
+    //     assert.isNotNull(dir, 'Service install directory should not be null');
+    // });
+
     test('Test installService function', async () => {
         let installedPath = await installService(undefined);
         assert.isNotNull(installedPath, 'Service installed path should not be null');
     });
 });
-
 
 

--- a/test/serviceInstallerUtils.test.ts
+++ b/test/serviceInstallerUtils.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assert } from 'chai';
-import { StubStatusView, StubLogger, getServiceInstallDirectoryRoot, installService } from '../src/languageservice/serviceInstallerUtil';
+import { StubStatusView, StubLogger, installService } from '../src/languageservice/serviceInstallerUtil';
 
 function setupConsole(): string[] {
     let logs = [];
@@ -97,17 +97,6 @@ suite('Stub Logger tests', () => {
 });
 
 suite('Test Service Installer Util functions', () => {
-
-    test('Test getServiceInstallDirectoryRoot function', () => {
-        let path = getServiceInstallDirectoryRoot();
-        assert.isNotNull(path, 'Service install directory root should not be null');
-    });
-
-    // test('Test getgetServiceInstallDirectory function', async () => {
-    //     let dir = await getServiceInstallDirectory(undefined);
-    //     assert.isNotNull(dir, 'Service install directory should not be null');
-    // });
-
     test('Test installService function', async () => {
         let installedPath = await installService(undefined);
         assert.isNotNull(installedPath, 'Service installed path should not be null');

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -25,6 +25,11 @@ declare module 'vscode-mssql' {
     export interface IExtension {
 
         /**
+         * Path to the root of the SQL Tools Service folder
+         */
+        readonly sqlToolsServicePath: string;
+
+        /**
          * Service for accessing DacFx functionality
          */
         readonly dacFx: IDacFxService;


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/16770

Export STS install path so that other extensions don't have to implement their own logic for determining where it's installed.