### PR TITLE
expose getAzureFunctions

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "3.0.0-release.118",
+        "version": "3.0.0-release.124",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-net5.0.zip",
             "Windows_7_64": "win-x64-net5.0.zip",

--- a/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
+++ b/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
@@ -7,8 +7,15 @@ import { RequestType } from 'vscode-languageclient';
 import * as mssql from 'vscode-mssql';
 
 /**
- * Adds a SQL Binding inside generated Azure Functions in a file
+ * Adds a SQL Binding to a specified Azure function in a file
  */
 export namespace AddSqlBindingRequest {
     export const type = new RequestType<mssql.AddSqlBindingParams, mssql.ResultStatus, void, void>('azureFunctions/sqlBinding');
+}
+
+/**
+ * Gets the names of the azure functions in a file
+ */
+export namespace GetAzureFunctionsRequest {
+    export const type = new RequestType<mssql.getAzureFunctionsParams, mssql.getAzureFunctionsResult, void, void>('azureFunctions/getAzureFunctions');
 }

--- a/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
+++ b/src/models/contracts/azureFunctions/azureFunctionsContracts.ts
@@ -14,8 +14,8 @@ export namespace AddSqlBindingRequest {
 }
 
 /**
- * Gets the names of the azure functions in a file
+ * Gets the names of the Azure functions in a file
  */
 export namespace GetAzureFunctionsRequest {
-    export const type = new RequestType<mssql.getAzureFunctionsParams, mssql.getAzureFunctionsResult, void, void>('azureFunctions/getAzureFunctions');
+    export const type = new RequestType<mssql.GetAzureFunctionsParams, mssql.GetAzureFunctionsResult, void, void>('azureFunctions/getAzureFunctions');
 }

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -48,8 +48,8 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
      * @param filePath Path of the file to get the Azure functions
      * @returns array of names of Azure functions in the file
      */
-    getAzureFunctions(filePath: string): Thenable<mssql.getAzureFunctionsResult> {
-        const params: mssql.getAzureFunctionsParams = {
+    getAzureFunctions(filePath: string): Thenable<mssql.GetAzureFunctionsResult> {
+        const params: mssql.GetAzureFunctionsParams = {
             filePath: filePath
         };
 

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -17,7 +17,7 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
     constructor(private _client: SqlToolsServiceClient) { }
 
     /**
-     *
+     * Adds a SQL Binding to a specified Azure function in a file
      * @param bindingType Type of SQL Binding
      * @param filePath Path of the file where the Azure Functions are
      * @param functionName Name of the function where the SQL Binding is to be added
@@ -41,5 +41,18 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
         };
 
         return this._client.sendRequest(azureFunctionsContracts.AddSqlBindingRequest.type, params);
+    }
+
+    /**
+     * Gets the names of the Azure functions in the file
+     * @param filePath Path of the file to get the Azure functions
+     * @returns array of names of Azure functions in the file
+     */
+    getAzureFunctions(filePath: string): Thenable<mssql.getAzureFunctionsResult> {
+        const params: mssql.getAzureFunctionsParams = {
+            filePath: filePath
+        };
+
+        return this._client.sendRequest(azureFunctionsContracts.GetAzureFunctionsRequest.type, params);
     }
 }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -264,8 +264,21 @@ declare module 'vscode-mssql' {
     }
 
     export interface IAzureFunctionsService {
+        /**
+         * Adds a SQL Binding to a specified Azure function in a file
+         * @param bindingType Type of SQL Binding
+         * @param filePath Path of the file where the Azure Functions are
+         * @param functionName Name of the function where the SQL Binding is to be added
+         * @param objectName Name of Object for the SQL Query
+         * @param connectionStringSetting Setting for the connection string
+         */
         addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Thenable<ResultStatus>;
-        getAzureFunctions(filePath: string): Thenable<getAzureFunctionsResult>;
+        /**
+         * Gets the names of the Azure functions in the file
+         * @param filePath Path of the file to get the Azure functions
+         * @returns array of names of Azure functions in the file
+         */
+        getAzureFunctions(filePath: string): Thenable<GetAzureFunctionsResult>;
     }
 
     export const enum TaskExecutionMode {
@@ -556,11 +569,11 @@ declare module 'vscode-mssql' {
         connectionStringSetting: string;
     }
 
-    export interface getAzureFunctionsParams {
+    export interface GetAzureFunctionsParams {
         filePath: string;
     }
 
-    export interface getAzureFunctionsResult extends ResultStatus {
+    export interface GetAzureFunctionsResult extends ResultStatus {
         azureFunctions: string[];
     }
 }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -265,6 +265,7 @@ declare module 'vscode-mssql' {
 
     export interface IAzureFunctionsService {
         addSqlBinding(bindingType: BindingType, filePath: string, functionName: string, objectName: string, connectionStringSetting: string): Thenable<ResultStatus>;
+        getAzureFunctions(filePath: string): Thenable<getAzureFunctionsResult>;
     }
 
     export const enum TaskExecutionMode {
@@ -553,5 +554,13 @@ declare module 'vscode-mssql' {
         objectName: string;
         bindingType: BindingType;
         connectionStringSetting: string;
+    }
+
+    export interface getAzureFunctionsParams {
+        filePath: string;
+    }
+
+    export interface getAzureFunctionsResult extends ResultStatus {
+        azureFunctions: string[];
     }
 }


### PR DESCRIPTION
Adds the getAzureFunctions api that was added to SqlToolsService in https://github.com/microsoft/sqltoolsservice/pull/1228. This will be used by the add sql bindings flow in sql database projects (https://github.com/microsoft/azuredatastudio/pull/16553)