### PR TITLE
Show last task status on completion

### DIFF
--- a/src/services/sqlTasksService.ts
+++ b/src/services/sqlTasksService.ts
@@ -62,7 +62,8 @@ namespace CancelTaskRequest {
 type ActiveTaskInfo = {
     taskInfo: TaskInfo,
     progressCallback: ProgressCallback,
-    completionPromise: Deferred<void>
+    completionPromise: Deferred<void>,
+    lastMessage?: string
 };
 type ProgressCallback = (value: { message?: string; increment?: number }) => void;
 
@@ -132,6 +133,10 @@ export class SqlTasksService {
             return;
         }
         const taskStatusString = toTaskStatusDisplayString(taskProgressInfo.status);
+        if (taskProgressInfo.message && (taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase())) {
+            taskInfo.lastMessage = taskProgressInfo.message;
+        }
+
         if (isTaskCompleted(taskProgressInfo.status)) {
             // Task is completed, complete the progress notification and display a final toast informing the
             // user of the final status.
@@ -142,10 +147,12 @@ export class SqlTasksService {
                 taskInfo.completionPromise.resolve();
             }
 
+            // Get the message to display, if the last status doesn't have a valid message then get the last valid one
+            const lastMessage = (taskProgressInfo.message && taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase()) ?? taskInfo.lastMessage;
             // Only include the message if it isn't the same as the task status string we already have - some (but not all) task status
             // notifications include this string as the message
-            const taskMessage = taskProgressInfo.message && taskProgressInfo.message.toLowerCase() !== taskStatusString.toLowerCase() ?
-                utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, taskProgressInfo.message) :
+            const taskMessage = lastMessage ?
+                utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, lastMessage) :
                 utils.formatString(localizedConstants.taskStatusWithName, taskInfo.taskInfo.name, taskStatusString);
             showCompletionMessage(taskProgressInfo.status, taskMessage);
             if (taskInfo.taskInfo.taskExecutionMode === TaskExecutionMode.script && taskProgressInfo.script) {

--- a/src/services/sqlTasksService.ts
+++ b/src/services/sqlTasksService.ts
@@ -152,7 +152,7 @@ export class SqlTasksService {
             // Only include the message if it isn't the same as the task status string we already have - some (but not all) task status
             // notifications include this string as the message
             const taskMessage = lastMessage ?
-                utils.formatString(localizedConstants.taskStatusWithMessage, taskInfo.taskInfo.name, taskStatusString, lastMessage) :
+                utils.formatString(localizedConstants.taskStatusWithNameAndMessage, taskInfo.taskInfo.name, taskStatusString, lastMessage) :
                 utils.formatString(localizedConstants.taskStatusWithName, taskInfo.taskInfo.name, taskStatusString);
             showCompletionMessage(taskProgressInfo.status, taskMessage);
             if (taskInfo.taskInfo.taskExecutionMode === TaskExecutionMode.script && taskProgressInfo.script) {


### PR DESCRIPTION
This is matching ADS behavior - we store the last valid status message for the task and show that in the final notification since not all tasks return the error message as part of the final completion status update. (Not sure if this is by design or what)

![image](https://user-images.githubusercontent.com/28519865/130704906-2f22d878-9bad-48d5-8c69-4eb86780f513.png)

![image](https://user-images.githubusercontent.com/28519865/130705303-f47d460d-01e7-4a78-bdeb-089d9c8abc58.png)

I also fixed an issue where the final message wasn't displaying the task name like was intended.

Further improvements could be to have the entire history of status messages logged somewhere for easy reviewing, but this at least lets users see things like errors when the deploy/publish task fails. 