### PR TITLE
generate source maps with correct options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,9 +68,7 @@ gulp.task('ext:compile-src', (done) => {
                 })
                 .pipe(nls.rewriteLocalizeCalls())
                 .pipe(nls.createAdditionalLanguageFiles(nls.coreLanguages, config.paths.project.root + '/localization/i18n', undefined, false))
-                .pipe(srcmap.write('.', {
-                   sourceRoot: function(file){ return file.cwd + '/src'; }
-                }))
+                .pipe(srcmap.write('.'))
                 .pipe(gulp.dest('out/src/'));
 });
 
@@ -83,9 +81,7 @@ gulp.task('ext:compile-view', (done) => {
         .pipe(tsProject())
         .pipe(nls.rewriteLocalizeCalls())
         .pipe(nls.createAdditionalLanguageFiles(nls.coreLanguages, config.paths.project.root + '/localization/i18n', undefined, false))
-        .pipe(srcmap.write('.', {
-            sourceRoot: function(file){ return file.cwd + '/src'; }
-        }))
+        .pipe(srcmap.write('.'))
         .pipe(gulp.dest('out/src/views/htmlcontent'));
 });
 
@@ -210,9 +206,7 @@ gulp.task('ext:compile-tests', (done) => {
                 process.exit(1);
             }
         })
-        .pipe(srcmap.write('.', {
-           sourceRoot: function(file){ return file.cwd + '/test'; }
-                }))
+        .pipe(srcmap.write('.'))
         .pipe(gulp.dest('out/test/'));
 
 });


### PR DESCRIPTION
I've been having issue debugging the extension with typescript files, the breakpoints are displayed as unbound, and Aditya said he also had the same problem for a long time, I spent some time today and realized path information in the generated .js.map is wrong, e.g. it has:
```
"sources":["../../src/controllers/mainController.ts"]
...
"sourceRoot":"C:\\git\\vscode-mssql/src"
```
this will result in non-exists location. (I tested that the mixed use of \\ and / is actually fine here).

fix:
there are 2 options.

1. make entries in sources property start from the source root, e.g. `controllers/mainController.ts`, tested manually and it works. but I don't see an option to make it this way.
2. remove the `sourceRoot` property and the path in the sources property will be resolved correctly. - the approach I used in this PR.

