### PR TITLE
Add icon to create new connection

### DIFF
--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -116,7 +116,7 @@ export class ConnectionStore {
     public getPickListItems(): IConnectionCredentialsQuickPickItem[] {
         let pickListItems: IConnectionCredentialsQuickPickItem[] = this.loadAllConnections(true);
         pickListItems.push(<IConnectionCredentialsQuickPickItem> {
-            label: LocalizedConstants.CreateProfileFromConnectionsListLabel,
+            label: `$(add) ${LocalizedConstants.CreateProfileFromConnectionsListLabel}`,
             connectionCreds: undefined,
             quickPickItemType: CredentialsQuickPickItemType.NewConnection
         });


### PR DESCRIPTION
I've been adding icons to the quickpick options for the sql proj extensions that launch actions vs just choosing a value (to more easily differentiate them from something like a server name) and figured I'd update this one too.

![image](https://user-images.githubusercontent.com/28519865/131414180-a9776a39-3ad6-4a5c-b207-9c473f632764.png)
