### PR TITLE
Enable scripting CREATE/DROP for triggers, keys, indexes, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,12 +259,12 @@
         },
         {
           "command": "mssql.scriptCreate",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
           "group": "MS_SQL@2"
         },
         {
           "command": "mssql.scriptDelete",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
           "group": "MS_SQL@3"
         },
         {

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "3.0.0-release.124",
+        "version": "3.0.0-release.127",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-net5.0.zip",
             "Windows_7_64": "win-x64-net5.0.zip",

--- a/src/models/contracts/scripting/scriptingRequest.ts
+++ b/src/models/contracts/scripting/scriptingRequest.ts
@@ -210,7 +210,7 @@ export interface IScriptingObject {
     /**
 	 * The parent object name which is needed for scripting subobjects like triggers or indexes
 	 */
-	parentName?: string;
+    parentName?: string;
 
 	/**
 	 * The parent object type name such as Table, View, etc.

--- a/src/models/contracts/scripting/scriptingRequest.ts
+++ b/src/models/contracts/scripting/scriptingRequest.ts
@@ -206,6 +206,16 @@ export interface IScriptingObject {
      * The database object name
      */
     name: string;
+
+    /**
+	 * The parent object name which is needed for scripting subobjects like triggers or indexes
+	 */
+	parentName: string;
+
+	/**
+	 * The parent object type name such as Table, View, etc.
+	 */
+    parentTypeName: string;
 }
 
 export interface IScriptingParams {

--- a/src/models/contracts/scripting/scriptingRequest.ts
+++ b/src/models/contracts/scripting/scriptingRequest.ts
@@ -210,12 +210,12 @@ export interface IScriptingObject {
     /**
 	 * The parent object name which is needed for scripting subobjects like triggers or indexes
 	 */
-	parentName: string;
+	parentName?: string;
 
 	/**
 	 * The parent object type name such as Table, View, etc.
 	 */
-    parentTypeName: string;
+    parentTypeName?: string;
 }
 
 export interface IScriptingParams {

--- a/src/models/contracts/scripting/scriptingRequest.ts
+++ b/src/models/contracts/scripting/scriptingRequest.ts
@@ -208,13 +208,13 @@ export interface IScriptingObject {
     name: string;
 
     /**
-	 * The parent object name which is needed for scripting subobjects like triggers or indexes
-	 */
+     * The parent object name which is needed for scripting subobjects like triggers or indexes
+     */
     parentName?: string;
 
-	/**
-	 * The parent object type name such as Table, View, etc.
-	 */
+    /**
+     * The parent object type name such as Table, View, etc.
+     */
     parentTypeName?: string;
 }
 

--- a/src/scripting/scriptingService.ts
+++ b/src/scripting/scriptingService.ts
@@ -52,7 +52,7 @@ export class ScriptingService {
             schema: metadata.schema,
             name: metadata.name,
             parentName: metadata.parentName,
-		    parentTypeName: metadata.parentTypeName
+            parentTypeName: metadata.parentTypeName
         };
         return scriptingObject;
     }

--- a/src/scripting/scriptingService.ts
+++ b/src/scripting/scriptingService.ts
@@ -50,7 +50,9 @@ export class ScriptingService {
         let scriptingObject: IScriptingObject = {
             type: metadata.metadataTypeName,
             schema: metadata.schema,
-            name: metadata.name
+            name: metadata.name,
+            parentName: metadata.parentName,
+		    parentTypeName: metadata.parentTypeName
         };
         return scriptingObject;
     }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -554,6 +554,10 @@ declare module 'vscode-mssql' {
         name: string;
 
         schema: string;
+
+	    parentName: string;
+
+	    parentTypeName: string;
     }
 
    /**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -555,9 +555,9 @@ declare module 'vscode-mssql' {
 
         schema: string;
 
-	    parentName: string;
+	    parentName?: string;
 
-	    parentTypeName: string;
+	    parentTypeName?: string;
     }
 
    /**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -555,9 +555,9 @@ declare module 'vscode-mssql' {
 
         schema: string;
 
-	    parentName?: string;
+        parentName?: string;
 
-	    parentTypeName?: string;
+        parentTypeName?: string;
     }
 
    /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/16962 by adding scripting commands to common schema objects, such as triggers.  This is porting over the ads change from https://github.com/microsoft/azuredatastudio/pull/16885.