### PR TITLE
Include AzureMFA as valid value in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,8 @@
                 "default": "SqlLogin",
                 "enum": [
                   "Integrated",
-                  "SqlLogin"
+                  "SqlLogin",
+                  "AzureMFA"
                 ],
                 "description": "[Optional] Specify the SQL Server authentication type."
               },


### PR DESCRIPTION
Added support for Settings.json to recognise AzureMFA as a valid value for authenticationType.