### PR TITLE
Fix publisher for ADS extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "vscode.sql"
   ],
   "extensionPack": [
-    "Microsoft.data-workspace-vscode",
-    "Microsoft.sql-database-projects-vscode"
+    "ms-mssql.data-workspace-vscode",
+    "ms-mssql.sql-database-projects-vscode"
   ],
   "devDependencies": {
     "@angular/common": "~2.1.2",


### PR DESCRIPTION
Publisher needs to match the ID of the one we own (ms-sql, not Microsoft)

Preceded by https://github.com/microsoft/azuredatastudio/pull/17505