### PR TITLE
Add expiresOn field to tokens

### DIFF
--- a/lib/ads-adal-library/src/engine/AzureAuth.ts
+++ b/lib/ads-adal-library/src/engine/AzureAuth.ts
@@ -122,6 +122,7 @@ export abstract class AzureAuth {
 			const currentTime = new Date().getTime() / 1000;
 
 			let accessToken = cachedTokens.accessToken;
+			let expiresOn = Number(cachedTokens.expiresOn);
 			const remainingTime = expiry - currentTime;
 			const maxTolerance = 2 * 60; // two minutes
 
@@ -131,11 +132,13 @@ export abstract class AzureAuth {
 					return undefined;
 				}
 				accessToken = result.accessToken;
+				expiresOn = Number(result.expiresOn);
 			}
 			// Let's just return here.
 			if (accessToken) {
 				return {
 					...accessToken,
+					expiresOn: expiresOn,
 					tokenType: 'Bearer'
 				};
 			}
@@ -155,6 +158,7 @@ export abstract class AzureAuth {
 		if (result?.accessToken) {
 			return {
 				...result.accessToken,
+				expiresOn: Number(result.accessToken),
 				tokenType: 'Bearer'
 			};
 		}

--- a/lib/ads-adal-library/src/models/auth.ts
+++ b/lib/ads-adal-library/src/models/auth.ts
@@ -32,6 +32,12 @@ export interface AccessToken extends TokenKey {
 	 * Access Token
 	 */
 	token: string;
+
+	/**
+	 * Access token expiry timestamp
+	 */
+	 expiresOn?: number;
+
 }
 
 export interface Token extends AccessToken {


### PR DESCRIPTION
Add expiresOn field to tokens so that we can easily check if a token is expired.  This will help fix https://github.com/microsoft/vscode-mssql/issues/17086 and is in line with the fix that @caohai implemented in ADS here: https://github.com/microsoft/azuredatastudio/pull/16936

Once this fix is merged I will do a new release of the ads-adal-library and then can proceed with the rest of the changes on the vscode-mssql side for https://github.com/microsoft/vscode-mssql/issues/17086.