### PR TITLE
Add build ads-adal-package to pipeline

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -61,6 +61,32 @@ steps:
     Contents: '*.vsix'
     TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
+  displayName: Install ads-adal-library dependencies
+  inputs:
+    projectDirectory: $(Build.SourcesDirectory)/lib/ads-adal-library
+    arguments: --frozen-lockfile
+
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
+  displayName: build ads-adal-library
+  inputs:
+    projectDirectory: $(Build.SourcesDirectory)/lib/ads-adal-library
+    arguments: build
+
+- task: Npm@1
+  displayName: Package ads-adal-library
+  inputs:
+    command: custom
+    customCommand: pack
+    workingDir: $(Build.SourcesDirectory)/lib/ads-adal-library
+
+- task: CopyFiles@2
+  displayName: 'Copy ads-adal-library package to: $(Build.ArtifactStagingDirectory)'
+  inputs:
+    SourceFolder: $(Build.SourcesDirectory)/lib/ads-adal-library
+    Contents: '*.tgz'
+    TargetFolder: $(Build.ArtifactStagingDirectory)
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: drop'
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -55,7 +55,7 @@ steps:
     targets: 'package:online'
 
 - task: CopyFiles@2
-  displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+  displayName: 'Copy VSIXs to artifacts directory'
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)'
     Contents: '*.vsix'
@@ -68,7 +68,7 @@ steps:
     arguments: --frozen-lockfile
 
 - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
-  displayName: build ads-adal-library
+  displayName: Build ads-adal-library
   inputs:
     projectDirectory: $(Build.SourcesDirectory)/lib/ads-adal-library
     arguments: build
@@ -81,7 +81,7 @@ steps:
     workingDir: $(Build.SourcesDirectory)/lib/ads-adal-library
 
 - task: CopyFiles@2
-  displayName: 'Copy ads-adal-library package to: $(Build.ArtifactStagingDirectory)'
+  displayName: 'Copy ads-adal-library package to artifacts directory'
   inputs:
     SourceFolder: $(Build.SourcesDirectory)/lib/ads-adal-library
     Contents: '*.tgz'

--- a/lib/ads-adal-library/.gitignore
+++ b/lib/ads-adal-library/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .DS_Store
 dist
+*.tgz

--- a/lib/ads-adal-library/.npmignore
+++ b/lib/ads-adal-library/.npmignore
@@ -1,0 +1,5 @@
+src
+.eslintignore
+.eslintrc.json
+*.tgz
+tsconfig.json

--- a/lib/ads-adal-library/package.json
+++ b/lib/ads-adal-library/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "yarn run build-ts && yarn run lint",
     "build-ts": "tsc",
-    "lint": "tsc --noEmit && eslint \"src/**/*.{js,ts}\" --quiet --fix",
+    "lint": "tsc --noEmit && eslint \"src/**/*.{js,ts}\" --quiet",
     "start-cli": "node dist/cli.js",
     "watch": "yarn run watch-ts",
     "watch-ts": "tsc -w"


### PR DESCRIPTION
This is important so we have a much more controlled publishing process (instead of building and pushing the package locally...)

The publish part will still be manual since we'll still want to control when we push new packages. (could easily make a release pipeline for that if we wanted to though)

Also removed fix from linting for that package since we'll be running it as part of the automated build now. Can always add another script to do that later if people find it useful.