### PR TITLE
Fix tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,13 +24,13 @@
         {
             "label": "cover:enable",
             "type": "gulp",
-            "task": "--no-color",
+            "task": "cover:disable",
             "problemMatcher": []
         },
         {
             "label": "cover:disable",
             "type": "gulp",
-            "task": "--no-color",
+            "task": "cover:disable",
             "problemMatcher": []
         }
     ]


### PR DESCRIPTION
The --no-color was already being added above, we need to specify the actual gulp command to run instead. (this was broken when updating to v2 of the tasks.json)