### PR TITLE
Add ads-adal-library to @microsoft scope

### DIFF
--- a/lib/ads-adal-library/PUBLISHING.md
+++ b/lib/ads-adal-library/PUBLISHING.md
@@ -1,0 +1,6 @@
+These steps should be followed to publish a new version of the package to npmjs.
+
+1. Bump version if needed
+2. Download ads-adal-library-X.X.X.tgz package from [Official Build Pipeline](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build?definitionId=391&_a=summary) artifacts
+3. Run `npm publish <PATH_TO_PACKAGE>/ads-adal-library-X.X.X.tgz`
+   * If you do not have permissions to publish see [Publishing Microsoft scoped packages](https://docs.opensource.microsoft.com/releasing/publish/npm/#publish-microsoft-scoped-packages) to get access

--- a/lib/ads-adal-library/package.json
+++ b/lib/ads-adal-library/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ads-adal-library",
+  "name": "@microsoft/ads-adal-library",
   "version": "1.0.13",
   "description": "ADAL NodeJS authentication library",
   "main": "dist/index.js",


### PR DESCRIPTION
All packages owned by our team should generally be published under the @microsoft scope

Added basic instructions - for now this will be a manual process since it isn't something I anticipate needing to be updated very often. 