### PR TITLE
Fix broken check

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -390,7 +390,7 @@ export default class ConnectionManager {
             connection.errorMessage = result.errorMessage;
         } else {
             const platformInfo = await PlatformInformation.getCurrent();
-            if (!platformInfo.isWindows() && result.errorMessage && result.errorMessage.includes('Kerberos')) {
+            if (!platformInfo.isWindows && result.errorMessage && result.errorMessage.includes('Kerberos')) {
                 const action = await this.vscodeWrapper.showErrorMessage(
                     Utils.formatString(LocalizedConstants.msgConnectionError2, result.errorMessage),
                     LocalizedConstants.macOpenSslHelpButton);

--- a/src/languageservice/serviceInstallerUtil.ts
+++ b/src/languageservice/serviceInstallerUtil.ts
@@ -64,7 +64,7 @@ let serverProvider = new  ServerProvider(downloadProvider, config, statusView);
 export function installService(runtime: Runtime): Promise<String> {
     if (runtime === undefined) {
         return PlatformInformation.getCurrent().then( platformInfo => {
-            if (platformInfo.isValidRuntime()) {
+            if (platformInfo.isValidRuntime) {
                 return serverProvider.getOrDownloadServer(platformInfo.runtimeId);
             } else {
                 throw new Error('unsupported runtime');
@@ -82,7 +82,7 @@ export function getServiceInstallDirectory(runtime: Runtime): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         if (runtime === undefined) {
             PlatformInformation.getCurrent().then( platformInfo => {
-                if (platformInfo.isValidRuntime()) {
+                if (platformInfo.isValidRuntime) {
                     resolve(downloadProvider.getInstallDirectory(platformInfo.runtimeId));
                 } else {
                     reject('unsupported runtime');

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -176,7 +176,7 @@ export default class SqlToolsServiceClient {
             this._logger.appendLine(Constants.commandsNotAvailableWhileInstallingTheService);
             this._logger.appendLine();
             this._logger.append(`Platform: ${platformInfo.toString()}`);
-            if (!platformInfo.isValidRuntime()) {
+            if (!platformInfo.isValidRuntime) {
                 Utils.showErrorMsg(Constants.unsupportedPlatformErrorMessage);
                 reject('Invalid Platform');
             } else {
@@ -198,12 +198,12 @@ export default class SqlToolsServiceClient {
                         }
                         let installedServerPath = await this._server.downloadServerFiles(platformInfo.runtimeId);
                         this._sqlToolsServicePath = path.dirname(installedServerPath);
-                        this.initializeLanguageClient(installedServerPath, context, platformInfo.isWindows());
+                        this.initializeLanguageClient(installedServerPath, context, platformInfo.isWindows);
                         await this._client.onReady();
                         resolve(new ServerInitializationResult(true, true, installedServerPath));
                     } else {
                         this._sqlToolsServicePath = path.dirname(serverPath);
-                        this.initializeLanguageClient(serverPath, context, platformInfo.isWindows());
+                        this.initializeLanguageClient(serverPath, context, platformInfo.isWindows);
                         await this._client.onReady();
                         resolve(new ServerInitializationResult(false, true, serverPath));
                     }
@@ -217,7 +217,7 @@ export default class SqlToolsServiceClient {
     }
 
     private updateServiceVersion(platformInfo: PlatformInformation): void {
-        if (platformInfo.isMacOS() && platformInfo.isMacVersionLessThan('10.12.0')) {
+        if (platformInfo.isMacOS && platformInfo.isMacVersionLessThan('10.12.0')) {
             // Version 1.0 is required as this is the last one supporting downlevel macOS versions
             this._config.useServiceVersion(1);
         }

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -144,19 +144,19 @@ export class PlatformInformation {
         }
     }
 
-    public isWindows(): boolean {
+    public get isWindows(): boolean {
         return this.platform === 'win32';
     }
 
-    public isMacOS(): boolean {
+    public get isMacOS(): boolean {
         return this.platform === 'darwin';
     }
 
-    public isLinux(): boolean {
+    public get isLinux(): boolean {
         return this.platform === 'linux';
     }
 
-    public isValidRuntime(): boolean {
+    public get isValidRuntime(): boolean {
         return this.runtimeId !== undefined && this.runtimeId !== Runtime.UnknownRuntime && this.runtimeId !== Runtime.UnknownVersion;
     }
 


### PR DESCRIPTION
https://github.com/microsoft/vscode-mssql/blob/main/src/models/platform.ts#L168 had incorrect logic for the if - `isMacOS` is a function but wasn't being called as one so would always return true.

I chose to refactor these to use the property getter functionality instead since that's easier to use.

(I looked into a tslint rule for preventing this but there isn't a good one unfortunately)

Note this doesn't actually break anything currently since errors are swallowed. This just saves a fs call that isn't needed and potential weird edge cases from causing issues. 