### PR TITLE
Remove default profiles when adding nodes

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1065,6 +1065,7 @@ export default class MainController implements vscode.Disposable {
             let needsRefresh = false;
             // user connections is a super set of object explorer connections
             let userConnections: any[] = this._vscodeWrapper.getConfiguration(Constants.extensionName).get(Constants.connectionsArrayName);
+            userConnections = userConnections.filter(conn => !Utils.isDefaultConnection(conn));
             let objectExplorerConnections = this._objectExplorerProvider.rootNodeConnections;
 
             // if a connection(s) was/were manually removed

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -494,3 +494,13 @@ export function generateQueryUri(scheme = 'vscode-mssql-adhoc'): vscode.Uri {
         authority: `Query${uriIndex++}`
     });
 }
+
+/**
+ * Returns whether a given saved connection in user connection is a default one
+ * or not
+ */
+export function isDefaultConnection(connection: IConnectionInfo): boolean {
+    return connection.database === '{{put-database-name-here}}' &&
+        connection.server === '{{put-server-name-here}}' &&
+        connection.user === '{{put-username-here}}';
+}


### PR DESCRIPTION
Remove default profiles when populating the OE nodes. Not sure why we need this template, we could perhaps get rid of it, but since it's been there forever, I don't want to assume it's use.

