### PR TITLE
fix toggle sqlcmd mode

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -504,7 +504,7 @@ export default class MainController implements vscode.Disposable {
     }
 
     /**
-     * Handles the command to enable SQLCMD mode
+     * Handles the command to toggle SQLCMD mode
      */
     private async onToggleSqlCmd(): Promise<void> {
         let isSqlCmd: boolean;

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -256,15 +256,6 @@ export default class MainController implements vscode.Disposable {
     }
 
     /**
-     * Helper function to toggle SQLCMD mode
-     */
-    private async toggleSqlCmdMode(isSqlCmd: boolean): Promise<boolean> {
-        await this._outputContentProvider.toggleSqlCmd(this._vscodeWrapper.activeTextEditorUri);
-        await this._connectionMgr.onChooseLanguageFlavor(true, !isSqlCmd);
-        return true;
-    }
-
-    /**
      * Creates a new Object Explorer session
      */
     private async createObjectExplorerSession(connectionCredentials?: IConnectionInfo): Promise<void> {
@@ -515,7 +506,7 @@ export default class MainController implements vscode.Disposable {
     /**
      * Handles the command to enable SQLCMD mode
      */
-    private async onToggleSqlCmd(): Promise<boolean> {
+    private async onToggleSqlCmd(): Promise<void> {
         let isSqlCmd: boolean;
         const uri = this._vscodeWrapper.activeTextEditorUri;
         const queryRunner = this._outputContentProvider.getQueryRunner(uri);
@@ -529,9 +520,9 @@ export default class MainController implements vscode.Disposable {
             const title = path.basename(editor.document.fileName);
             this._outputContentProvider.createQueryRunner(this._statusview, uri, title);
         }
+        await this._outputContentProvider.toggleSqlCmd(this._vscodeWrapper.activeTextEditorUri);
+        await this._connectionMgr.onChooseLanguageFlavor(true, !isSqlCmd);
         this._statusview.sqlCmdModeChanged(this._vscodeWrapper.activeTextEditorUri, !isSqlCmd);
-        const result = await this.toggleSqlCmdMode(!isSqlCmd);
-        return result;
     }
 
     /**


### PR DESCRIPTION
this pr fixes #17071

root cause: for connectionMagr.onChooseLanguageFlavor call, we are toggling the boolean value in the main method and then it got toggled again in the helper method.


with this PR:

sqlcmd: on
![image](https://user-images.githubusercontent.com/13777222/144344930-36b3b57d-ed6a-48c8-9ef6-332e284cff9f.png)


sqlcmd:off
![image](https://user-images.githubusercontent.com/13777222/144344946-eda39a3c-2006-4603-98fe-4cb564261a7b.png)
