### PR TITLE
Fixes connection issue with existing Azure SQL connections

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -705,6 +705,11 @@ export default class ConnectionManager {
             }
         }
         let connectionPromise = new Promise<boolean>(async (resolve, reject) => {
+            if (connectionCreds.connectionString.includes(ConnectionStore.CRED_PREFIX) && connectionCreds.connectionString.includes('isConnectionString:true')) {
+                let connectionString = await this.connectionStore.lookupPassword(connectionCreds, true);
+                connectionCreds.connectionString = connectionString;
+            }
+
             let connectionInfo: ConnectionInfo = new ConnectionInfo();
             connectionInfo.credentials = connectionCreds;
             connectionInfo.connecting = true;

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -705,7 +705,8 @@ export default class ConnectionManager {
             }
         }
         let connectionPromise = new Promise<boolean>(async (resolve, reject) => {
-            if (connectionCreds.connectionString.includes(ConnectionStore.CRED_PREFIX) && connectionCreds.connectionString.includes('isConnectionString:true')) {
+            if (connectionCreds.connectionString.includes(ConnectionStore.CRED_PREFIX)
+                && connectionCreds.connectionString.includes('isConnectionString:true')) {
                 let connectionString = await this.connectionStore.lookupPassword(connectionCreds, true);
                 connectionCreds.connectionString = connectionString;
             }


### PR DESCRIPTION
This PR fixes #16964 

### Description
The change in this PR resolves errors that are encountered while reconnecting to a previously connected database connection. The reason for the connection errors was a result of passing a credential ID, stored in the connection string property, instead of the actual connection string to the SQL Tools Service. When the SQL Tools Service attempted to instantiate a `SqlConnectionStringBuilder` using the credential ID, a formatting exception would be thrown that stopped the connection attempt from completing.

### Test Steps
* Open VS Code
* Install the "SQL Server (MSSQL)" extension
* Open the command palette and enter `>MS SQL: Add Connection`
* Add a connection to an Azure SQL database by providing a connection string:

      Server={uri,port};Initial Catalog={connName};Persist Security Info=False;User ID={userName};Password={password};Connection Timeout=60;

* Close VS Code
* Open VS Code
* Open SQL Server tab and connect to the previously added connection
* Expand `Tables` folder > right click on any of the listed tables > click "Select Top 1000"
* Query results appear and no errors