### PR TITLE
Bump SQL Tools Service to 3.0.0.169

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "3.0.0-release.165",
+        "version": "3.0.0-release.169",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-net5.0.zip",
             "Windows_7_64": "win-x64-net5.0.zip",

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://azuredatastudiobuilds.blob.core.windows.net/sqltoolsservice/v{#version#}/Microsoft.SqlTools.ServiceLayer-{#fileName#}",
-        "version": "3.0.0-release.165",
+        "version": "3.0.0-release.169",
         "downloadFileNames": {
             "Windows_7_86": "win-x86-net5.0.zip",
             "Windows_7_64": "win-x64-net5.0.zip",


### PR DESCRIPTION
Bump SQL Tools Service to 3.0.0.169 so that the 1.12 release uses same STS build as 1.34 ADS release.  This PR is related to https://github.com/microsoft/vscode-mssql/issues/17170.