### PR TITLE
Expose getConnectionString API 

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -260,9 +260,9 @@ export default class ConnectionManager {
     }
 
     /**
-     * Get the connection string for the provided connection ID
-     * @param connectionId The connection ID for the connection.
-     * @param includePassword if password should be included in connection string.
+     * Get the connection string for the provided connection Uri
+     * @param connectionUri The connection Uri for the connection.
+     * @param includePassword (optional) if password should be included in connection string.
      * @returns connection string for the connection
      */
     public async getConnectionString(connectionUri: string, includePassword: boolean = false): Promise<string> {

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -265,7 +265,7 @@ export default class ConnectionManager {
      * @param includePassword if password should be included in connection string.
      * @returns connection string for the connection
      */
-    public async getConnectionString(connectionId: string, includePassword: boolean = false): Promise<string> {
+    public async getConnectionString(connectionInfo: IConnectionInfo, includePassword: boolean = false): Promise<string> {
         const listParams = new ConnectionContracts.GetConnectionStringParams();
         const result = await this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
         return result.connectionString;

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -266,7 +266,9 @@ export default class ConnectionManager {
      * @returns connection string for the connection
      */
     public async getConnectionString(connectionInfo: IConnectionInfo, includePassword: boolean = false): Promise<string> {
+        const uri = Utils.generateQueryUri().toString();
         const listParams = new ConnectionContracts.GetConnectionStringParams();
+        listParams.ownerUri = uri;
         const result = await this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
         return result.connectionString;
     }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -268,6 +268,7 @@ export default class ConnectionManager {
     public async getConnectionString(connectionUri: string, includePassword: boolean = false): Promise<string> {
         const listParams = new ConnectionContracts.GetConnectionStringParams();
         listParams.ownerUri = connectionUri;
+        listParams.includePassword = includePassword;
         const result = await this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
         return result.connectionString;
     }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -260,6 +260,18 @@ export default class ConnectionManager {
     }
 
     /**
+     * Get the connection string for the provided connection ID
+     * @param connectionId The connection ID for the connection.
+     * @param includePassword if password should be included in connection string.
+     * @returns connection string for the connection
+     */
+    public async getConnectionString(connectionId: string, includePassword: boolean = false): Promise<string> {
+        const listParams = new ConnectionContracts.GetConnectionStringParams();
+        const result = await this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
+        return result.connectionString;
+    }
+
+    /**
      * Exposed for testing purposes.
      */
     public getConnectionInfo(fileUri: string): ConnectionInfo {

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -265,10 +265,9 @@ export default class ConnectionManager {
      * @param includePassword if password should be included in connection string.
      * @returns connection string for the connection
      */
-    public async getConnectionString(connectionInfo: IConnectionInfo, includePassword: boolean = false): Promise<string> {
-        const uri = Utils.generateQueryUri().toString();
+    public async getConnectionString(connectionUri: string, includePassword: boolean = false): Promise<string> {
         const listParams = new ConnectionContracts.GetConnectionStringParams();
-        listParams.ownerUri = uri;
+        listParams.ownerUri = connectionUri;
         const result = await this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
         return result.connectionString;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,8 +62,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         dacFx: controller.dacFxService,
         schemaCompare: controller.schemaCompareService,
         azureFunctions: controller.azureFunctionsService,
-        getConnectionString: (connectionInfo: IConnectionInfo, includePassword: boolean) => {
-            return controller.connectionManager.getConnectionString(connectionInfo, includePassword);
+        getConnectionString: (connectionUri: string, includePassword: boolean) => {
+            return controller.connectionManager.getConnectionString(connectionUri, includePassword);
         }
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,8 +62,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         dacFx: controller.dacFxService,
         schemaCompare: controller.schemaCompareService,
         azureFunctions: controller.azureFunctionsService,
-        getConnectionString: (connectionId: string, includePassword: boolean) => {
-            return controller.connectionManager.getConnectionString(connectionId, includePassword);
+        getConnectionString: (connectionInfo: IConnectionInfo, includePassword: boolean) => {
+            return controller.connectionManager.getConnectionString(connectionInfo, includePassword);
         }
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         },
         dacFx: controller.dacFxService,
         schemaCompare: controller.schemaCompareService,
-        azureFunctions: controller.azureFunctionsService
+        azureFunctions: controller.azureFunctionsService,
+        getConnectionString: (connectionId: string, includePassword: boolean) => {
+            return controller.connectionManager.getConnectionString(connectionId, includePassword);
+        }
     };
 }
 

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -256,22 +256,31 @@ export class ListDatabasesResult {
 // ------------------------------- </ List Databases Request > --------------------------------------
 
 // ------------------------------- < Connection String Request > ---------------------------------------
-
-// Get Connection String request callback declaration
+/**
+ * Get Connection String request callback declaration
+ */
 export namespace GetConnectionStringRequest {
     export const type = new RequestType<GetConnectionStringParams, GetConnectionStringResult, void, void>('connection/getconnectionstring');
 }
 
-// Get Connection String request format
+/**
+ * Get Connection String request format
+ */
 export class GetConnectionStringParams {
-    // Connection key to lookup connection string for the provided connection Uri
+    /**
+     * Connection key to lookup connection string for the provided connection Uri
+     */
     public ownerUri: string;
 
-    // Indicates whether to include the password in the connection string
+    /**
+     * Indicates whether to include the password in the connection string
+     */
     public includePassword?: boolean;
 }
 
-// Connection string response format
+/**
+ * Connection string response format
+ */
 export class GetConnectionStringResult {
     public connectionString: string;
 }

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -264,7 +264,7 @@ export namespace GetConnectionStringRequest {
 
 // Get Connection String request format
 export class GetConnectionStringParams {
-    // Connection key to lookup connection string for
+    // Connection key to lookup connection string for the provided connection Uri
     public ownerUri: string;
 
     // Indicates whether to include the password in the connection string

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -254,3 +254,26 @@ export class ListDatabasesResult {
 }
 
 // ------------------------------- </ List Databases Request > --------------------------------------
+
+// ------------------------------- < Connection String Request > ---------------------------------------
+
+// Get Connection String request callback declaration
+export namespace GetConnectionStringRequest {
+    export const type = new RequestType<GetConnectionStringParams, GetConnectionStringResult, void, void>('connection/getconnectionstring');
+}
+
+// Get Connection String request format
+export class GetConnectionStringParams {
+    // Connection key to lookup connection string for
+    public ownerUri: string;
+
+    // Indicates whether to include the password in the connection string
+    public includePassword?: boolean;
+}
+
+// Connection string response format
+export class GetConnectionStringResult {
+    public connectionString: string;
+}
+
+// ------------------------------- </ Connection String Request > --------------------------------------

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -78,7 +78,10 @@ declare module 'vscode-mssql' {
 
         /**
          * Get the connection string for the provided connection Uri
-        */
+         * @param connectionUri The URI of the connection to get the connection string for.
+         * @param includePassword to include password with connection string
+         * @returns connection string
+         */
         getConnectionString(connectionUri: String, includePassword: boolean): Promise<string>;
     }
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -76,6 +76,10 @@ declare module 'vscode-mssql' {
          */
         getDatabaseNameFromTreeNode(node: ITreeNodeInfo): string;
 
+        /**
+         * Get the connection string for the provided connection ID
+        */
+        getConnectionString(connectionId: string, includePassword: boolean): Promise<string>;
     }
 
     /**
@@ -568,9 +572,9 @@ declare module 'vscode-mssql' {
         parentTypeName?: string;
     }
 
-   /**
-     * Azure functions binding type
-     */
+    /**
+      * Azure functions binding type
+      */
     export const enum BindingType {
         input,
         output

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -79,7 +79,7 @@ declare module 'vscode-mssql' {
         /**
          * Get the connection string for the provided connection ID
         */
-        getConnectionString(connectionId: string, includePassword: boolean): Promise<string>;
+        getConnectionString(connectionInfo: IConnectionInfo, includePassword: boolean): Promise<string>;
     }
 
     /**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -82,7 +82,7 @@ declare module 'vscode-mssql' {
          * @param includePassword to include password with connection string
          * @returns connection string
          */
-        getConnectionString(connectionUri: String, includePassword: boolean): Promise<string>;
+        getConnectionString(connectionUri: String, includePassword?: boolean): Promise<string>;
     }
 
     /**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -79,7 +79,7 @@ declare module 'vscode-mssql' {
         /**
          * Get the connection string for the provided connection ID
         */
-        getConnectionString(connectionInfo: IConnectionInfo, includePassword: boolean): Promise<string>;
+        getConnectionString(connectionUri: String, includePassword: boolean): Promise<string>;
     }
 
     /**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -77,7 +77,7 @@ declare module 'vscode-mssql' {
         getDatabaseNameFromTreeNode(node: ITreeNodeInfo): string;
 
         /**
-         * Get the connection string for the provided connection ID
+         * Get the connection string for the provided connection Uri
         */
         getConnectionString(connectionUri: String, includePassword: boolean): Promise<string>;
     }
@@ -572,9 +572,9 @@ declare module 'vscode-mssql' {
         parentTypeName?: string;
     }
 
-    /**
-      * Azure functions binding type
-      */
+   /**
+    * Azure functions binding type
+    */
     export const enum BindingType {
         input,
         output


### PR DESCRIPTION
To be used by the sql-database-projects extension to be used for the Add SQL Binding scenarios. 

In order to get the connectionString for SQL Server, we must set up a way to utilize the STS request for [GetConnectionStringRequest](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs#L953). I utilized the connect() API in sql-db extension to first get the connectionUri and then pass that into the request param for it to then return the connection string.