### PR TITLE
Include AzureMFA as valid value in settings (#17060)

### DIFF
--- a/package.json
+++ b/package.json
@@ -615,7 +615,8 @@
                 "default": "SqlLogin",
                 "enum": [
                   "Integrated",
-                  "SqlLogin"
+                  "SqlLogin",
+                  "AzureMFA"
                 ],
                 "description": "%mssql.connection.authenticationType%"
               },


### PR DESCRIPTION
Added support for Settings.json to recognise AzureMFA as a valid value for authenticationType.

(port of https://github.com/microsoft/vscode-mssql/pull/17060 which was accidently merged into dev branch)