### PR TITLE
Fix spacing in build.yml

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -86,7 +86,7 @@ steps:
       Contents: "*.tgz"
       TargetFolder: $(Build.ArtifactStagingDirectory)
 
- - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM Generation Task'
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
A example space got added into build.yaml when merging spaces->tabs change from main.