### PR TITLE
Added new shortCut color based on what is currently in vscode.light theme

### DIFF
--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -154,11 +154,6 @@
     border-color: silver;
   }
 
-  .vscode-light .shortCut {
-    color: #0A0A0A;
-  }
-
-
   /** Dark Theme and High Contrast **/
 
   .vscode-dark *, .vscode-high-contrast * {
@@ -265,6 +260,7 @@
     background: transparent;
   }
 
+  .vscode-light .shortCut,
   .vscode-dark .shortCut,
   .vscode-high-contrast .shortCut {
     color: var(--color-content);

--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -155,7 +155,7 @@
   }
 
   .vscode-light .shortCut {
-    color: grey;
+    color: #0A0A0A;
   }
 
 

--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -260,9 +260,7 @@
     background: transparent;
   }
 
-  .vscode-light .shortCut,
-  .vscode-dark .shortCut,
-  .vscode-high-contrast .shortCut {
+  .shortCut {
     color: var(--color-content);
   }
 


### PR DESCRIPTION
This changes the color of the shortcut to match what is currently found in the light theme for content in vscode, this is to fix #17195 and also helps it keep consistent with the rest of the vscode light theme