### PR TITLE
Vscode-mssql bugs fixes for table

### DIFF
--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -40,8 +40,8 @@ export interface IGridDataSet {
 
 // tslint:disable:max-line-length
 const template = `
-<div class="fullsize vertBox">
-    <div *ngIf="dataSets.length > 0" role="button" id="resultspane" tabIndex="0" class="boxRow header collapsible"
+<div class="fullsize vertBox" tabindex="-1">
+    <div *ngIf="dataSets.length > 0" role="button" id="resultspane" tabIndex="1" class="boxRow header collapsible"
         [class.collapsed]="!resultActive"
         (click)="toggleResultsPane()"
         (keydown)="handleResultsKeydown($event)"
@@ -50,15 +50,15 @@ const template = `
         <span> {{Constants.resultPaneLabel}} </span>
         <span class="shortCut"> {{resultShortcut}} </span>
     </div>
-    <div id="results" tabIndex="0" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
+    <div id="results" tabindex="-1" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
          (onScroll)="onScroll($event)"
          [scrollEnabled]="scrollEnabled"
          [class.hidden]="!resultActive">
-        <div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index"
+        <div class="boxRow content horzBox slickgrid" tabindex="-1" *ngFor="let dataSet of renderedDataSets; let i = index"
             [style.max-height]="renderedDataSets.length > 1 ? dataSet.maxHeight + 'px' : 'inherit'"
             [style.min-height]="renderedDataSets.length > 1 ? dataSet.minHeight + 'px' : 'inherit'"
             [style.font-size]="resultsFontSize + 'px'">
-            <slick-grid tabindex="0" #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
+            <slick-grid #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
                         [ngClass]="i === activeGrid ? 'active' : ''"
                         [dataRows]="dataSet.dataRows"
                         (contextMenu)="openContextMenu($event, dataSet.batchId, dataSet.resultId, i)"
@@ -69,11 +69,12 @@ const template = `
                         (mousedown)="navigateToGrid(i)"
                         [selectionModel]="selectionModel"
                         [plugins]="slickgridPlugins"
-                        class="boxCol content vertBox slickgrid">
+                        class="boxCol content vertBox slickgrid"
+						tabindex="2">
             </slick-grid>
             <span class="boxCol content vertBox">
-                <div class="boxRow content maxHeight" *ngFor="let icon of dataIcons">
-                    <div *ngIf="icon.showCondition()" class="gridIcon">
+                <div class="boxRow content maxHeight" tabindex="-1"  *ngFor="let icon of dataIcons">
+                    <div *ngIf="icon.showCondition()" class="gridIcon" tabindex="3">
                         <a class="icon" href="#" role="button"
                         (click)="icon.functionality(dataSet.batchId, dataSet.resultId, i)"
                         [title]="icon.hoverText()" [ngClass]="icon.icon()">
@@ -85,7 +86,7 @@ const template = `
     </div>
     <context-menu #contextmenu (clickEvent)="handleContextClick($event)"></context-menu>
     <msg-context-menu #messagescontextmenu (clickEvent)="handleMessagesContextClick($event)"></msg-context-menu>
-    <div id="messagepane" role="button" tabIndex="1" class="boxRow header collapsible"
+    <div id="messagepane" role="button" tabIndex="4" class="boxRow header collapsible"
         [class.collapsed]="!messageActive"
         [attr.aria-label]="Constants.messagePaneLabel"
         [attr.aria-expanded]="messageActive"
@@ -96,7 +97,7 @@ const template = `
         <span> {{Constants.messagePaneLabel}} </span>
         <span class="shortCut"> {{messageShortcut}} </span>
     </div>
-    <div id="messages" class="scrollable messages" [class.hidden]="!messageActive"
+    <div id="messages" class="scrollable messages" tabindex="5" [class.hidden]="!messageActive"
         (contextmenu)="openMessagesContextMenu($event)"
         (mousedown)="onMouseDown($event)">
         <br>
@@ -126,7 +127,7 @@ const template = `
             </tbody>
         </table>
     </div>
-    <div id="resizeHandle" [class.hidden]="!resizing" [style.top.px]="resizeHandleTop"></div>
+    <div id="resizeHandle" tabindex="-1" [class.hidden]="!resizing" [style.top.px]="resizeHandleTop"></div>
 </div>
 `;
 // tslint:enable:max-line-length

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -40,7 +40,7 @@ export interface IGridDataSet {
 
 // tslint:disable:max-line-length
 const template = `
-<div class="fullsize vertBox" tabindex="-1">
+<div class="fullsize vertBox">
     <div *ngIf="dataSets.length > 0" role="button" id="resultspane" tabIndex="1" class="boxRow header collapsible"
         [class.collapsed]="!resultActive"
         (click)="toggleResultsPane()"
@@ -50,15 +50,15 @@ const template = `
         <span> {{Constants.resultPaneLabel}} </span>
         <span class="shortCut"> {{resultShortcut}} </span>
     </div>
-    <div id="results" tabindex="-1" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
+    <div id="results" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
          (onScroll)="onScroll($event)"
          [scrollEnabled]="scrollEnabled"
          [class.hidden]="!resultActive">
-        <div class="boxRow content horzBox slickgrid" tabindex="-1" *ngFor="let dataSet of renderedDataSets; let i = index"
+        <div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index"
             [style.max-height]="renderedDataSets.length > 1 ? dataSet.maxHeight + 'px' : 'inherit'"
             [style.min-height]="renderedDataSets.length > 1 ? dataSet.minHeight + 'px' : 'inherit'"
             [style.font-size]="resultsFontSize + 'px'">
-            <slick-grid #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
+            <slick-grid tabindex="2" #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
                         [ngClass]="i === activeGrid ? 'active' : ''"
                         [dataRows]="dataSet.dataRows"
                         (contextMenu)="openContextMenu($event, dataSet.batchId, dataSet.resultId, i)"
@@ -69,11 +69,10 @@ const template = `
                         (mousedown)="navigateToGrid(i)"
                         [selectionModel]="selectionModel"
                         [plugins]="slickgridPlugins"
-                        class="boxCol content vertBox slickgrid"
-						tabindex="2">
+                        class="boxCol content vertBox slickgrid">
             </slick-grid>
             <span class="boxCol content vertBox">
-                <div class="boxRow content maxHeight" tabindex="-1"  *ngFor="let icon of dataIcons">
+                <div class="boxRow content maxHeight" *ngFor="let icon of dataIcons">
                     <div *ngIf="icon.showCondition()" class="gridIcon" tabindex="3">
                         <a class="icon" href="#" role="button"
                         (click)="icon.functionality(dataSet.batchId, dataSet.resultId, i)"
@@ -127,7 +126,7 @@ const template = `
             </tbody>
         </table>
     </div>
-    <div id="resizeHandle" tabindex="-1" [class.hidden]="!resizing" [style.top.px]="resizeHandleTop"></div>
+    <div id="resizeHandle" [class.hidden]="!resizing" [style.top.px]="resizeHandleTop"></div>
 </div>
 `;
 // tslint:enable:max-line-length

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -46,7 +46,7 @@ const template = `
         (click)="toggleResultsPane()"
         (keydown)="handleResultsKeydown($event)"
         [attr.aria-label]="Constants.resultPaneLabel"
-        [attr.aria-expanded]="!resultActive">
+        [attr.aria-expanded]="resultActive">
         <span> {{Constants.resultPaneLabel}} </span>
         <span class="shortCut"> {{resultShortcut}} </span>
     </div>
@@ -88,7 +88,7 @@ const template = `
     <div id="messagepane" role="button" tabIndex="1" class="boxRow header collapsible"
         [class.collapsed]="!messageActive"
         [attr.aria-label]="Constants.messagePaneLabel"
-        [attr.aria-expanded]="!messageActive"
+        [attr.aria-expanded]="messageActive"
         (click)="toggleMessagesPane()"
         (keydown)="handleMessagesKeydown($event)"
         style="position: relative">

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -41,7 +41,7 @@ export interface IGridDataSet {
 // tslint:disable:max-line-length
 const template = `
 <div class="fullsize vertBox">
-    <div *ngIf="dataSets.length > 0" role="button" id="resultspane" tabIndex="1" class="boxRow header collapsible"
+    <div *ngIf="dataSets.length > 0" role="button" id="resultspane" tabIndex="0" class="boxRow header collapsible"
         [class.collapsed]="!resultActive"
         (click)="toggleResultsPane()"
         (keydown)="handleResultsKeydown($event)"
@@ -58,7 +58,7 @@ const template = `
             [style.max-height]="renderedDataSets.length > 1 ? dataSet.maxHeight + 'px' : 'inherit'"
             [style.min-height]="renderedDataSets.length > 1 ? dataSet.minHeight + 'px' : 'inherit'"
             [style.font-size]="resultsFontSize + 'px'">
-            <slick-grid tabindex="2" #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
+            <slick-grid #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
                         [ngClass]="i === activeGrid ? 'active' : ''"
                         [dataRows]="dataSet.dataRows"
                         (contextMenu)="openContextMenu($event, dataSet.batchId, dataSet.resultId, i)"
@@ -73,7 +73,7 @@ const template = `
             </slick-grid>
             <span class="boxCol content vertBox">
                 <div class="boxRow content maxHeight" *ngFor="let icon of dataIcons">
-                    <div *ngIf="icon.showCondition()" class="gridIcon" tabindex="3">
+                    <div *ngIf="icon.showCondition()" class="gridIcon">
                         <a class="icon" href="#" role="button"
                         (click)="icon.functionality(dataSet.batchId, dataSet.resultId, i)"
                         [title]="icon.hoverText()" [ngClass]="icon.icon()">
@@ -85,7 +85,7 @@ const template = `
     </div>
     <context-menu #contextmenu (clickEvent)="handleContextClick($event)"></context-menu>
     <msg-context-menu #messagescontextmenu (clickEvent)="handleMessagesContextClick($event)"></msg-context-menu>
-    <div id="messagepane" role="button" tabIndex="4" class="boxRow header collapsible"
+    <div id="messagepane" role="button" tabIndex="0" class="boxRow header collapsible"
         [class.collapsed]="!messageActive"
         [attr.aria-label]="Constants.messagePaneLabel"
         [attr.aria-expanded]="messageActive"
@@ -96,7 +96,7 @@ const template = `
         <span> {{Constants.messagePaneLabel}} </span>
         <span class="shortCut"> {{messageShortcut}} </span>
     </div>
-    <div id="messages" class="scrollable messages" tabindex="5" [class.hidden]="!messageActive"
+    <div id="messages" class="scrollable messages" [class.hidden]="!messageActive"
         (contextmenu)="openMessagesContextMenu($event)"
         (mousedown)="onMouseDown($event)">
         <br>


### PR DESCRIPTION
Fixes #17198

also 

Fixes #17209

The changes here that I made are:

Changing the aria-expanded label of the results/messages header to properly reflect the current state of the collapsed/expanded dropdown. (Previously the state announced by the screen reader was opposite), instead of !resultActive/!messageActive, its now simply resultActive/messageActive

<img width="505" alt="aria-expanded-true-screenshot" src="https://user-images.githubusercontent.com/18018452/152609045-a5045cd8-9704-4041-84b9-36d0c0b47e17.png">

The slickgrid is no longer keyboard focusable
