### PR TITLE
vBump STS to 1.9.5 & add optional application name parameter for connection string

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -3,17 +3,17 @@
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
     "version": "3.0.0-release.195",
     "downloadFileNames": {
-      "Windows_7_86": "win-x86-net5.0.zip",
-      "Windows_7_64": "win-x64-net5.0.zip",
-      "OSX_10_11_64": "osx-x64-net5.0.tar.gz",
-      "CentOS_7": "rhel-x64-net5.0.tar.gz",
-      "Debian_8": "rhel-x64-net5.0.tar.gz",
-      "Fedora_23": "rhel-x64-net5.0.tar.gz",
-      "OpenSUSE_13_2": "rhel-x64-net5.0.tar.gz",
-      "SLES_12_2": "rhel-x64-net5.0.tar.gz",
-      "RHEL_7": "rhel-x64-net5.0.tar.gz",
-      "Ubuntu_14": "rhel-x64-net5.0.tar.gz",
-      "Ubuntu_16": "rhel-x64-net5.0.tar.gz"
+      "Windows_7_86": "win-x86-net6.0.zip",
+      "Windows_7_64": "win-x64-net6.0.zip",
+      "OSX_10_11_64": "osx-x64-net6.0.tar.gz",
+      "CentOS_7": "rhel-x64-net6.0.tar.gz",
+      "Debian_8": "rhel-x64-net6.0.tar.gz",
+      "Fedora_23": "rhel-x64-net6.0.tar.gz",
+      "OpenSUSE_13_2": "rhel-x64-net6.0.tar.gz",
+      "SLES_12_2": "rhel-x64-net6.0.tar.gz",
+      "RHEL_7": "rhel-x64-net6.0.tar.gz",
+      "Ubuntu_14": "rhel-x64-net6.0.tar.gz",
+      "Ubuntu_16": "rhel-x64-net6.0.tar.gz"
     },
     "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
     "executableFiles": [

--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "3.0.0-release.174",
+    "version": "3.0.0-release.195",
     "downloadFileNames": {
       "Windows_7_86": "win-x86-net5.0.zip",
       "Windows_7_64": "win-x64-net5.0.zip",

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -265,10 +265,11 @@ export default class ConnectionManager {
 	 * @param includePassword (optional) if password should be included in connection string.
 	 * @returns connection string for the connection
 	 */
-	public async getConnectionString(connectionUri: string, includePassword: boolean = false): Promise<string> {
+	public async getConnectionString(connectionUri: string, includePassword: boolean = false, includeApplicationName: boolean = true): Promise<string> {
 		const listParams = new ConnectionContracts.GetConnectionStringParams();
 		listParams.ownerUri = connectionUri;
 		listParams.includePassword = includePassword;
+		listParams.includeApplicationName = includeApplicationName;
 		return this.client.sendRequest(ConnectionContracts.GetConnectionStringRequest.type, listParams);
 	}
 

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -263,6 +263,7 @@ export default class ConnectionManager {
 	 * Get the connection string for the provided connection Uri
 	 * @param connectionUri The connection Uri for the connection.
 	 * @param includePassword (optional) if password should be included in connection string.
+	 * @param includeApplicationName (optional) if application name should be included in connection string.
 	 * @returns connection string for the connection
 	 */
 	public async getConnectionString(connectionUri: string, includePassword: boolean = false, includeApplicationName: boolean = true): Promise<string> {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -443,7 +443,7 @@ export default class MainController implements vscode.Disposable {
 		// Generate Azure Function command
 		this._context.subscriptions.push(vscode.commands.registerCommand(Constants.cmdCreateAzureFunction, async (node: TreeNodeInfo) => {
 			const connectionUri = this._connectionMgr.getUriForConnection(node.connectionInfo);
-			const connectionString = await this._connectionMgr.getConnectionString(connectionUri);
+			const connectionString = await this._connectionMgr.getConnectionString(connectionUri, false, false);
 			await this.azureFunctionsService.createAzureFunction(connectionString, node.metadata.schema, node.metadata.name);
 		}));
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		dacFx: controller.dacFxService,
 		schemaCompare: controller.schemaCompareService,
 		azureFunctions: controller.azureFunctionsService,
-		getConnectionString: (connectionUri: string, includePassword: boolean, includeApplicationName: boolean) => {
+		getConnectionString: (connectionUri: string, includePassword?: boolean, includeApplicationName?: boolean) => {
 			return controller.connectionManager.getConnectionString(connectionUri, includePassword, includeApplicationName);
 		}
 	};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,8 +62,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		dacFx: controller.dacFxService,
 		schemaCompare: controller.schemaCompareService,
 		azureFunctions: controller.azureFunctionsService,
-		getConnectionString: (connectionUri: string, includePassword: boolean) => {
-			return controller.connectionManager.getConnectionString(connectionUri, includePassword);
+		getConnectionString: (connectionUri: string, includePassword: boolean, includeApplicationName: boolean) => {
+			return controller.connectionManager.getConnectionString(connectionUri, includePassword, includeApplicationName);
 		}
 	};
 }

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -276,6 +276,11 @@ export class GetConnectionStringParams {
 	 * Indicates whether to include the password in the connection string
 	 */
 	public includePassword?: boolean;
+
+	/**
+	 * Indicates whether to include the password in the connection string
+	 */
+	public includeApplicationName?: boolean;
 }
 
 // ------------------------------- </ Connection String Request > --------------------------------------

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -279,6 +279,7 @@ export class GetConnectionStringParams {
 
 	/**
 	 * Indicates whether to include the password in the connection string
+	 * default is set to true
 	 */
 	public includeApplicationName?: boolean;
 }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -80,6 +80,7 @@ declare module 'vscode-mssql' {
 		 * Get the connection string for the provided connection Uri
 		 * @param connectionUri The URI of the connection to get the connection string for.
 		 * @param includePassword to include password with connection string
+		 * @param includeApplicationName to include application name with connection string
 		 * @returns connection string
 		 */
 		getConnectionString(connectionUri: String, includePassword?: boolean, includeApplicationName?: boolean): Promise<string>;

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -82,7 +82,7 @@ declare module 'vscode-mssql' {
 		 * @param includePassword to include password with connection string
 		 * @returns connection string
 		 */
-		getConnectionString(connectionUri: String, includePassword?: boolean): Promise<string>;
+		getConnectionString(connectionUri: String, includePassword?: boolean, includeApplicationName?: boolean): Promise<string>;
 	}
 
 	/**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -79,8 +79,8 @@ declare module 'vscode-mssql' {
 		/**
 		 * Get the connection string for the provided connection Uri
 		 * @param connectionUri The URI of the connection to get the connection string for.
-		 * @param includePassword to include password with connection string
-		 * @param includeApplicationName to include application name with connection string
+		 * @param includePassword Whether the Password is included in the connection string. Default is false.
+		 * @param includeApplicationName Whether the Application Name is included in the connection string. Default is true
 		 * @returns connection string
 		 */
 		getConnectionString(connectionUri: String, includePassword?: boolean, includeApplicationName?: boolean): Promise<string>;


### PR DESCRIPTION
STS PR: https://github.com/microsoft/sqltoolsservice/pull/1380

The goal is to make the application name in the connection string be optional to include. 

Only when is it set to false will it not be set.

[Edit by @smartguest ] Also fixes #17221