### PR TITLE
Add task to generate package.nls.json from English package xlf

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -236,7 +236,7 @@ gulp.task('ext:copy-js', () => {
 // Copy the files which aren't used in compilation
 gulp.task('ext:copy', gulp.series('ext:copy-tests', 'ext:copy-js', 'ext:copy-config', 'ext:copy-systemjs-config', 'ext:copy-dependencies', 'ext:copy-html', 'ext:copy-css', 'ext:copy-images'));
 
-gulp.task('ext:localization', gulp.series('ext:localization:xliff-to-ts', 'ext:localization:xliff-to-json', 'ext:localization:xliff-to-package.nls'));
+gulp.task('ext:localization', gulp.series('ext:localization:generate-eng-package.nls', 'ext:localization:xliff-to-ts', 'ext:localization:xliff-to-json', 'ext:localization:xliff-to-package.nls'));
 
 gulp.task('ext:build', gulp.series('ext:localization', 'ext:copy', 'ext:clean-library-ts-files', 'ext:compile', 'ext:compile-view')); // removed lint before copy
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -236,6 +236,7 @@ gulp.task('ext:copy-js', () => {
 // Copy the files which aren't used in compilation
 gulp.task('ext:copy', gulp.series('ext:copy-tests', 'ext:copy-js', 'ext:copy-config', 'ext:copy-systemjs-config', 'ext:copy-dependencies', 'ext:copy-html', 'ext:copy-css', 'ext:copy-images'));
 
+// Localization (or build) task must be run twice separately to update localized package.nls file after the main English one is updated.
 gulp.task('ext:localization', gulp.series('ext:localization:generate-eng-package.nls', 'ext:localization:xliff-to-ts', 'ext:localization:xliff-to-json', 'ext:localization:xliff-to-package.nls'));
 
 gulp.task('ext:build', gulp.series('ext:localization', 'ext:copy', 'ext:clean-library-ts-files', 'ext:compile', 'ext:compile-view')); // removed lint before copy

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -236,7 +236,6 @@ gulp.task('ext:copy-js', () => {
 // Copy the files which aren't used in compilation
 gulp.task('ext:copy', gulp.series('ext:copy-tests', 'ext:copy-js', 'ext:copy-config', 'ext:copy-systemjs-config', 'ext:copy-dependencies', 'ext:copy-html', 'ext:copy-css', 'ext:copy-images'));
 
-// Localization (or build) task must be run twice separately to update localized package.nls file after the main English one is updated.
 gulp.task('ext:localization', gulp.series('ext:localization:generate-eng-package.nls', 'ext:localization:xliff-to-ts', 'ext:localization:xliff-to-json', 'ext:localization:xliff-to-package.nls'));
 
 gulp.task('ext:build', gulp.series('ext:localization', 'ext:copy', 'ext:clean-library-ts-files', 'ext:compile', 'ext:compile-view')); // removed lint before copy

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -244,8 +244,9 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 				file.basename = 'package.nls.' + iso639_3_to_2[language] + '.json';
 			}
 
-			// Make the new file create on root
-			file.dirname = file.dirname.replace(language, '').replace('xliff', '').replace('localization', '');
+			// Make the new file create on root.
+			// the original directory path was 'vscode-mssql\localization\xliff\<lang>'
+			file.dirname = file.dirname.replace(language, '').replace('localization', '').replace('xliff', '');
 
 			// callback to notify we have completed the current file
 			callback(null, file);

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -1,3 +1,4 @@
+var os = require('os');
 var dom = require('xmldom').DOMParser
 var gulp = require('gulp')
 var config = require('./config')
@@ -132,11 +133,11 @@ gulp.task('ext:localization:xliff-to-ts', function () {
 					contents.push(instantiation);
 				}
 			}
-			// end the function
+
 			contents.push('};');
 
 			// Join with new lines in between
-			let fullFileContents = contents.join('\r\n') + '\r\n';
+			let fullFileContents = contents.join(os.EOL) + os.EOL;
 			file.contents = new Buffer(fullFileContents);
 
 			// Name our file
@@ -156,7 +157,7 @@ gulp.task('ext:localization:generate-eng-package.nls', function () {
 			let dict = convertXmlToDictionary(String(file.contents), false);
 
 			var contents = ['{'];
-			var regxForReplacingQuots = new RegExp('"', 'g');
+			var regxForReplacingQuotes = new RegExp('"', 'g');
 
 			// Get all keys and values from localizedPackage.json.enu.xlf
 			Object.keys(dict).forEach(key => {
@@ -168,17 +169,16 @@ gulp.task('ext:localization:generate-eng-package.nls', function () {
 					value = dict[key]['source'];
 				}
 				if (value && value.indexOf('"') >= 0) {
-					value = value.replace(regxForReplacingQuots, '\'');
+					value = value.replace(regxForReplacingQuotes, '\'');
 				}
 				let instantiation = '"' + key + '":"' + value + '"';
 				contents.push(instantiation);
 			});
 
-			// end the function
 			contents.push('}');
 
 			// Join with new lines in between
-			let fullFileContents = contents.join('\r\n') + '\r\n';
+			let fullFileContents = contents.join(os.EOL) + os.EOL;
 			file.contents = new Buffer(fullFileContents);
 
 			let indexToStart = 'localizedPackage.json.'.length + 1;
@@ -206,7 +206,7 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 			var packageAllKeys = require('./../package.nls.json')
 
 			var contents = ['{'];
-			var regxForReplacingQuots = new RegExp('"', 'g');
+			var regxForReplacingQuotes = new RegExp('"', 'g');
 
 			// Get all the keys from package.nls.json which is the English version and get the localized value from xlf
 			// Use the English value if not translated, right now there's no fall back to English if the text is not localized.
@@ -225,18 +225,17 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 				}
 
 				if (value && value.indexOf('"') >= 0) {
-					value = value.replace(regxForReplacingQuots, '\'');
+					value = value.replace(regxForReplacingQuotes, '\'');
 				}
 				let instantiation = '"' + key + '":"' + value + '"';
 				contents.push(instantiation);
 
 			});
 
-			// end the function
 			contents.push('}');
 
 			// Join with new lines in between
-			let fullFileContents = contents.join('\r\n') + '\r\n';
+			let fullFileContents = contents.join(os.EOL) + os.EOL;
 			file.contents = new Buffer(fullFileContents);
 
 			let indexToStart = 'localizedPackage.json.'.length + 1;

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -2,7 +2,6 @@ var dom = require('xmldom').DOMParser
 var gulp = require('gulp')
 var config = require('./config')
 var through = require('through2')
-var packageAllKeys = require('./../package.nls.json')
 
 const iso639_3_to_2 = {
 	chs: 'zh-cn',
@@ -203,6 +202,8 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 		.pipe(through.obj(function (file, enc, callback) {
 			// convert xliff into json document
 			let dict = convertXmlToDictionary(String(file.contents), false);
+			// Get the latest changes from package.nls.json after being updated.
+			var packageAllKeys = require('./../package.nls.json')
 
 			var contents = ['{'];
 			var regxForReplacingQuots = new RegExp('"', 'g');

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -180,7 +180,6 @@ gulp.task('ext:localization:generate-eng-package.nls', function () {
 
 			// Join with new lines in between
 			let fullFileContents = contents.join('\r\n') + '\r\n';
-			console.log(fullFileContents);
 			file.contents = new Buffer(fullFileContents);
 
 			let indexToStart = 'localizedPackage.json.'.length + 1;
@@ -252,7 +251,6 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 
 			// Make the new file create on root
 			file.dirname = file.dirname.replace(language, '').replace('xliff', '').replace('localization', '');
-			console.log('dirname is ' + file.dirname);
 
 			// callback to notify we have completed the current file
 			callback(null, file);

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -144,110 +144,91 @@ gulp.task('ext:localization:xliff-to-ts', function () {
 		.pipe(gulp.dest(config.paths.project.root + '/src/constants/'));
 });
 
-// Generates a package.nls.json file from localizedPackage.json.enu.xlf
+// Main function used for creating the package.nls.json files, both the original English and localizedFiles.
+function dictionaryMapping(file, packageAllKeys = undefined) {
+	// convert xliff into json document (get the contents of the input XLF file)
+	let dict = convertXmlToDictionary(String(file.contents), false);
+
+	var contents = ['{'];
+	var regxForReplacingQuotes = new RegExp('"', 'g');
+
+	// If packageAllKeys is provided, that means we are updating a localized package.nls.*.json file.
+	let mainKeys = packageAllKeys ? packageAllKeys : dict;
+
+	// If running in English package.nls.json mode:
+
+	// Get keys from the XLF dictionary and use them directly for the file content.
+
+	// If running in Localized package.nls.*.json mode:
+
+	// Get all the keys from package.nls.json which is the English version and get the localized value from xlf
+	// Use the English value if not translated, right now there's no fall back to English if the text is not localized.
+	// So all the keys have to exist in all package.nls.*.json
+	Object.keys(mainKeys).forEach(key => {
+		let value = '';
+		if (contents.length >= 2) {
+			contents[contents.length - 1] += ',';
+		}
+		if (dict.hasOwnProperty(key)) {
+			value = dict[key]['target'];
+		}
+		if (packageAllKeys && value === '') {
+			// If localizing and value is not provided, use original English value.
+			value = packageAllKeys[key];
+		}
+
+		if (value && value.indexOf('"') >= 0) {
+			value = value.replace(regxForReplacingQuotes, '\'');
+		}
+		let instantiation = '"' + key + '":"' + value + '"';
+		contents.push(instantiation);
+
+	});
+
+	contents.push('}');
+
+	// Join with new lines in between
+	let fullFileContents = contents.join(os.EOL) + os.EOL;
+	file.contents = new Buffer(fullFileContents);
+
+	let indexToStart = 'localizedPackage.json.'.length + 1;
+	let languageIndex = file.basename.indexOf('.', indexToStart);
+	let language = file.basename.substr(indexToStart - 1, (languageIndex - indexToStart) + 1);
+
+	// Name our file
+	if (language === 'enu') {
+		file.basename = 'package.nls.json';
+	} else {
+		file.basename = 'package.nls.' + iso639_3_to_2[language] + '.json';
+	}
+
+	// Make the new file create on root.
+	// the original directory path was 'vscode-mssql\localization\xliff\<lang>'
+	file.dirname = file.dirname.replace(language, '').replace('localization', '').replace('xliff', '');
+}
+
+// Generates a package.nls.json file from localizedPackage.json.enu.xlf by using the
+// dictionaryMapping function to write the contents of the xlf file into package.nls.json.
 gulp.task('ext:localization:generate-eng-package.nls', function () {
 	return gulp.src([config.paths.project.localization + '/xliff/enu/localizedPackage.json.enu.xlf'], { base: '.' })
 		.pipe(through.obj(function (file, enc, callback) {
-			// convert xliff into json document
-			let dict = convertXmlToDictionary(String(file.contents), false);
-
-			var contents = ['{'];
-			var regxForReplacingQuotes = new RegExp('"', 'g');
-
-			// Get all keys and values from localizedPackage.json.enu.xlf
-			Object.keys(dict).forEach(key => {
-				let value = '';
-				if (contents.length >= 2) {
-					contents[contents.length - 1] += ',';
-				}
-				if (dict.hasOwnProperty(key)) {
-					value = dict[key]['source'];
-				}
-				if (value && value.indexOf('"') >= 0) {
-					value = value.replace(regxForReplacingQuotes, '\'');
-				}
-				let instantiation = '"' + key + '":"' + value + '"';
-				contents.push(instantiation);
-			});
-
-			contents.push('}');
-
-			// Join with new lines in between
-			let fullFileContents = contents.join(os.EOL) + os.EOL;
-			file.contents = new Buffer(fullFileContents);
-
-			let indexToStart = 'localizedPackage.json.'.length + 1;
-			let languageIndex = file.basename.indexOf('.', indexToStart);
-			let language = file.basename.substr(indexToStart - 1, (languageIndex - indexToStart) + 1);
-
-			file.basename = 'package.nls.json';
-
-			// Make the new file create on root
-			file.dirname = file.dirname.replace(language, '').replace('xliff', '').replace('localization', '');
-
+			dictionaryMapping(file);
 			// callback to notify we have completed the current file
 			callback(null, file);
 		}))
 		.pipe(gulp.dest(config.paths.project.root));
 })
 
-// Generates a localized package.nls.*.json
+// Generates a localized package.nls.*.json file from localizedPackage.json.*.xlf files by
+// using the dictionaryMapping function to replace contents of the package.nls.json file with
+// localized content if possible and write them to a new localized package.nls file.
 gulp.task('ext:localization:xliff-to-package.nls', function () {
 	return gulp.src([config.paths.project.localization + '/xliff/**/localizedPackage.json.*.xlf', '!' + config.paths.project.localization + '/xliff/enu/localizedPackage.json.enu.xlf'], { base: '.' })
 		.pipe(through.obj(function (file, enc, callback) {
-			// convert xliff into json document
-			let dict = convertXmlToDictionary(String(file.contents), false);
-			// Get the latest changes from package.nls.json after being updated.
+
+			// Get the latest changes from package.nls.json after being updated (base English strings).
 			var packageAllKeys = require('./../package.nls.json')
-
-			var contents = ['{'];
-			var regxForReplacingQuotes = new RegExp('"', 'g');
-
-			// Get all the keys from package.nls.json which is the English version and get the localized value from xlf
-			// Use the English value if not translated, right now there's no fall back to English if the text is not localized.
-			// So all the keys have to exist in all package.nls.*.json
-			Object.keys(packageAllKeys).forEach(key => {
-				let value = packageAllKeys[key];
-				if (contents.length >= 2) {
-					contents[contents.length - 1] += ',';
-				}
-				if (dict.hasOwnProperty(key)) {
-
-					value = dict[key]['target'];
-				}
-				if (value === '') {
-					value = packageAllKeys[key];
-				}
-
-				if (value && value.indexOf('"') >= 0) {
-					value = value.replace(regxForReplacingQuotes, '\'');
-				}
-				let instantiation = '"' + key + '":"' + value + '"';
-				contents.push(instantiation);
-
-			});
-
-			contents.push('}');
-
-			// Join with new lines in between
-			let fullFileContents = contents.join(os.EOL) + os.EOL;
-			file.contents = new Buffer(fullFileContents);
-
-			let indexToStart = 'localizedPackage.json.'.length + 1;
-			let languageIndex = file.basename.indexOf('.', indexToStart);
-			let language = file.basename.substr(indexToStart - 1, (languageIndex - indexToStart) + 1);
-
-			// Name our file
-			if (language === 'enu') {
-				file.basename = 'package.nls.json';
-			} else {
-				file.basename = 'package.nls.' + iso639_3_to_2[language] + '.json';
-			}
-
-			// Make the new file create on root.
-			// the original directory path was 'vscode-mssql\localization\xliff\<lang>'
-			file.dirname = file.dirname.replace(language, '').replace('localization', '').replace('xliff', '');
-
+			dictionaryMapping(file, packageAllKeys);
 			// callback to notify we have completed the current file
 			callback(null, file);
 		}))

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -72,11 +72,6 @@ function escapeChars(input, escapeChar = true) {
 	}
 }
 
-// converts plain text json into a json object
-function convertJsonToDictionary(jsonInput) {
-	return JSON.parse(jsonInput);
-}
-
 // export json files from *.xlf
 // mirrors the file paths and names
 gulp.task('ext:localization:xliff-to-json', function () {

--- a/tasks/localizationtasks.js
+++ b/tasks/localizationtasks.js
@@ -149,9 +149,8 @@ gulp.task('ext:localization:xliff-to-ts', function () {
 		.pipe(gulp.dest(config.paths.project.root + '/src/constants/'));
 });
 
-// Generates a localized package.nls.*.json
-gulp.task('ext:localization:xliff-to-package.nls', function () {
-	return gulp.src([config.paths.project.localization + '/xliff/**/localizedPackage.json.*.xlf', '!' + config.paths.project.localization + '/xliff/enu/localizedPackage.json.enu.xlf'], { base: '' })
+gulp.task('ext:localization:generate-eng-package.nls', function () {
+	return gulp.src([config.paths.project.localization + '/xliff/enu/localizedPackage.json.enu.xlf'], { base: '.' })
 		.pipe(through.obj(function (file, enc, callback) {
 			// convert xliff into json document
 			let dict = convertXmlToDictionary(String(file.contents), false);
@@ -202,7 +201,69 @@ gulp.task('ext:localization:xliff-to-package.nls', function () {
 			}
 
 			// Make the new file create on root
-			file.dirname = file.dirname.replace(language, '');
+			file.dirname = file.dirname.replace(language, '').replace('xliff', '').replace('localization', '');
+			console.log('dirname is ' + file.dirname);
+
+			// callback to notify we have completed the current file
+			callback(null, file);
+		}))
+})
+
+// Generates a localized package.nls.*.json
+gulp.task('ext:localization:xliff-to-package.nls', function () {
+	return gulp.src([config.paths.project.localization + '/xliff/**/localizedPackage.json.*.xlf', '!' + config.paths.project.localization + '/xliff/enu/localizedPackage.json.enu.xlf'], { base: '.' })
+		.pipe(through.obj(function (file, enc, callback) {
+			// convert xliff into json document
+			let dict = convertXmlToDictionary(String(file.contents), false);
+
+			var contents = ['{'];
+			var regxForReplacingQuots = new RegExp('"', 'g');
+
+			// Get all the keys from package.nls.json which is the English version and get the localized value from xlf
+			// Use the English value if not translated, right now there's no fall back to English if the text is not localized.
+			// So all the keys have to exist in all package.nls.*.json
+			Object.keys(packageAllKeys).forEach(key => {
+				let value = packageAllKeys[key];
+				if (contents.length >= 2) {
+					contents[contents.length - 1] += ',';
+				}
+				if (dict.hasOwnProperty(key)) {
+
+					value = dict[key]['target'];
+				}
+				if (value === '') {
+					value = packageAllKeys[key];
+				}
+
+				if (value && value.indexOf('"') >= 0) {
+					value = value.replace(regxForReplacingQuots, '\'');
+				}
+				let instantiation = '"' + key + '":"' + value + '"';
+				contents.push(instantiation);
+
+			});
+
+			// end the function
+			contents.push('}');
+
+			// Join with new lines in between
+			let fullFileContents = contents.join('\r\n') + '\r\n';
+			file.contents = new Buffer(fullFileContents);
+
+			let indexToStart = 'localizedPackage.json.'.length + 1;
+			let languageIndex = file.basename.indexOf('.', indexToStart);
+			let language = file.basename.substr(indexToStart - 1, (languageIndex - indexToStart) + 1);
+
+			// Name our file
+			if (language === 'enu') {
+				file.basename = 'package.nls.json';
+			} else {
+				file.basename = 'package.nls.' + iso639_3_to_2[language] + '.json';
+			}
+
+			// Make the new file create on root
+			file.dirname = file.dirname.replace(language, '').replace('xliff', '').replace('localization', '');
+			console.log('dirname is ' + file.dirname);
 
 			// callback to notify we have completed the current file
 			callback(null, file);


### PR DESCRIPTION
This change adds in a gulp task that generates package.nls.json from the English XLF files, and also fixes the file paths of the localized package.nls.json files. This makes it so we are able to generate the package.nls.json files from the localized package XLF file (already the localizedConstants.ts file is generated this way). It is a separate task from the package.nls.*.json generation task because that one relies on using package.nls.json to fill in strings that are missing from the localized XLF file.

However, you will need to run build twice due to a small bug where if you make a change to the English XLF, it will only show up in the package.nls.json file and not in the localized one unless you run the gulp task again, but this is probably due to limitations with gulp/file writing and is a minor thing. 

I've tested both package.nls.json and the localized constants file (which was already in the code) and it seems to work for both. 

This will require adding strings that are currently in package.nls.json and not in the XLF to the XLF itself afterwards.