### PR TITLE
Update to XLFs and constants.ts

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" original="extension.i18ntest.JSON" source-language="en">
+  <file datatype="xml" original="src/constants/localizedConstants" source-language="en">
     <body>
         <trans-unit id="msgStartedExecute">
             <source xml:lang="en">Started query execution for document "{0}"</source>
@@ -92,9 +92,6 @@
         <trans-unit id="databasePlaceholder">
             <source xml:lang="en">[Optional] Database to connect (press Enter to connect to &lt;default&gt; database)</source>
         </trans-unit>
-        <trans-unit id="azureAuthTypePrompt">
-            <source xml:lang="en">Azure Authentication Type</source>
-        </trans-unit>
         <trans-unit id="authTypePrompt">
             <source xml:lang="en">Authentication Type</source>
         </trans-unit>
@@ -151,18 +148,6 @@
         </trans-unit>
         <trans-unit id="profileNamePlaceholder">
             <source xml:lang="en">[Optional] Enter a display name for this connection profile</source>
-        </trans-unit>
-        <trans-unit id="filepathPrompt">
-            <source xml:lang="en">File path</source>
-        </trans-unit>
-        <trans-unit id="filepathMessage">
-            <source xml:lang="en">File name</source>
-        </trans-unit>
-        <trans-unit id="overwritePrompt">
-            <source xml:lang="en">A file with this name already exists. Do you want to replace the existing file?</source>
-        </trans-unit>
-        <trans-unit id="overwritePlaceholder">
-            <source xml:lang="en">A file with this name already exists</source>
         </trans-unit>
         <trans-unit id="msgCannotOpenContent">
             <source xml:lang="en">Error occurred opening content in editor.</source>
@@ -266,9 +251,6 @@
         <trans-unit id="msgPromptRetryConnectionDifferentCredentials">
             <source xml:lang="en">Error: Login failed. Retry using different credentials?</source>
         </trans-unit>
-        <trans-unit id="msgPromptRetryFirewallRuleExtNotInstalled">
-            <source xml:lang="en">Your client IP address does not have access to the server. Download and install the Azure Account extension to sign in to an Azure account and create a new firewall rule to enable access.</source>
-        </trans-unit>
         <trans-unit id="msgPromptRetryFirewallRuleNotSignedIn">
             <source xml:lang="en">Your client IP address does not have access to the server. Add an Azure account and create a new firewall rule to enable access.</source>
         </trans-unit>
@@ -283,12 +265,6 @@
         </trans-unit>
         <trans-unit id="msgUnableToExpand">
             <source xml:lang="en">Unable to expand. Please check logs for more information.</source>
-        </trans-unit>
-        <trans-unit id="msgPromptAzureExtensionActivatedNotSignedIn">
-            <source xml:lang="en">Azure Account extension activated. Sign in to an Azure account? </source>
-        </trans-unit>
-        <trans-unit id="msgPromptAzureExtensionActivatedSignedIn">
-            <source xml:lang="en">Azure Account extension activated and signed in.</source>
         </trans-unit>
         <trans-unit id="msgPromptFirewallRuleCreated">
             <source xml:lang="en">Firewall rule successfully created.</source>
@@ -316,12 +292,6 @@
         </trans-unit>
         <trans-unit id="retryLabel">
             <source xml:lang="en">Retry</source>
-        </trans-unit>
-        <trans-unit id="signInLabel">
-            <source xml:lang="en">Sign In</source>
-        </trans-unit>
-        <trans-unit id="downloadAndInstallLabel">
-            <source xml:lang="en">Download and Install</source>
         </trans-unit>
         <trans-unit id="createFirewallRuleLabel">
             <source xml:lang="en">Create Firewall Rule</source>
@@ -373,12 +343,6 @@
         </trans-unit>
         <trans-unit id="msgDisconnected">
             <source xml:lang="en">Disconnected on document "{0}"</source>
-        </trans-unit>
-        <trans-unit id="msgErrorReadingConfigFile">
-            <source xml:lang="en">Error: Unable to load connection profiles from [{0}]. Check if the file is formatted correctly.</source>
-        </trans-unit>
-        <trans-unit id="titleResultsPane">
-            <source xml:lang="en">Results: {0}</source>
         </trans-unit>
         <trans-unit id="macOpenSslErrorMessage">
             <source xml:lang="en">OpenSSL version >=1.0.1 is required to connect.</source>
@@ -479,9 +443,6 @@
         <trans-unit id="noneProviderName">
             <source xml:lang="en">None</source>
         </trans-unit>
-        <trans-unit id="chooseSqlLang">
-            <source xml:lang="en">Choose SQL Language</source>
-        </trans-unit>
         <trans-unit id="flavorChooseLanguage">
             <source xml:lang="en">Choose SQL Language</source>
         </trans-unit>
@@ -490,12 +451,6 @@
         </trans-unit>
         <trans-unit id="flavorDescriptionNone">
             <source xml:lang="en">Disable intellisense and syntax error checking on current document</source>
-        </trans-unit>
-        <trans-unit id="queryOutputDocumentTitle">
-            <source xml:lang="en">Query Output Document</source>
-        </trans-unit>
-        <trans-unit id="queryOutputHostTitle">
-            <source xml:lang="en">Query Output Document Host</source>
         </trans-unit>
         <trans-unit id="msgAddConnection">
             <source xml:lang="en">Add Connection</source>
@@ -526,6 +481,7 @@
         </trans-unit>
         <trans-unit id="azureFunctionsProjectMustBeOpened">
             <source xml:lang="en">A C# Azure Functions project must be present in order to create a new Azure Function for this table.</source>
+        </trans-unit>
         <trans-unit id="taskStatusWithName">
             <source xml:lang="en">{0}: {1}</source>
         </trans-unit>
@@ -564,6 +520,36 @@
         </trans-unit>
         <trans-unit id="msgClearedRecentConnectionsWithErrors">
             <source xml:lang="en">The recent connections list has been cleared but there were errors while deleting some associated credentials. View the errors in the MSSQL output channel.</source>
+        </trans-unit>
+        <trans-unit id="failedToParse">
+            <source xml:lang="en">Failed to parse "{0}": {1}.</source>
+        </trans-unit>
+        <trans-unit id="settingAlreadyExists">
+            <source xml:lang="en">Local app setting '{0}' already exists. Overwrite?</source>
+        </trans-unit>
+        <trans-unit id="yesString">
+            <source xml:lang="en">Yes</source>
+        </trans-unit>
+        <trans-unit id="functionNameTitle">
+            <source xml:lang="en">Function Name</source>
+        </trans-unit>
+        <trans-unit id="selectProject">
+            <source xml:lang="en">Select the Azure Function project for the SQL Binding</source>
+        </trans-unit>
+        <trans-unit id="timeoutError">
+            <source xml:lang="en">Timed out waiting for azure function file creation</source>
+        </trans-unit>
+        <trans-unit id="azureFunctionsExtensionNotFound">
+            <source xml:lang="en">The Azure Functions extension is required to create a new Azure Function with SQL binding but is not installed, install it now?</source>
+        </trans-unit>
+        <trans-unit id="install">
+            <source xml:lang="en">Install</source>
+        </trans-unit>
+        <trans-unit id="learnMore">
+            <source xml:lang="en">Learn more</source>
+        </trans-unit>
+        <trans-unit id="doNotInstall">
+            <source xml:lang="en">Do not install</source>
         </trans-unit>
     </body>
   </file>

--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -1,51 +1,105 @@
 <?xml version="1.0" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" original="extension.i18ntest.JSON" source-language="en">
+  <file datatype="xml" original="package" source-language="en">
     <body>
-        <trans-unit id="extension.runQuery">
+        <trans-unit id="mssql.runQuery">
             <source xml:lang="en">Execute Query</source>
         </trans-unit>
-        <trans-unit id="extension.runCurrentStatement">
+        <trans-unit id="mssql.runCurrentStatement">
             <source xml:lang="en">Execute Current Statement</source>
         </trans-unit>
-        <trans-unit id="extension.cancelQuery">
+        <trans-unit id="mssql.cancelQuery">
             <source xml:lang="en">Cancel Query</source>
         </trans-unit>
-        <trans-unit id="extension.connect">
+        <trans-unit id="mssql.addObjectExplorer">
+            <source xml:lang="en">Add Connection</source>
+        </trans-unit>
+        <trans-unit id="mssql.scriptSelect">
+            <source xml:lang="en">Select Top 1000</source>
+        </trans-unit>
+        <trans-unit id="mssql.scriptCreate">
+            <source xml:lang="en">Script as Create</source>
+        </trans-unit>
+        <trans-unit id="mssql.scriptDelete">
+            <source xml:lang="en">Script as Drop</source>
+        </trans-unit>
+        <trans-unit id="mssql.scriptExecute">
+            <source xml:lang="en">Script as Execute</source>
+        </trans-unit>
+        <trans-unit id="mssql.scriptAlter">
+            <source xml:lang="en">Script as Alter</source>
+        </trans-unit>
+        <trans-unit id="mssql.openQueryHistory">
+            <source xml:lang="en">Open Query</source>
+        </trans-unit>
+        <trans-unit id="mssql.runQueryHistory">
+            <source xml:lang="en">Run Query</source>
+        </trans-unit>
+        <trans-unit id="mssql.deleteQueryHistory">
+            <source xml:lang="en">Delete</source>
+        </trans-unit>
+        <trans-unit id="mssql.clearAllQueryHistory">
+            <source xml:lang="en">Clear All Query History</source>
+        </trans-unit>
+        <trans-unit id="mssql.enableQueryHistoryCapture">
+            <source xml:lang="en">Enable Query History Capture</source>
+        </trans-unit>
+        <trans-unit id="mssql.startQueryHistoryCapture">
+            <source xml:lang="en">Start Query History Capture</source>
+        </trans-unit>
+        <trans-unit id="mssql.pauseQueryHistoryCapture">
+            <source xml:lang="en">Pause Query History Capture</source>
+        </trans-unit>
+        <trans-unit id="mssql.commandPaletteQueryHistory">
+            <source xml:lang="en">Open Query History in Command Palette</source>
+        </trans-unit>
+        <trans-unit id="mssql.removeObjectExplorerNode">
+            <source xml:lang="en">Remove</source>
+        </trans-unit>
+        <trans-unit id="mssql.refreshObjectExplorerNode">
+            <source xml:lang="en">Refresh</source>
+        </trans-unit>
+        <trans-unit id="extension.connections">
+            <source xml:lang="en">Connections</source>
+        </trans-unit>
+        <trans-unit id="extension.queryHistory">
+            <source xml:lang="en">Query History</source>
+        </trans-unit>
+        <trans-unit id="mssql.connect">
             <source xml:lang="en">Connect</source>
         </trans-unit>
-        <trans-unit id="extension.disconnect">
+        <trans-unit id="mssql.disconnect">
             <source xml:lang="en">Disconnect</source>
         </trans-unit>
-        <trans-unit id="extension.manageProfiles">
+        <trans-unit id="mssql.manageProfiles">
             <source xml:lang="en">Manage Connection Profiles</source>
         </trans-unit>
-        <trans-unit id="extension.chooseDatabase">
+        <trans-unit id="mssql.chooseDatabase">
             <source xml:lang="en">Use Database</source>
         </trans-unit>
-        <trans-unit id="extension.chooseLanguageFlavor">
+        <trans-unit id="mssql.chooseLanguageFlavor">
             <source xml:lang="en">Choose SQL handler for this file</source>
         </trans-unit>
-        <trans-unit id="extension.showGettingStarted">
+        <trans-unit id="mssql.showGettingStarted">
             <source xml:lang="en">Getting Started Guide</source>
         </trans-unit>
-        <trans-unit id="extension.newQuery">
+        <trans-unit id="mssql.newQuery">
             <source xml:lang="en">New Query</source>
         </trans-unit>
-        <trans-unit id="extension.rebuildIntelliSenseCache">
+        <trans-unit id="mssql.objectExplorerNewQuery">
+            <source xml:lang="en">New Query</source>
+        </trans-unit>
+        <trans-unit id="mssql.toggleSqlCmd">
+            <source xml:lang="en">Toggle SQLCMD Mode</source>
+        </trans-unit>
+        <trans-unit id="mssql.copyObjectName">
+            <source xml:lang="en">Copy Object Name</source>
+        </trans-unit>
+        <trans-unit id="mssql.removeAadAccount">
+            <source xml:lang="en">Remove Azure Account</source>
+        </trans-unit>
+        <trans-unit id="mssql.rebuildIntelliSenseCache">
             <source xml:lang="en">Refresh IntelliSense Cache</source>
-        </trans-unit>
-        <trans-unit id="mssql.Configuration">
-            <source xml:lang="en">MSSQL configuration</source>
-        </trans-unit>
-        <trans-unit id="mssql.chooseAuthMethod">
-            <source xml:lang="en">Chooses which Authentication method to use</source>
-        </trans-unit>
-        <trans-unit id="mssql.authCodeGrant.description">
-            <source xml:lang="en">Prompts users to sign in using their browser.</source>
-        </trans-unit>
-        <trans-unit id="mssql.deviceCode.description">
-            <source xml:lang="en">Allows users to sign in to input-constrained devices.</source>
         </trans-unit>
         <trans-unit id="mssql.logDebugInfo">
             <source xml:lang="en">[Optional] Log debug output to the VS Code console (Help -> Toggle Developer Tools)</source>
@@ -57,7 +111,7 @@
             <source xml:lang="en">Connection profiles defined in 'User Settings' are shown under 'MS SQL: Connect' command in the command palette.</source>
         </trans-unit>
         <trans-unit id="mssql.connection.server">
-            <source xml:lang="en"><![CDATA[[Required] Specify the server name to connect to. Use 'hostname\\instance' or '<server>.database.windows.net' for Azure SQL Database.]]></source>
+            <source xml:lang="en"><![CDATA[[Required] Specify the server name to connect to. Use 'hostname instance' or '<server>.database.windows.net' for Azure SQL Database.]]></source>
         </trans-unit>
         <trans-unit id="mssql.connection.database">
             <source xml:lang="en">[Optional] Specify the database name to connect to. If database is not specified, the default user database setting is used, typically 'master'.</source>
@@ -221,11 +275,113 @@
         <trans-unit id="mssql.intelliSense.enableQuickInfo">
             <source xml:lang="en">Should IntelliSense quick info be enabled</source>
         </trans-unit>
+        <trans-unit id="mssql.enableQueryHistoryFeature">
+            <source xml:lang="en">Should Query History feature be enabled</source>
+        </trans-unit>
         <trans-unit id="mssql.intelliSense.lowerCaseSuggestions">
             <source xml:lang="en">Should IntelliSense suggestions be lowercase</source>
         </trans-unit>
         <trans-unit id="mssql.persistQueryResultTabs">
             <source xml:lang="en">Should query result selections and scroll positions be saved when switching tabs (may impact performance)</source>
+        </trans-unit>
+        <trans-unit id="mssql.queryHistoryLimit">
+            <source xml:lang="en">Number of query history entries to show in the Query History view</source>
+        </trans-unit>
+        <trans-unit id="mssql.createAzureFunction">
+            <source xml:lang="en">Create Azure Function with SQL input binding</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.maxXmlCharsToStore">
+            <source xml:lang="en">Number of XML characters to store after running a query</source>
+        </trans-unit>
+        <trans-unit id="mssql.tracingLevel">
+            <source xml:lang="en">[Optional] Log level for backend services. Azure Data Studio generates a file name every time it starts and if the file already exists the logs entries are appended to that file. For cleanup of old log files see logRetentionMinutes and logFilesRemovalLimit settings. The default tracingLevel does not log much. Changing verbosity could lead to extensive logging and disk space requirements for the logs. Error includes Critical, Warning includes Error, Information includes Warning and Verbose includes Information</source>
+        </trans-unit>
+        <trans-unit id="mssql.logRetentionMinutes">
+            <source xml:lang="en">Number of minutes to retain log files for backend services. Default is 1 week.</source>
+        </trans-unit>
+        <trans-unit id="mssql.logFilesRemovalLimit">
+            <source xml:lang="en">Maximum number of old files to remove upon startup that have expired mssql.logRetentionMinutes. Files that do not get cleaned up due to this limitation get cleaned up next time Azure Data Studio starts up.</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.setRowCount">
+            <source xml:lang="en">Maximum number of rows to return before the server stops processing your query.</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.textSize">
+            <source xml:lang="en">Maximum size of text and ntext data returned from a SELECT statement</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.executionTimeout">
+            <source xml:lang="en">An execution time-out of 0 indicates an unlimited wait (no time-out)</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.noCount">
+            <source xml:lang="en">Enable SET NOCOUNT option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.noExec">
+            <source xml:lang="en">Enable SET NOEXEC option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.parseOnly">
+            <source xml:lang="en">Enable SET PARSEONLY option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.arithAbort">
+            <source xml:lang="en">Enable SET ARITHABORT option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.statisticsTime">
+            <source xml:lang="en">Enable SET STATISTICS TIME option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.statisticsIO">
+            <source xml:lang="en">Enable SET STATISTICS IO option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.xactAbortOn">
+            <source xml:lang="en">Enable SET XACT_ABORT ON option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.transactionIsolationLevel">
+            <source xml:lang="en">Enable SET TRANSACTION ISOLATION LEVEL option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.deadlockPriority">
+            <source xml:lang="en">Enable SET DEADLOCK_PRIORITY option</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.lockTimeout">
+            <source xml:lang="en">Enable SET LOCK TIMEOUT option (in milliseconds)</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.queryGovernorCostLimit">
+            <source xml:lang="en">Enable SET QUERY_GOVERNOR_COST_LIMIT</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.ansiDefaults">
+            <source xml:lang="en">Enable SET ANSI_DEFAULTS</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.quotedIdentifier">
+            <source xml:lang="en">Enable SET QUOTED_IDENTIFIER</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.ansiNullDefaultOn">
+            <source xml:lang="en">Enable SET ANSI_NULL_DFLT_ON</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.implicitTransactions">
+            <source xml:lang="en">Enable SET IMPLICIT_TRANSACTIONS</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.cursorCloseOnCommit">
+            <source xml:lang="en">Enable SET CURSOR_CLOSE_ON_COMMIT</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.ansiPadding">
+            <source xml:lang="en">Enable SET ANSI_PADDING</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.ansiWarnings">
+            <source xml:lang="en">Enable SET ANSI_WARNINGS</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.ansiNulls">
+            <source xml:lang="en">Enable SET ANSI_NULLS</source>
+        </trans-unit>
+        <trans-unit id="mssql.query.alwaysEncryptedParameterization">
+            <source xml:lang="en">Enable Parameterization for Always Encrypted</source>
+        </trans-unit>
+        <trans-unit id="mssql.ignorePlatformWarning">
+            <source xml:lang="en">[Optional] Do not show unsupported platform warnings</source>
+        </trans-unit>
+        <trans-unit id="mssql.chooseAuthMethod">
+            <source xml:lang="en">Chooses which Authentication method to use</source>
+        </trans-unit>
+        <trans-unit id="mssql.authCodeGrant.description">
+            <source xml:lang="en">Prompts users to sign in using their browser.</source>
+        </trans-unit>
+        <trans-unit id="mssql.deviceCode.description">
+            <source xml:lang="en">Allows users to sign in to input-constrained devices.</source>
         </trans-unit>
     </body>
   </file>

--- a/src/azureFunction/azureFunctionUtils.ts
+++ b/src/azureFunction/azureFunctionUtils.ts
@@ -64,7 +64,10 @@ export async function setLocalAppSetting(projectFolder: string, key: string, val
 		// don't do anything if it's the same as the existing value
 		return true;
 	} else if (settings.Values[key]) {
-		const result = await vscode.window.showWarningMessage(utils.formatString(LocalizedConstants.settingAlreadyExists, key), { modal: true }, LocalizedConstants.yesString);
+		const result = await vscode.window.showWarningMessage(
+			utils.formatString(LocalizedConstants.settingAlreadyExists, key), { modal: true },
+			LocalizedConstants.yesString
+		);
 		if (result !== LocalizedConstants.yesString) {
 			// key already exists and user doesn't want to overwrite it
 			return false;

--- a/src/azureFunction/azureFunctionUtils.ts
+++ b/src/azureFunction/azureFunctionUtils.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as utils from '../models/utils';
 import * as constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/localizedConstants';
 // https://github.com/microsoft/vscode-azurefunctions/blob/main/src/vscode-azurefunctions.api.d.ts
@@ -37,7 +38,7 @@ export async function getLocalSettingsJson(localSettingsPath: string): Promise<I
 			return JSON.parse(data);
 		} catch (error) {
 			console.log(error);
-			throw new Error(constants.failedToParse(error.message));
+			throw new Error(utils.formatString(LocalizedConstants.failedToParse, constants.azureFunctionLocalSettingsFileName, error.message));
 		}
 	}
 
@@ -63,8 +64,8 @@ export async function setLocalAppSetting(projectFolder: string, key: string, val
 		// don't do anything if it's the same as the existing value
 		return true;
 	} else if (settings.Values[key]) {
-		const result = await vscode.window.showWarningMessage(constants.settingAlreadyExists(key), { modal: true }, constants.yesString);
-		if (result !== constants.yesString) {
+		const result = await vscode.window.showWarningMessage(utils.formatString(LocalizedConstants.settingAlreadyExists, key), { modal: true }, LocalizedConstants.yesString);
+		if (result !== LocalizedConstants.yesString) {
 			// key already exists and user doesn't want to overwrite it
 			return false;
 		}
@@ -84,12 +85,12 @@ export async function setLocalAppSetting(projectFolder: string, key: string, val
 export async function getAzureFunctionsExtensionApi(): Promise<AzureFunctionsExtensionApi | undefined> {
 	let apiProvider = await vscode.extensions.getExtension(constants.azureFunctionsExtensionName)?.activate() as AzureExtensionApiProvider;
 	if (!apiProvider) {
-		const response = await vscode.window.showInformationMessage(constants.azureFunctionsExtensionNotFound,
-			constants.installAzureFunction, constants.learnMore, constants.doNotInstall);
-		if (response === constants.installAzureFunction) {
+		const response = await vscode.window.showInformationMessage(LocalizedConstants.azureFunctionsExtensionNotFound,
+			LocalizedConstants.install, LocalizedConstants.learnMore, LocalizedConstants.doNotInstall);
+		if (response === LocalizedConstants.install) {
 			const extensionInstalled = new Promise<void>((resolve, reject) => {
 				const timeout = setTimeout(async () => {
-					reject(new Error(constants.timeoutError));
+					reject(new Error(LocalizedConstants.timeoutError));
 					extensionChange.dispose();
 				}, 10000);
 				let extensionChange = vscode.extensions.onDidChange(async () => {
@@ -112,7 +113,7 @@ export async function getAzureFunctionsExtensionApi(): Promise<AzureFunctionsExt
 			// the extension has not been notified that the azure function extension is installed so wait till it is to then activate it
 			await extensionInstalled;
 			apiProvider = await vscode.extensions.getExtension(constants.azureFunctionsExtensionName)?.activate() as AzureExtensionApiProvider;
-		} else if (response === constants.learnMore) {
+		} else if (response === LocalizedConstants.learnMore) {
 			await vscode.env.openExternal(vscode.Uri.parse(constants.linkToAzureFunctionExtension));
 			return undefined;
 		} else {
@@ -170,7 +171,7 @@ export async function getAzureFunctionProject(): Promise<string | undefined> {
 				// select project to add azure function to
 				selectedProjectFile = (await vscode.window.showQuickPick(projectFiles, {
 					canPickMany: false,
-					title: constants.selectProject,
+					title: LocalizedConstants.selectProject,
 					ignoreFocusOut: true
 				}));
 				return selectedProjectFile;
@@ -229,7 +230,7 @@ export function waitForNewFunctionFile(projectFile: string): Promise<string> {
 		const watcher = vscode.workspace.createFileSystemWatcher((
 			path.dirname(projectFile), '**/*.cs'), false, true, true);
 		const timeout = setTimeout(async () => {
-			reject(new Error(constants.timeoutError));
+			reject(new Error(LocalizedConstants.timeoutError));
 			watcher.dispose();
 		}, 10000);
 		watcher.onDidCreate((e) => {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,8 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
 
 // Collection of Non-localizable Constants
 export const languageId = 'sql';
@@ -172,18 +170,3 @@ export const defaultBindingResult = 'return new OkObjectResult(responseMessage);
 export const sqlBindingResult = `return new OkObjectResult(result);`;
 export const azureFunctionLocalSettingsFileName = 'local.settings.json';
 export const sqlExtensionPackageName = 'Microsoft.Azure.WebJobs.Extensions.Sql';
-export function failedToParse(errorMessage: string): string {
-	return localize('failedToParse', 'Failed to parse "{0}": {1}.',
-		azureFunctionLocalSettingsFileName, errorMessage);
-}
-export function settingAlreadyExists(settingName: string): string {
-	return localize('SettingAlreadyExists', 'Local app setting \'{0}\' already exists. Overwrite?', settingName);
-}
-export const yesString = localize('yesString', 'Yes');
-export const functionNameTitle = localize('functionNameTitle', 'Function Name');
-export const selectProject = localize('selectProject', 'Select the Azure Function project for the SQL Binding');
-export const timeoutError = localize('timeoutError', 'Timed out waiting for azure function file creation');
-export const azureFunctionsExtensionNotFound = localize('azureFunctionsExtensionNotFound', 'The Azure Functions extension is required to create a new Azure Function with SQL binding but is not installed, install it now?');
-export const installAzureFunction = localize('install', 'Install');
-export const learnMore = localize('learnMore', 'Learn more');
-export const doNotInstall = localize('doNotInstall', 'Do not install');

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -78,7 +78,7 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 
 		// get function name from user
 		const functionName = await vscode.window.showInputBox({
-			title: constants.functionNameTitle,
+			title: LocalizedConstants.functionNameTitle,
 			value: table,
 			ignoreFocusOut: true
 		});


### PR DESCRIPTION
Fixes: #17247

This PR adds in updated XLFs that removes unused strings from the localizedConstants xlf and makes the localizedPackage xlf reflect the current package.nls.json. 

Additionally, the constants.ts file had localized calls that weren't being recognized at all or translated, I decided to move them to the localizedConstants xlf file where they should belong. 

Finally, the original file attribute of the xlfs has been changed to match ADS and better reflect the actual original file (it doesn't affect the functionality but it's just for consistency)