### PR TITLE
Add tenant selection during adding connection using AAD auth

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -128,6 +128,12 @@
         <trans-unit id="aad">
             <source xml:lang="en">AAD</source>
         </trans-unit>
+        <trans-unit id="azureChooseTenant">
+            <source xml:lang="en">Choose an Azure tenant</source>
+        </trans-unit>
+        <trans-unit id="tenant">
+            <source xml:lang="en">Tenant</source>
+        </trans-unit>
         <trans-unit id="usernamePrompt">
             <source xml:lang="en">User name</source>
         </trans-unit>

--- a/src/azure/azureController.ts
+++ b/src/azure/azureController.ts
@@ -100,12 +100,16 @@ export class AzureController {
 
 	private async promptForTenantChoice(account: AzureAccount, profile: ConnectionProfile): Promise<void> {
 		let tenantChoices: INameValueChoice[] = account.properties.tenants?.map(t => ({ name: t.displayName, value: t }));
+		if (tenantChoices.length === 1) {
+			profile.tenantId = tenantChoices[0].value.id;
+			return;
+		}
 		let tenantQuestion: IQuestion = {
 			type: QuestionTypes.expand,
 			name: LocalizedConstants.tenant,
 			message: LocalizedConstants.azureChooseTenant,
 			choices: tenantChoices,
-			shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length !== 0,
+			shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length > 1,
 			onAnswered: (value: Tenant) => {
 				profile.tenantId = value.id;
 			}

--- a/src/azure/azureController.ts
+++ b/src/azure/azureController.ts
@@ -105,11 +105,11 @@ export class AzureController {
 			name: LocalizedConstants.tenant,
 			message: LocalizedConstants.azureChooseTenant,
 			choices: tenantChoices,
-			shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length != 0,
+			shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length !== 0,
 			onAnswered: (value: Tenant) => {
 				profile.tenantId = value.id;
 			}
-		}
+		};
 		await this.prompter.promptSingle(tenantQuestion, true);
 	}
 
@@ -120,7 +120,7 @@ export class AzureController {
 			let azureCodeGrant = await this.createAuthCodeGrant();
 			account = await azureCodeGrant.startLogin();
 			await accountStore.addAccount(account);
-			if (profile.tenantId == undefined) {
+			if (profile.tenantId === undefined) {
 				await this.promptForTenantChoice(account, profile);
 			}
 			const token = await azureCodeGrant.getAccountSecurityToken(
@@ -138,7 +138,7 @@ export class AzureController {
 			let azureDeviceCode = await this.createDeviceCode();
 			account = await azureDeviceCode.startLogin();
 			await accountStore.addAccount(account);
-			if (profile.tenantId == undefined) {
+			if (profile.tenantId === undefined) {
 				await this.promptForTenantChoice(account, profile);
 			}
 			const token = await azureDeviceCode.getAccountSecurityToken(
@@ -181,7 +181,7 @@ export class AzureController {
 		return profile;
 	}
 
-	public async refreshToken(account: IAccount, accountStore: AccountStore, settings: AADResource, tenantId: string = null): Promise<Token | undefined> {
+	public async refreshToken(account: IAccount, accountStore: AccountStore, settings: AADResource, tenantId: string = undefined): Promise<Token | undefined> {
 		try {
 			let token: Token;
 			if (account.properties.azureAuthType === 0) {

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -120,7 +120,7 @@ export default class ConnectionManager {
 		}
 
 		if (!this.azureController) {
-			this.azureController = new AzureController(context);
+			this.azureController = new AzureController(context, prompter);
 			this.azureController.init();
 		}
 
@@ -702,7 +702,7 @@ export default class ConnectionManager {
 			if (!connectionCreds.azureAccountToken || connectionCreds.expiresOn - currentTime < maxTolerance) {
 				let account = this.accountStore.getAccount(connectionCreds.accountId);
 				let profile = new ConnectionProfile(connectionCreds);
-				let azureAccountToken = await this.azureController.refreshToken(account, this.accountStore, providerSettings.resources.databaseResource);
+				let azureAccountToken = await this.azureController.refreshToken(account, this.accountStore, providerSettings.resources.databaseResource, profile.tenantId);
 				if (!azureAccountToken) {
 					let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
 					let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -20,6 +20,7 @@ export class ConnectionCredentials implements IConnectionInfo {
 	public password: string;
 	public email: string | undefined;
 	public accountId: string | undefined;
+	public tenantId: string | undefined;
 	public port: number;
 	public authenticationType: string;
 	public azureAccountToken: string | undefined;

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -15,6 +15,7 @@ import { AzureController } from '../azure/azureController';
 import { AccountStore } from '../azure/accountStore';
 import { IAccount } from './contracts/azure/accountInterfaces';
 import providerSettings from '../azure/providerSettings';
+import { Tenant, AzureAccount } from '@microsoft/ads-adal-library';
 
 // Concrete implementation of the IConnectionProfile interface
 
@@ -30,11 +31,13 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 	public expiresOn: number | undefined;
 	public accountStore: AccountStore;
 	public accountId: string;
+	public tenantId: string;
 
 	constructor(connectionCredentials?: ConnectionCredentials) {
 		super();
 		if (connectionCredentials) {
 			this.accountId = connectionCredentials.accountId;
+			this.tenantId = connectionCredentials.tenantId;
 			this.authenticationType = connectionCredentials.authenticationType;
 			this.azureAccountToken = connectionCredentials.azureAccountToken;
 			this.expiresOn = connectionCredentials.expiresOn;
@@ -68,6 +71,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 		let azureAccountChoices: INameValueChoice[] = ConnectionProfile.getAccountChoices(accountStore);
 		let accountAnswer: IAccount;
 		azureAccountChoices.unshift({ name: LocalizedConstants.azureAddAccount, value: 'addAccount' });
+		let tenantChoices: INameValueChoice[] = [];
 
 
 		let questions: IQuestion[] = await ConnectionCredentials.getRequiredCredentialValuesQuestions(profile, true,
@@ -88,7 +92,23 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 				message: LocalizedConstants.azureChooseAccount,
 				choices: azureAccountChoices,
 				shouldPrompt: (answers) => profile.isAzureActiveDirectory(),
-				onAnswered: (value: IAccount) => accountAnswer = value
+				onAnswered: (value) => {
+					accountAnswer = value;
+					if (value !== 'addAccount') {
+						let account: AzureAccount = value;
+						tenantChoices.push(...account?.properties?.tenants.map(t => ({ name: t.displayName, value: t })));
+					}
+				}
+			},
+			{
+				type: QuestionTypes.expand,
+				name: LocalizedConstants.tenant,
+				message: LocalizedConstants.azureChooseTenant,
+				choices: tenantChoices,
+				shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length != 0,
+				onAnswered: (value: Tenant) => {
+					profile.tenantId = value.id;
+				}
 			},
 			{
 				type: QuestionTypes.input,

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -97,6 +97,9 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 					if (value !== 'addAccount') {
 						let account: AzureAccount = value;
 						tenantChoices.push(...account?.properties?.tenants.map(t => ({ name: t.displayName, value: t })));
+						if (tenantChoices.length === 1) {
+							profile.tenantId = tenantChoices[0].value.id;
+						}
 					}
 				}
 			},
@@ -105,7 +108,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 				name: LocalizedConstants.tenant,
 				message: LocalizedConstants.azureChooseTenant,
 				choices: tenantChoices,
-				shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length !== 0,
+				shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length > 1,
 				onAnswered: (value: Tenant) => {
 					profile.tenantId = value.id;
 				}

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -105,7 +105,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 				name: LocalizedConstants.tenant,
 				message: LocalizedConstants.azureChooseTenant,
 				choices: tenantChoices,
-				shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length != 0,
+				shouldPrompt: (answers) => profile.isAzureActiveDirectory() && tenantChoices.length !== 0,
 				onAnswered: (value: Tenant) => {
 					profile.tenantId = value.id;
 				}

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -439,7 +439,7 @@ export class ObjectExplorerService {
 					let profile = new ConnectionProfile(connectionCredentials);
 					if (!connectionCredentials.azureAccountToken) {
 						let azureAccountToken = await azureController.refreshToken(
-							account, this._connectionManager.accountStore, providerSettings.resources.databaseResource);
+							account, this._connectionManager.accountStore, providerSettings.resources.databaseResource, connectionCredentials.tenantId);
 						if (!azureAccountToken) {
 							let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
 							await this._connectionManager.vscodeWrapper.showErrorMessage(

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -28,6 +28,7 @@ function createTestCredentials(): IConnectionInfo {
 		password: '12345678',
 		email: 'test-email',
 		accountId: 'test-account-id',
+		tenantId: 'test-tenant-id',
 		port: 1234,
 		authenticationType: AuthenticationTypes[AuthenticationTypes.SqlLogin],
 		azureAccountToken: '',

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -106,6 +106,7 @@ suite('Connection Profile tests', () => {
 			LocalizedConstants.passwordPrompt,   // Password
 			LocalizedConstants.msgSavePassword,  // Save Password
 			LocalizedConstants.aad,              // Choose AAD Account
+			LocalizedConstants.tenant,           // Choose AAD Tenant
 			LocalizedConstants.profileNamePrompt // Profile Name
 		];
 

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -64,6 +64,7 @@ suite('Connection Profile tests', () => {
 	let mockAccountStore: AccountStore;
 	let mockAzureController: AzureController;
 	let mockContext: TypeMoq.IMock<vscode.ExtensionContext>;
+	let mockPrompter: TypeMoq.IMock<IPrompter>;
 	let globalstate: TypeMoq.IMock<vscode.Memento>;
 
 	setup(() => {
@@ -71,7 +72,7 @@ suite('Connection Profile tests', () => {
 		globalstate = TypeMoq.Mock.ofType<vscode.Memento>();
 		mockContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
 		mockContext.setup(c => c.workspaceState).returns(() => globalstate.object);
-		mockAzureController = new AzureController(mockContext.object);
+		mockAzureController = new AzureController(mockContext.object, mockPrompter.object);
 		mockAccountStore = new AccountStore(mockContext.object);
 	});
 

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -50,6 +50,7 @@ function createTestCredentials(): IConnectionInfo {
 		password: '12345678',
 		email: 'test-email',
 		accountId: 'test-account-id',
+		tenantId: 'test-tenant-id',
 		port: 1234,
 		authenticationType: AuthenticationTypes[AuthenticationTypes.SqlLogin],
 		azureAccountToken: '',

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -121,6 +121,11 @@ declare module 'vscode-mssql' {
 		accountId: string | undefined;
 
 		/**
+		 * tenantId
+		 */
+		tenantId: string | undefined;
+
+		/**
 		 * The port number to connect to.
 		 */
 		port: number;


### PR DESCRIPTION
Fixes #17042

Root cause: The current AAD implementation always chooses default tenant to use and doesn't handle the case where the user has multiple home tenants. This causes failure when the user tries to access resources that are not in the default tenant.

https://github.com/microsoft/vscode-mssql/blob/e36ef1f2c4bb3d4887b90232af2b5241abacd487/src/azure/azureController.ts#L159-L169
https://github.com/microsoft/vscode-mssql/blob/593a01c345170d349f3475d6adadccd3135a7536/lib/ads-adal-library/src/engine/AzureAuth.ts#L62-L65

Eventually the endpoint url for getToken calls contains tenant id.
https://github.com/microsoft/vscode-mssql/blob/593a01c345170d349f3475d6adadccd3135a7536/lib/ads-adal-library/src/engine/AzureAuth.ts#L190-L191
Fix: prompt the user for a tenant selection if there are multiple tenants available on the account.
1) If the user is adding a connection using an added account, prompt a tenant selection after account selection.
2) If the user is adding a new account during adding a connection, prompt a tenant selection after the account is successfully added.

![image](https://user-images.githubusercontent.com/21186993/154753364-f18e6415-bce9-4172-8aa2-2f67a6652f61.png)

To test this change locally, you'll need to add another tenant to your Azure account.