### PR TITLE
Start the Add SQL Binding flow once azure project is created

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -569,6 +569,9 @@
         <trans-unit id="timeoutAzureFunctionFileError">
             <source xml:lang="en">Timed out waiting for Azure Function file to be created</source>
         </trans-unit>
+         <trans-unit id="timeoutProjectError">
+            <source xml:lang="en">Timed out waiting for project to be created</source>
+        </trans-unit>
          <trans-unit id="nameMustNotBeEmpty">
             <source xml:lang="en">Name must not be empty</source>
         </trans-unit>

--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -572,6 +572,9 @@
          <trans-unit id="nameMustNotBeEmpty">
             <source xml:lang="en">Name must not be empty</source>
         </trans-unit>
+        <trans-unit id="errorNewAzureFunction">
+            <source xml:lang="en">Error creating new Azure Function: </source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -576,7 +576,7 @@
             <source xml:lang="en">Name must not be empty</source>
         </trans-unit>
         <trans-unit id="errorNewAzureFunction">
-            <source xml:lang="en">Error creating new Azure Function: </source>
+            <source xml:lang="en">Error creating new Azure Function: {0}</source>
         </trans-unit>
     </body>
   </file>

--- a/src/azureFunction/azureFunctionUtils.ts
+++ b/src/azureFunction/azureFunctionUtils.ts
@@ -248,6 +248,23 @@ export function waitForNewFunctionFile(projectFile: string): IFileFunctionObject
 }
 
 /**
+ * Retrieves the new host project file once it has created and the watcher disposable
+ * @returns the host file path once created and the watcher disposable
+ */
+export function waitForNewHostFile(): IFileFunctionObject {
+	const watcher = vscode.workspace.createFileSystemWatcher('**/host.json', false, true, true);
+	const filePromise = new Promise<string>((resolve, _) => {
+		watcher.onDidCreate((e) => {
+			resolve(e.fsPath);
+		});
+	});
+	return {
+		filePromise,
+		watcherDisposable: watcher
+	};
+}
+
+/**
  * Adds the required nuget package to the project
  * @param selectedProjectFile is the users selected project file path
  */

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -77,7 +77,14 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 				// start the create azure function project flow
 				await azureFunctionApi.createFunction({});
 			}
-			return;
+			if (await azureFunctionUtils.getHostFiles()) {
+				// once project is created then start sql binding flow
+				projectFile = await azureFunctionUtils.getAzureFunctionProject();
+			} else {
+				// if user cancels prompt show warning
+				vscode.window.showErrorMessage(LocalizedConstants.azureFunctionsProjectMustBeOpened);
+				return;
+			}
 		}
 
 		// because of an AF extension API issue, we have to get the newly created file by adding

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -73,6 +73,7 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 				LocalizedConstants.createProject, LocalizedConstants.learnMore);
 			if (projectCreate === LocalizedConstants.learnMore) {
 				vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(constants.sqlBindingsDoc));
+				return;
 			} else if (projectCreate === LocalizedConstants.createProject) {
 				// start the create azure function project flow
 				await azureFunctionApi.createFunction({});

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -91,7 +91,7 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 						projectFile = await azureFunctionUtils.getAzureFunctionProject();
 					}
 				} catch (error) {
-					vscode.window.showErrorMessage(utils.formatString(LocalizedConstants.errorNewAzureFunction, error.message) ?? error);
+					vscode.window.showErrorMessage(utils.formatString(LocalizedConstants.errorNewAzureFunction, error.message ?? error));
 					return;
 				} finally {
 					newHostProjectFile.watcherDisposable.dispose();

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -82,15 +82,15 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 					// start the create azure function project flow
 					// create a watcher to see if the host file is created after the flow is complete
 					newHostProjectFile = await azureFunctionUtils.waitForNewHostFile();
-					const timeoutForHostFile = timeoutPromise(LocalizedConstants.azureFunctionsProjectMustBeOpened);
 					await azureFunctionApi.createFunction({});
+					const timeoutForHostFile = timeoutPromise(LocalizedConstants.azureFunctionsProjectMustBeOpened);
 					hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);
 					if (hostFile) {
 						// start the add sql binding flow
 						projectFile = await azureFunctionUtils.getAzureFunctionProject();
 					}
 				} catch (error) {
-					vscode.window.showErrorMessage(error.message);
+					vscode.window.showErrorMessage(LocalizedConstants.errorNewAzureFunction + error.message ?? error);
 					return;
 				} finally {
 					newHostProjectFile.watcherDisposable.dispose();

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -12,6 +12,7 @@ import * as azureFunctionUtils from '../azureFunction/azureFunctionUtils';
 import * as constants from '../constants/constants';
 import { generateQuotedFullName, timeoutPromise, getUniqueFileName } from '../utils/utils';
 import * as LocalizedConstants from '../constants/localizedConstants';
+import * as utils from '../models/utils';
 
 export const hostFileName: string = 'host.json';
 
@@ -83,14 +84,14 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 					// create a watcher to see if the host file is created after the flow is complete
 					newHostProjectFile = await azureFunctionUtils.waitForNewHostFile();
 					await azureFunctionApi.createFunction({});
-					const timeoutForHostFile = timeoutPromise(LocalizedConstants.azureFunctionsProjectMustBeOpened);
+					const timeoutForHostFile = timeoutPromise(LocalizedConstants.timeoutProjectError);
 					hostFile = await Promise.race([newHostProjectFile.filePromise, timeoutForHostFile]);
 					if (hostFile) {
 						// start the add sql binding flow
 						projectFile = await azureFunctionUtils.getAzureFunctionProject();
 					}
 				} catch (error) {
-					vscode.window.showErrorMessage(LocalizedConstants.errorNewAzureFunction + error.message ?? error);
+					vscode.window.showErrorMessage(utils.formatString(LocalizedConstants.errorNewAzureFunction, error.message) ?? error);
 					return;
 				} finally {
 					newHostProjectFile.watcherDisposable.dispose();

--- a/src/services/azureFunctionsService.ts
+++ b/src/services/azureFunctionsService.ts
@@ -79,9 +79,10 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 				vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(constants.sqlBindingsDoc));
 				return;
 			} else if (projectCreate === LocalizedConstants.createProject) {
+				// start the create azure function project flow
 				try {
-					// start the create azure function project flow
-					// create a watcher to see if the host file is created after the flow is complete
+					// because of an AF extension API issue, we have to get the newly created file by adding a watcher
+					// issue: https://github.com/microsoft/vscode-azurefunctions/issues/3052
 					newHostProjectFile = await azureFunctionUtils.waitForNewHostFile();
 					await azureFunctionApi.createFunction({});
 					const timeoutForHostFile = timeoutPromise(LocalizedConstants.timeoutProjectError);
@@ -99,8 +100,8 @@ export class AzureFunctionsService implements mssql.IAzureFunctionsService {
 			}
 		}
 
-		// because of an AF extension API issue, we have to get the newly created file by adding
-		// a watcher: https://github.com/microsoft/vscode-azurefunctions/issues/2908
+		// because of an AF extension API issue, we have to get the newly created file by adding a watcher
+		// issue: https://github.com/microsoft/vscode-azurefunctions/issues/2908
 		const newFunctionFileObject = azureFunctionUtils.waitForNewFunctionFile(projectFile);
 		let functionFile: string;
 		let functionName: string;


### PR DESCRIPTION
Fixes #17250

This will ensure we wait for createFunction to be completed if the user chooses to do so and start the Add SQL binding flow to the newly created function project.