### PR TITLE
Fix to find child function folder

### DIFF
--- a/src/azureFunction/azureFunctionUtils.ts
+++ b/src/azureFunction/azureFunctionUtils.ts
@@ -203,7 +203,7 @@ export async function getAzureFunctionProjectFiles(): Promise<string[] | undefin
 		return undefined;
 	}
 	for (let host of hostFiles) {
-		let projectFile = await vscode.workspace.findFiles('**/*.csproj', path.dirname(host));
+		let projectFile = await vscode.workspace.findFiles(new vscode.RelativePattern(path.dirname(host), '*.csproj'));
 		projectFile.filter(file => path.dirname(file.fsPath) === path.dirname(host) ? projFiles.push(file?.fsPath) : projFiles);
 	}
 	return projFiles.length > 0 ? projFiles : undefined;

--- a/src/azureFunction/azureFunctionUtils.ts
+++ b/src/azureFunction/azureFunctionUtils.ts
@@ -203,7 +203,7 @@ export async function getAzureFunctionProjectFiles(): Promise<string[] | undefin
 		return undefined;
 	}
 	for (let host of hostFiles) {
-		let projectFile = await vscode.workspace.findFiles('*.csproj', path.dirname(host));
+		let projectFile = await vscode.workspace.findFiles('**/*.csproj', path.dirname(host));
 		projectFile.filter(file => path.dirname(file.fsPath) === path.dirname(host) ? projFiles.push(file?.fsPath) : projFiles);
 	}
 	return projFiles.length > 0 ? projFiles : undefined;


### PR DESCRIPTION
Fixes #17269

This will ensure we check to get all function files even if it is a subfolder of another folder.