### PR TITLE
Include database in connection string when creating az func from table

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -443,7 +443,11 @@ export default class MainController implements vscode.Disposable {
 
 		// Generate Azure Function command
 		this._context.subscriptions.push(vscode.commands.registerCommand(Constants.cmdCreateAzureFunction, async (node: TreeNodeInfo) => {
-			const connectionDetails = ConnectionCredentials.createConnectionDetails(node.connectionInfo);
+			let connectionInfo = node.connectionInfo;
+			// set the database containing the selected table so it can be used
+			// for the initial catalog property of the connection string
+			connectionInfo.database = node.parentNode.parentNode.label as string;
+			const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionInfo);
 			const connectionString = await this._connectionMgr.getConnectionString(connectionDetails, false, false);
 			await this.azureFunctionsService.createAzureFunction(connectionString, node.metadata.schema, node.metadata.name);
 		}));

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -446,7 +446,7 @@ export default class MainController implements vscode.Disposable {
 			let connectionInfo = node.connectionInfo;
 			// set the database containing the selected table so it can be used
 			// for the initial catalog property of the connection string
-			connectionInfo.database = node.parentNode.parentNode.label as string;
+			connectionInfo.database = node.parentNode.parentNode.metadata.name;
 			const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionInfo);
 			const connectionString = await this._connectionMgr.getConnectionString(connectionDetails, false, false);
 			await this.azureFunctionsService.createAzureFunction(connectionString, node.metadata.schema, node.metadata.name);

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -447,7 +447,7 @@ export default class MainController implements vscode.Disposable {
 			// set the database containing the selected table so it can be used
 			// for the initial catalog property of the connection string
 			let newNode: TreeNodeInfo = node;
-			while (true) {
+			while (newNode) {
 				if (newNode.nodeType === 'Database') {
 					connectionInfo.database = newNode.metadata.name;
 					break;

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -446,7 +446,15 @@ export default class MainController implements vscode.Disposable {
 			let connectionInfo = node.connectionInfo;
 			// set the database containing the selected table so it can be used
 			// for the initial catalog property of the connection string
-			connectionInfo.database = node.parentNode.parentNode.metadata.name;
+			let newNode: TreeNodeInfo = node;
+			while (true) {
+				if (newNode.nodeType === 'Database') {
+					connectionInfo.database = newNode.metadata.name;
+					break;
+				} else {
+					newNode = newNode.parentNode;
+				}
+			}
 			const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionInfo);
 			const connectionString = await this._connectionMgr.getConnectionString(connectionDetails, false, false);
 			await this.azureFunctionsService.createAzureFunction(connectionString, node.metadata.schema, node.metadata.name);


### PR DESCRIPTION
Fixes #17267

After looking at the connection node that we get back from right-clicking a table and doing `Create Azure function with SQL binding" I found that the database property in the node.connectionInfo was undefined. 

As such, I found that we can use the label from the two-parent nodes above (first parent node label being table name) to get the database name. Once we set that, and pass it to STS we will get back the connection string to include Initial Catalog='database' (master or user's db).