### PR TITLE
Add createConnectionDetails API

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -280,6 +280,16 @@ export default class ConnectionManager {
 	}
 
 	/**
+	 * Set connection details for the provided connection info
+	 * Able to use this for getConnectionString requests to STS that require ConnectionDetails type
+	 * @param connectionInfo connection info of the connection
+	 * @returns connection details credentials for the connection
+	 */
+	public createConnectionDetails(connectionInfo: IConnectionInfo): ConnectionDetails {
+		return ConnectionCredentials.createConnectionDetails(connectionInfo);
+	}
+
+	/**
 	 * Exposed for testing purposes.
 	 */
 	public getConnectionInfo(fileUri: string): ConnectionInfo {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		azureFunctions: controller.azureFunctionsService,
 		getConnectionString: (connectionUriOrDetails: string | ConnectionDetails, includePassword?: boolean, includeApplicationName?: boolean) => {
 			return controller.connectionManager.getConnectionString(connectionUriOrDetails, includePassword, includeApplicationName);
+		},
+		createConnectionDetails: (connectionInfo: IConnectionInfo) => {
+			return controller.connectionManager.createConnectionDetails(connectionInfo);
 		}
 	};
 }

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -84,6 +84,14 @@ declare module 'vscode-mssql' {
 		 * @returns connection string for the connection
 		 */
 		getConnectionString(connectionUriOrDetails: string | ConnectionDetails, includePassword?: boolean, includeApplicationName?: boolean): Promise<string>;
+
+		/**
+	 	 * Set connection details for the provided connection info
+	 	 * Able to use this for getConnectionString requests to STS that require ConnectionDetails type
+	 	 * @param connectionInfo connection info of the connection
+	 	 * @returns connection details credentials for the connection
+	 	 */
+		createConnectionDetails(connectionInfo: IConnectionInfo): ConnectionDetails;
 	}
 
 	/**


### PR DESCRIPTION
This will be leveraged in sql-bindings extension and that way we would not need to bring over connectionContracts code but leverage what is already in vscode-mssql. 

This specific functionality is needed to get the connectionString prior to running the command the [createAzureFunction](https://github.com/microsoft/vscode-mssql/blob/main/src/services/azureFunctionsService.ts#L66).