### PR TITLE
Fix null ref error when running query for first time

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -745,7 +745,7 @@ export default class MainController implements vscode.Disposable {
 				await self.onNewConnection();
 			}
 			// check if current connection is still valid / active - if not, refresh azure account token
-			await this._connectionMgr.refreshAzureAccountToken(uri);
+			await self._connectionMgr.refreshAzureAccountToken(uri);
 
 			let title = path.basename(editor.document.fileName);
 			let querySelection: ISelectionData;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/17299

This function is being called in a callback, so `this` doesn't exist. We should be using the self - which is set to the passed in this context.