### PR TITLE
Have launch task build first

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
-            "preLaunchTask": "cover:disable"
+            "preLaunchTask": "build"
         },
         {
             "name": "Launch Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,6 @@
         {
             "label": "build",
             "type": "gulp",
-
             "task": "build",
             "problemMatcher": [
                 "$lessCompile",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,8 @@
         {
             "label": "build",
             "type": "gulp",
-            "task": "--no-color",
+
+            "task": "build",
             "problemMatcher": [
                 "$lessCompile",
                 "$tsc",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
     "ms-mssql.data-workspace-vscode",
     "ms-mssql.sql-database-projects-vscode"
   ],
+  "scripts": {
+    "build": "gulp build",
+    "compile": "gulp ext:compile",
+    "watch": "gulp watch"
+  },
   "devDependencies": {
     "@angular/common": "~2.1.2",
     "@angular/compiler": "~2.1.2",


### PR DESCRIPTION
Make the launch task build before launching to ensure that it's launching with the current code.

Ideally this should be launching the watch task instead so it compiles as changes are made so the user only has to reload the window, but I was having issues getting the gulp watch task working as expected so just leaving it with this for now as at least a general improvement. 

I removed the cover:disable since I don't really see why that matters for launching the extension. If it ends up being something we need we can always add it as a dependent task of build or something. 

Also added a few yarn/npm scripts to make it easier for people to run the gulp tasks in case they aren't aware we use gulp for this stuff.