### PR TITLE
Fix Prompt for Connection when user moves focus away

### DIFF
--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -136,7 +136,7 @@ export class ConnectionUI {
 			matchOptions: options,
 			choices: choices
 		};
-		return this._prompter.promptSingle(question);
+		return this._prompter.promptSingle(question, question.matchOptions.ignoreFocusOut);
 	}
 
 	/**

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -90,7 +90,7 @@ export class ConnectionUI {
 		const selection = await this.promptItemChoice({
 			placeHolder: LocalizedConstants.recentConnectionsPlaceholder,
 			matchOnDescription: true,
-			ignoreFocusOut
+			ignoreFocusOut: ignoreFocusOut
 		}, picklist);
 		if (selection) {
 			return this.handleSelectedConnection(selection);


### PR DESCRIPTION
This was found from this issue: https://github.com/microsoft/azuredatastudio/issues/19108

This will respect the parameter that would be passed in via the API and keep the prompt open