### PR TITLE
Prompt For Connection Improvements 

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -521,6 +521,9 @@
         <trans-unit id="msgClearedRecentConnectionsWithErrors">
             <source xml:lang="en">The recent connections list has been cleared but there were errors while deleting some associated credentials. View the errors in the MSSQL output channel.</source>
         </trans-unit>
+         <trans-unit id="connectProgressNoticationTitle">
+            <source xml:lang="en">Testing connection profile...</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -720,7 +720,6 @@ export default class ConnectionManager {
 
 	// create a new connection with the connectionCreds provided
 	public async connect(fileUri: string, connectionCreds: IConnectionInfo, promise?: Deferred<boolean>): Promise<boolean> {
-		const self = this;
 		return await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
 			title: LocalizedConstants.connectProgressNoticationTitle,
@@ -762,12 +761,12 @@ export default class ConnectionManager {
 				this._connections[fileUri] = connectionInfo;
 
 				// Note: must call flavor changed before connecting, or the timer showing an animation doesn't occur
-				if (self.statusView) {
-					self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
-					self.statusView.connecting(fileUri, connectionCreds);
-					self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+				if (this.statusView) {
+					this.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+					this.statusView.connecting(fileUri, connectionCreds);
+					this.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
 				}
-				self.vscodeWrapper.logToOutputChannel(
+				this.vscodeWrapper.logToOutputChannel(
 					Utils.formatString(LocalizedConstants.msgConnecting, connectionCreds.server, fileUri)
 				);
 
@@ -789,7 +788,7 @@ export default class ConnectionManager {
 				// send connection request message to service host
 				this._uriToConnectionPromiseMap.set(connectParams.ownerUri, promise);
 				try {
-					const result = await self.client.sendRequest(ConnectionContracts.ConnectionRequest.type, connectParams);
+					const result = await this.client.sendRequest(ConnectionContracts.ConnectionRequest.type, connectParams);
 					if (!result) {
 						// Failed to process connect request
 						resolve(false);
@@ -798,8 +797,7 @@ export default class ConnectionManager {
 					reject(error);
 				}
 			});
-			let connectionResult = await connectionPromise;
-			return connectionResult;
+			return await connectionPromise;
 		});
 	}
 

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -739,7 +739,7 @@ export default class ConnectionManager {
 								profile, this.accountStore, providerSettings.resources.databaseResource);
 
 						} else {
-							throw new Error(`${LocalizedConstants.cannotConnect}`);
+							throw new Error(LocalizedConstants.cannotConnect);
 						}
 					} else {
 						connectionCreds.azureAccountToken = azureAccountToken.token;
@@ -797,7 +797,7 @@ export default class ConnectionManager {
 					reject(error);
 				}
 			});
-			return await connectionPromise;
+			return connectionPromise;
 		});
 	}
 

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -721,79 +721,86 @@ export default class ConnectionManager {
 	// create a new connection with the connectionCreds provided
 	public async connect(fileUri: string, connectionCreds: IConnectionInfo, promise?: Deferred<boolean>): Promise<boolean> {
 		const self = this;
-		// Check if the azure account token is present before sending connect request
-		if (connectionCreds.authenticationType === Constants.azureMfa) {
-			if (AzureController.isTokenInValid(connectionCreds.azureAccountToken, connectionCreds.expiresOn)) {
-				let account = this.accountStore.getAccount(connectionCreds.accountId);
-				let profile = new ConnectionProfile(connectionCreds);
-				let azureAccountToken = await this.azureController.refreshToken(account, this.accountStore, providerSettings.resources.databaseResource, profile.tenantId);
-				if (!azureAccountToken) {
-					let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
-					let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
-					if (refreshResult === LocalizedConstants.refreshTokenLabel) {
-						await this.azureController.populateAccountProperties(
-							profile, this.accountStore, providerSettings.resources.databaseResource);
+		return await vscode.window.withProgress({
+			location: vscode.ProgressLocation.Notification,
+			title: LocalizedConstants.connectProgressNoticationTitle,
+			cancellable: false
+		}, async (_progress, _token) => {
+			// Check if the azure account token is present before sending connect request
+			if (connectionCreds.authenticationType === Constants.azureMfa) {
+				if (AzureController.isTokenInValid(connectionCreds.azureAccountToken, connectionCreds.expiresOn)) {
+					let account = this.accountStore.getAccount(connectionCreds.accountId);
+					let profile = new ConnectionProfile(connectionCreds);
+					let azureAccountToken = await this.azureController.refreshToken(account, this.accountStore, providerSettings.resources.databaseResource, profile.tenantId);
+					if (!azureAccountToken) {
+						let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
+						let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
+						if (refreshResult === LocalizedConstants.refreshTokenLabel) {
+							await this.azureController.populateAccountProperties(
+								profile, this.accountStore, providerSettings.resources.databaseResource);
 
+						} else {
+							throw new Error(`${LocalizedConstants.cannotConnect}`);
+						}
 					} else {
-						throw new Error(`${LocalizedConstants.cannotConnect}`);
+						connectionCreds.azureAccountToken = azureAccountToken.token;
+						connectionCreds.expiresOn = azureAccountToken.expiresOn;
 					}
-				} else {
-					connectionCreds.azureAccountToken = azureAccountToken.token;
-					connectionCreds.expiresOn = azureAccountToken.expiresOn;
 				}
 			}
-		}
-		let connectionPromise = new Promise<boolean>(async (resolve, reject) => {
-			if (connectionCreds.connectionString?.includes(ConnectionStore.CRED_PREFIX)
-				&& connectionCreds.connectionString?.includes('isConnectionString:true')) {
-				let connectionString = await this.connectionStore.lookupPassword(connectionCreds, true);
-				connectionCreds.connectionString = connectionString;
-			}
+			let connectionPromise = new Promise<boolean>(async (resolve, reject) => {
 
-			let connectionInfo: ConnectionInfo = new ConnectionInfo();
-			connectionInfo.credentials = connectionCreds;
-			connectionInfo.connecting = true;
-			this._connections[fileUri] = connectionInfo;
+				if (connectionCreds.connectionString?.includes(ConnectionStore.CRED_PREFIX)
+					&& connectionCreds.connectionString?.includes('isConnectionString:true')) {
+					let connectionString = await this.connectionStore.lookupPassword(connectionCreds, true);
+					connectionCreds.connectionString = connectionString;
+				}
 
-			// Note: must call flavor changed before connecting, or the timer showing an animation doesn't occur
-			if (self.statusView) {
-				self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
-				self.statusView.connecting(fileUri, connectionCreds);
-				self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
-			}
-			self.vscodeWrapper.logToOutputChannel(
-				Utils.formatString(LocalizedConstants.msgConnecting, connectionCreds.server, fileUri)
-			);
+				let connectionInfo: ConnectionInfo = new ConnectionInfo();
+				connectionInfo.credentials = connectionCreds;
+				connectionInfo.connecting = true;
+				this._connections[fileUri] = connectionInfo;
 
-			// Setup the handler for the connection complete notification to call
-			connectionInfo.connectHandler = ((connectResult, error) => {
-				if (error) {
+				// Note: must call flavor changed before connecting, or the timer showing an animation doesn't occur
+				if (self.statusView) {
+					self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+					self.statusView.connecting(fileUri, connectionCreds);
+					self.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+				}
+				self.vscodeWrapper.logToOutputChannel(
+					Utils.formatString(LocalizedConstants.msgConnecting, connectionCreds.server, fileUri)
+				);
+
+				// Setup the handler for the connection complete notification to call
+				connectionInfo.connectHandler = ((connectResult, error) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve(connectResult);
+					}
+				});
+
+				// package connection details for request message
+				const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionCreds);
+				let connectParams = new ConnectionContracts.ConnectParams();
+				connectParams.ownerUri = fileUri;
+				connectParams.connection = connectionDetails;
+
+				// send connection request message to service host
+				this._uriToConnectionPromiseMap.set(connectParams.ownerUri, promise);
+				try {
+					const result = await self.client.sendRequest(ConnectionContracts.ConnectionRequest.type, connectParams);
+					if (!result) {
+						// Failed to process connect request
+						resolve(false);
+					}
+				} catch (error) {
 					reject(error);
-				} else {
-					resolve(connectResult);
 				}
 			});
-
-			// package connection details for request message
-			const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionCreds);
-			let connectParams = new ConnectionContracts.ConnectParams();
-			connectParams.ownerUri = fileUri;
-			connectParams.connection = connectionDetails;
-
-			// send connection request message to service host
-			this._uriToConnectionPromiseMap.set(connectParams.ownerUri, promise);
-			try {
-				const result = await self.client.sendRequest(ConnectionContracts.ConnectionRequest.type, connectParams);
-				if (!result) {
-					// Failed to process connect request
-					resolve(false);
-				}
-			} catch (error) {
-				reject(error);
-			}
+			let connectionResult = await connectionPromise;
+			return connectionResult;
 		});
-		let connectionResult = await connectionPromise;
-		return connectionResult;
 	}
 
 	public async onCancelConnect(): Promise<void> {

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -127,7 +127,9 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 			});
 
 		return prompter.prompt(questions, true).then(async answers => {
-			if (answers.authenticationType === 'AzureMFA') {
+			if(!answers){
+				return undefined;
+			} else if (answers?.authenticationType === 'AzureMFA') {
 				if (answers.AAD === 'addAccount') {
 					profile = await azureController.populateAccountProperties(profile, accountStore, providerSettings.resources.databaseResource);
 				} else {

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -127,9 +127,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
 			});
 
 		return prompter.prompt(questions, true).then(async answers => {
-			if(!answers){
-				return undefined;
-			} else if (answers?.authenticationType === 'AzureMFA') {
+			if (answers.authenticationType === 'AzureMFA') {
 				if (answers.AAD === 'addAccount') {
 					profile = await azureController.populateAccountProperties(profile, accountStore, providerSettings.resources.databaseResource);
 				} else {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,3 +13,5 @@ export async function exists(path: string): Promise<boolean> {
 		return false;
 	}
 }
+
+export class CancelError extends Error { }

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -562,17 +562,16 @@ export class ConnectionUI {
 	public async promptForRetryCreateProfile(profile: IConnectionProfile, isFirewallError: boolean = false): Promise<IConnectionProfile> {
 		// Ask if the user would like to fix the profile
 		let errorMessage = isFirewallError ? LocalizedConstants.msgPromptRetryFirewallRuleAdded : LocalizedConstants.msgPromptRetryCreateProfile;
-		return this._vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.retryLabel).then(result => {
-			if (result === LocalizedConstants.retryLabel) {
-				return ConnectionProfile.createProfile(this._prompter, this._connectionStore, this._context,
-					this.connectionManager.azureController, this._accountStore, profile);
-			} else {
-				// user cancelled the prompt - throw error so that we know user cancelled
-				return new Promise((_, reject) => {
-					reject(new CancelError('User cancelled retry connection warning'));
-				});
-			}
-		});
+		let result = await this._vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.retryLabel);
+		if (result === LocalizedConstants.retryLabel) {
+			return ConnectionProfile.createProfile(this._prompter, this._connectionStore, this._context,
+				this.connectionManager.azureController, this._accountStore, profile);
+		} else {
+			// user cancelled the prompt - throw error so that we know user cancelled
+			return new Promise((_, reject) => {
+				reject(new CancelError('User cancelled retry connection warning'));
+			});
+		}
 	}
 
 	private async promptForIpAddress(startIpAddress: string): Promise<IFirewallIpAddressRange> {

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -336,16 +336,15 @@ export class ConnectionUI {
 	}
 
 	private handleSelectedConnection(selection: IConnectionCredentialsQuickPickItem): Promise<IConnectionInfo> {
-		const self = this;
 		return new Promise<IConnectionInfo>((resolve, reject) => {
 			if (selection !== undefined) {
 				let connectFunc: Promise<IConnectionInfo>;
 				if (selection.quickPickItemType === CredentialsQuickPickItemType.NewConnection) {
 					// call the workflow to create a new connection
-					connectFunc = self.createAndSaveProfile();
+					connectFunc = this.createAndSaveProfile();
 				} else {
 					// user chose a connection from picklist. Prompt for mandatory info that's missing (e.g. username and/or password)
-					connectFunc = self.fillOrPromptForMissingInfo(selection);
+					connectFunc = this.fillOrPromptForMissingInfo(selection);
 				}
 
 				connectFunc.then((resolvedConnectionCreds) => {
@@ -353,7 +352,9 @@ export class ConnectionUI {
 						resolve(undefined);
 					}
 					resolve(resolvedConnectionCreds);
-				}, err => reject(err));
+				}, err =>
+					// we will send back a cancelled error in order to re-prompt the promptForConnection
+					reject(err));
 			} else {
 				resolve(undefined);
 			}

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -85,7 +85,7 @@ export class ConnectionUI {
 	 * @returns The connectionInfo choosen or created from the user, or undefined if the user cancels the prompt.
 	 */
 	public async promptForConnection(ignoreFocusOut: boolean = false): Promise<IConnectionInfo | undefined> {
-		return await new Promise<IConnectionInfo | undefined>((resolve, reject) => {
+		return await new Promise<IConnectionInfo | undefined>((resolve, _) => {
 			let connectionProfileList = this._connectionStore.getPickListItems();
 			// We have recent connections - show them in a prompt for connection profiles
 			const connectionProfileQuickPick = vscode.window.createQuickPick<IConnectionCredentialsQuickPickItem>();


### PR DESCRIPTION
This PR is not intended to go out with June Release (due to potential risk).

Initial Improvements to add more flexibility to promptForConnection: fixes #17325 

Fixes #17335: [Line here](https://github.com/microsoft/vscode-mssql/compare/vabhog/promptForConnectionImprovements?expand=1#diff-a6dd0c29a881dd2fd108e3f0fdcbeea035a85a1b43f37065a8b7fd6ba092e3d3R724)
Add Progress Notification when user is using `Create a Connection` we will show progress notification after they fill in the connection info:
<img width="323" alt="Screen Shot 2022-06-02 at 4 42 42 PM" src="https://user-images.githubusercontent.com/23587151/171741987-c5a55be5-00a7-4851-9f3e-8669e88d5b25.png">. 

Also in order to fix this issue: https://github.com/microsoft/vscode-mssql/issues/17348 need to throw an error so that I would be able to re-prompt to the connection profile prompt for SQL bindings experiences. 
https://github.com/microsoft/azuredatastudio/blob/main/extensions/sql-bindings/src/services/azureFunctionsService.ts#L127
