### PR TITLE
Fix test task to fail on test failures

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -104,22 +104,6 @@ steps:
     inputs:
       targets: "ext:install-service"
 
-  - task: gulp@0
-    displayName: "gulp cover:jenkins"
-    inputs:
-      targets: "cover:jenkins"
-      publishJUnitResults: true
-      testResultsFiles: "$(Build.SourcesDirectory)/test-reports/*.xml"
-    enabled: false
-    continueOnError: true
-
-  - task: PublishCodeCoverageResults@1
-    displayName: "Publish code coverage from $(Build.SourcesDirectory)/coverage/cobertura-coverage.xml"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Build.SourcesDirectory)/coverage/cobertura-coverage.xml"
-    enabled: false
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: "Component Detection"
     inputs:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,20 +247,12 @@ gulp.task('ext:test', async (done) => {
 	let vscodeVersion = packageJson.engines.vscode.slice(1);
 	let extensionTestsPath = `${workspace}/out/test`;
 	let vscodePath = await vscodeTest.downloadAndUnzipVSCode(vscodeVersion);
-	try {
-		await vscodeTest.runTests({
-			vscodeExecutablePath: vscodePath,
-			extensionDevelopmentPath: workspace,
-			extensionTestsPath: extensionTestsPath,
-			launchArgs: args
-		});
-	} catch (error) {
-		console.log(`stdout: ${process.stdout}`);
-		console.log(`stderr: ${process.stderr}`);
-		console.error(`exec error: ${error}`);
-	}
-	done();
-	process.exit(0);
+	await vscodeTest.runTests({
+		vscodeExecutablePath: vscodePath,
+		extensionDevelopmentPath: workspace,
+		extensionTestsPath: extensionTestsPath,
+		launchArgs: args
+	});
 });
 
 gulp.task('test', gulp.series('ext:test'));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/17376

We weren't failing the task when test failures occurred so the builds would happily complete.

I also did some cleanup by removing some unnecessary logging statements (the output and error messages are already printed out) and removing some disabled tasks from the pipeline definitions. 

This does mean we'll have failing tests, @kisantia @Benjin I'll leave that to your team as the owners to decide how you want to handle them. (with a preference towards getting them fixed of course 😄)