### PR TITLE
fix 'promptLanguageFlavor should prompt for a language flavor' test

### DIFF
--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -102,9 +102,9 @@ suite('Connection UI tests', () => {
 
 	test('promptLanguageFlavor should prompt for a language flavor', () => {
 		let mockProvider = { providerId: 'test' };
-		prompter.setup(p => p.promptSingle(TypeMoq.It.isAny())).returns(() => Promise.resolve(mockProvider));
+		prompter.setup(p => p.promptSingle(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(mockProvider));
 		return connectionUI.promptLanguageFlavor().then(() => {
-			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny()), TypeMoq.Times.once());
+			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 	});
 


### PR DESCRIPTION
This test was failing because ignoreFocusOut was added as a parameter here in https://github.com/microsoft/vscode-mssql/pull/17322, so the mock call signature in this test no longer matched.

 https://github.com/microsoft/vscode-mssql/blob/20750346a745890c93637ddfc2b4093c13904337/src/views/connectionUI.ts#L153