### PR TITLE
Fix connection UI tests

### DIFF
--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -60,7 +60,7 @@ suite('Connection UI tests', () => {
 		outputChannel.verify(c => c.show(true), TypeMoq.Times.once());
 	});
 
-	test('showConnections with recent and new connection', () => {
+	test.skip('showConnections with recent and new connection', () => {
 		let item: IConnectionCredentialsQuickPickItem = {
 			connectionCreds: undefined,
 			quickPickItemType: CredentialsQuickPickItemType.NewConnection,
@@ -75,7 +75,7 @@ suite('Connection UI tests', () => {
 		});
 	});
 
-	test('showConnections with recent and edit connection', () => {
+	test.skip('showConnections with recent and edit connection', () => {
 		let testCreds = new ConnectionCredentials();
 		testCreds.connectionString = 'test';
 		let item: IConnectionCredentialsQuickPickItem = {
@@ -92,7 +92,7 @@ suite('Connection UI tests', () => {
 		});
 	});
 
-	test('showConnections with recent but no selection', () => {
+	test.skip('showConnections with recent but no selection', () => {
 		prompter.setup(p => p.promptSingle(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 		return connectionUI.promptForConnection().then(() => {
 			connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -71,7 +71,7 @@ suite('Connection UI tests', () => {
 		prompter.setup(p => p.prompt(TypeMoq.It.isAny(), true)).returns(() => Promise.resolve(mockConnection));
 		return connectionUI.promptForConnection().then(() => {
 			connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
-			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny()), TypeMoq.Times.once());
+			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 	});
 
@@ -88,7 +88,7 @@ suite('Connection UI tests', () => {
 		prompter.setup(p => p.prompt(TypeMoq.It.isAny(), true)).returns(() => Promise.resolve(mockConnection));
 		return connectionUI.promptForConnection().then(() => {
 			connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
-			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny()), TypeMoq.Times.once());
+			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 	});
 
@@ -96,7 +96,7 @@ suite('Connection UI tests', () => {
 		prompter.setup(p => p.promptSingle(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 		return connectionUI.promptForConnection().then(() => {
 			connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
-			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny()), TypeMoq.Times.once());
+			prompter.verify(p => p.promptSingle(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 	});
 


### PR DESCRIPTION
This gets the 3 failing Connection UI tests passing as of commit b7cbc19d5453c2e0ec41e786bee38b2969060e41 - I ran the vscode-mssql adhoc pipeline with this commit on a branch off of that previous commit and verified these tests were passing. They were initially failing for the same reason as the test fixed in #17379. 

However, these 3 tests were then broken by the changes in https://github.com/microsoft/vscode-mssql/pull/17350, which significantly changed the code in `promptForConnection()`. @VasuBhog please fix these tests when you have a chance. 

Since the tests no longer are accurately testing the code in `promptForConnection()`, I'm skipping them until they get fixed.