### PR TITLE
Fix Connection Tests 

### DIFF
--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -248,6 +248,10 @@ export default class VscodeWrapper {
 		return vscode.window.showQuickPick(items, options);
 	}
 
+	public createQuickPick<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> {
+		return vscode.window.createQuickPick<T>();
+	}
+
 	/**
 	 * Shows a selection list.
 	 *

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -88,7 +88,7 @@ export class ConnectionUI {
 		return await new Promise<IConnectionInfo | undefined>((resolve, _) => {
 			let connectionProfileList = this._connectionStore.getPickListItems();
 			// We have recent connections - show them in a prompt for connection profiles
-			const connectionProfileQuickPick = vscode.window.createQuickPick<IConnectionCredentialsQuickPickItem>();
+			const connectionProfileQuickPick = this.vscodeWrapper.createQuickPick<IConnectionCredentialsQuickPickItem>();
 			connectionProfileQuickPick.items = connectionProfileList;
 			connectionProfileQuickPick.placeholder = LocalizedConstants.recentConnectionsPlaceholder;
 			connectionProfileQuickPick.matchOnDescription = true;

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -300,16 +300,15 @@ suite('Connection Profile tests', () => {
 			connectionStoreMock.object, mockAccountStore, prompter.object, vscodeWrapperMock.object);
 
 		// create a new connection profile
-		connectionUI.createAndSaveProfile().then(profile => {
+		connectionUI.createAndSaveProfile()
+		// CancelError will be thrown (expected)
+		.catch(() => {
 			// connection is attempted
-			connectionManagerMock.verify(x => x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
+			connectionManagerMock.verify(x => x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 
 			// profile is not saved
-			connectionStoreMock.verify(x => x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.never());
-
+			connectionStoreMock.verify(x => x.saveProfile(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.never());
 			done();
-		}).catch(err => {
-			done(err);
 		});
 	});
 

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -294,7 +294,7 @@ suite('Connection Profile tests', () => {
 
 		let vscodeWrapperMock = TypeMoq.Mock.ofType(VscodeWrapper);
 		vscodeWrapperMock.setup(x => x.activeTextEditorUri).returns(() => 'test.sql');
-		// user cancels out of error message
+		// user cancels out of retry prompt
 		vscodeWrapperMock.setup(x => x.showErrorMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 
 		let connectionUI = new ConnectionUI(connectionManagerMock.object, contextMock.object,

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -294,6 +294,7 @@ suite('Connection Profile tests', () => {
 
 		let vscodeWrapperMock = TypeMoq.Mock.ofType(VscodeWrapper);
 		vscodeWrapperMock.setup(x => x.activeTextEditorUri).returns(() => 'test.sql');
+		// user cancels out of error message
 		vscodeWrapperMock.setup(x => x.showErrorMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 
 		let connectionUI = new ConnectionUI(connectionManagerMock.object, contextMock.object,

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -41,14 +41,15 @@ suite('Connection UI tests', () => {
 		vscodeWrapper.setup(v => v.createOutputChannel(TypeMoq.It.isAny())).returns(() => outputChannel.object);
 		vscodeWrapper.setup(v => v.showErrorMessage(TypeMoq.It.isAny()));
 		vscodeWrapper.setup(v => v.executeCommand(TypeMoq.It.isAnyString()));
-		quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
 		prompter = TypeMoq.Mock.ofType<IPrompter>();
 		mockContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
 		mockContext.setup(c => c.globalState).returns(() => globalstate.object);
 		connectionStore = TypeMoq.Mock.ofType(ConnectionStore, TypeMoq.MockBehavior.Loose, mockContext.object);
-		connectionStore.setup(c => c.getPickListItems()).returns(() => [TypeMoq.It.isAny()]);
 		connectionManager = TypeMoq.Mock.ofType(ConnectionManager, TypeMoq.MockBehavior.Loose, mockContext.object);
 		globalstate = TypeMoq.Mock.ofType<vscode.Memento & { setKeysForSync(keys: readonly string[]): void; }>();
+		quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
+		quickPickMock.setup(q => q.items);
+		quickPickMock.setup(q => q.show());
 
 		mockAccountStore = new AccountStore(mockContext.object);
 		connectionUI = new ConnectionUI(connectionManager.object, mockContext.object,
@@ -68,23 +69,25 @@ suite('Connection UI tests', () => {
 			quickPickItemType: CredentialsQuickPickItemType.NewConnection,
 			label: undefined
 		};
-
-		quickPickMock.setup(q => q.items);
-		quickPickMock.setup(q => q.show());
 		quickPickMock.object.items = [item];
-		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
-		quickPickMock.object.onDidChangeSelection((e) => [item] = e);
-		quickPickMock.setup(q => q.onDidHide(() => false));
+		let mockConnection = { connectionString: 'test' };
+		// setup stubbed event for us to trigger later
+		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
+		quickPickMock.setup(q => q.onDidChangeSelection).returns(() => onDidChangeSelectionEventEmitter.event);
 		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
+		// createProfile prompter stub
+		prompter.setup(p => p.prompt(TypeMoq.It.isAny(), true)).returns(() => Promise.resolve(mockConnection));
 
 		const promptPromise = connectionUI.promptForConnection();
+		// Trigger onDidChangeSelection event to simulate user selecting new connection option
+		onDidChangeSelectionEventEmitter.fire([item]);
 		await promptPromise;
+
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
-		quickPickMock.object.dispose();
 	});
 
-	test('showConnections with recent and edit connection', () => {
+	test('showConnections with recent and edit connection', async () => {
 		let testCreds = new ConnectionCredentials();
 		testCreds.connectionString = 'test';
 		let item: IConnectionCredentialsQuickPickItem = {
@@ -92,34 +95,22 @@ suite('Connection UI tests', () => {
 			quickPickItemType: CredentialsQuickPickItemType.Mru,
 			label: undefined
 		};
-
-		quickPickMock.setup(q => q.items);
-		quickPickMock.setup(q => q.show());
 		quickPickMock.object.items = [item];
-		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
-		quickPickMock.object.onDidChangeSelection((e) => [item] = e);
-		quickPickMock.setup(q => q.onDidHide(() => false));
+		// setup stubbed event for us to trigger later
+		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
+		quickPickMock.setup(q => q.onDidChangeSelection).returns(() => onDidChangeSelectionEventEmitter.event);
 		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
-		connectionUI.promptForConnection();
+		const promptPromise = connectionUI.promptForConnection();
+		// Trigger onDidChangeSelection event to simulate user selecting edit connection option
+		onDidChangeSelectionEventEmitter.fire([item]);
+		await promptPromise;
+
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
-		quickPickMock.object.dispose();
 	});
 
 	test('showConnections with recent but no selection', async () => {
-		let testCreds = new ConnectionCredentials();
-		testCreds.connectionString = 'test';
-		let item: IConnectionCredentialsQuickPickItem = {
-			connectionCreds: testCreds,
-			quickPickItemType: CredentialsQuickPickItemType.Profile,
-			label: undefined
-		};
-
-		quickPickMock.setup(q => q.items);
-		quickPickMock.setup(q => q.show());
-		quickPickMock.object.items = [item];
-
 		// setup stubbed event for us to trigger later
 		const onDidHideEventEmitter = new vscode.EventEmitter<void>();
 		quickPickMock.setup(q => q.onDidHide).returns(() => onDidHideEventEmitter.event);

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -70,7 +70,6 @@ suite('Connection UI tests', () => {
 			quickPickItemType: CredentialsQuickPickItemType.NewConnection,
 			label: undefined
 		};
-		quickPickMock.object.items = [item];
 		let mockConnection = { connectionString: 'test' };
 		// setup stubbed event for us to trigger later
 		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
@@ -95,7 +94,6 @@ suite('Connection UI tests', () => {
 			quickPickItemType: CredentialsQuickPickItemType.Mru,
 			label: undefined
 		};
-		quickPickMock.object.items = [item];
 		// setup stubbed event for us to trigger later
 		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
 		quickPickMock.setup(q => q.onDidChangeSelection).returns(() => onDidChangeSelectionEventEmitter.event);

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -72,10 +72,11 @@ suite('Connection UI tests', () => {
 		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
 		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
+		quickPickMock.object.onDidChangeSelection((e) => [item] = e);
 		quickPickMock.setup(q => q.onDidHide(() => false));
 		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
-		await connectionUI.promptForConnection();
+		connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
 	});
@@ -94,10 +95,11 @@ suite('Connection UI tests', () => {
 		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
 		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
+		quickPickMock.object.onDidChangeSelection((e) => [item] = e);
 		quickPickMock.setup(q => q.onDidHide(() => false));
 		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
-		await connectionUI.promptForConnection();
+		connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
 	});
@@ -115,11 +117,12 @@ suite('Connection UI tests', () => {
 		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
 		quickPickMock.setup(q => q.onDidChangeSelection((e) => [] = e));
+		quickPickMock.object.onDidChangeSelection(undefined);
 		quickPickMock.setup(q => q.onDidHide(() => false));
 		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
 
-		await connectionUI.promptForConnection();
+		connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
 	});

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -38,18 +38,19 @@ suite('Connection UI tests', () => {
 		outputChannel.setup(c => c.clear());
 		outputChannel.setup(c => c.append(TypeMoq.It.isAny()));
 		outputChannel.setup(c => c.show(TypeMoq.It.isAny()));
+		quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
+		quickPickMock.setup(q => q.items);
+		quickPickMock.setup(q => q.show());
 		vscodeWrapper.setup(v => v.createOutputChannel(TypeMoq.It.isAny())).returns(() => outputChannel.object);
 		vscodeWrapper.setup(v => v.showErrorMessage(TypeMoq.It.isAny()));
 		vscodeWrapper.setup(v => v.executeCommand(TypeMoq.It.isAnyString()));
+		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 		prompter = TypeMoq.Mock.ofType<IPrompter>();
 		mockContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
 		mockContext.setup(c => c.globalState).returns(() => globalstate.object);
 		connectionStore = TypeMoq.Mock.ofType(ConnectionStore, TypeMoq.MockBehavior.Loose, mockContext.object);
 		connectionManager = TypeMoq.Mock.ofType(ConnectionManager, TypeMoq.MockBehavior.Loose, mockContext.object);
 		globalstate = TypeMoq.Mock.ofType<vscode.Memento & { setKeysForSync(keys: readonly string[]): void; }>();
-		quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
-		quickPickMock.setup(q => q.items);
-		quickPickMock.setup(q => q.show());
 
 		mockAccountStore = new AccountStore(mockContext.object);
 		connectionUI = new ConnectionUI(connectionManager.object, mockContext.object,
@@ -74,7 +75,6 @@ suite('Connection UI tests', () => {
 		// setup stubbed event for us to trigger later
 		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
 		quickPickMock.setup(q => q.onDidChangeSelection).returns(() => onDidChangeSelectionEventEmitter.event);
-		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 		// createProfile prompter stub
 		prompter.setup(p => p.prompt(TypeMoq.It.isAny(), true)).returns(() => Promise.resolve(mockConnection));
 
@@ -99,7 +99,6 @@ suite('Connection UI tests', () => {
 		// setup stubbed event for us to trigger later
 		const onDidChangeSelectionEventEmitter = new vscode.EventEmitter<IConnectionCredentialsQuickPickItem[]>();
 		quickPickMock.setup(q => q.onDidChangeSelection).returns(() => onDidChangeSelectionEventEmitter.event);
-		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
 		const promptPromise = connectionUI.promptForConnection();
 		// Trigger onDidChangeSelection event to simulate user selecting edit connection option
@@ -114,7 +113,6 @@ suite('Connection UI tests', () => {
 		// setup stubbed event for us to trigger later
 		const onDidHideEventEmitter = new vscode.EventEmitter<void>();
 		quickPickMock.setup(q => q.onDidHide).returns(() => onDidHideEventEmitter.event);
-		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 		const promptForConnectionPromise = connectionUI.promptForConnection();
 		// Trigger onDidHide event to simulate user exiting the dialog without choosing anything
 		onDidHideEventEmitter.fire();

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -68,10 +68,12 @@ suite('Connection UI tests', () => {
 		};
 
 		let quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
-		quickPickMock.setup(q => q.items).returns(() => [item]);
+		quickPickMock.setup(q => q.items);
+		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
-		quickPickMock.setup(q => q.onDidChangeSelection(TypeMoq.It.isAny())).returns(await Promise.resolve(item as any));
-		quickPickMock.setup(q => q.onDidHide(TypeMoq.It.isAny())).returns(await Promise.resolve(undefined));
+		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
+		quickPickMock.setup(q => q.onDidHide(() => false));
+		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
 		await connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
@@ -88,10 +90,12 @@ suite('Connection UI tests', () => {
 		};
 
 		let quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
-		quickPickMock.setup(q => q.items).returns(() => [item]);
+		quickPickMock.setup(q => q.items);
+		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
-		quickPickMock.setup(q => q.onDidChangeSelection(TypeMoq.It.isAny())).returns(await Promise.resolve(undefined));
-		quickPickMock.setup(q => q.onDidHide(TypeMoq.It.isAny())).returns(await Promise.resolve(undefined));
+		quickPickMock.setup(q => q.onDidChangeSelection((e) => [item] = e));
+		quickPickMock.setup(q => q.onDidHide(() => false));
+		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
 
 		await connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());
@@ -99,11 +103,21 @@ suite('Connection UI tests', () => {
 	});
 
 	test('showConnections with recent but no selection', async () => {
+		let testCreds = new ConnectionCredentials();
+		testCreds.connectionString = 'test';
+		let item: IConnectionCredentialsQuickPickItem = {
+			connectionCreds: testCreds,
+			quickPickItemType: CredentialsQuickPickItemType.Profile,
+			label: undefined
+		};
 		let quickPickMock = TypeMoq.Mock.ofType<vscode.QuickPick<IConnectionCredentialsQuickPickItem>>();
-		quickPickMock.setup(q => q.items).returns(() => undefined);
+		quickPickMock.setup(q => q.items);
+		quickPickMock.object.items = [item];
 		quickPickMock.setup(q => q.show());
-		quickPickMock.setup(q => q.onDidChangeSelection(TypeMoq.It.isAny())).returns(await Promise.resolve(undefined));
-		quickPickMock.setup(q => q.onDidHide(TypeMoq.It.isAny())).returns(await Promise.resolve(undefined));
+		quickPickMock.setup(q => q.onDidChangeSelection((e) => [] = e));
+		quickPickMock.setup(q => q.onDidHide(() => false));
+		vscodeWrapper.setup(v => v.createQuickPick()).returns(() => quickPickMock.object);
+
 
 		await connectionUI.promptForConnection();
 		connectionStore.verify(c => c.getPickListItems(), TypeMoq.Times.once());

--- a/test/connectionUI.test.ts
+++ b/test/connectionUI.test.ts
@@ -60,7 +60,7 @@ suite('Connection UI tests', () => {
 		outputChannel.verify(c => c.show(true), TypeMoq.Times.once());
 	});
 
-	test('showConnections with recent and new connection', async () => {
+	test('showConnections with recent and new connection', () => {
 		let item: IConnectionCredentialsQuickPickItem = {
 			connectionCreds: undefined,
 			quickPickItemType: CredentialsQuickPickItemType.NewConnection,
@@ -81,7 +81,7 @@ suite('Connection UI tests', () => {
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
 	});
 
-	test('showConnections with recent and edit connection', async () => {
+	test('showConnections with recent and edit connection', () => {
 		let testCreds = new ConnectionCredentials();
 		testCreds.connectionString = 'test';
 		let item: IConnectionCredentialsQuickPickItem = {
@@ -104,7 +104,7 @@ suite('Connection UI tests', () => {
 		quickPickMock.verify(q => q.show(), TypeMoq.Times.once());
 	});
 
-	test('showConnections with recent but no selection', async () => {
+	test('showConnections with recent but no selection', () => {
 		let testCreds = new ConnectionCredentials();
 		testCreds.connectionString = 'test';
 		let item: IConnectionCredentialsQuickPickItem = {


### PR DESCRIPTION
These tests were failing due to many changes to the promptForConnection improvements. 

The main PR that changed the functionality of promptForConnection is [here](https://github.com/microsoft/vscode-mssql/pull/17350). Instead of using prompter we now use createQuickPick to add flexibility as well as extensibility further down the road. 

The tests that were updated to setup the proper mocking aspects for the test to be verified. We verify the same assertions that we're originally being tested for these tests. 

Follow-up item: https://github.com/microsoft/vscode-mssql/issues/17394