### PR TITLE
Use latest VS Code when running tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,6 @@ var nls = require('vscode-nls-dev');
 var argv = require('yargs').argv;
 var min = (argv.min === undefined) ? false : true;
 var vscodeTest = require('vscode-test');
-var packageJson = require('./package.json');
 
 require('./tasks/packagetasks');
 require('./tasks/localizationtasks');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -244,9 +244,8 @@ gulp.task('ext:test', async () => {
 	}
 	process.env.JUNIT_REPORT_PATH = workspace + '/test-reports/test-results-ext.xml';
 	var args = ['--verbose', '--disable-gpu', '--disable-telemetry', '--disable-updates', '-n'];
-	let vscodeVersion = packageJson.engines.vscode.slice(1);
 	let extensionTestsPath = `${workspace}/out/test`;
-	let vscodePath = await vscodeTest.downloadAndUnzipVSCode(vscodeVersion);
+	let vscodePath = await vscodeTest.downloadAndUnzipVSCode();
 	await vscodeTest.runTests({
 		vscodeExecutablePath: vscodePath,
 		extensionDevelopmentPath: workspace,


### PR DESCRIPTION
Currently we're pinned to using the version specified in the engine field of package.json, but that's just the minimum version. We primarily want to make sure everything works with the latest so removing the version specification. 

At some point we could consider running tests against multiple versions, but that doesn't seem that useful right now since the suggestion is for users to always have the latest updates. 