### PR TITLE
ObjectTypedictionary added to the deploymentOptions interface to get the object types options and display names 

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.2.0.6",
+    "version": "4.2.0.10",
     "downloadFileNames": {
       "Windows_86": "win-x86-net6.0.zip",
       "Windows_64": "win-x64-net6.0.zip",

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -501,7 +501,7 @@ declare module 'vscode-mssql' {
 	/**
 	* Interface containing deployment options of string[] type, value property holds enum names (nothing but option name) from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
 	*/
-	export interface DacDeployOptionPropertyObject  {
+	export interface DacDeployOptionPropertyObject {
 		value: string[];
 		description: string;
 		displayName: string;
@@ -512,7 +512,7 @@ declare module 'vscode-mssql' {
 	* These property names should match with the properties defined in <sqltoolsservice>\src\Microsoft.SqlTools.ServiceLayer\DacFx\Contracts\DeploymentOptions.cs
 	*/
 	export interface DeploymentOptions {
-		excludeObjectTypes: DacDeployOptionPropertyObject ;
+		excludeObjectTypes: DacDeployOptionPropertyObject;
 		// key will be the boolean option name
 		booleanOptionsDictionary: { [key: string]: DacDeployOptionPropertyBoolean };
 		// key will be the object type enum name (nothing but option name)

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -499,9 +499,9 @@ declare module 'vscode-mssql' {
 	}
 
 	/**
-	* Interface containing deployment options of string[] type, value property holds enum names(nothing but option name) from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
+	* Interface containing deployment options of string[] type, value property holds enum names (nothing but option name) from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
 	*/
-	export interface DacDeployOptionPropertyStringArray {
+	export interface DacDeployOptionPropertyObject  {
 		value: string[];
 		description: string;
 		displayName: string;
@@ -512,10 +512,10 @@ declare module 'vscode-mssql' {
 	* These property names should match with the properties defined in <sqltoolsservice>\src\Microsoft.SqlTools.ServiceLayer\DacFx\Contracts\DeploymentOptions.cs
 	*/
 	export interface DeploymentOptions {
-		excludeObjectTypes: DacDeployOptionPropertyStringArray;
+		excludeObjectTypes: DacDeployOptionPropertyObject ;
 		// key will be the boolean option name
 		booleanOptionsDictionary: { [key: string]: DacDeployOptionPropertyBoolean };
-		// key will be the object type enum name(nothing but option name)
+		// key will be the object type enum name (nothing but option name)
 		objectTypesDictionary: { [key: string]: string };
 	}
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -499,10 +499,10 @@ declare module 'vscode-mssql' {
 	}
 
 	/**
-	* Interface containing deployment options of integer type, value property holds values from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
+	* Interface containing deployment options of string[] type, value property holds enum names from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
 	*/
-	export interface DacDeployOptionPropertyObject {
-		value: number[];
+	export interface DacDeployOptionPropertyStringArray {
+		value: string[];
 		description: string;
 		displayName: string;
 	}
@@ -512,9 +512,11 @@ declare module 'vscode-mssql' {
 	* These property names should match with the properties defined in <sqltoolsservice>\src\Microsoft.SqlTools.ServiceLayer\DacFx\Contracts\DeploymentOptions.cs
 	*/
 	export interface DeploymentOptions {
-		excludeObjectTypes: DacDeployOptionPropertyObject;
+		excludeObjectTypes: DacDeployOptionPropertyStringArray;
 		// key will be the boolean option name
 		booleanOptionsDictionary: { [key: string]: DacDeployOptionPropertyBoolean };
+		// key will be the object type option name
+		includeObjectsDictionary: { [key: string]: string };
 	}
 
 	/**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -499,7 +499,7 @@ declare module 'vscode-mssql' {
 	}
 
 	/**
-	* Interface containing deployment options of string[] type, value property holds enum names from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
+	* Interface containing deployment options of string[] type, value property holds enum names(nothing but option name) from <DacFx>\Product\Source\DeploymentApi\ObjectTypes.cs enum
 	*/
 	export interface DacDeployOptionPropertyStringArray {
 		value: string[];
@@ -515,8 +515,8 @@ declare module 'vscode-mssql' {
 		excludeObjectTypes: DacDeployOptionPropertyStringArray;
 		// key will be the boolean option name
 		booleanOptionsDictionary: { [key: string]: DacDeployOptionPropertyBoolean };
-		// key will be the object type option name
-		includeObjectsDictionary: { [key: string]: string };
+		// key will be the object type enum name(nothing but option name)
+		objectTypesDictionary: { [key: string]: string };
 	}
 
 	/**


### PR DESCRIPTION
This PR contains:
1. The include object type options dictionary that holds Key:OptionsName, Value:DisplayName coming from the DacFx API through the STS
2. DacDeployOptionPropertyStringArray value holds the EnumNames(AKA option name) corresponding to the option display nameThis property is being used for SC and SQL DB project extensions.
3. Also, helps to completely avoid the hardcoded option names in the ADS repo.
4. Corresponding STS PR: https://github.com/microsoft/sqltoolsservice/pull/1574