### PR TITLE
block query execution when in multi-selection mode

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -524,6 +524,9 @@
          <trans-unit id="connectProgressNoticationTitle">
             <source xml:lang="en">Testing connection profile...</source>
         </trans-unit>
+        <trans-unit id="msgMultipleSelectionModeNotSupported">
+            <source xml:lang="en">Running query is not supported when the editor is in multiple selection mode.</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -745,6 +745,13 @@ export default class MainController implements vscode.Disposable {
 			let editor = self._vscodeWrapper.activeTextEditor;
 			let uri = self._vscodeWrapper.activeTextEditorUri;
 
+			// Do not execute when there are multiple selections in the editor until it can be properly handled.
+			// Otherwise only the first selection will be executed and cause unexpected issues.
+			if (editor.selections?.length > 1) {
+				self._vscodeWrapper.showErrorMessage(LocalizedConstants.msgMultipleSelectionModeNotSupported);
+				return;
+			}
+
 			// create new connection
 			if (!self.connectionManager.isConnected(uri)) {
 				await self.onNewConnection();


### PR DESCRIPTION
the issue:https://github.com/microsoft/azuredatastudio/issues/20008 also exists in vscode-mssql extension. 

block it for now until we have properly implemented support for multi selection mode.

with the change: 
![image](https://user-images.githubusercontent.com/13777222/181866381-025ad1cd-d1d3-4ab7-85cf-b7feaa7fefd6.png)

ADS change: https://github.com/microsoft/azuredatastudio/pull/20213