### PR TITLE
Update vmimage and remove duplicate install vscode task

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: "macOS-10.15"
+  vmImage: "macos-latest"
 
 steps:
   - task: NodeTool@0
@@ -99,11 +99,6 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: "Publish Artifact: drop"
-
-  - script: |
-      brew update
-      brew install --cask visual-studio-code
-    displayName: "Install VS Code for testing"
 
   - task: gulp@0
     displayName: "gulp ext:install-service"


### PR DESCRIPTION
addresses issues brought up in today's DRI meetings: removes unnecessary VS install task and updates the vm image to one that isn't deprecated.