### PR TITLE
Includes ts files in coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tools
 examples
 sqltoolsservice
 coverage
+coverage-remapped
 test-reports
 .vscode-test
 localization/i18n/

--- a/build/build.yml
+++ b/build/build.yml
@@ -34,6 +34,9 @@ steps:
       testResultsFiles: 'test-reports/test-results-ext.xml'
     condition: succeededOrFailed()
 
+  - bash: "gulp remap-coverage"
+    displayName: "gulp remap-coverage"
+
   - bash: "gulp cover:combine-json"
     displayName: "gulp cover:combine-json"
 
@@ -41,7 +44,7 @@ steps:
     inputs:
       codeCoverageTool: 'Cobertura'
       summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
-      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage/coverage.json
+      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage-remapped/coverage.json
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
     displayName: Install vsce

--- a/build/build.yml
+++ b/build/build.yml
@@ -41,7 +41,7 @@ steps:
     inputs:
       codeCoverageTool: 'Cobertura'
       summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
-      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage/coverage.json
+      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage/coverage-final.json
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
     displayName: Install vsce

--- a/build/build.yml
+++ b/build/build.yml
@@ -41,7 +41,7 @@ steps:
     inputs:
       codeCoverageTool: 'Cobertura'
       summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
-      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage/coverage-final.json
+      additionalCodeCoverageFiles: $(System.DefaultWorkingDirectory)/coverage/coverage.json
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
     displayName: Install vsce

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "gulp-uglify": "^2.0.0",
     "istanbul": "^0.4.5",
     "pm-mocha-jenkins-reporter": "^0.2.6",
-    "remap-istanbul": "^0.6.4",
+    "remap-istanbul": "0.9.6",
     "rxjs": "5.0.0-beta.12",
     "sinon": "^14.0.0",
     "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",

--- a/package.json
+++ b/package.json
@@ -1,1133 +1,1139 @@
 {
-  "name": "mssql",
-  "displayName": "SQL Server (mssql)",
-  "version": "1.16.0",
-  "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
-  "publisher": "ms-mssql",
-  "preview": false,
-  "license": "SEE LICENSE IN LICENSE.txt",
-  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
-  "icon": "images/sqlserver.png",
-  "galleryBanner": {
-    "color": "#2F2F2F",
-    "theme": "dark"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Microsoft/vscode-mssql.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Microsoft/vscode-mssql/issues"
-  },
-  "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
-  "engines": {
-    "vscode": "^1.57.0"
-  },
-  "categories": [
-    "Programming Languages",
-    "Azure"
-  ],
-  "keywords": [
-    "SQL",
-    "MSSQL",
-    "SQL Server",
-    "Azure SQL Database",
-    "Azure SQL Data Warehouse",
-    "multi-root ready"
-  ],
-  "activationEvents": [
-    "onView:objectExplorer",
-    "onLanguage:sql",
-    "onCommand:mssql.connect",
-    "onCommand:mssql.runQuery",
-    "onCommand:mssql.runCurrentStatement",
-    "onCommand:mssql.disconnect",
-    "onCommand:mssql.manageProfiles",
-    "onCommand:mssql.chooseDatabase",
-    "onCommand:mssql.cancelQuery",
-    "onCommand:mssql.showGettingStarted",
-    "onCommand:mssql.newQuery",
-    "onCommand:mssql.rebuildIntelliSenseCache",
-    "onCommand:mssql.addObjectExplorer",
-    "onCommand:mssql.objectExplorerNewQuery",
-    "onCommand:mssql.toggleSqlCmd",
-    "onCommand:mssql.loadCompletionExtension",
-    "onCommand:mssql.removeAadAccount"
-  ],
-  "main": "./out/src/extension",
-  "extensionDependencies": [
-    "vscode.sql"
-  ],
-  "extensionPack": [
-    "ms-mssql.data-workspace-vscode",
-    "ms-mssql.sql-database-projects-vscode",
-    "ms-mssql.sql-bindings-vscode"
-  ],
-  "scripts": {
-    "build": "gulp build",
-    "compile": "gulp ext:compile",
-    "watch": "gulp watch"
-  },
-  "devDependencies": {
-    "@angular/common": "~2.1.2",
-    "@angular/compiler": "~2.1.2",
-    "@angular/core": "~2.1.2",
-    "@angular/forms": "~2.1.2",
-    "@angular/platform-browser": "~2.1.2",
-    "@angular/platform-browser-dynamic": "~2.1.2",
-    "@angular/router": "~3.1.2",
-    "@angular/upgrade": "~2.1.2",
-    "@types/ejs": "^3.1.0",
-    "@types/jquery": "^3.3.31",
-    "@types/jqueryui": "^1.12.7",
-    "@types/keytar": "^4.4.2",
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^14.14.16",
-    "@types/sinon": "^10.0.12",
-    "@types/tmp": "0.0.28",
-    "@types/underscore": "1.8.3",
-    "@types/vscode": "1.57.0",
-    "angular-in-memory-web-api": "0.1.13",
-    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
-    "assert": "^1.4.1",
-    "chai": "^3.5.0",
-    "coveralls": "^3.0.2",
-    "decache": "^4.1.0",
-    "del": "^2.2.1",
-    "gulp": "^4.0.2",
-    "gulp-concat": "^2.6.0",
-    "gulp-istanbul-report": "0.0.1",
-    "gulp-json-editor": "^2.2.1",
-    "gulp-rename": "^1.2.2",
-    "gulp-shell": "^0.7.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-tslint": "^8.1.4",
-    "gulp-typescript": "^5.0.1",
-    "gulp-uglify": "^2.0.0",
-    "istanbul": "^0.4.5",
-    "pm-mocha-jenkins-reporter": "^0.2.6",
-    "remap-istanbul": "^0.6.4",
-    "rxjs": "5.0.0-beta.12",
-    "sinon": "^14.0.0",
-    "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
-    "systemjs": "0.19.40",
-    "systemjs-builder": "^0.15.32",
-    "systemjs-plugin-json": "^0.2.0",
-    "tslint": "^6.1.3",
-    "tslint-microsoft-contrib": "^5.2.0",
-    "typemoq": "^1.7.0",
-    "typescript": "^3.5.3",
-    "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
-    "vscode-nls-dev": "2.0.1",
-    "@vscode/test-electron": "^2.1.5",
-    "@xmldom/xmldom": "^0.8.2",
-    "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
-  },
-  "dependencies": {
-    "@azure/arm-resources": "^5.0.0",
-    "@azure/arm-sql": "^9.0.0",
-    "@azure/arm-subscriptions": "^5.0.0",
-    "@microsoft/ads-adal-library": "1.0.15",
-    "core-js": "^2.4.1",
-    "decompress-zip": "^0.2.2",
-    "ejs": "^3.1.7",
-    "error-ex": "^1.3.0",
-    "figures": "^1.4.0",
-    "find-remove": "1.2.1",
-    "getmac": "1.2.1",
-    "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
-    "jquery": "^3.4.1",
-    "opener": "1.4.2",
-    "plist": "^3.0.5",
-    "pretty-data": "^0.40.0",
-    "rangy": "^1.3.0",
-    "reflect-metadata": "0.1.12",
-    "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-    "tar": "^6.1.9",
-    "tmp": "^0.0.28",
-    "underscore": "^1.8.3",
-    "vscode-languageclient": "5.2.1",
-    "vscode-nls": "^2.0.2",
-    "zone.js": "^0.6.26"
-  },
-  "capabilities": {
-    "untrustedWorkspaces": {
-      "supported": true
-    }
-  },
-  "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "objectExplorer",
-          "title": "SQL Server",
-          "icon": "./images/server_page_inverse.svg"
-        }
-      ]
-    },
-    "views": {
-      "objectExplorer": [
-        {
-          "id": "objectExplorer",
-          "name": "%extension.connections%"
-        },
-        {
-          "id": "queryHistory",
-          "name": "%extension.queryHistory%",
-          "when": "config.mssql.enableQueryHistoryFeature"
-        }
-      ]
-    },
-    "languages": [
-      {
-        "id": "sql",
-        "extensions": [
-          ".sql"
-        ],
-        "aliases": [
-          "SQL"
-        ],
-        "configuration": "./syntaxes/sql.configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "sql",
-        "scopeName": "source.sql",
-        "path": "./syntaxes/SQL.plist"
-      }
-    ],
-    "snippets": [
-      {
-        "language": "sql",
-        "path": "./snippets/mssql.json"
-      }
-    ],
-    "menus": {
-      "editor/title": [
-        {
-          "command": "mssql.runQuery",
-          "when": "editorLangId == sql",
-          "group": "navigation@1"
-        },
-        {
-          "command": "mssql.cancelQuery",
-          "when": "editorLangId == sql && resourcePath in mssql.runningQueries",
-          "group": "navigation@2"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "mssql.runQuery",
-          "when": "editorLangId == sql"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "mssql.addObjectExplorer",
-          "when": "view == objectExplorer",
-          "title": "%mssql.addObjectExplorer%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.startQueryHistoryCapture",
-          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
-          "title": "%mssql.startQueryHistoryCapture%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.pauseQueryHistoryCapture",
-          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
-          "title": "%mssql.pauseQueryHistoryCapture%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.clearAllQueryHistory",
-          "when": "view == queryHistory",
-          "title": "%mssql.clearAllQueryHistory%",
-          "group": "secondary"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "mssql.objectExplorerNewQuery",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.removeObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
-          "group": "MS_SQL@4"
-        },
-        {
-          "command": "mssql.refreshObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem != disconnectedServer",
-          "group": "MS_SQL@10"
-        },
-        {
-          "command": "mssql.disconnectObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem == Server",
-          "group": "MS_SQL@3"
-        },
-        {
-          "command": "mssql.scriptSelect",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.scriptCreate",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-          "group": "MS_SQL@2"
-        },
-        {
-          "command": "mssql.scriptDelete",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-          "group": "MS_SQL@3"
-        },
-        {
-          "command": "mssql.scriptExecute",
-          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
-          "group": "MS_SQL@5"
-        },
-        {
-          "command": "mssql.scriptAlter",
-          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
-          "group": "MS_SQL@4"
-        },
-        {
-          "command": "mssql.openQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.runQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@2"
-        },
-        {
-          "command": "mssql.deleteQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@3"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "mssql.objectExplorerNewQuery",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
-        },
-        {
-          "command": "mssql.removeObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
-        },
-        {
-          "command": "mssql.refreshObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem != disconnectedServer"
-        },
-        {
-          "command": "mssql.scriptSelect",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
-        },
-        {
-          "command": "mssql.scriptCreate",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-        },
-        {
-          "command": "mssql.scriptDelete",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-        },
-        {
-          "command": "mssql.scriptExecute",
-          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
-        },
-        {
-          "command": "mssql.scriptAlter",
-          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
-        },
-        {
-          "command": "mssql.disconnectObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem == Server"
-        },
-        {
-          "command": "mssql.toggleSqlCmd",
-          "when": "editorFocus && editorLangId == 'sql'"
-        },
-        {
-          "command": "mssql.startQueryHistoryCapture",
-          "when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
-        },
-        {
-          "command": "mssql.pauseQueryHistoryCapture",
-          "when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
-        },
-        {
-          "command": "mssql.copyObjectName",
-          "when": "view == objectExplorer && viewItem != Folder"
-        },
-        {
-          "command": "mssql.runQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "mssql.runQuery",
-        "title": "%mssql.runQuery%",
-        "category": "MS SQL",
-        "icon": "$(debug-start)"
-      },
-      {
-        "command": "mssql.runCurrentStatement",
-        "title": "%mssql.runCurrentStatement%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.cancelQuery",
-        "title": "%mssql.cancelQuery%",
-        "category": "MS SQL",
-        "icon": "$(debug-stop)"
-      },
-      {
-        "command": "mssql.connect",
-        "title": "%mssql.connect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.disconnect",
-        "title": "%mssql.disconnect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.manageProfiles",
-        "title": "%mssql.manageProfiles%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.chooseDatabase",
-        "title": "%mssql.chooseDatabase%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.chooseLanguageFlavor",
-        "title": "%mssql.chooseLanguageFlavor%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.showGettingStarted",
-        "title": "%mssql.showGettingStarted%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.newQuery",
-        "title": "%mssql.newQuery%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.rebuildIntelliSenseCache",
-        "title": "%mssql.rebuildIntelliSenseCache%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.toggleSqlCmd",
-        "title": "%mssql.toggleSqlCmd%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.addObjectExplorer",
-        "title": "%mssql.addObjectExplorer%",
-        "category": "MS SQL",
-        "icon": "$(add)"
-      },
-      {
-        "command": "mssql.objectExplorerNewQuery",
-        "title": "%mssql.objectExplorerNewQuery%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.removeObjectExplorerNode",
-        "title": "%mssql.removeObjectExplorerNode%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.refreshObjectExplorerNode",
-        "title": "%mssql.refreshObjectExplorerNode%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.disconnectObjectExplorerNode",
-        "title": "%mssql.disconnect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptSelect",
-        "title": "%mssql.scriptSelect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptCreate",
-        "title": "%mssql.scriptCreate%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptDelete",
-        "title": "%mssql.scriptDelete%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptExecute",
-        "title": "%mssql.scriptExecute%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptAlter",
-        "title": "%mssql.scriptAlter%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.openQueryHistory",
-        "title": "%mssql.openQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.runQueryHistory",
-        "title": "%mssql.runQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.deleteQueryHistory",
-        "title": "%mssql.deleteQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.clearAllQueryHistory",
-        "title": "%mssql.clearAllQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.startQueryHistoryCapture",
-        "title": "%mssql.startQueryHistoryCapture%",
-        "category": "MS SQL",
-        "icon": "$(debug-start)"
-      },
-      {
-        "command": "mssql.pauseQueryHistoryCapture",
-        "title": "%mssql.pauseQueryHistoryCapture%",
-        "category": "MS SQL",
-        "icon": "$(debug-stop)"
-      },
-      {
-        "command": "mssql.commandPaletteQueryHistory",
-        "title": "%mssql.commandPaletteQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.copyObjectName",
-        "title": "%mssql.copyObjectName%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.removeAadAccount",
-        "title": "%mssql.removeAadAccount%",
-        "category": "MS SQL"
-      }
-    ],
-    "keybindings": [
-      {
-        "command": "mssql.runQuery",
-        "key": "ctrl+shift+e",
-        "mac": "cmd+shift+e",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "mssql.connect",
-        "key": "ctrl+shift+c",
-        "mac": "cmd+shift+c",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "mssql.disconnect",
-        "key": "ctrl+shift+d",
-        "mac": "cmd+shift+d",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "workbench.view.extension.objectExplorer",
-        "key": "ctrl+alt+d",
-        "mac": "cmd+alt+d"
-      },
-      {
-        "command": "mssql.copyObjectName",
-        "key": "ctrl+c",
-        "mac": "cmd+c",
-        "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
-      }
-    ],
-    "configuration": {
-      "type": "object",
-      "title": "%mssql.Configuration%",
-      "properties": {
-        "mssql.azureActiveDirectory": {
-          "type": "string",
-          "default": "AuthCodeGrant",
-          "description": "%mssql.chooseAuthMethod%",
-          "enum": [
-            "AuthCodeGrant",
-            "DeviceCode"
-          ],
-          "enumDescriptions": [
-            "%mssql.authCodeGrant.description%",
-            "%mssql.deviceCode.description%"
-          ],
-          "scope": "application"
-        },
-        "mssql.logDebugInfo": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.logDebugInfo%",
-          "scope": "window"
-        },
-        "mssql.maxRecentConnections": {
-          "type": "number",
-          "default": 5,
-          "description": "%mssql.maxRecentConnections%",
-          "scope": "window"
-        },
-        "mssql.connections": {
-          "type": "array",
-          "description": "%mssql.connections%",
-          "items": {
-            "type": "object",
-            "properties": {
-              "server": {
-                "type": "string",
-                "default": "{{put-server-name-here}}",
-                "description": "%mssql.connection.server%"
-              },
-              "database": {
-                "type": "string",
-                "default": "{{put-database-name-here}}",
-                "description": "%mssql.connection.database%"
-              },
-              "user": {
-                "type": "string",
-                "default": "{{put-username-here}}",
-                "description": "%mssql.connection.user%"
-              },
-              "password": {
-                "type": "string",
-                "default": "{{put-password-here}}",
-                "description": "%mssql.connection.password%"
-              },
-              "authenticationType": {
-                "type": "string",
-                "default": "SqlLogin",
-                "enum": [
-                  "Integrated",
-                  "SqlLogin",
-                  "AzureMFA"
-                ],
-                "description": "%mssql.connection.authenticationType%"
-              },
-              "port": {
-                "type": "number",
-                "default": 1433,
-                "description": "%mssql.connection.port%"
-              },
-              "encrypt": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.encrypt%"
-              },
-              "trustServerCertificate": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.trustServerCertificate%"
-              },
-              "persistSecurityInfo": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.persistSecurityInfo%"
-              },
-              "connectTimeout": {
-                "type": "number",
-                "default": 15,
-                "description": "%mssql.connection.connectTimeout%"
-              },
-              "connectRetryCount": {
-                "type": "number",
-                "default": 1,
-                "description": "%mssql.connection.connectRetryCount%"
-              },
-              "connectRetryInterval": {
-                "type": "number",
-                "default": 10,
-                "description": "%mssql.connection.connectRetryInterval%"
-              },
-              "applicationName": {
-                "type": "string",
-                "default": "vscode-mssql",
-                "description": "%mssql.connection.applicationName%"
-              },
-              "workstationId": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.workstationId%"
-              },
-              "applicationIntent": {
-                "type": "string",
-                "default": "ReadWrite",
-                "enum": [
-                  "ReadWrite",
-                  "ReadOnly"
-                ],
-                "description": "%mssql.connection.applicationIntent%"
-              },
-              "currentLanguage": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.currentLanguage%"
-              },
-              "pooling": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.pooling%"
-              },
-              "maxPoolSize": {
-                "type": "number",
-                "default": 100,
-                "description": "%mssql.connection.maxPoolSize%"
-              },
-              "minPoolSize": {
-                "type": "number",
-                "default": 0,
-                "description": "%mssql.connection.minPoolSize%"
-              },
-              "loadBalanceTimeout": {
-                "type": "number",
-                "default": 0,
-                "description": "%mssql.connection.loadBalanceTimeout%"
-              },
-              "replication": {
-                "type": "boolean",
-                "default": true,
-                "description": "%mssql.connection.replication%"
-              },
-              "attachDbFilename": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.attachDbFilename%"
-              },
-              "failoverPartner": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.failoverPartner%"
-              },
-              "multiSubnetFailover": {
-                "type": "boolean",
-                "default": true,
-                "description": "%mssql.connection.multiSubnetFailover%"
-              },
-              "multipleActiveResultSets": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.multipleActiveResultSets%"
-              },
-              "packetSize": {
-                "type": "number",
-                "default": 8192,
-                "description": "%mssql.connection.packetSize%"
-              },
-              "typeSystemVersion": {
-                "type": "string",
-                "enum": [
-                  "Latest"
-                ],
-                "description": "%mssql.connection.typeSystemVersion%"
-              },
-              "connectionString": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.connectionString%"
-              },
-              "profileName": {
-                "type": "string",
-                "description": "%mssql.connection.profileName%"
-              },
-              "savePassword": {
-                "type": "boolean",
-                "description": "%mssql.connection.savePassword%"
-              },
-              "emptyPasswordInput": {
-                "type": "boolean",
-                "description": "%mssql.connection.emptyPasswordInput%"
-              }
-            }
-          },
-          "scope": "resource"
-        },
-        "mssql.shortcuts": {
-          "type": "object",
-          "description": "%mssql.shortcuts%",
-          "default": {
-            "_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
-            "event.toggleResultPane": "ctrl+alt+R",
-            "event.focusResultsGrid": "ctrl+alt+G",
-            "event.toggleMessagePane": "ctrl+alt+Y",
-            "event.prevGrid": "ctrl+up",
-            "event.nextGrid": "ctrl+down",
-            "event.copySelection": "ctrl+C",
-            "event.copyWithHeaders": "",
-            "event.copyAllHeaders": "",
-            "event.maximizeGrid": "",
-            "event.selectAll": "ctrl+A",
-            "event.saveAsJSON": "",
-            "event.saveAsCSV": "",
-            "event.saveAsExcel": ""
-          },
-          "scope": "resource"
-        },
-        "mssql.messagesDefaultOpen": {
-          "type": "boolean",
-          "description": "%mssql.messagesDefaultOpen%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.resultsFontFamily": {
-          "type": "string",
-          "description": "%mssql.resultsFontFamily%",
-          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-          "scope": "resource"
-        },
-        "mssql.resultsFontSize": {
-          "type": "number",
-          "description": "%mssql.resultsFontSize%",
-          "default": 13,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.includeHeaders": {
-          "type": "boolean",
-          "description": "%mssql.saveAsCsv.includeHeaders%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.delimiter": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.delimiter%",
-          "default": ",",
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.lineSeparator": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.lineSeparator%",
-          "default": null,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.textIdentifier": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.textIdentifier%",
-          "default": "\"",
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.encoding": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.encoding%",
-          "default": "utf-8",
-          "scope": "resource"
-        },
-        "mssql.copyIncludeHeaders": {
-          "type": "boolean",
-          "description": "%mssql.copyIncludeHeaders%",
-          "default": false,
-          "scope": "resource"
-        },
-        "mssql.copyRemoveNewLine": {
-          "type": "boolean",
-          "description": "%mssql.copyRemoveNewLine%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.showBatchTime": {
-          "type": "boolean",
-          "description": "%mssql.showBatchTime%",
-          "default": false,
-          "scope": "resource"
-        },
-        "mssql.splitPaneSelection": {
-          "type": "string",
-          "description": "%mssql.splitPaneSelection%",
-          "default": "next",
-          "enum": [
-            "next",
-            "current",
-            "end"
-          ],
-          "scope": "resource"
-        },
-        "mssql.format.alignColumnDefinitionsInColumns": {
-          "type": "boolean",
-          "description": "%mssql.format.alignColumnDefinitionsInColumns%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.format.datatypeCasing": {
-          "type": "string",
-          "description": "%mssql.format.datatypeCasing%",
-          "default": "none",
-          "enum": [
-            "none",
-            "uppercase",
-            "lowercase"
-          ],
-          "scope": "window"
-        },
-        "mssql.format.keywordCasing": {
-          "type": "string",
-          "description": "%mssql.format.keywordCasing%",
-          "default": "none",
-          "enum": [
-            "none",
-            "uppercase",
-            "lowercase"
-          ],
-          "scope": "window"
-        },
-        "mssql.format.placeCommasBeforeNextStatement": {
-          "type": "boolean",
-          "description": "%mssql.format.placeCommasBeforeNextStatement%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.format.placeSelectStatementReferencesOnNewLine": {
-          "type": "boolean",
-          "description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.applyLocalization": {
-          "type": "boolean",
-          "description": "%mssql.applyLocalization%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.query.displayBitAsNumber": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.displayBitAsNumber%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableIntelliSense": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableIntelliSense%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableErrorChecking": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableErrorChecking%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableSuggestions": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableSuggestions%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableQuickInfo": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableQuickInfo%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.lowerCaseSuggestions": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.intelliSense.lowerCaseSuggestions%",
-          "scope": "window"
-        },
-        "mssql.persistQueryResultTabs": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.persistQueryResultTabs%",
-          "scope": "window"
-        },
-        "mssql.queryHistoryLimit": {
-          "type": "number",
-          "default": 20,
-          "description": "%mssql.queryHistoryLimit%",
-          "scope": "window"
-        },
-        "mssql.enableQueryHistoryCapture": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.enableQueryHistoryCapture%",
-          "scope": "window"
-        },
-        "mssql.enableQueryHistoryFeature": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.enableQueryHistoryFeature%",
-          "scope": "window"
-        },
-        "mssql.query.maxXmlCharsToStore": {
-          "type": "number",
-          "default": 2097152,
-          "description": "%mssql.query.maxXmlCharsToStore%"
-        },
-        "mssql.tracingLevel": {
-          "type": "string",
-          "description": "%mssql.tracingLevel%",
-          "default": "Critical",
-          "enum": [
-            "All",
-            "Off",
-            "Critical",
-            "Error",
-            "Warning",
-            "Information",
-            "Verbose"
-          ]
-        },
-        "mssql.logRetentionMinutes": {
-          "type": "number",
-          "default": 10080,
-          "description": "%mssql.logRetentionMinutes%"
-        },
-        "mssql.logFilesRemovalLimit": {
-          "type": "number",
-          "default": 100,
-          "description": "%mssql.logFilesRemovalLimit%"
-        },
-        "mssql.query.rowCount": {
-          "type": "number",
-          "default": 0,
-          "description": "%mssql.query.setRowCount%"
-        },
-        "mssql.query.textSize": {
-          "type": "number",
-          "default": 2147483647,
-          "description": "%mssql.query.textSize%"
-        },
-        "mssql.query.executionTimeout": {
-          "type": "number",
-          "default": 0,
-          "description": "%mssql.query.executionTimeout%"
-        },
-        "mssql.query.noCount": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.noCount%"
-        },
-        "mssql.query.noExec": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.noExec%"
-        },
-        "mssql.query.parseOnly": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.parseOnly%"
-        },
-        "mssql.query.arithAbort": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.arithAbort%"
-        },
-        "mssql.query.statisticsTime": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.statisticsTime%"
-        },
-        "mssql.query.statisticsIO": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.statisticsIO%"
-        },
-        "mssql.query.xactAbortOn": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.xactAbortOn%"
-        },
-        "mssql.query.transactionIsolationLevel": {
-          "enum": [
-            "READ COMMITTED",
-            "READ UNCOMMITTED",
-            "REPEATABLE READ",
-            "SERIALIZABLE"
-          ],
-          "default": "READ COMMITTED",
-          "description": "%mssql.query.transactionIsolationLevel%"
-        },
-        "mssql.query.deadlockPriority": {
-          "enum": [
-            "Normal",
-            "Low"
-          ],
-          "default": "Normal",
-          "description": "%mssql.query.deadlockPriority%"
-        },
-        "mssql.query.lockTimeout": {
-          "type": "number",
-          "default": -1,
-          "description": "%mssql.query.lockTimeout%"
-        },
-        "mssql.query.queryGovernorCostLimit": {
-          "type": "number",
-          "default": -1,
-          "description": "%mssql.query.queryGovernorCostLimit%"
-        },
-        "mssql.query.ansiDefaults": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.ansiDefaults%"
-        },
-        "mssql.query.quotedIdentifier": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.quotedIdentifier%"
-        },
-        "mssql.query.ansiNullDefaultOn": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiNullDefaultOn%"
-        },
-        "mssql.query.implicitTransactions": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.implicitTransactions%"
-        },
-        "mssql.query.cursorCloseOnCommit": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.cursorCloseOnCommit%"
-        },
-        "mssql.query.ansiPadding": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiPadding%"
-        },
-        "mssql.query.ansiWarnings": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiWarnings%"
-        },
-        "mssql.query.ansiNulls": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiNulls%"
-        },
-        "mssql.query.alwaysEncryptedParameterization": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.alwaysEncryptedParameterization%"
-        },
-        "mssql.ignorePlatformWarning": {
-          "type": "boolean",
-          "description": "%mssql.ignorePlatformWarning%",
-          "default": false
-        }
-      }
-    }
-  }
+	"name": "mssql",
+	"displayName": "SQL Server (mssql)",
+	"version": "1.16.0",
+	"description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
+	"publisher": "ms-mssql",
+	"preview": false,
+	"license": "SEE LICENSE IN LICENSE.txt",
+	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"icon": "images/sqlserver.png",
+	"galleryBanner": {
+		"color": "#2F2F2F",
+		"theme": "dark"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Microsoft/vscode-mssql.git"
+	},
+	"bugs": {
+		"url": "https://github.com/Microsoft/vscode-mssql/issues"
+	},
+	"homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
+	"engines": {
+		"vscode": "^1.57.0"
+	},
+	"categories": [
+		"Programming Languages",
+		"Azure"
+	],
+	"keywords": [
+		"SQL",
+		"MSSQL",
+		"SQL Server",
+		"Azure SQL Database",
+		"Azure SQL Data Warehouse",
+		"multi-root ready"
+	],
+	"activationEvents": [
+		"onView:objectExplorer",
+		"onLanguage:sql",
+		"onCommand:mssql.connect",
+		"onCommand:mssql.runQuery",
+		"onCommand:mssql.runCurrentStatement",
+		"onCommand:mssql.disconnect",
+		"onCommand:mssql.manageProfiles",
+		"onCommand:mssql.chooseDatabase",
+		"onCommand:mssql.cancelQuery",
+		"onCommand:mssql.showGettingStarted",
+		"onCommand:mssql.newQuery",
+		"onCommand:mssql.rebuildIntelliSenseCache",
+		"onCommand:mssql.addObjectExplorer",
+		"onCommand:mssql.objectExplorerNewQuery",
+		"onCommand:mssql.toggleSqlCmd",
+		"onCommand:mssql.loadCompletionExtension",
+		"onCommand:mssql.removeAadAccount"
+	],
+	"main": "./out/src/extension",
+	"extensionDependencies": [
+		"vscode.sql"
+	],
+	"extensionPack": [
+		"ms-mssql.data-workspace-vscode",
+		"ms-mssql.sql-database-projects-vscode",
+		"ms-mssql.sql-bindings-vscode"
+	],
+	"scripts": {
+		"build": "gulp build",
+		"compile": "gulp ext:compile",
+		"watch": "gulp watch"
+	},
+	"devDependencies": {
+		"@angular/common": "~2.1.2",
+		"@angular/compiler": "~2.1.2",
+		"@angular/core": "~2.1.2",
+		"@angular/forms": "~2.1.2",
+		"@angular/platform-browser": "~2.1.2",
+		"@angular/platform-browser-dynamic": "~2.1.2",
+		"@angular/router": "~3.1.2",
+		"@angular/upgrade": "~2.1.2",
+		"@types/ejs": "^3.1.0",
+		"@types/jquery": "^3.3.31",
+		"@types/jqueryui": "^1.12.7",
+		"@types/keytar": "^4.4.2",
+		"@types/mocha": "^5.2.7",
+		"@types/node": "^14.14.16",
+		"@types/sinon": "^10.0.12",
+		"@types/tmp": "0.0.28",
+		"@types/underscore": "1.8.3",
+		"@types/vscode": "1.57.0",
+		"angular-in-memory-web-api": "0.1.13",
+		"angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
+		"assert": "^1.4.1",
+		"chai": "^3.5.0",
+		"coveralls": "^3.0.2",
+		"decache": "^4.1.0",
+		"del": "^2.2.1",
+		"gulp": "^4.0.2",
+		"gulp-concat": "^2.6.0",
+		"gulp-istanbul-report": "0.0.1",
+		"gulp-json-editor": "^2.2.1",
+		"gulp-rename": "^1.2.2",
+		"gulp-shell": "^0.7.0",
+		"gulp-sourcemaps": "^1.6.0",
+		"gulp-tslint": "^8.1.4",
+		"gulp-typescript": "^5.0.1",
+		"gulp-uglify": "^2.0.0",
+		"istanbul": "^0.4.5",
+		"pm-mocha-jenkins-reporter": "^0.2.6",
+		"remap-istanbul": "^0.6.4",
+		"rxjs": "5.0.0-beta.12",
+		"sinon": "^14.0.0",
+		"slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
+		"systemjs": "0.19.40",
+		"systemjs-builder": "^0.15.32",
+		"systemjs-plugin-json": "^0.2.0",
+		"tslint": "^6.1.3",
+		"tslint-microsoft-contrib": "^5.2.0",
+		"typemoq": "^1.7.0",
+		"typescript": "^3.5.3",
+		"uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
+		"vscode-nls-dev": "2.0.1",
+		"@vscode/test-electron": "^2.1.5",
+		"@xmldom/xmldom": "^0.8.2",
+		"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+	},
+	"dependencies": {
+		"@azure/arm-resources": "^5.0.0",
+		"@azure/arm-sql": "^9.0.0",
+		"@azure/arm-subscriptions": "^5.0.0",
+		"@microsoft/ads-adal-library": "1.0.15",
+		"core-js": "^2.4.1",
+		"decompress-zip": "^0.2.2",
+		"ejs": "^3.1.7",
+		"error-ex": "^1.3.0",
+		"figures": "^1.4.0",
+		"find-remove": "1.2.1",
+		"getmac": "1.2.1",
+		"http-proxy-agent": "^2.1.0",
+		"https-proxy-agent": "^2.2.1",
+		"jquery": "^3.4.1",
+		"opener": "1.4.2",
+		"plist": "^3.0.5",
+		"pretty-data": "^0.40.0",
+		"rangy": "^1.3.0",
+		"reflect-metadata": "0.1.12",
+		"semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+		"tar": "^6.1.9",
+		"tmp": "^0.0.28",
+		"underscore": "^1.8.3",
+		"vscode-languageclient": "5.2.1",
+		"vscode-nls": "^2.0.2",
+		"zone.js": "^0.6.26"
+	},
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
+	"contributes": {
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "objectExplorer",
+					"title": "SQL Server",
+					"icon": "./images/server_page_inverse.svg"
+				}
+			]
+		},
+		"views": {
+			"objectExplorer": [
+				{
+					"id": "objectExplorer",
+					"name": "%extension.connections%"
+				},
+				{
+					"id": "queryHistory",
+					"name": "%extension.queryHistory%",
+					"when": "config.mssql.enableQueryHistoryFeature"
+				}
+			]
+		},
+		"languages": [
+			{
+				"id": "sql",
+				"extensions": [
+					".sql"
+				],
+				"aliases": [
+					"SQL"
+				],
+				"configuration": "./syntaxes/sql.configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "sql",
+				"scopeName": "source.sql",
+				"path": "./syntaxes/SQL.plist"
+			}
+		],
+		"snippets": [
+			{
+				"language": "sql",
+				"path": "./snippets/mssql.json"
+			}
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "mssql.runQuery",
+					"when": "editorLangId == sql",
+					"group": "navigation@1"
+				},
+				{
+					"command": "mssql.cancelQuery",
+					"when": "editorLangId == sql && resourcePath in mssql.runningQueries",
+					"group": "navigation@2"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "mssql.runQuery",
+					"when": "editorLangId == sql"
+				}
+			],
+			"view/title": [
+				{
+					"command": "mssql.addObjectExplorer",
+					"when": "view == objectExplorer",
+					"title": "%mssql.addObjectExplorer%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.startQueryHistoryCapture",
+					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
+					"title": "%mssql.startQueryHistoryCapture%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.pauseQueryHistoryCapture",
+					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
+					"title": "%mssql.pauseQueryHistoryCapture%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.clearAllQueryHistory",
+					"when": "view == queryHistory",
+					"title": "%mssql.clearAllQueryHistory%",
+					"group": "secondary"
+				}
+			],
+			"view/item/context": [
+				{
+					"command": "mssql.objectExplorerNewQuery",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.removeObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
+					"group": "MS_SQL@4"
+				},
+				{
+					"command": "mssql.refreshObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem != disconnectedServer",
+					"group": "MS_SQL@10"
+				},
+				{
+					"command": "mssql.disconnectObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem == Server",
+					"group": "MS_SQL@3"
+				},
+				{
+					"command": "mssql.scriptSelect",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.scriptCreate",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+					"group": "MS_SQL@2"
+				},
+				{
+					"command": "mssql.scriptDelete",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+					"group": "MS_SQL@3"
+				},
+				{
+					"command": "mssql.scriptExecute",
+					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
+					"group": "MS_SQL@5"
+				},
+				{
+					"command": "mssql.scriptAlter",
+					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
+					"group": "MS_SQL@4"
+				},
+				{
+					"command": "mssql.openQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.runQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@2"
+				},
+				{
+					"command": "mssql.deleteQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@3"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "mssql.objectExplorerNewQuery",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
+				},
+				{
+					"command": "mssql.removeObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
+				},
+				{
+					"command": "mssql.refreshObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem != disconnectedServer"
+				},
+				{
+					"command": "mssql.scriptSelect",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
+				},
+				{
+					"command": "mssql.scriptCreate",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+				},
+				{
+					"command": "mssql.scriptDelete",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+				},
+				{
+					"command": "mssql.scriptExecute",
+					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
+				},
+				{
+					"command": "mssql.scriptAlter",
+					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
+				},
+				{
+					"command": "mssql.disconnectObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem == Server"
+				},
+				{
+					"command": "mssql.toggleSqlCmd",
+					"when": "editorFocus && editorLangId == 'sql'"
+				},
+				{
+					"command": "mssql.startQueryHistoryCapture",
+					"when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
+				},
+				{
+					"command": "mssql.pauseQueryHistoryCapture",
+					"when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
+				},
+				{
+					"command": "mssql.copyObjectName",
+					"when": "view == objectExplorer && viewItem != Folder"
+				},
+				{
+					"command": "mssql.runQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "mssql.runQuery",
+				"title": "%mssql.runQuery%",
+				"category": "MS SQL",
+				"icon": "$(debug-start)"
+			},
+			{
+				"command": "mssql.runCurrentStatement",
+				"title": "%mssql.runCurrentStatement%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.cancelQuery",
+				"title": "%mssql.cancelQuery%",
+				"category": "MS SQL",
+				"icon": "$(debug-stop)"
+			},
+			{
+				"command": "mssql.connect",
+				"title": "%mssql.connect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.disconnect",
+				"title": "%mssql.disconnect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.manageProfiles",
+				"title": "%mssql.manageProfiles%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.chooseDatabase",
+				"title": "%mssql.chooseDatabase%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.chooseLanguageFlavor",
+				"title": "%mssql.chooseLanguageFlavor%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.showGettingStarted",
+				"title": "%mssql.showGettingStarted%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.newQuery",
+				"title": "%mssql.newQuery%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.rebuildIntelliSenseCache",
+				"title": "%mssql.rebuildIntelliSenseCache%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.toggleSqlCmd",
+				"title": "%mssql.toggleSqlCmd%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.addObjectExplorer",
+				"title": "%mssql.addObjectExplorer%",
+				"category": "MS SQL",
+				"icon": "$(add)"
+			},
+			{
+				"command": "mssql.objectExplorerNewQuery",
+				"title": "%mssql.objectExplorerNewQuery%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.removeObjectExplorerNode",
+				"title": "%mssql.removeObjectExplorerNode%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.refreshObjectExplorerNode",
+				"title": "%mssql.refreshObjectExplorerNode%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.disconnectObjectExplorerNode",
+				"title": "%mssql.disconnect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptSelect",
+				"title": "%mssql.scriptSelect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptCreate",
+				"title": "%mssql.scriptCreate%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptDelete",
+				"title": "%mssql.scriptDelete%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptExecute",
+				"title": "%mssql.scriptExecute%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptAlter",
+				"title": "%mssql.scriptAlter%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.openQueryHistory",
+				"title": "%mssql.openQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.runQueryHistory",
+				"title": "%mssql.runQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.deleteQueryHistory",
+				"title": "%mssql.deleteQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.clearAllQueryHistory",
+				"title": "%mssql.clearAllQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.startQueryHistoryCapture",
+				"title": "%mssql.startQueryHistoryCapture%",
+				"category": "MS SQL",
+				"icon": "$(debug-start)"
+			},
+			{
+				"command": "mssql.pauseQueryHistoryCapture",
+				"title": "%mssql.pauseQueryHistoryCapture%",
+				"category": "MS SQL",
+				"icon": "$(debug-stop)"
+			},
+			{
+				"command": "mssql.commandPaletteQueryHistory",
+				"title": "%mssql.commandPaletteQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.copyObjectName",
+				"title": "%mssql.copyObjectName%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.removeAadAccount",
+				"title": "%mssql.removeAadAccount%",
+				"category": "MS SQL"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "mssql.runQuery",
+				"key": "ctrl+shift+e",
+				"mac": "cmd+shift+e",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "mssql.connect",
+				"key": "ctrl+shift+c",
+				"mac": "cmd+shift+c",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "mssql.disconnect",
+				"key": "ctrl+shift+d",
+				"mac": "cmd+shift+d",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "workbench.view.extension.objectExplorer",
+				"key": "ctrl+alt+d",
+				"mac": "cmd+alt+d"
+			},
+			{
+				"command": "mssql.copyObjectName",
+				"key": "ctrl+c",
+				"mac": "cmd+c",
+				"when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "%mssql.Configuration%",
+			"properties": {
+				"mssql.azureActiveDirectory": {
+					"type": "string",
+					"default": "AuthCodeGrant",
+					"description": "%mssql.chooseAuthMethod%",
+					"enum": [
+						"AuthCodeGrant",
+						"DeviceCode"
+					],
+					"enumDescriptions": [
+						"%mssql.authCodeGrant.description%",
+						"%mssql.deviceCode.description%"
+					],
+					"scope": "application"
+				},
+				"mssql.logDebugInfo": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.logDebugInfo%",
+					"scope": "window"
+				},
+				"mssql.maxRecentConnections": {
+					"type": "number",
+					"default": 5,
+					"description": "%mssql.maxRecentConnections%",
+					"scope": "window"
+				},
+				"mssql.connections": {
+					"type": "array",
+					"description": "%mssql.connections%",
+					"items": {
+						"type": "object",
+						"properties": {
+							"server": {
+								"type": "string",
+								"default": "{{put-server-name-here}}",
+								"description": "%mssql.connection.server%"
+							},
+							"database": {
+								"type": "string",
+								"default": "{{put-database-name-here}}",
+								"description": "%mssql.connection.database%"
+							},
+							"user": {
+								"type": "string",
+								"default": "{{put-username-here}}",
+								"description": "%mssql.connection.user%"
+							},
+							"password": {
+								"type": "string",
+								"default": "{{put-password-here}}",
+								"description": "%mssql.connection.password%"
+							},
+							"authenticationType": {
+								"type": "string",
+								"default": "SqlLogin",
+								"enum": [
+									"Integrated",
+									"SqlLogin",
+									"AzureMFA"
+								],
+								"description": "%mssql.connection.authenticationType%"
+							},
+							"port": {
+								"type": "number",
+								"default": 1433,
+								"description": "%mssql.connection.port%"
+							},
+							"encrypt": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.encrypt%"
+							},
+							"trustServerCertificate": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.trustServerCertificate%"
+							},
+							"persistSecurityInfo": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.persistSecurityInfo%"
+							},
+							"connectTimeout": {
+								"type": "number",
+								"default": 15,
+								"description": "%mssql.connection.connectTimeout%"
+							},
+							"connectRetryCount": {
+								"type": "number",
+								"default": 1,
+								"description": "%mssql.connection.connectRetryCount%"
+							},
+							"connectRetryInterval": {
+								"type": "number",
+								"default": 10,
+								"description": "%mssql.connection.connectRetryInterval%"
+							},
+							"applicationName": {
+								"type": "string",
+								"default": "vscode-mssql",
+								"description": "%mssql.connection.applicationName%"
+							},
+							"workstationId": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.workstationId%"
+							},
+							"applicationIntent": {
+								"type": "string",
+								"default": "ReadWrite",
+								"enum": [
+									"ReadWrite",
+									"ReadOnly"
+								],
+								"description": "%mssql.connection.applicationIntent%"
+							},
+							"currentLanguage": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.currentLanguage%"
+							},
+							"pooling": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.pooling%"
+							},
+							"maxPoolSize": {
+								"type": "number",
+								"default": 100,
+								"description": "%mssql.connection.maxPoolSize%"
+							},
+							"minPoolSize": {
+								"type": "number",
+								"default": 0,
+								"description": "%mssql.connection.minPoolSize%"
+							},
+							"loadBalanceTimeout": {
+								"type": "number",
+								"default": 0,
+								"description": "%mssql.connection.loadBalanceTimeout%"
+							},
+							"replication": {
+								"type": "boolean",
+								"default": true,
+								"description": "%mssql.connection.replication%"
+							},
+							"attachDbFilename": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.attachDbFilename%"
+							},
+							"failoverPartner": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.failoverPartner%"
+							},
+							"multiSubnetFailover": {
+								"type": "boolean",
+								"default": true,
+								"description": "%mssql.connection.multiSubnetFailover%"
+							},
+							"multipleActiveResultSets": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.multipleActiveResultSets%"
+							},
+							"packetSize": {
+								"type": "number",
+								"default": 8192,
+								"description": "%mssql.connection.packetSize%"
+							},
+							"typeSystemVersion": {
+								"type": "string",
+								"enum": [
+									"Latest"
+								],
+								"description": "%mssql.connection.typeSystemVersion%"
+							},
+							"connectionString": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.connectionString%"
+							},
+							"profileName": {
+								"type": "string",
+								"description": "%mssql.connection.profileName%"
+							},
+							"savePassword": {
+								"type": "boolean",
+								"description": "%mssql.connection.savePassword%"
+							},
+							"emptyPasswordInput": {
+								"type": "boolean",
+								"description": "%mssql.connection.emptyPasswordInput%"
+							}
+						}
+					},
+					"scope": "resource"
+				},
+				"mssql.shortcuts": {
+					"type": "object",
+					"description": "%mssql.shortcuts%",
+					"default": {
+						"_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
+						"event.toggleResultPane": "ctrl+alt+R",
+						"event.focusResultsGrid": "ctrl+alt+G",
+						"event.toggleMessagePane": "ctrl+alt+Y",
+						"event.prevGrid": "ctrl+up",
+						"event.nextGrid": "ctrl+down",
+						"event.copySelection": "ctrl+C",
+						"event.copyWithHeaders": "",
+						"event.copyAllHeaders": "",
+						"event.maximizeGrid": "",
+						"event.selectAll": "ctrl+A",
+						"event.saveAsJSON": "",
+						"event.saveAsCSV": "",
+						"event.saveAsExcel": ""
+					},
+					"scope": "resource"
+				},
+				"mssql.messagesDefaultOpen": {
+					"type": "boolean",
+					"description": "%mssql.messagesDefaultOpen%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.resultsFontFamily": {
+					"type": "string",
+					"description": "%mssql.resultsFontFamily%",
+					"default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
+					"scope": "resource"
+				},
+				"mssql.resultsFontSize": {
+					"type": "number",
+					"description": "%mssql.resultsFontSize%",
+					"default": 13,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.includeHeaders": {
+					"type": "boolean",
+					"description": "%mssql.saveAsCsv.includeHeaders%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.delimiter": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.delimiter%",
+					"default": ",",
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.lineSeparator": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.lineSeparator%",
+					"default": null,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.textIdentifier": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.textIdentifier%",
+					"default": "\"",
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.encoding": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.encoding%",
+					"default": "utf-8",
+					"scope": "resource"
+				},
+				"mssql.copyIncludeHeaders": {
+					"type": "boolean",
+					"description": "%mssql.copyIncludeHeaders%",
+					"default": false,
+					"scope": "resource"
+				},
+				"mssql.copyRemoveNewLine": {
+					"type": "boolean",
+					"description": "%mssql.copyRemoveNewLine%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.showBatchTime": {
+					"type": "boolean",
+					"description": "%mssql.showBatchTime%",
+					"default": false,
+					"scope": "resource"
+				},
+				"mssql.splitPaneSelection": {
+					"type": "string",
+					"description": "%mssql.splitPaneSelection%",
+					"default": "next",
+					"enum": [
+						"next",
+						"current",
+						"end"
+					],
+					"scope": "resource"
+				},
+				"mssql.format.alignColumnDefinitionsInColumns": {
+					"type": "boolean",
+					"description": "%mssql.format.alignColumnDefinitionsInColumns%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.format.datatypeCasing": {
+					"type": "string",
+					"description": "%mssql.format.datatypeCasing%",
+					"default": "none",
+					"enum": [
+						"none",
+						"uppercase",
+						"lowercase"
+					],
+					"scope": "window"
+				},
+				"mssql.format.keywordCasing": {
+					"type": "string",
+					"description": "%mssql.format.keywordCasing%",
+					"default": "none",
+					"enum": [
+						"none",
+						"uppercase",
+						"lowercase"
+					],
+					"scope": "window"
+				},
+				"mssql.format.placeCommasBeforeNextStatement": {
+					"type": "boolean",
+					"description": "%mssql.format.placeCommasBeforeNextStatement%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.format.placeSelectStatementReferencesOnNewLine": {
+					"type": "boolean",
+					"description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.applyLocalization": {
+					"type": "boolean",
+					"description": "%mssql.applyLocalization%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.query.displayBitAsNumber": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.displayBitAsNumber%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableIntelliSense": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableIntelliSense%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableErrorChecking": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableErrorChecking%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableSuggestions": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableSuggestions%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableQuickInfo": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableQuickInfo%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.lowerCaseSuggestions": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.intelliSense.lowerCaseSuggestions%",
+					"scope": "window"
+				},
+				"mssql.persistQueryResultTabs": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.persistQueryResultTabs%",
+					"scope": "window"
+				},
+				"mssql.queryHistoryLimit": {
+					"type": "number",
+					"default": 20,
+					"description": "%mssql.queryHistoryLimit%",
+					"scope": "window"
+				},
+				"mssql.enableQueryHistoryCapture": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.enableQueryHistoryCapture%",
+					"scope": "window"
+				},
+				"mssql.enableQueryHistoryFeature": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.enableQueryHistoryFeature%",
+					"scope": "window"
+				},
+				"mssql.query.maxXmlCharsToStore": {
+					"type": "number",
+					"default": 2097152,
+					"description": "%mssql.query.maxXmlCharsToStore%"
+				},
+				"mssql.tracingLevel": {
+					"type": "string",
+					"description": "%mssql.tracingLevel%",
+					"default": "Critical",
+					"enum": [
+						"All",
+						"Off",
+						"Critical",
+						"Error",
+						"Warning",
+						"Information",
+						"Verbose"
+					]
+				},
+				"mssql.logRetentionMinutes": {
+					"type": "number",
+					"default": 10080,
+					"description": "%mssql.logRetentionMinutes%"
+				},
+				"mssql.logFilesRemovalLimit": {
+					"type": "number",
+					"default": 100,
+					"description": "%mssql.logFilesRemovalLimit%"
+				},
+				"mssql.query.rowCount": {
+					"type": "number",
+					"default": 0,
+					"description": "%mssql.query.setRowCount%"
+				},
+				"mssql.query.textSize": {
+					"type": "number",
+					"default": 2147483647,
+					"description": "%mssql.query.textSize%"
+				},
+				"mssql.query.executionTimeout": {
+					"type": "number",
+					"default": 0,
+					"description": "%mssql.query.executionTimeout%"
+				},
+				"mssql.query.noCount": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.noCount%"
+				},
+				"mssql.query.noExec": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.noExec%"
+				},
+				"mssql.query.parseOnly": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.parseOnly%"
+				},
+				"mssql.query.arithAbort": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.arithAbort%"
+				},
+				"mssql.query.statisticsTime": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.statisticsTime%"
+				},
+				"mssql.query.statisticsIO": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.statisticsIO%"
+				},
+				"mssql.query.xactAbortOn": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.xactAbortOn%"
+				},
+				"mssql.query.transactionIsolationLevel": {
+					"enum": [
+						"READ COMMITTED",
+						"READ UNCOMMITTED",
+						"REPEATABLE READ",
+						"SERIALIZABLE"
+					],
+					"default": "READ COMMITTED",
+					"description": "%mssql.query.transactionIsolationLevel%"
+				},
+				"mssql.query.deadlockPriority": {
+					"enum": [
+						"Normal",
+						"Low"
+					],
+					"default": "Normal",
+					"description": "%mssql.query.deadlockPriority%"
+				},
+				"mssql.query.lockTimeout": {
+					"type": "number",
+					"default": -1,
+					"description": "%mssql.query.lockTimeout%"
+				},
+				"mssql.query.queryGovernorCostLimit": {
+					"type": "number",
+					"default": -1,
+					"description": "%mssql.query.queryGovernorCostLimit%"
+				},
+				"mssql.query.ansiDefaults": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.ansiDefaults%"
+				},
+				"mssql.query.quotedIdentifier": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.quotedIdentifier%"
+				},
+				"mssql.query.ansiNullDefaultOn": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiNullDefaultOn%"
+				},
+				"mssql.query.implicitTransactions": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.implicitTransactions%"
+				},
+				"mssql.query.cursorCloseOnCommit": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.cursorCloseOnCommit%"
+				},
+				"mssql.query.ansiPadding": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiPadding%"
+				},
+				"mssql.query.ansiWarnings": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiWarnings%"
+				},
+				"mssql.query.ansiNulls": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiNulls%"
+				},
+				"mssql.query.alwaysEncryptedParameterization": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.alwaysEncryptedParameterization%"
+				},
+				"mssql.ignorePlatformWarning": {
+					"type": "boolean",
+					"description": "%mssql.ignorePlatformWarning%",
+					"default": false
+				}
+			}
+		}
+	},
+	"__metadata": {
+		"id": "4bf45e86-a448-4531-8c01-ef33f4536306",
+		"publisherDisplayName": "Microsoft",
+		"publisherId": "60b3df88-4640-44d4-a7e5-6ba8004700bb",
+		"isPreReleaseVersion": false
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,1133 +1,1140 @@
 {
-  "name": "mssql",
-  "displayName": "SQL Server (mssql)",
-  "version": "1.16.0",
-  "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
-  "publisher": "ms-mssql",
-  "preview": false,
-  "license": "SEE LICENSE IN LICENSE.txt",
-  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
-  "icon": "images/sqlserver.png",
-  "galleryBanner": {
-    "color": "#2F2F2F",
-    "theme": "dark"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Microsoft/vscode-mssql.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Microsoft/vscode-mssql/issues"
-  },
-  "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
-  "engines": {
-    "vscode": "^1.57.0"
-  },
-  "categories": [
-    "Programming Languages",
-    "Azure"
-  ],
-  "keywords": [
-    "SQL",
-    "MSSQL",
-    "SQL Server",
-    "Azure SQL Database",
-    "Azure SQL Data Warehouse",
-    "multi-root ready"
-  ],
-  "activationEvents": [
-    "onView:objectExplorer",
-    "onLanguage:sql",
-    "onCommand:mssql.connect",
-    "onCommand:mssql.runQuery",
-    "onCommand:mssql.runCurrentStatement",
-    "onCommand:mssql.disconnect",
-    "onCommand:mssql.manageProfiles",
-    "onCommand:mssql.chooseDatabase",
-    "onCommand:mssql.cancelQuery",
-    "onCommand:mssql.showGettingStarted",
-    "onCommand:mssql.newQuery",
-    "onCommand:mssql.rebuildIntelliSenseCache",
-    "onCommand:mssql.addObjectExplorer",
-    "onCommand:mssql.objectExplorerNewQuery",
-    "onCommand:mssql.toggleSqlCmd",
-    "onCommand:mssql.loadCompletionExtension",
-    "onCommand:mssql.removeAadAccount"
-  ],
-  "main": "./out/src/extension",
-  "extensionDependencies": [
-    "vscode.sql"
-  ],
-  "extensionPack": [
-    "ms-mssql.data-workspace-vscode",
-    "ms-mssql.sql-database-projects-vscode",
-    "ms-mssql.sql-bindings-vscode"
-  ],
-  "scripts": {
-    "build": "gulp build",
-    "compile": "gulp ext:compile",
-    "watch": "gulp watch"
-  },
-  "devDependencies": {
-    "@angular/common": "~2.1.2",
-    "@angular/compiler": "~2.1.2",
-    "@angular/core": "~2.1.2",
-    "@angular/forms": "~2.1.2",
-    "@angular/platform-browser": "~2.1.2",
-    "@angular/platform-browser-dynamic": "~2.1.2",
-    "@angular/router": "~3.1.2",
-    "@angular/upgrade": "~2.1.2",
-    "@types/ejs": "^3.1.0",
-    "@types/jquery": "^3.3.31",
-    "@types/jqueryui": "^1.12.7",
-    "@types/keytar": "^4.4.2",
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^14.14.16",
-    "@types/sinon": "^10.0.12",
-    "@types/tmp": "0.0.28",
-    "@types/underscore": "1.8.3",
-    "@types/vscode": "1.57.0",
-    "angular-in-memory-web-api": "0.1.13",
-    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
-    "assert": "^1.4.1",
-    "chai": "^3.5.0",
-    "coveralls": "^3.0.2",
-    "decache": "^4.1.0",
-    "del": "^2.2.1",
-    "gulp": "^4.0.2",
-    "gulp-concat": "^2.6.0",
-    "gulp-istanbul-report": "0.0.1",
-    "gulp-json-editor": "^2.2.1",
-    "gulp-rename": "^1.2.2",
-    "gulp-shell": "^0.7.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-tslint": "^8.1.4",
-    "gulp-typescript": "^5.0.1",
-    "gulp-uglify": "^2.0.0",
-    "istanbul": "^0.4.5",
-    "pm-mocha-jenkins-reporter": "^0.2.6",
-    "remap-istanbul": "^0.6.4",
-    "rxjs": "5.0.0-beta.12",
-    "sinon": "^14.0.0",
-    "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
-    "systemjs": "0.19.40",
-    "systemjs-builder": "^0.15.32",
-    "systemjs-plugin-json": "^0.2.0",
-    "tslint": "^6.1.3",
-    "tslint-microsoft-contrib": "^5.2.0",
-    "typemoq": "^1.7.0",
-    "typescript": "^3.5.3",
-    "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
-    "vscode-nls-dev": "2.0.1",
-    "@vscode/test-electron": "^2.1.5",
-    "@xmldom/xmldom": "^0.8.2",
-    "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
-  },
-  "dependencies": {
-    "@azure/arm-resources": "^5.0.0",
-    "@azure/arm-sql": "^9.0.0",
-    "@azure/arm-subscriptions": "^5.0.0",
-    "@microsoft/ads-adal-library": "1.0.15",
-    "core-js": "^2.4.1",
-    "decompress-zip": "^0.2.2",
-    "ejs": "^3.1.7",
-    "error-ex": "^1.3.0",
-    "figures": "^1.4.0",
-    "find-remove": "1.2.1",
-    "getmac": "1.2.1",
-    "http-proxy-agent": "^2.1.0",
-    "https-proxy-agent": "^2.2.1",
-    "jquery": "^3.4.1",
-    "opener": "1.4.2",
-    "plist": "^3.0.5",
-    "pretty-data": "^0.40.0",
-    "rangy": "^1.3.0",
-    "reflect-metadata": "0.1.12",
-    "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-    "tar": "^6.1.9",
-    "tmp": "^0.0.28",
-    "underscore": "^1.8.3",
-    "vscode-languageclient": "5.2.1",
-    "vscode-nls": "^2.0.2",
-    "zone.js": "^0.6.26"
-  },
-  "capabilities": {
-    "untrustedWorkspaces": {
-      "supported": true
-    }
-  },
-  "contributes": {
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "objectExplorer",
-          "title": "SQL Server",
-          "icon": "./images/server_page_inverse.svg"
-        }
-      ]
-    },
-    "views": {
-      "objectExplorer": [
-        {
-          "id": "objectExplorer",
-          "name": "%extension.connections%"
-        },
-        {
-          "id": "queryHistory",
-          "name": "%extension.queryHistory%",
-          "when": "config.mssql.enableQueryHistoryFeature"
-        }
-      ]
-    },
-    "languages": [
-      {
-        "id": "sql",
-        "extensions": [
-          ".sql"
-        ],
-        "aliases": [
-          "SQL"
-        ],
-        "configuration": "./syntaxes/sql.configuration.json"
-      }
-    ],
-    "grammars": [
-      {
-        "language": "sql",
-        "scopeName": "source.sql",
-        "path": "./syntaxes/SQL.plist"
-      }
-    ],
-    "snippets": [
-      {
-        "language": "sql",
-        "path": "./snippets/mssql.json"
-      }
-    ],
-    "menus": {
-      "editor/title": [
-        {
-          "command": "mssql.runQuery",
-          "when": "editorLangId == sql",
-          "group": "navigation@1"
-        },
-        {
-          "command": "mssql.cancelQuery",
-          "when": "editorLangId == sql && resourcePath in mssql.runningQueries",
-          "group": "navigation@2"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "mssql.runQuery",
-          "when": "editorLangId == sql"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "mssql.addObjectExplorer",
-          "when": "view == objectExplorer",
-          "title": "%mssql.addObjectExplorer%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.startQueryHistoryCapture",
-          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
-          "title": "%mssql.startQueryHistoryCapture%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.pauseQueryHistoryCapture",
-          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
-          "title": "%mssql.pauseQueryHistoryCapture%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.clearAllQueryHistory",
-          "when": "view == queryHistory",
-          "title": "%mssql.clearAllQueryHistory%",
-          "group": "secondary"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "mssql.objectExplorerNewQuery",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.removeObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
-          "group": "MS_SQL@4"
-        },
-        {
-          "command": "mssql.refreshObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem != disconnectedServer",
-          "group": "MS_SQL@10"
-        },
-        {
-          "command": "mssql.disconnectObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem == Server",
-          "group": "MS_SQL@3"
-        },
-        {
-          "command": "mssql.scriptSelect",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.scriptCreate",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-          "group": "MS_SQL@2"
-        },
-        {
-          "command": "mssql.scriptDelete",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-          "group": "MS_SQL@3"
-        },
-        {
-          "command": "mssql.scriptExecute",
-          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
-          "group": "MS_SQL@5"
-        },
-        {
-          "command": "mssql.scriptAlter",
-          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
-          "group": "MS_SQL@4"
-        },
-        {
-          "command": "mssql.openQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@1"
-        },
-        {
-          "command": "mssql.runQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@2"
-        },
-        {
-          "command": "mssql.deleteQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode",
-          "group": "MS_SQL@3"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "mssql.objectExplorerNewQuery",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
-        },
-        {
-          "command": "mssql.removeObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
-        },
-        {
-          "command": "mssql.refreshObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem != disconnectedServer"
-        },
-        {
-          "command": "mssql.scriptSelect",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
-        },
-        {
-          "command": "mssql.scriptCreate",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-        },
-        {
-          "command": "mssql.scriptDelete",
-          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-        },
-        {
-          "command": "mssql.scriptExecute",
-          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
-        },
-        {
-          "command": "mssql.scriptAlter",
-          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
-        },
-        {
-          "command": "mssql.disconnectObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem == Server"
-        },
-        {
-          "command": "mssql.toggleSqlCmd",
-          "when": "editorFocus && editorLangId == 'sql'"
-        },
-        {
-          "command": "mssql.startQueryHistoryCapture",
-          "when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
-        },
-        {
-          "command": "mssql.pauseQueryHistoryCapture",
-          "when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
-        },
-        {
-          "command": "mssql.copyObjectName",
-          "when": "view == objectExplorer && viewItem != Folder"
-        },
-        {
-          "command": "mssql.runQueryHistory",
-          "when": "view == queryHistory && viewItem == queryHistoryNode"
-        }
-      ]
-    },
-    "commands": [
-      {
-        "command": "mssql.runQuery",
-        "title": "%mssql.runQuery%",
-        "category": "MS SQL",
-        "icon": "$(debug-start)"
-      },
-      {
-        "command": "mssql.runCurrentStatement",
-        "title": "%mssql.runCurrentStatement%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.cancelQuery",
-        "title": "%mssql.cancelQuery%",
-        "category": "MS SQL",
-        "icon": "$(debug-stop)"
-      },
-      {
-        "command": "mssql.connect",
-        "title": "%mssql.connect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.disconnect",
-        "title": "%mssql.disconnect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.manageProfiles",
-        "title": "%mssql.manageProfiles%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.chooseDatabase",
-        "title": "%mssql.chooseDatabase%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.chooseLanguageFlavor",
-        "title": "%mssql.chooseLanguageFlavor%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.showGettingStarted",
-        "title": "%mssql.showGettingStarted%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.newQuery",
-        "title": "%mssql.newQuery%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.rebuildIntelliSenseCache",
-        "title": "%mssql.rebuildIntelliSenseCache%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.toggleSqlCmd",
-        "title": "%mssql.toggleSqlCmd%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.addObjectExplorer",
-        "title": "%mssql.addObjectExplorer%",
-        "category": "MS SQL",
-        "icon": "$(add)"
-      },
-      {
-        "command": "mssql.objectExplorerNewQuery",
-        "title": "%mssql.objectExplorerNewQuery%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.removeObjectExplorerNode",
-        "title": "%mssql.removeObjectExplorerNode%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.refreshObjectExplorerNode",
-        "title": "%mssql.refreshObjectExplorerNode%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.disconnectObjectExplorerNode",
-        "title": "%mssql.disconnect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptSelect",
-        "title": "%mssql.scriptSelect%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptCreate",
-        "title": "%mssql.scriptCreate%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptDelete",
-        "title": "%mssql.scriptDelete%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptExecute",
-        "title": "%mssql.scriptExecute%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.scriptAlter",
-        "title": "%mssql.scriptAlter%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.openQueryHistory",
-        "title": "%mssql.openQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.runQueryHistory",
-        "title": "%mssql.runQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.deleteQueryHistory",
-        "title": "%mssql.deleteQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.clearAllQueryHistory",
-        "title": "%mssql.clearAllQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.startQueryHistoryCapture",
-        "title": "%mssql.startQueryHistoryCapture%",
-        "category": "MS SQL",
-        "icon": "$(debug-start)"
-      },
-      {
-        "command": "mssql.pauseQueryHistoryCapture",
-        "title": "%mssql.pauseQueryHistoryCapture%",
-        "category": "MS SQL",
-        "icon": "$(debug-stop)"
-      },
-      {
-        "command": "mssql.commandPaletteQueryHistory",
-        "title": "%mssql.commandPaletteQueryHistory%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.copyObjectName",
-        "title": "%mssql.copyObjectName%",
-        "category": "MS SQL"
-      },
-      {
-        "command": "mssql.removeAadAccount",
-        "title": "%mssql.removeAadAccount%",
-        "category": "MS SQL"
-      }
-    ],
-    "keybindings": [
-      {
-        "command": "mssql.runQuery",
-        "key": "ctrl+shift+e",
-        "mac": "cmd+shift+e",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "mssql.connect",
-        "key": "ctrl+shift+c",
-        "mac": "cmd+shift+c",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "mssql.disconnect",
-        "key": "ctrl+shift+d",
-        "mac": "cmd+shift+d",
-        "when": "editorTextFocus && editorLangId == 'sql'"
-      },
-      {
-        "command": "workbench.view.extension.objectExplorer",
-        "key": "ctrl+alt+d",
-        "mac": "cmd+alt+d"
-      },
-      {
-        "command": "mssql.copyObjectName",
-        "key": "ctrl+c",
-        "mac": "cmd+c",
-        "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
-      }
-    ],
-    "configuration": {
-      "type": "object",
-      "title": "%mssql.Configuration%",
-      "properties": {
-        "mssql.azureActiveDirectory": {
-          "type": "string",
-          "default": "AuthCodeGrant",
-          "description": "%mssql.chooseAuthMethod%",
-          "enum": [
-            "AuthCodeGrant",
-            "DeviceCode"
-          ],
-          "enumDescriptions": [
-            "%mssql.authCodeGrant.description%",
-            "%mssql.deviceCode.description%"
-          ],
-          "scope": "application"
-        },
-        "mssql.logDebugInfo": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.logDebugInfo%",
-          "scope": "window"
-        },
-        "mssql.maxRecentConnections": {
-          "type": "number",
-          "default": 5,
-          "description": "%mssql.maxRecentConnections%",
-          "scope": "window"
-        },
-        "mssql.connections": {
-          "type": "array",
-          "description": "%mssql.connections%",
-          "items": {
-            "type": "object",
-            "properties": {
-              "server": {
-                "type": "string",
-                "default": "{{put-server-name-here}}",
-                "description": "%mssql.connection.server%"
-              },
-              "database": {
-                "type": "string",
-                "default": "{{put-database-name-here}}",
-                "description": "%mssql.connection.database%"
-              },
-              "user": {
-                "type": "string",
-                "default": "{{put-username-here}}",
-                "description": "%mssql.connection.user%"
-              },
-              "password": {
-                "type": "string",
-                "default": "{{put-password-here}}",
-                "description": "%mssql.connection.password%"
-              },
-              "authenticationType": {
-                "type": "string",
-                "default": "SqlLogin",
-                "enum": [
-                  "Integrated",
-                  "SqlLogin",
-                  "AzureMFA"
-                ],
-                "description": "%mssql.connection.authenticationType%"
-              },
-              "port": {
-                "type": "number",
-                "default": 1433,
-                "description": "%mssql.connection.port%"
-              },
-              "encrypt": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.encrypt%"
-              },
-              "trustServerCertificate": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.trustServerCertificate%"
-              },
-              "persistSecurityInfo": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.persistSecurityInfo%"
-              },
-              "connectTimeout": {
-                "type": "number",
-                "default": 15,
-                "description": "%mssql.connection.connectTimeout%"
-              },
-              "connectRetryCount": {
-                "type": "number",
-                "default": 1,
-                "description": "%mssql.connection.connectRetryCount%"
-              },
-              "connectRetryInterval": {
-                "type": "number",
-                "default": 10,
-                "description": "%mssql.connection.connectRetryInterval%"
-              },
-              "applicationName": {
-                "type": "string",
-                "default": "vscode-mssql",
-                "description": "%mssql.connection.applicationName%"
-              },
-              "workstationId": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.workstationId%"
-              },
-              "applicationIntent": {
-                "type": "string",
-                "default": "ReadWrite",
-                "enum": [
-                  "ReadWrite",
-                  "ReadOnly"
-                ],
-                "description": "%mssql.connection.applicationIntent%"
-              },
-              "currentLanguage": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.currentLanguage%"
-              },
-              "pooling": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.pooling%"
-              },
-              "maxPoolSize": {
-                "type": "number",
-                "default": 100,
-                "description": "%mssql.connection.maxPoolSize%"
-              },
-              "minPoolSize": {
-                "type": "number",
-                "default": 0,
-                "description": "%mssql.connection.minPoolSize%"
-              },
-              "loadBalanceTimeout": {
-                "type": "number",
-                "default": 0,
-                "description": "%mssql.connection.loadBalanceTimeout%"
-              },
-              "replication": {
-                "type": "boolean",
-                "default": true,
-                "description": "%mssql.connection.replication%"
-              },
-              "attachDbFilename": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.attachDbFilename%"
-              },
-              "failoverPartner": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.failoverPartner%"
-              },
-              "multiSubnetFailover": {
-                "type": "boolean",
-                "default": true,
-                "description": "%mssql.connection.multiSubnetFailover%"
-              },
-              "multipleActiveResultSets": {
-                "type": "boolean",
-                "default": false,
-                "description": "%mssql.connection.multipleActiveResultSets%"
-              },
-              "packetSize": {
-                "type": "number",
-                "default": 8192,
-                "description": "%mssql.connection.packetSize%"
-              },
-              "typeSystemVersion": {
-                "type": "string",
-                "enum": [
-                  "Latest"
-                ],
-                "description": "%mssql.connection.typeSystemVersion%"
-              },
-              "connectionString": {
-                "type": "string",
-                "default": "",
-                "description": "%mssql.connection.connectionString%"
-              },
-              "profileName": {
-                "type": "string",
-                "description": "%mssql.connection.profileName%"
-              },
-              "savePassword": {
-                "type": "boolean",
-                "description": "%mssql.connection.savePassword%"
-              },
-              "emptyPasswordInput": {
-                "type": "boolean",
-                "description": "%mssql.connection.emptyPasswordInput%"
-              }
-            }
-          },
-          "scope": "resource"
-        },
-        "mssql.shortcuts": {
-          "type": "object",
-          "description": "%mssql.shortcuts%",
-          "default": {
-            "_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
-            "event.toggleResultPane": "ctrl+alt+R",
-            "event.focusResultsGrid": "ctrl+alt+G",
-            "event.toggleMessagePane": "ctrl+alt+Y",
-            "event.prevGrid": "ctrl+up",
-            "event.nextGrid": "ctrl+down",
-            "event.copySelection": "ctrl+C",
-            "event.copyWithHeaders": "",
-            "event.copyAllHeaders": "",
-            "event.maximizeGrid": "",
-            "event.selectAll": "ctrl+A",
-            "event.saveAsJSON": "",
-            "event.saveAsCSV": "",
-            "event.saveAsExcel": ""
-          },
-          "scope": "resource"
-        },
-        "mssql.messagesDefaultOpen": {
-          "type": "boolean",
-          "description": "%mssql.messagesDefaultOpen%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.resultsFontFamily": {
-          "type": "string",
-          "description": "%mssql.resultsFontFamily%",
-          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-          "scope": "resource"
-        },
-        "mssql.resultsFontSize": {
-          "type": "number",
-          "description": "%mssql.resultsFontSize%",
-          "default": 13,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.includeHeaders": {
-          "type": "boolean",
-          "description": "%mssql.saveAsCsv.includeHeaders%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.delimiter": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.delimiter%",
-          "default": ",",
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.lineSeparator": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.lineSeparator%",
-          "default": null,
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.textIdentifier": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.textIdentifier%",
-          "default": "\"",
-          "scope": "resource"
-        },
-        "mssql.saveAsCsv.encoding": {
-          "type": "string",
-          "description": "%mssql.saveAsCsv.encoding%",
-          "default": "utf-8",
-          "scope": "resource"
-        },
-        "mssql.copyIncludeHeaders": {
-          "type": "boolean",
-          "description": "%mssql.copyIncludeHeaders%",
-          "default": false,
-          "scope": "resource"
-        },
-        "mssql.copyRemoveNewLine": {
-          "type": "boolean",
-          "description": "%mssql.copyRemoveNewLine%",
-          "default": true,
-          "scope": "resource"
-        },
-        "mssql.showBatchTime": {
-          "type": "boolean",
-          "description": "%mssql.showBatchTime%",
-          "default": false,
-          "scope": "resource"
-        },
-        "mssql.splitPaneSelection": {
-          "type": "string",
-          "description": "%mssql.splitPaneSelection%",
-          "default": "next",
-          "enum": [
-            "next",
-            "current",
-            "end"
-          ],
-          "scope": "resource"
-        },
-        "mssql.format.alignColumnDefinitionsInColumns": {
-          "type": "boolean",
-          "description": "%mssql.format.alignColumnDefinitionsInColumns%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.format.datatypeCasing": {
-          "type": "string",
-          "description": "%mssql.format.datatypeCasing%",
-          "default": "none",
-          "enum": [
-            "none",
-            "uppercase",
-            "lowercase"
-          ],
-          "scope": "window"
-        },
-        "mssql.format.keywordCasing": {
-          "type": "string",
-          "description": "%mssql.format.keywordCasing%",
-          "default": "none",
-          "enum": [
-            "none",
-            "uppercase",
-            "lowercase"
-          ],
-          "scope": "window"
-        },
-        "mssql.format.placeCommasBeforeNextStatement": {
-          "type": "boolean",
-          "description": "%mssql.format.placeCommasBeforeNextStatement%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.format.placeSelectStatementReferencesOnNewLine": {
-          "type": "boolean",
-          "description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.applyLocalization": {
-          "type": "boolean",
-          "description": "%mssql.applyLocalization%",
-          "default": false,
-          "scope": "window"
-        },
-        "mssql.query.displayBitAsNumber": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.displayBitAsNumber%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableIntelliSense": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableIntelliSense%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableErrorChecking": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableErrorChecking%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableSuggestions": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableSuggestions%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.enableQuickInfo": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.intelliSense.enableQuickInfo%",
-          "scope": "window"
-        },
-        "mssql.intelliSense.lowerCaseSuggestions": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.intelliSense.lowerCaseSuggestions%",
-          "scope": "window"
-        },
-        "mssql.persistQueryResultTabs": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.persistQueryResultTabs%",
-          "scope": "window"
-        },
-        "mssql.queryHistoryLimit": {
-          "type": "number",
-          "default": 20,
-          "description": "%mssql.queryHistoryLimit%",
-          "scope": "window"
-        },
-        "mssql.enableQueryHistoryCapture": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.enableQueryHistoryCapture%",
-          "scope": "window"
-        },
-        "mssql.enableQueryHistoryFeature": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.enableQueryHistoryFeature%",
-          "scope": "window"
-        },
-        "mssql.query.maxXmlCharsToStore": {
-          "type": "number",
-          "default": 2097152,
-          "description": "%mssql.query.maxXmlCharsToStore%"
-        },
-        "mssql.tracingLevel": {
-          "type": "string",
-          "description": "%mssql.tracingLevel%",
-          "default": "Critical",
-          "enum": [
-            "All",
-            "Off",
-            "Critical",
-            "Error",
-            "Warning",
-            "Information",
-            "Verbose"
-          ]
-        },
-        "mssql.logRetentionMinutes": {
-          "type": "number",
-          "default": 10080,
-          "description": "%mssql.logRetentionMinutes%"
-        },
-        "mssql.logFilesRemovalLimit": {
-          "type": "number",
-          "default": 100,
-          "description": "%mssql.logFilesRemovalLimit%"
-        },
-        "mssql.query.rowCount": {
-          "type": "number",
-          "default": 0,
-          "description": "%mssql.query.setRowCount%"
-        },
-        "mssql.query.textSize": {
-          "type": "number",
-          "default": 2147483647,
-          "description": "%mssql.query.textSize%"
-        },
-        "mssql.query.executionTimeout": {
-          "type": "number",
-          "default": 0,
-          "description": "%mssql.query.executionTimeout%"
-        },
-        "mssql.query.noCount": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.noCount%"
-        },
-        "mssql.query.noExec": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.noExec%"
-        },
-        "mssql.query.parseOnly": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.parseOnly%"
-        },
-        "mssql.query.arithAbort": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.arithAbort%"
-        },
-        "mssql.query.statisticsTime": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.statisticsTime%"
-        },
-        "mssql.query.statisticsIO": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.statisticsIO%"
-        },
-        "mssql.query.xactAbortOn": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.xactAbortOn%"
-        },
-        "mssql.query.transactionIsolationLevel": {
-          "enum": [
-            "READ COMMITTED",
-            "READ UNCOMMITTED",
-            "REPEATABLE READ",
-            "SERIALIZABLE"
-          ],
-          "default": "READ COMMITTED",
-          "description": "%mssql.query.transactionIsolationLevel%"
-        },
-        "mssql.query.deadlockPriority": {
-          "enum": [
-            "Normal",
-            "Low"
-          ],
-          "default": "Normal",
-          "description": "%mssql.query.deadlockPriority%"
-        },
-        "mssql.query.lockTimeout": {
-          "type": "number",
-          "default": -1,
-          "description": "%mssql.query.lockTimeout%"
-        },
-        "mssql.query.queryGovernorCostLimit": {
-          "type": "number",
-          "default": -1,
-          "description": "%mssql.query.queryGovernorCostLimit%"
-        },
-        "mssql.query.ansiDefaults": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.ansiDefaults%"
-        },
-        "mssql.query.quotedIdentifier": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.quotedIdentifier%"
-        },
-        "mssql.query.ansiNullDefaultOn": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiNullDefaultOn%"
-        },
-        "mssql.query.implicitTransactions": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.implicitTransactions%"
-        },
-        "mssql.query.cursorCloseOnCommit": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.cursorCloseOnCommit%"
-        },
-        "mssql.query.ansiPadding": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiPadding%"
-        },
-        "mssql.query.ansiWarnings": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiWarnings%"
-        },
-        "mssql.query.ansiNulls": {
-          "type": "boolean",
-          "default": true,
-          "description": "%mssql.query.ansiNulls%"
-        },
-        "mssql.query.alwaysEncryptedParameterization": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.query.alwaysEncryptedParameterization%"
-        },
-        "mssql.ignorePlatformWarning": {
-          "type": "boolean",
-          "description": "%mssql.ignorePlatformWarning%",
-          "default": false
-        }
-      }
-    }
-  }
+	"name": "mssql",
+	"displayName": "SQL Server (mssql)",
+	"version": "1.16.0",
+	"description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
+	"publisher": "ms-mssql",
+	"preview": false,
+	"license": "SEE LICENSE IN LICENSE.txt",
+	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"icon": "images/sqlserver.png",
+	"galleryBanner": {
+		"color": "#2F2F2F",
+		"theme": "dark"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Microsoft/vscode-mssql.git"
+	},
+	"bugs": {
+		"url": "https://github.com/Microsoft/vscode-mssql/issues"
+	},
+	"homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
+	"engines": {
+		"vscode": "^1.57.0"
+	},
+	"categories": [
+		"Programming Languages",
+		"Azure"
+	],
+	"keywords": [
+		"SQL",
+		"MSSQL",
+		"SQL Server",
+		"Azure SQL Database",
+		"Azure SQL Data Warehouse",
+		"multi-root ready"
+	],
+	"activationEvents": [
+		"onView:objectExplorer",
+		"onLanguage:sql",
+		"onCommand:mssql.connect",
+		"onCommand:mssql.runQuery",
+		"onCommand:mssql.runCurrentStatement",
+		"onCommand:mssql.disconnect",
+		"onCommand:mssql.manageProfiles",
+		"onCommand:mssql.chooseDatabase",
+		"onCommand:mssql.cancelQuery",
+		"onCommand:mssql.showGettingStarted",
+		"onCommand:mssql.newQuery",
+		"onCommand:mssql.rebuildIntelliSenseCache",
+		"onCommand:mssql.addObjectExplorer",
+		"onCommand:mssql.objectExplorerNewQuery",
+		"onCommand:mssql.toggleSqlCmd",
+		"onCommand:mssql.loadCompletionExtension",
+		"onCommand:mssql.removeAadAccount"
+	],
+	"main": "./out/src/extension",
+	"extensionDependencies": [
+		"vscode.sql"
+	],
+	"extensionPack": [
+		"ms-mssql.data-workspace-vscode",
+		"ms-mssql.sql-database-projects-vscode",
+		"ms-mssql.sql-bindings-vscode"
+	],
+	"scripts": {
+		"build": "gulp build",
+		"compile": "gulp ext:compile",
+		"watch": "gulp watch"
+	},
+	"devDependencies": {
+		"@angular/common": "~2.1.2",
+		"@angular/compiler": "~2.1.2",
+		"@angular/core": "~2.1.2",
+		"@angular/forms": "~2.1.2",
+		"@angular/platform-browser": "~2.1.2",
+		"@angular/platform-browser-dynamic": "~2.1.2",
+		"@angular/router": "~3.1.2",
+		"@angular/upgrade": "~2.1.2",
+		"@types/ejs": "^3.1.0",
+		"@types/jquery": "^3.3.31",
+		"@types/jqueryui": "^1.12.7",
+		"@types/keytar": "^4.4.2",
+		"@types/mocha": "^5.2.7",
+		"@types/node": "^14.14.16",
+		"@types/sinon": "^10.0.12",
+		"@types/tmp": "0.0.28",
+		"@types/underscore": "1.8.3",
+		"@types/vscode": "1.57.0",
+		"angular-in-memory-web-api": "0.1.13",
+		"angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
+		"assert": "^1.4.1",
+		"chai": "^3.5.0",
+		"coveralls": "^3.0.2",
+		"decache": "^4.1.0",
+		"del": "^2.2.1",
+		"gulp": "^4.0.2",
+		"gulp-concat": "^2.6.0",
+		"gulp-istanbul-report": "0.0.1",
+		"gulp-json-editor": "^2.2.1",
+		"gulp-rename": "^1.2.2",
+		"gulp-shell": "^0.7.0",
+		"gulp-sourcemaps": "^1.6.0",
+		"gulp-tslint": "^8.1.4",
+		"gulp-typescript": "^5.0.1",
+		"gulp-uglify": "^2.0.0",
+		"istanbul": "^0.4.5",
+		"pm-mocha-jenkins-reporter": "^0.2.6",
+		"remap-istanbul": "^0.6.4",
+		"rxjs": "5.0.0-beta.12",
+		"sinon": "^14.0.0",
+		"slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
+		"source-map-support": "^0.5.21",
+		"systemjs": "0.19.40",
+		"systemjs-builder": "^0.15.32",
+		"systemjs-plugin-json": "^0.2.0",
+		"tslint": "^6.1.3",
+		"tslint-microsoft-contrib": "^5.2.0",
+		"typemoq": "^1.7.0",
+		"typescript": "^3.5.3",
+		"uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
+		"vscode-nls-dev": "2.0.1",
+		"@vscode/test-electron": "^2.1.5",
+		"@xmldom/xmldom": "^0.8.2",
+		"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+	},
+	"dependencies": {
+		"@azure/arm-resources": "^5.0.0",
+		"@azure/arm-sql": "^9.0.0",
+		"@azure/arm-subscriptions": "^5.0.0",
+		"@microsoft/ads-adal-library": "1.0.15",
+		"core-js": "^2.4.1",
+		"decompress-zip": "^0.2.2",
+		"ejs": "^3.1.7",
+		"error-ex": "^1.3.0",
+		"figures": "^1.4.0",
+		"find-remove": "1.2.1",
+		"getmac": "1.2.1",
+		"http-proxy-agent": "^2.1.0",
+		"https-proxy-agent": "^2.2.1",
+		"jquery": "^3.4.1",
+		"opener": "1.4.2",
+		"plist": "^3.0.5",
+		"pretty-data": "^0.40.0",
+		"rangy": "^1.3.0",
+		"reflect-metadata": "0.1.12",
+		"semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+		"tar": "^6.1.9",
+		"tmp": "^0.0.28",
+		"underscore": "^1.8.3",
+		"vscode-languageclient": "5.2.1",
+		"vscode-nls": "^2.0.2",
+		"zone.js": "^0.6.26"
+	},
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
+	"contributes": {
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "objectExplorer",
+					"title": "SQL Server",
+					"icon": "./images/server_page_inverse.svg"
+				}
+			]
+		},
+		"views": {
+			"objectExplorer": [
+				{
+					"id": "objectExplorer",
+					"name": "%extension.connections%"
+				},
+				{
+					"id": "queryHistory",
+					"name": "%extension.queryHistory%",
+					"when": "config.mssql.enableQueryHistoryFeature"
+				}
+			]
+		},
+		"languages": [
+			{
+				"id": "sql",
+				"extensions": [
+					".sql"
+				],
+				"aliases": [
+					"SQL"
+				],
+				"configuration": "./syntaxes/sql.configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "sql",
+				"scopeName": "source.sql",
+				"path": "./syntaxes/SQL.plist"
+			}
+		],
+		"snippets": [
+			{
+				"language": "sql",
+				"path": "./snippets/mssql.json"
+			}
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "mssql.runQuery",
+					"when": "editorLangId == sql",
+					"group": "navigation@1"
+				},
+				{
+					"command": "mssql.cancelQuery",
+					"when": "editorLangId == sql && resourcePath in mssql.runningQueries",
+					"group": "navigation@2"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "mssql.runQuery",
+					"when": "editorLangId == sql"
+				}
+			],
+			"view/title": [
+				{
+					"command": "mssql.addObjectExplorer",
+					"when": "view == objectExplorer",
+					"title": "%mssql.addObjectExplorer%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.startQueryHistoryCapture",
+					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
+					"title": "%mssql.startQueryHistoryCapture%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.pauseQueryHistoryCapture",
+					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
+					"title": "%mssql.pauseQueryHistoryCapture%",
+					"group": "navigation"
+				},
+				{
+					"command": "mssql.clearAllQueryHistory",
+					"when": "view == queryHistory",
+					"title": "%mssql.clearAllQueryHistory%",
+					"group": "secondary"
+				}
+			],
+			"view/item/context": [
+				{
+					"command": "mssql.objectExplorerNewQuery",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.removeObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
+					"group": "MS_SQL@4"
+				},
+				{
+					"command": "mssql.refreshObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem != disconnectedServer",
+					"group": "MS_SQL@10"
+				},
+				{
+					"command": "mssql.disconnectObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem == Server",
+					"group": "MS_SQL@3"
+				},
+				{
+					"command": "mssql.scriptSelect",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.scriptCreate",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+					"group": "MS_SQL@2"
+				},
+				{
+					"command": "mssql.scriptDelete",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+					"group": "MS_SQL@3"
+				},
+				{
+					"command": "mssql.scriptExecute",
+					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
+					"group": "MS_SQL@5"
+				},
+				{
+					"command": "mssql.scriptAlter",
+					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
+					"group": "MS_SQL@4"
+				},
+				{
+					"command": "mssql.openQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@1"
+				},
+				{
+					"command": "mssql.runQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@2"
+				},
+				{
+					"command": "mssql.deleteQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode",
+					"group": "MS_SQL@3"
+				}
+			],
+			"commandPalette": [
+				{
+					"command": "mssql.objectExplorerNewQuery",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
+				},
+				{
+					"command": "mssql.removeObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
+				},
+				{
+					"command": "mssql.refreshObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem != disconnectedServer"
+				},
+				{
+					"command": "mssql.scriptSelect",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
+				},
+				{
+					"command": "mssql.scriptCreate",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+				},
+				{
+					"command": "mssql.scriptDelete",
+					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+				},
+				{
+					"command": "mssql.scriptExecute",
+					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
+				},
+				{
+					"command": "mssql.scriptAlter",
+					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
+				},
+				{
+					"command": "mssql.disconnectObjectExplorerNode",
+					"when": "view == objectExplorer && viewItem == Server"
+				},
+				{
+					"command": "mssql.toggleSqlCmd",
+					"when": "editorFocus && editorLangId == 'sql'"
+				},
+				{
+					"command": "mssql.startQueryHistoryCapture",
+					"when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
+				},
+				{
+					"command": "mssql.pauseQueryHistoryCapture",
+					"when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
+				},
+				{
+					"command": "mssql.copyObjectName",
+					"when": "view == objectExplorer && viewItem != Folder"
+				},
+				{
+					"command": "mssql.runQueryHistory",
+					"when": "view == queryHistory && viewItem == queryHistoryNode"
+				}
+			]
+		},
+		"commands": [
+			{
+				"command": "mssql.runQuery",
+				"title": "%mssql.runQuery%",
+				"category": "MS SQL",
+				"icon": "$(debug-start)"
+			},
+			{
+				"command": "mssql.runCurrentStatement",
+				"title": "%mssql.runCurrentStatement%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.cancelQuery",
+				"title": "%mssql.cancelQuery%",
+				"category": "MS SQL",
+				"icon": "$(debug-stop)"
+			},
+			{
+				"command": "mssql.connect",
+				"title": "%mssql.connect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.disconnect",
+				"title": "%mssql.disconnect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.manageProfiles",
+				"title": "%mssql.manageProfiles%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.chooseDatabase",
+				"title": "%mssql.chooseDatabase%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.chooseLanguageFlavor",
+				"title": "%mssql.chooseLanguageFlavor%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.showGettingStarted",
+				"title": "%mssql.showGettingStarted%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.newQuery",
+				"title": "%mssql.newQuery%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.rebuildIntelliSenseCache",
+				"title": "%mssql.rebuildIntelliSenseCache%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.toggleSqlCmd",
+				"title": "%mssql.toggleSqlCmd%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.addObjectExplorer",
+				"title": "%mssql.addObjectExplorer%",
+				"category": "MS SQL",
+				"icon": "$(add)"
+			},
+			{
+				"command": "mssql.objectExplorerNewQuery",
+				"title": "%mssql.objectExplorerNewQuery%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.removeObjectExplorerNode",
+				"title": "%mssql.removeObjectExplorerNode%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.refreshObjectExplorerNode",
+				"title": "%mssql.refreshObjectExplorerNode%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.disconnectObjectExplorerNode",
+				"title": "%mssql.disconnect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptSelect",
+				"title": "%mssql.scriptSelect%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptCreate",
+				"title": "%mssql.scriptCreate%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptDelete",
+				"title": "%mssql.scriptDelete%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptExecute",
+				"title": "%mssql.scriptExecute%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.scriptAlter",
+				"title": "%mssql.scriptAlter%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.openQueryHistory",
+				"title": "%mssql.openQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.runQueryHistory",
+				"title": "%mssql.runQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.deleteQueryHistory",
+				"title": "%mssql.deleteQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.clearAllQueryHistory",
+				"title": "%mssql.clearAllQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.startQueryHistoryCapture",
+				"title": "%mssql.startQueryHistoryCapture%",
+				"category": "MS SQL",
+				"icon": "$(debug-start)"
+			},
+			{
+				"command": "mssql.pauseQueryHistoryCapture",
+				"title": "%mssql.pauseQueryHistoryCapture%",
+				"category": "MS SQL",
+				"icon": "$(debug-stop)"
+			},
+			{
+				"command": "mssql.commandPaletteQueryHistory",
+				"title": "%mssql.commandPaletteQueryHistory%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.copyObjectName",
+				"title": "%mssql.copyObjectName%",
+				"category": "MS SQL"
+			},
+			{
+				"command": "mssql.removeAadAccount",
+				"title": "%mssql.removeAadAccount%",
+				"category": "MS SQL"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "mssql.runQuery",
+				"key": "ctrl+shift+e",
+				"mac": "cmd+shift+e",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "mssql.connect",
+				"key": "ctrl+shift+c",
+				"mac": "cmd+shift+c",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "mssql.disconnect",
+				"key": "ctrl+shift+d",
+				"mac": "cmd+shift+d",
+				"when": "editorTextFocus && editorLangId == 'sql'"
+			},
+			{
+				"command": "workbench.view.extension.objectExplorer",
+				"key": "ctrl+alt+d",
+				"mac": "cmd+alt+d"
+			},
+			{
+				"command": "mssql.copyObjectName",
+				"key": "ctrl+c",
+				"mac": "cmd+c",
+				"when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "%mssql.Configuration%",
+			"properties": {
+				"mssql.azureActiveDirectory": {
+					"type": "string",
+					"default": "AuthCodeGrant",
+					"description": "%mssql.chooseAuthMethod%",
+					"enum": [
+						"AuthCodeGrant",
+						"DeviceCode"
+					],
+					"enumDescriptions": [
+						"%mssql.authCodeGrant.description%",
+						"%mssql.deviceCode.description%"
+					],
+					"scope": "application"
+				},
+				"mssql.logDebugInfo": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.logDebugInfo%",
+					"scope": "window"
+				},
+				"mssql.maxRecentConnections": {
+					"type": "number",
+					"default": 5,
+					"description": "%mssql.maxRecentConnections%",
+					"scope": "window"
+				},
+				"mssql.connections": {
+					"type": "array",
+					"description": "%mssql.connections%",
+					"items": {
+						"type": "object",
+						"properties": {
+							"server": {
+								"type": "string",
+								"default": "{{put-server-name-here}}",
+								"description": "%mssql.connection.server%"
+							},
+							"database": {
+								"type": "string",
+								"default": "{{put-database-name-here}}",
+								"description": "%mssql.connection.database%"
+							},
+							"user": {
+								"type": "string",
+								"default": "{{put-username-here}}",
+								"description": "%mssql.connection.user%"
+							},
+							"password": {
+								"type": "string",
+								"default": "{{put-password-here}}",
+								"description": "%mssql.connection.password%"
+							},
+							"authenticationType": {
+								"type": "string",
+								"default": "SqlLogin",
+								"enum": [
+									"Integrated",
+									"SqlLogin",
+									"AzureMFA"
+								],
+								"description": "%mssql.connection.authenticationType%"
+							},
+							"port": {
+								"type": "number",
+								"default": 1433,
+								"description": "%mssql.connection.port%"
+							},
+							"encrypt": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.encrypt%"
+							},
+							"trustServerCertificate": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.trustServerCertificate%"
+							},
+							"persistSecurityInfo": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.persistSecurityInfo%"
+							},
+							"connectTimeout": {
+								"type": "number",
+								"default": 15,
+								"description": "%mssql.connection.connectTimeout%"
+							},
+							"connectRetryCount": {
+								"type": "number",
+								"default": 1,
+								"description": "%mssql.connection.connectRetryCount%"
+							},
+							"connectRetryInterval": {
+								"type": "number",
+								"default": 10,
+								"description": "%mssql.connection.connectRetryInterval%"
+							},
+							"applicationName": {
+								"type": "string",
+								"default": "vscode-mssql",
+								"description": "%mssql.connection.applicationName%"
+							},
+							"workstationId": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.workstationId%"
+							},
+							"applicationIntent": {
+								"type": "string",
+								"default": "ReadWrite",
+								"enum": [
+									"ReadWrite",
+									"ReadOnly"
+								],
+								"description": "%mssql.connection.applicationIntent%"
+							},
+							"currentLanguage": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.currentLanguage%"
+							},
+							"pooling": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.pooling%"
+							},
+							"maxPoolSize": {
+								"type": "number",
+								"default": 100,
+								"description": "%mssql.connection.maxPoolSize%"
+							},
+							"minPoolSize": {
+								"type": "number",
+								"default": 0,
+								"description": "%mssql.connection.minPoolSize%"
+							},
+							"loadBalanceTimeout": {
+								"type": "number",
+								"default": 0,
+								"description": "%mssql.connection.loadBalanceTimeout%"
+							},
+							"replication": {
+								"type": "boolean",
+								"default": true,
+								"description": "%mssql.connection.replication%"
+							},
+							"attachDbFilename": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.attachDbFilename%"
+							},
+							"failoverPartner": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.failoverPartner%"
+							},
+							"multiSubnetFailover": {
+								"type": "boolean",
+								"default": true,
+								"description": "%mssql.connection.multiSubnetFailover%"
+							},
+							"multipleActiveResultSets": {
+								"type": "boolean",
+								"default": false,
+								"description": "%mssql.connection.multipleActiveResultSets%"
+							},
+							"packetSize": {
+								"type": "number",
+								"default": 8192,
+								"description": "%mssql.connection.packetSize%"
+							},
+							"typeSystemVersion": {
+								"type": "string",
+								"enum": [
+									"Latest"
+								],
+								"description": "%mssql.connection.typeSystemVersion%"
+							},
+							"connectionString": {
+								"type": "string",
+								"default": "",
+								"description": "%mssql.connection.connectionString%"
+							},
+							"profileName": {
+								"type": "string",
+								"description": "%mssql.connection.profileName%"
+							},
+							"savePassword": {
+								"type": "boolean",
+								"description": "%mssql.connection.savePassword%"
+							},
+							"emptyPasswordInput": {
+								"type": "boolean",
+								"description": "%mssql.connection.emptyPasswordInput%"
+							}
+						}
+					},
+					"scope": "resource"
+				},
+				"mssql.shortcuts": {
+					"type": "object",
+					"description": "%mssql.shortcuts%",
+					"default": {
+						"_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
+						"event.toggleResultPane": "ctrl+alt+R",
+						"event.focusResultsGrid": "ctrl+alt+G",
+						"event.toggleMessagePane": "ctrl+alt+Y",
+						"event.prevGrid": "ctrl+up",
+						"event.nextGrid": "ctrl+down",
+						"event.copySelection": "ctrl+C",
+						"event.copyWithHeaders": "",
+						"event.copyAllHeaders": "",
+						"event.maximizeGrid": "",
+						"event.selectAll": "ctrl+A",
+						"event.saveAsJSON": "",
+						"event.saveAsCSV": "",
+						"event.saveAsExcel": ""
+					},
+					"scope": "resource"
+				},
+				"mssql.messagesDefaultOpen": {
+					"type": "boolean",
+					"description": "%mssql.messagesDefaultOpen%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.resultsFontFamily": {
+					"type": "string",
+					"description": "%mssql.resultsFontFamily%",
+					"default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
+					"scope": "resource"
+				},
+				"mssql.resultsFontSize": {
+					"type": "number",
+					"description": "%mssql.resultsFontSize%",
+					"default": 13,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.includeHeaders": {
+					"type": "boolean",
+					"description": "%mssql.saveAsCsv.includeHeaders%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.delimiter": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.delimiter%",
+					"default": ",",
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.lineSeparator": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.lineSeparator%",
+					"default": null,
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.textIdentifier": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.textIdentifier%",
+					"default": "\"",
+					"scope": "resource"
+				},
+				"mssql.saveAsCsv.encoding": {
+					"type": "string",
+					"description": "%mssql.saveAsCsv.encoding%",
+					"default": "utf-8",
+					"scope": "resource"
+				},
+				"mssql.copyIncludeHeaders": {
+					"type": "boolean",
+					"description": "%mssql.copyIncludeHeaders%",
+					"default": false,
+					"scope": "resource"
+				},
+				"mssql.copyRemoveNewLine": {
+					"type": "boolean",
+					"description": "%mssql.copyRemoveNewLine%",
+					"default": true,
+					"scope": "resource"
+				},
+				"mssql.showBatchTime": {
+					"type": "boolean",
+					"description": "%mssql.showBatchTime%",
+					"default": false,
+					"scope": "resource"
+				},
+				"mssql.splitPaneSelection": {
+					"type": "string",
+					"description": "%mssql.splitPaneSelection%",
+					"default": "next",
+					"enum": [
+						"next",
+						"current",
+						"end"
+					],
+					"scope": "resource"
+				},
+				"mssql.format.alignColumnDefinitionsInColumns": {
+					"type": "boolean",
+					"description": "%mssql.format.alignColumnDefinitionsInColumns%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.format.datatypeCasing": {
+					"type": "string",
+					"description": "%mssql.format.datatypeCasing%",
+					"default": "none",
+					"enum": [
+						"none",
+						"uppercase",
+						"lowercase"
+					],
+					"scope": "window"
+				},
+				"mssql.format.keywordCasing": {
+					"type": "string",
+					"description": "%mssql.format.keywordCasing%",
+					"default": "none",
+					"enum": [
+						"none",
+						"uppercase",
+						"lowercase"
+					],
+					"scope": "window"
+				},
+				"mssql.format.placeCommasBeforeNextStatement": {
+					"type": "boolean",
+					"description": "%mssql.format.placeCommasBeforeNextStatement%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.format.placeSelectStatementReferencesOnNewLine": {
+					"type": "boolean",
+					"description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.applyLocalization": {
+					"type": "boolean",
+					"description": "%mssql.applyLocalization%",
+					"default": false,
+					"scope": "window"
+				},
+				"mssql.query.displayBitAsNumber": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.displayBitAsNumber%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableIntelliSense": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableIntelliSense%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableErrorChecking": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableErrorChecking%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableSuggestions": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableSuggestions%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.enableQuickInfo": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.intelliSense.enableQuickInfo%",
+					"scope": "window"
+				},
+				"mssql.intelliSense.lowerCaseSuggestions": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.intelliSense.lowerCaseSuggestions%",
+					"scope": "window"
+				},
+				"mssql.persistQueryResultTabs": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.persistQueryResultTabs%",
+					"scope": "window"
+				},
+				"mssql.queryHistoryLimit": {
+					"type": "number",
+					"default": 20,
+					"description": "%mssql.queryHistoryLimit%",
+					"scope": "window"
+				},
+				"mssql.enableQueryHistoryCapture": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.enableQueryHistoryCapture%",
+					"scope": "window"
+				},
+				"mssql.enableQueryHistoryFeature": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.enableQueryHistoryFeature%",
+					"scope": "window"
+				},
+				"mssql.query.maxXmlCharsToStore": {
+					"type": "number",
+					"default": 2097152,
+					"description": "%mssql.query.maxXmlCharsToStore%"
+				},
+				"mssql.tracingLevel": {
+					"type": "string",
+					"description": "%mssql.tracingLevel%",
+					"default": "Critical",
+					"enum": [
+						"All",
+						"Off",
+						"Critical",
+						"Error",
+						"Warning",
+						"Information",
+						"Verbose"
+					]
+				},
+				"mssql.logRetentionMinutes": {
+					"type": "number",
+					"default": 10080,
+					"description": "%mssql.logRetentionMinutes%"
+				},
+				"mssql.logFilesRemovalLimit": {
+					"type": "number",
+					"default": 100,
+					"description": "%mssql.logFilesRemovalLimit%"
+				},
+				"mssql.query.rowCount": {
+					"type": "number",
+					"default": 0,
+					"description": "%mssql.query.setRowCount%"
+				},
+				"mssql.query.textSize": {
+					"type": "number",
+					"default": 2147483647,
+					"description": "%mssql.query.textSize%"
+				},
+				"mssql.query.executionTimeout": {
+					"type": "number",
+					"default": 0,
+					"description": "%mssql.query.executionTimeout%"
+				},
+				"mssql.query.noCount": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.noCount%"
+				},
+				"mssql.query.noExec": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.noExec%"
+				},
+				"mssql.query.parseOnly": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.parseOnly%"
+				},
+				"mssql.query.arithAbort": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.arithAbort%"
+				},
+				"mssql.query.statisticsTime": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.statisticsTime%"
+				},
+				"mssql.query.statisticsIO": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.statisticsIO%"
+				},
+				"mssql.query.xactAbortOn": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.xactAbortOn%"
+				},
+				"mssql.query.transactionIsolationLevel": {
+					"enum": [
+						"READ COMMITTED",
+						"READ UNCOMMITTED",
+						"REPEATABLE READ",
+						"SERIALIZABLE"
+					],
+					"default": "READ COMMITTED",
+					"description": "%mssql.query.transactionIsolationLevel%"
+				},
+				"mssql.query.deadlockPriority": {
+					"enum": [
+						"Normal",
+						"Low"
+					],
+					"default": "Normal",
+					"description": "%mssql.query.deadlockPriority%"
+				},
+				"mssql.query.lockTimeout": {
+					"type": "number",
+					"default": -1,
+					"description": "%mssql.query.lockTimeout%"
+				},
+				"mssql.query.queryGovernorCostLimit": {
+					"type": "number",
+					"default": -1,
+					"description": "%mssql.query.queryGovernorCostLimit%"
+				},
+				"mssql.query.ansiDefaults": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.ansiDefaults%"
+				},
+				"mssql.query.quotedIdentifier": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.quotedIdentifier%"
+				},
+				"mssql.query.ansiNullDefaultOn": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiNullDefaultOn%"
+				},
+				"mssql.query.implicitTransactions": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.implicitTransactions%"
+				},
+				"mssql.query.cursorCloseOnCommit": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.cursorCloseOnCommit%"
+				},
+				"mssql.query.ansiPadding": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiPadding%"
+				},
+				"mssql.query.ansiWarnings": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiWarnings%"
+				},
+				"mssql.query.ansiNulls": {
+					"type": "boolean",
+					"default": true,
+					"description": "%mssql.query.ansiNulls%"
+				},
+				"mssql.query.alwaysEncryptedParameterization": {
+					"type": "boolean",
+					"default": false,
+					"description": "%mssql.query.alwaysEncryptedParameterization%"
+				},
+				"mssql.ignorePlatformWarning": {
+					"type": "boolean",
+					"description": "%mssql.ignorePlatformWarning%",
+					"default": false
+				}
+			}
+		}
+	},
+	"__metadata": {
+		"id": "4bf45e86-a448-4531-8c01-ef33f4536306",
+		"publisherDisplayName": "Microsoft",
+		"publisherId": "60b3df88-4640-44d4-a7e5-6ba8004700bb",
+		"isPreReleaseVersion": false
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,1140 +1,1133 @@
 {
-	"name": "mssql",
-	"displayName": "SQL Server (mssql)",
-	"version": "1.16.0",
-	"description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
-	"publisher": "ms-mssql",
-	"preview": false,
-	"license": "SEE LICENSE IN LICENSE.txt",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
-	"icon": "images/sqlserver.png",
-	"galleryBanner": {
-		"color": "#2F2F2F",
-		"theme": "dark"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-mssql.git"
-	},
-	"bugs": {
-		"url": "https://github.com/Microsoft/vscode-mssql/issues"
-	},
-	"homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
-	"engines": {
-		"vscode": "^1.57.0"
-	},
-	"categories": [
-		"Programming Languages",
-		"Azure"
-	],
-	"keywords": [
-		"SQL",
-		"MSSQL",
-		"SQL Server",
-		"Azure SQL Database",
-		"Azure SQL Data Warehouse",
-		"multi-root ready"
-	],
-	"activationEvents": [
-		"onView:objectExplorer",
-		"onLanguage:sql",
-		"onCommand:mssql.connect",
-		"onCommand:mssql.runQuery",
-		"onCommand:mssql.runCurrentStatement",
-		"onCommand:mssql.disconnect",
-		"onCommand:mssql.manageProfiles",
-		"onCommand:mssql.chooseDatabase",
-		"onCommand:mssql.cancelQuery",
-		"onCommand:mssql.showGettingStarted",
-		"onCommand:mssql.newQuery",
-		"onCommand:mssql.rebuildIntelliSenseCache",
-		"onCommand:mssql.addObjectExplorer",
-		"onCommand:mssql.objectExplorerNewQuery",
-		"onCommand:mssql.toggleSqlCmd",
-		"onCommand:mssql.loadCompletionExtension",
-		"onCommand:mssql.removeAadAccount"
-	],
-	"main": "./out/src/extension",
-	"extensionDependencies": [
-		"vscode.sql"
-	],
-	"extensionPack": [
-		"ms-mssql.data-workspace-vscode",
-		"ms-mssql.sql-database-projects-vscode",
-		"ms-mssql.sql-bindings-vscode"
-	],
-	"scripts": {
-		"build": "gulp build",
-		"compile": "gulp ext:compile",
-		"watch": "gulp watch"
-	},
-	"devDependencies": {
-		"@angular/common": "~2.1.2",
-		"@angular/compiler": "~2.1.2",
-		"@angular/core": "~2.1.2",
-		"@angular/forms": "~2.1.2",
-		"@angular/platform-browser": "~2.1.2",
-		"@angular/platform-browser-dynamic": "~2.1.2",
-		"@angular/router": "~3.1.2",
-		"@angular/upgrade": "~2.1.2",
-		"@types/ejs": "^3.1.0",
-		"@types/jquery": "^3.3.31",
-		"@types/jqueryui": "^1.12.7",
-		"@types/keytar": "^4.4.2",
-		"@types/mocha": "^5.2.7",
-		"@types/node": "^14.14.16",
-		"@types/sinon": "^10.0.12",
-		"@types/tmp": "0.0.28",
-		"@types/underscore": "1.8.3",
-		"@types/vscode": "1.57.0",
-		"angular-in-memory-web-api": "0.1.13",
-		"angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
-		"assert": "^1.4.1",
-		"chai": "^3.5.0",
-		"coveralls": "^3.0.2",
-		"decache": "^4.1.0",
-		"del": "^2.2.1",
-		"gulp": "^4.0.2",
-		"gulp-concat": "^2.6.0",
-		"gulp-istanbul-report": "0.0.1",
-		"gulp-json-editor": "^2.2.1",
-		"gulp-rename": "^1.2.2",
-		"gulp-shell": "^0.7.0",
-		"gulp-sourcemaps": "^1.6.0",
-		"gulp-tslint": "^8.1.4",
-		"gulp-typescript": "^5.0.1",
-		"gulp-uglify": "^2.0.0",
-		"istanbul": "^0.4.5",
-		"pm-mocha-jenkins-reporter": "^0.2.6",
-		"remap-istanbul": "^0.6.4",
-		"rxjs": "5.0.0-beta.12",
-		"sinon": "^14.0.0",
-		"slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
-		"source-map-support": "^0.5.21",
-		"systemjs": "0.19.40",
-		"systemjs-builder": "^0.15.32",
-		"systemjs-plugin-json": "^0.2.0",
-		"tslint": "^6.1.3",
-		"tslint-microsoft-contrib": "^5.2.0",
-		"typemoq": "^1.7.0",
-		"typescript": "^3.5.3",
-		"uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
-		"vscode-nls-dev": "2.0.1",
-		"@vscode/test-electron": "^2.1.5",
-		"@xmldom/xmldom": "^0.8.2",
-		"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
-	},
-	"dependencies": {
-		"@azure/arm-resources": "^5.0.0",
-		"@azure/arm-sql": "^9.0.0",
-		"@azure/arm-subscriptions": "^5.0.0",
-		"@microsoft/ads-adal-library": "1.0.15",
-		"core-js": "^2.4.1",
-		"decompress-zip": "^0.2.2",
-		"ejs": "^3.1.7",
-		"error-ex": "^1.3.0",
-		"figures": "^1.4.0",
-		"find-remove": "1.2.1",
-		"getmac": "1.2.1",
-		"http-proxy-agent": "^2.1.0",
-		"https-proxy-agent": "^2.2.1",
-		"jquery": "^3.4.1",
-		"opener": "1.4.2",
-		"plist": "^3.0.5",
-		"pretty-data": "^0.40.0",
-		"rangy": "^1.3.0",
-		"reflect-metadata": "0.1.12",
-		"semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-		"tar": "^6.1.9",
-		"tmp": "^0.0.28",
-		"underscore": "^1.8.3",
-		"vscode-languageclient": "5.2.1",
-		"vscode-nls": "^2.0.2",
-		"zone.js": "^0.6.26"
-	},
-	"capabilities": {
-		"untrustedWorkspaces": {
-			"supported": true
-		}
-	},
-	"contributes": {
-		"viewsContainers": {
-			"activitybar": [
-				{
-					"id": "objectExplorer",
-					"title": "SQL Server",
-					"icon": "./images/server_page_inverse.svg"
-				}
-			]
-		},
-		"views": {
-			"objectExplorer": [
-				{
-					"id": "objectExplorer",
-					"name": "%extension.connections%"
-				},
-				{
-					"id": "queryHistory",
-					"name": "%extension.queryHistory%",
-					"when": "config.mssql.enableQueryHistoryFeature"
-				}
-			]
-		},
-		"languages": [
-			{
-				"id": "sql",
-				"extensions": [
-					".sql"
-				],
-				"aliases": [
-					"SQL"
-				],
-				"configuration": "./syntaxes/sql.configuration.json"
-			}
-		],
-		"grammars": [
-			{
-				"language": "sql",
-				"scopeName": "source.sql",
-				"path": "./syntaxes/SQL.plist"
-			}
-		],
-		"snippets": [
-			{
-				"language": "sql",
-				"path": "./snippets/mssql.json"
-			}
-		],
-		"menus": {
-			"editor/title": [
-				{
-					"command": "mssql.runQuery",
-					"when": "editorLangId == sql",
-					"group": "navigation@1"
-				},
-				{
-					"command": "mssql.cancelQuery",
-					"when": "editorLangId == sql && resourcePath in mssql.runningQueries",
-					"group": "navigation@2"
-				}
-			],
-			"editor/context": [
-				{
-					"command": "mssql.runQuery",
-					"when": "editorLangId == sql"
-				}
-			],
-			"view/title": [
-				{
-					"command": "mssql.addObjectExplorer",
-					"when": "view == objectExplorer",
-					"title": "%mssql.addObjectExplorer%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.startQueryHistoryCapture",
-					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
-					"title": "%mssql.startQueryHistoryCapture%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.pauseQueryHistoryCapture",
-					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
-					"title": "%mssql.pauseQueryHistoryCapture%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.clearAllQueryHistory",
-					"when": "view == queryHistory",
-					"title": "%mssql.clearAllQueryHistory%",
-					"group": "secondary"
-				}
-			],
-			"view/item/context": [
-				{
-					"command": "mssql.objectExplorerNewQuery",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.removeObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
-					"group": "MS_SQL@4"
-				},
-				{
-					"command": "mssql.refreshObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem != disconnectedServer",
-					"group": "MS_SQL@10"
-				},
-				{
-					"command": "mssql.disconnectObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem == Server",
-					"group": "MS_SQL@3"
-				},
-				{
-					"command": "mssql.scriptSelect",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.scriptCreate",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-					"group": "MS_SQL@2"
-				},
-				{
-					"command": "mssql.scriptDelete",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-					"group": "MS_SQL@3"
-				},
-				{
-					"command": "mssql.scriptExecute",
-					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
-					"group": "MS_SQL@5"
-				},
-				{
-					"command": "mssql.scriptAlter",
-					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
-					"group": "MS_SQL@4"
-				},
-				{
-					"command": "mssql.openQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.runQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@2"
-				},
-				{
-					"command": "mssql.deleteQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@3"
-				}
-			],
-			"commandPalette": [
-				{
-					"command": "mssql.objectExplorerNewQuery",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
-				},
-				{
-					"command": "mssql.removeObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
-				},
-				{
-					"command": "mssql.refreshObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem != disconnectedServer"
-				},
-				{
-					"command": "mssql.scriptSelect",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
-				},
-				{
-					"command": "mssql.scriptCreate",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-				},
-				{
-					"command": "mssql.scriptDelete",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-				},
-				{
-					"command": "mssql.scriptExecute",
-					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
-				},
-				{
-					"command": "mssql.scriptAlter",
-					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
-				},
-				{
-					"command": "mssql.disconnectObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem == Server"
-				},
-				{
-					"command": "mssql.toggleSqlCmd",
-					"when": "editorFocus && editorLangId == 'sql'"
-				},
-				{
-					"command": "mssql.startQueryHistoryCapture",
-					"when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
-				},
-				{
-					"command": "mssql.pauseQueryHistoryCapture",
-					"when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
-				},
-				{
-					"command": "mssql.copyObjectName",
-					"when": "view == objectExplorer && viewItem != Folder"
-				},
-				{
-					"command": "mssql.runQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode"
-				}
-			]
-		},
-		"commands": [
-			{
-				"command": "mssql.runQuery",
-				"title": "%mssql.runQuery%",
-				"category": "MS SQL",
-				"icon": "$(debug-start)"
-			},
-			{
-				"command": "mssql.runCurrentStatement",
-				"title": "%mssql.runCurrentStatement%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.cancelQuery",
-				"title": "%mssql.cancelQuery%",
-				"category": "MS SQL",
-				"icon": "$(debug-stop)"
-			},
-			{
-				"command": "mssql.connect",
-				"title": "%mssql.connect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.disconnect",
-				"title": "%mssql.disconnect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.manageProfiles",
-				"title": "%mssql.manageProfiles%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.chooseDatabase",
-				"title": "%mssql.chooseDatabase%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.chooseLanguageFlavor",
-				"title": "%mssql.chooseLanguageFlavor%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.showGettingStarted",
-				"title": "%mssql.showGettingStarted%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.newQuery",
-				"title": "%mssql.newQuery%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.rebuildIntelliSenseCache",
-				"title": "%mssql.rebuildIntelliSenseCache%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.toggleSqlCmd",
-				"title": "%mssql.toggleSqlCmd%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.addObjectExplorer",
-				"title": "%mssql.addObjectExplorer%",
-				"category": "MS SQL",
-				"icon": "$(add)"
-			},
-			{
-				"command": "mssql.objectExplorerNewQuery",
-				"title": "%mssql.objectExplorerNewQuery%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.removeObjectExplorerNode",
-				"title": "%mssql.removeObjectExplorerNode%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.refreshObjectExplorerNode",
-				"title": "%mssql.refreshObjectExplorerNode%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.disconnectObjectExplorerNode",
-				"title": "%mssql.disconnect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptSelect",
-				"title": "%mssql.scriptSelect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptCreate",
-				"title": "%mssql.scriptCreate%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptDelete",
-				"title": "%mssql.scriptDelete%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptExecute",
-				"title": "%mssql.scriptExecute%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptAlter",
-				"title": "%mssql.scriptAlter%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.openQueryHistory",
-				"title": "%mssql.openQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.runQueryHistory",
-				"title": "%mssql.runQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.deleteQueryHistory",
-				"title": "%mssql.deleteQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.clearAllQueryHistory",
-				"title": "%mssql.clearAllQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.startQueryHistoryCapture",
-				"title": "%mssql.startQueryHistoryCapture%",
-				"category": "MS SQL",
-				"icon": "$(debug-start)"
-			},
-			{
-				"command": "mssql.pauseQueryHistoryCapture",
-				"title": "%mssql.pauseQueryHistoryCapture%",
-				"category": "MS SQL",
-				"icon": "$(debug-stop)"
-			},
-			{
-				"command": "mssql.commandPaletteQueryHistory",
-				"title": "%mssql.commandPaletteQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.copyObjectName",
-				"title": "%mssql.copyObjectName%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.removeAadAccount",
-				"title": "%mssql.removeAadAccount%",
-				"category": "MS SQL"
-			}
-		],
-		"keybindings": [
-			{
-				"command": "mssql.runQuery",
-				"key": "ctrl+shift+e",
-				"mac": "cmd+shift+e",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "mssql.connect",
-				"key": "ctrl+shift+c",
-				"mac": "cmd+shift+c",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "mssql.disconnect",
-				"key": "ctrl+shift+d",
-				"mac": "cmd+shift+d",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "workbench.view.extension.objectExplorer",
-				"key": "ctrl+alt+d",
-				"mac": "cmd+alt+d"
-			},
-			{
-				"command": "mssql.copyObjectName",
-				"key": "ctrl+c",
-				"mac": "cmd+c",
-				"when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
-			}
-		],
-		"configuration": {
-			"type": "object",
-			"title": "%mssql.Configuration%",
-			"properties": {
-				"mssql.azureActiveDirectory": {
-					"type": "string",
-					"default": "AuthCodeGrant",
-					"description": "%mssql.chooseAuthMethod%",
-					"enum": [
-						"AuthCodeGrant",
-						"DeviceCode"
-					],
-					"enumDescriptions": [
-						"%mssql.authCodeGrant.description%",
-						"%mssql.deviceCode.description%"
-					],
-					"scope": "application"
-				},
-				"mssql.logDebugInfo": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.logDebugInfo%",
-					"scope": "window"
-				},
-				"mssql.maxRecentConnections": {
-					"type": "number",
-					"default": 5,
-					"description": "%mssql.maxRecentConnections%",
-					"scope": "window"
-				},
-				"mssql.connections": {
-					"type": "array",
-					"description": "%mssql.connections%",
-					"items": {
-						"type": "object",
-						"properties": {
-							"server": {
-								"type": "string",
-								"default": "{{put-server-name-here}}",
-								"description": "%mssql.connection.server%"
-							},
-							"database": {
-								"type": "string",
-								"default": "{{put-database-name-here}}",
-								"description": "%mssql.connection.database%"
-							},
-							"user": {
-								"type": "string",
-								"default": "{{put-username-here}}",
-								"description": "%mssql.connection.user%"
-							},
-							"password": {
-								"type": "string",
-								"default": "{{put-password-here}}",
-								"description": "%mssql.connection.password%"
-							},
-							"authenticationType": {
-								"type": "string",
-								"default": "SqlLogin",
-								"enum": [
-									"Integrated",
-									"SqlLogin",
-									"AzureMFA"
-								],
-								"description": "%mssql.connection.authenticationType%"
-							},
-							"port": {
-								"type": "number",
-								"default": 1433,
-								"description": "%mssql.connection.port%"
-							},
-							"encrypt": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.encrypt%"
-							},
-							"trustServerCertificate": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.trustServerCertificate%"
-							},
-							"persistSecurityInfo": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.persistSecurityInfo%"
-							},
-							"connectTimeout": {
-								"type": "number",
-								"default": 15,
-								"description": "%mssql.connection.connectTimeout%"
-							},
-							"connectRetryCount": {
-								"type": "number",
-								"default": 1,
-								"description": "%mssql.connection.connectRetryCount%"
-							},
-							"connectRetryInterval": {
-								"type": "number",
-								"default": 10,
-								"description": "%mssql.connection.connectRetryInterval%"
-							},
-							"applicationName": {
-								"type": "string",
-								"default": "vscode-mssql",
-								"description": "%mssql.connection.applicationName%"
-							},
-							"workstationId": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.workstationId%"
-							},
-							"applicationIntent": {
-								"type": "string",
-								"default": "ReadWrite",
-								"enum": [
-									"ReadWrite",
-									"ReadOnly"
-								],
-								"description": "%mssql.connection.applicationIntent%"
-							},
-							"currentLanguage": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.currentLanguage%"
-							},
-							"pooling": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.pooling%"
-							},
-							"maxPoolSize": {
-								"type": "number",
-								"default": 100,
-								"description": "%mssql.connection.maxPoolSize%"
-							},
-							"minPoolSize": {
-								"type": "number",
-								"default": 0,
-								"description": "%mssql.connection.minPoolSize%"
-							},
-							"loadBalanceTimeout": {
-								"type": "number",
-								"default": 0,
-								"description": "%mssql.connection.loadBalanceTimeout%"
-							},
-							"replication": {
-								"type": "boolean",
-								"default": true,
-								"description": "%mssql.connection.replication%"
-							},
-							"attachDbFilename": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.attachDbFilename%"
-							},
-							"failoverPartner": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.failoverPartner%"
-							},
-							"multiSubnetFailover": {
-								"type": "boolean",
-								"default": true,
-								"description": "%mssql.connection.multiSubnetFailover%"
-							},
-							"multipleActiveResultSets": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.multipleActiveResultSets%"
-							},
-							"packetSize": {
-								"type": "number",
-								"default": 8192,
-								"description": "%mssql.connection.packetSize%"
-							},
-							"typeSystemVersion": {
-								"type": "string",
-								"enum": [
-									"Latest"
-								],
-								"description": "%mssql.connection.typeSystemVersion%"
-							},
-							"connectionString": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.connectionString%"
-							},
-							"profileName": {
-								"type": "string",
-								"description": "%mssql.connection.profileName%"
-							},
-							"savePassword": {
-								"type": "boolean",
-								"description": "%mssql.connection.savePassword%"
-							},
-							"emptyPasswordInput": {
-								"type": "boolean",
-								"description": "%mssql.connection.emptyPasswordInput%"
-							}
-						}
-					},
-					"scope": "resource"
-				},
-				"mssql.shortcuts": {
-					"type": "object",
-					"description": "%mssql.shortcuts%",
-					"default": {
-						"_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
-						"event.toggleResultPane": "ctrl+alt+R",
-						"event.focusResultsGrid": "ctrl+alt+G",
-						"event.toggleMessagePane": "ctrl+alt+Y",
-						"event.prevGrid": "ctrl+up",
-						"event.nextGrid": "ctrl+down",
-						"event.copySelection": "ctrl+C",
-						"event.copyWithHeaders": "",
-						"event.copyAllHeaders": "",
-						"event.maximizeGrid": "",
-						"event.selectAll": "ctrl+A",
-						"event.saveAsJSON": "",
-						"event.saveAsCSV": "",
-						"event.saveAsExcel": ""
-					},
-					"scope": "resource"
-				},
-				"mssql.messagesDefaultOpen": {
-					"type": "boolean",
-					"description": "%mssql.messagesDefaultOpen%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.resultsFontFamily": {
-					"type": "string",
-					"description": "%mssql.resultsFontFamily%",
-					"default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-					"scope": "resource"
-				},
-				"mssql.resultsFontSize": {
-					"type": "number",
-					"description": "%mssql.resultsFontSize%",
-					"default": 13,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.includeHeaders": {
-					"type": "boolean",
-					"description": "%mssql.saveAsCsv.includeHeaders%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.delimiter": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.delimiter%",
-					"default": ",",
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.lineSeparator": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.lineSeparator%",
-					"default": null,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.textIdentifier": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.textIdentifier%",
-					"default": "\"",
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.encoding": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.encoding%",
-					"default": "utf-8",
-					"scope": "resource"
-				},
-				"mssql.copyIncludeHeaders": {
-					"type": "boolean",
-					"description": "%mssql.copyIncludeHeaders%",
-					"default": false,
-					"scope": "resource"
-				},
-				"mssql.copyRemoveNewLine": {
-					"type": "boolean",
-					"description": "%mssql.copyRemoveNewLine%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.showBatchTime": {
-					"type": "boolean",
-					"description": "%mssql.showBatchTime%",
-					"default": false,
-					"scope": "resource"
-				},
-				"mssql.splitPaneSelection": {
-					"type": "string",
-					"description": "%mssql.splitPaneSelection%",
-					"default": "next",
-					"enum": [
-						"next",
-						"current",
-						"end"
-					],
-					"scope": "resource"
-				},
-				"mssql.format.alignColumnDefinitionsInColumns": {
-					"type": "boolean",
-					"description": "%mssql.format.alignColumnDefinitionsInColumns%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.format.datatypeCasing": {
-					"type": "string",
-					"description": "%mssql.format.datatypeCasing%",
-					"default": "none",
-					"enum": [
-						"none",
-						"uppercase",
-						"lowercase"
-					],
-					"scope": "window"
-				},
-				"mssql.format.keywordCasing": {
-					"type": "string",
-					"description": "%mssql.format.keywordCasing%",
-					"default": "none",
-					"enum": [
-						"none",
-						"uppercase",
-						"lowercase"
-					],
-					"scope": "window"
-				},
-				"mssql.format.placeCommasBeforeNextStatement": {
-					"type": "boolean",
-					"description": "%mssql.format.placeCommasBeforeNextStatement%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.format.placeSelectStatementReferencesOnNewLine": {
-					"type": "boolean",
-					"description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.applyLocalization": {
-					"type": "boolean",
-					"description": "%mssql.applyLocalization%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.query.displayBitAsNumber": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.displayBitAsNumber%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableIntelliSense": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableIntelliSense%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableErrorChecking": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableErrorChecking%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableSuggestions": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableSuggestions%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableQuickInfo": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableQuickInfo%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.lowerCaseSuggestions": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.intelliSense.lowerCaseSuggestions%",
-					"scope": "window"
-				},
-				"mssql.persistQueryResultTabs": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.persistQueryResultTabs%",
-					"scope": "window"
-				},
-				"mssql.queryHistoryLimit": {
-					"type": "number",
-					"default": 20,
-					"description": "%mssql.queryHistoryLimit%",
-					"scope": "window"
-				},
-				"mssql.enableQueryHistoryCapture": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.enableQueryHistoryCapture%",
-					"scope": "window"
-				},
-				"mssql.enableQueryHistoryFeature": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.enableQueryHistoryFeature%",
-					"scope": "window"
-				},
-				"mssql.query.maxXmlCharsToStore": {
-					"type": "number",
-					"default": 2097152,
-					"description": "%mssql.query.maxXmlCharsToStore%"
-				},
-				"mssql.tracingLevel": {
-					"type": "string",
-					"description": "%mssql.tracingLevel%",
-					"default": "Critical",
-					"enum": [
-						"All",
-						"Off",
-						"Critical",
-						"Error",
-						"Warning",
-						"Information",
-						"Verbose"
-					]
-				},
-				"mssql.logRetentionMinutes": {
-					"type": "number",
-					"default": 10080,
-					"description": "%mssql.logRetentionMinutes%"
-				},
-				"mssql.logFilesRemovalLimit": {
-					"type": "number",
-					"default": 100,
-					"description": "%mssql.logFilesRemovalLimit%"
-				},
-				"mssql.query.rowCount": {
-					"type": "number",
-					"default": 0,
-					"description": "%mssql.query.setRowCount%"
-				},
-				"mssql.query.textSize": {
-					"type": "number",
-					"default": 2147483647,
-					"description": "%mssql.query.textSize%"
-				},
-				"mssql.query.executionTimeout": {
-					"type": "number",
-					"default": 0,
-					"description": "%mssql.query.executionTimeout%"
-				},
-				"mssql.query.noCount": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.noCount%"
-				},
-				"mssql.query.noExec": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.noExec%"
-				},
-				"mssql.query.parseOnly": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.parseOnly%"
-				},
-				"mssql.query.arithAbort": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.arithAbort%"
-				},
-				"mssql.query.statisticsTime": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.statisticsTime%"
-				},
-				"mssql.query.statisticsIO": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.statisticsIO%"
-				},
-				"mssql.query.xactAbortOn": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.xactAbortOn%"
-				},
-				"mssql.query.transactionIsolationLevel": {
-					"enum": [
-						"READ COMMITTED",
-						"READ UNCOMMITTED",
-						"REPEATABLE READ",
-						"SERIALIZABLE"
-					],
-					"default": "READ COMMITTED",
-					"description": "%mssql.query.transactionIsolationLevel%"
-				},
-				"mssql.query.deadlockPriority": {
-					"enum": [
-						"Normal",
-						"Low"
-					],
-					"default": "Normal",
-					"description": "%mssql.query.deadlockPriority%"
-				},
-				"mssql.query.lockTimeout": {
-					"type": "number",
-					"default": -1,
-					"description": "%mssql.query.lockTimeout%"
-				},
-				"mssql.query.queryGovernorCostLimit": {
-					"type": "number",
-					"default": -1,
-					"description": "%mssql.query.queryGovernorCostLimit%"
-				},
-				"mssql.query.ansiDefaults": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.ansiDefaults%"
-				},
-				"mssql.query.quotedIdentifier": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.quotedIdentifier%"
-				},
-				"mssql.query.ansiNullDefaultOn": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiNullDefaultOn%"
-				},
-				"mssql.query.implicitTransactions": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.implicitTransactions%"
-				},
-				"mssql.query.cursorCloseOnCommit": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.cursorCloseOnCommit%"
-				},
-				"mssql.query.ansiPadding": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiPadding%"
-				},
-				"mssql.query.ansiWarnings": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiWarnings%"
-				},
-				"mssql.query.ansiNulls": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiNulls%"
-				},
-				"mssql.query.alwaysEncryptedParameterization": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.alwaysEncryptedParameterization%"
-				},
-				"mssql.ignorePlatformWarning": {
-					"type": "boolean",
-					"description": "%mssql.ignorePlatformWarning%",
-					"default": false
-				}
-			}
-		}
-	},
-	"__metadata": {
-		"id": "4bf45e86-a448-4531-8c01-ef33f4536306",
-		"publisherDisplayName": "Microsoft",
-		"publisherId": "60b3df88-4640-44d4-a7e5-6ba8004700bb",
-		"isPreReleaseVersion": false
-	}
+  "name": "mssql",
+  "displayName": "SQL Server (mssql)",
+  "version": "1.16.0",
+  "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
+  "publisher": "ms-mssql",
+  "preview": false,
+  "license": "SEE LICENSE IN LICENSE.txt",
+  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+  "icon": "images/sqlserver.png",
+  "galleryBanner": {
+    "color": "#2F2F2F",
+    "theme": "dark"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-mssql.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-mssql/issues"
+  },
+  "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
+  "engines": {
+    "vscode": "^1.57.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Azure"
+  ],
+  "keywords": [
+    "SQL",
+    "MSSQL",
+    "SQL Server",
+    "Azure SQL Database",
+    "Azure SQL Data Warehouse",
+    "multi-root ready"
+  ],
+  "activationEvents": [
+    "onView:objectExplorer",
+    "onLanguage:sql",
+    "onCommand:mssql.connect",
+    "onCommand:mssql.runQuery",
+    "onCommand:mssql.runCurrentStatement",
+    "onCommand:mssql.disconnect",
+    "onCommand:mssql.manageProfiles",
+    "onCommand:mssql.chooseDatabase",
+    "onCommand:mssql.cancelQuery",
+    "onCommand:mssql.showGettingStarted",
+    "onCommand:mssql.newQuery",
+    "onCommand:mssql.rebuildIntelliSenseCache",
+    "onCommand:mssql.addObjectExplorer",
+    "onCommand:mssql.objectExplorerNewQuery",
+    "onCommand:mssql.toggleSqlCmd",
+    "onCommand:mssql.loadCompletionExtension",
+    "onCommand:mssql.removeAadAccount"
+  ],
+  "main": "./out/src/extension",
+  "extensionDependencies": [
+    "vscode.sql"
+  ],
+  "extensionPack": [
+    "ms-mssql.data-workspace-vscode",
+    "ms-mssql.sql-database-projects-vscode",
+    "ms-mssql.sql-bindings-vscode"
+  ],
+  "scripts": {
+    "build": "gulp build",
+    "compile": "gulp ext:compile",
+    "watch": "gulp watch"
+  },
+  "devDependencies": {
+    "@angular/common": "~2.1.2",
+    "@angular/compiler": "~2.1.2",
+    "@angular/core": "~2.1.2",
+    "@angular/forms": "~2.1.2",
+    "@angular/platform-browser": "~2.1.2",
+    "@angular/platform-browser-dynamic": "~2.1.2",
+    "@angular/router": "~3.1.2",
+    "@angular/upgrade": "~2.1.2",
+    "@types/ejs": "^3.1.0",
+    "@types/jquery": "^3.3.31",
+    "@types/jqueryui": "^1.12.7",
+    "@types/keytar": "^4.4.2",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^14.14.16",
+    "@types/sinon": "^10.0.12",
+    "@types/tmp": "0.0.28",
+    "@types/underscore": "1.8.3",
+    "@types/vscode": "1.57.0",
+    "angular-in-memory-web-api": "0.1.13",
+    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
+    "assert": "^1.4.1",
+    "chai": "^3.5.0",
+    "coveralls": "^3.0.2",
+    "decache": "^4.1.0",
+    "del": "^2.2.1",
+    "gulp": "^4.0.2",
+    "gulp-concat": "^2.6.0",
+    "gulp-istanbul-report": "0.0.1",
+    "gulp-json-editor": "^2.2.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.7.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-tslint": "^8.1.4",
+    "gulp-typescript": "^5.0.1",
+    "gulp-uglify": "^2.0.0",
+    "istanbul": "^0.4.5",
+    "pm-mocha-jenkins-reporter": "^0.2.6",
+    "remap-istanbul": "^0.6.4",
+    "rxjs": "5.0.0-beta.12",
+    "sinon": "^14.0.0",
+    "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
+    "systemjs": "0.19.40",
+    "systemjs-builder": "^0.15.32",
+    "systemjs-plugin-json": "^0.2.0",
+    "tslint": "^6.1.3",
+    "tslint-microsoft-contrib": "^5.2.0",
+    "typemoq": "^1.7.0",
+    "typescript": "^3.5.3",
+    "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
+    "vscode-nls-dev": "2.0.1",
+    "@vscode/test-electron": "^2.1.5",
+    "@xmldom/xmldom": "^0.8.2",
+    "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+  },
+  "dependencies": {
+    "@azure/arm-resources": "^5.0.0",
+    "@azure/arm-sql": "^9.0.0",
+    "@azure/arm-subscriptions": "^5.0.0",
+    "@microsoft/ads-adal-library": "1.0.15",
+    "core-js": "^2.4.1",
+    "decompress-zip": "^0.2.2",
+    "ejs": "^3.1.7",
+    "error-ex": "^1.3.0",
+    "figures": "^1.4.0",
+    "find-remove": "1.2.1",
+    "getmac": "1.2.1",
+    "http-proxy-agent": "^2.1.0",
+    "https-proxy-agent": "^2.2.1",
+    "jquery": "^3.4.1",
+    "opener": "1.4.2",
+    "plist": "^3.0.5",
+    "pretty-data": "^0.40.0",
+    "rangy": "^1.3.0",
+    "reflect-metadata": "0.1.12",
+    "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+    "tar": "^6.1.9",
+    "tmp": "^0.0.28",
+    "underscore": "^1.8.3",
+    "vscode-languageclient": "5.2.1",
+    "vscode-nls": "^2.0.2",
+    "zone.js": "^0.6.26"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "objectExplorer",
+          "title": "SQL Server",
+          "icon": "./images/server_page_inverse.svg"
+        }
+      ]
+    },
+    "views": {
+      "objectExplorer": [
+        {
+          "id": "objectExplorer",
+          "name": "%extension.connections%"
+        },
+        {
+          "id": "queryHistory",
+          "name": "%extension.queryHistory%",
+          "when": "config.mssql.enableQueryHistoryFeature"
+        }
+      ]
+    },
+    "languages": [
+      {
+        "id": "sql",
+        "extensions": [
+          ".sql"
+        ],
+        "aliases": [
+          "SQL"
+        ],
+        "configuration": "./syntaxes/sql.configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "sql",
+        "scopeName": "source.sql",
+        "path": "./syntaxes/SQL.plist"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "sql",
+        "path": "./snippets/mssql.json"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "mssql.runQuery",
+          "when": "editorLangId == sql",
+          "group": "navigation@1"
+        },
+        {
+          "command": "mssql.cancelQuery",
+          "when": "editorLangId == sql && resourcePath in mssql.runningQueries",
+          "group": "navigation@2"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "mssql.runQuery",
+          "when": "editorLangId == sql"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "mssql.addObjectExplorer",
+          "when": "view == objectExplorer",
+          "title": "%mssql.addObjectExplorer%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.startQueryHistoryCapture",
+          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
+          "title": "%mssql.startQueryHistoryCapture%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.pauseQueryHistoryCapture",
+          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
+          "title": "%mssql.pauseQueryHistoryCapture%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.clearAllQueryHistory",
+          "when": "view == queryHistory",
+          "title": "%mssql.clearAllQueryHistory%",
+          "group": "secondary"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "mssql.objectExplorerNewQuery",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.removeObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
+          "group": "MS_SQL@4"
+        },
+        {
+          "command": "mssql.refreshObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem != disconnectedServer",
+          "group": "MS_SQL@10"
+        },
+        {
+          "command": "mssql.disconnectObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem == Server",
+          "group": "MS_SQL@3"
+        },
+        {
+          "command": "mssql.scriptSelect",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.scriptCreate",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+          "group": "MS_SQL@2"
+        },
+        {
+          "command": "mssql.scriptDelete",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+          "group": "MS_SQL@3"
+        },
+        {
+          "command": "mssql.scriptExecute",
+          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
+          "group": "MS_SQL@5"
+        },
+        {
+          "command": "mssql.scriptAlter",
+          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
+          "group": "MS_SQL@4"
+        },
+        {
+          "command": "mssql.openQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.runQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@2"
+        },
+        {
+          "command": "mssql.deleteQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@3"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "mssql.objectExplorerNewQuery",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
+        },
+        {
+          "command": "mssql.removeObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
+        },
+        {
+          "command": "mssql.refreshObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem != disconnectedServer"
+        },
+        {
+          "command": "mssql.scriptSelect",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
+        },
+        {
+          "command": "mssql.scriptCreate",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+        },
+        {
+          "command": "mssql.scriptDelete",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+        },
+        {
+          "command": "mssql.scriptExecute",
+          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
+        },
+        {
+          "command": "mssql.scriptAlter",
+          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
+        },
+        {
+          "command": "mssql.disconnectObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem == Server"
+        },
+        {
+          "command": "mssql.toggleSqlCmd",
+          "when": "editorFocus && editorLangId == 'sql'"
+        },
+        {
+          "command": "mssql.startQueryHistoryCapture",
+          "when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
+        },
+        {
+          "command": "mssql.pauseQueryHistoryCapture",
+          "when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
+        },
+        {
+          "command": "mssql.copyObjectName",
+          "when": "view == objectExplorer && viewItem != Folder"
+        },
+        {
+          "command": "mssql.runQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "mssql.runQuery",
+        "title": "%mssql.runQuery%",
+        "category": "MS SQL",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "mssql.runCurrentStatement",
+        "title": "%mssql.runCurrentStatement%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.cancelQuery",
+        "title": "%mssql.cancelQuery%",
+        "category": "MS SQL",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "mssql.connect",
+        "title": "%mssql.connect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.disconnect",
+        "title": "%mssql.disconnect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.manageProfiles",
+        "title": "%mssql.manageProfiles%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.chooseDatabase",
+        "title": "%mssql.chooseDatabase%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.chooseLanguageFlavor",
+        "title": "%mssql.chooseLanguageFlavor%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.showGettingStarted",
+        "title": "%mssql.showGettingStarted%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.newQuery",
+        "title": "%mssql.newQuery%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.rebuildIntelliSenseCache",
+        "title": "%mssql.rebuildIntelliSenseCache%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.toggleSqlCmd",
+        "title": "%mssql.toggleSqlCmd%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.addObjectExplorer",
+        "title": "%mssql.addObjectExplorer%",
+        "category": "MS SQL",
+        "icon": "$(add)"
+      },
+      {
+        "command": "mssql.objectExplorerNewQuery",
+        "title": "%mssql.objectExplorerNewQuery%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.removeObjectExplorerNode",
+        "title": "%mssql.removeObjectExplorerNode%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.refreshObjectExplorerNode",
+        "title": "%mssql.refreshObjectExplorerNode%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.disconnectObjectExplorerNode",
+        "title": "%mssql.disconnect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptSelect",
+        "title": "%mssql.scriptSelect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptCreate",
+        "title": "%mssql.scriptCreate%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptDelete",
+        "title": "%mssql.scriptDelete%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptExecute",
+        "title": "%mssql.scriptExecute%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptAlter",
+        "title": "%mssql.scriptAlter%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.openQueryHistory",
+        "title": "%mssql.openQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.runQueryHistory",
+        "title": "%mssql.runQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.deleteQueryHistory",
+        "title": "%mssql.deleteQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.clearAllQueryHistory",
+        "title": "%mssql.clearAllQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.startQueryHistoryCapture",
+        "title": "%mssql.startQueryHistoryCapture%",
+        "category": "MS SQL",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "mssql.pauseQueryHistoryCapture",
+        "title": "%mssql.pauseQueryHistoryCapture%",
+        "category": "MS SQL",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "mssql.commandPaletteQueryHistory",
+        "title": "%mssql.commandPaletteQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "title": "%mssql.copyObjectName%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.removeAadAccount",
+        "title": "%mssql.removeAadAccount%",
+        "category": "MS SQL"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "mssql.runQuery",
+        "key": "ctrl+shift+e",
+        "mac": "cmd+shift+e",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "mssql.connect",
+        "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "mssql.disconnect",
+        "key": "ctrl+shift+d",
+        "mac": "cmd+shift+d",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "workbench.view.extension.objectExplorer",
+        "key": "ctrl+alt+d",
+        "mac": "cmd+alt+d"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "key": "ctrl+c",
+        "mac": "cmd+c",
+        "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "%mssql.Configuration%",
+      "properties": {
+        "mssql.azureActiveDirectory": {
+          "type": "string",
+          "default": "AuthCodeGrant",
+          "description": "%mssql.chooseAuthMethod%",
+          "enum": [
+            "AuthCodeGrant",
+            "DeviceCode"
+          ],
+          "enumDescriptions": [
+            "%mssql.authCodeGrant.description%",
+            "%mssql.deviceCode.description%"
+          ],
+          "scope": "application"
+        },
+        "mssql.logDebugInfo": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.logDebugInfo%",
+          "scope": "window"
+        },
+        "mssql.maxRecentConnections": {
+          "type": "number",
+          "default": 5,
+          "description": "%mssql.maxRecentConnections%",
+          "scope": "window"
+        },
+        "mssql.connections": {
+          "type": "array",
+          "description": "%mssql.connections%",
+          "items": {
+            "type": "object",
+            "properties": {
+              "server": {
+                "type": "string",
+                "default": "{{put-server-name-here}}",
+                "description": "%mssql.connection.server%"
+              },
+              "database": {
+                "type": "string",
+                "default": "{{put-database-name-here}}",
+                "description": "%mssql.connection.database%"
+              },
+              "user": {
+                "type": "string",
+                "default": "{{put-username-here}}",
+                "description": "%mssql.connection.user%"
+              },
+              "password": {
+                "type": "string",
+                "default": "{{put-password-here}}",
+                "description": "%mssql.connection.password%"
+              },
+              "authenticationType": {
+                "type": "string",
+                "default": "SqlLogin",
+                "enum": [
+                  "Integrated",
+                  "SqlLogin",
+                  "AzureMFA"
+                ],
+                "description": "%mssql.connection.authenticationType%"
+              },
+              "port": {
+                "type": "number",
+                "default": 1433,
+                "description": "%mssql.connection.port%"
+              },
+              "encrypt": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.encrypt%"
+              },
+              "trustServerCertificate": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.trustServerCertificate%"
+              },
+              "persistSecurityInfo": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.persistSecurityInfo%"
+              },
+              "connectTimeout": {
+                "type": "number",
+                "default": 15,
+                "description": "%mssql.connection.connectTimeout%"
+              },
+              "connectRetryCount": {
+                "type": "number",
+                "default": 1,
+                "description": "%mssql.connection.connectRetryCount%"
+              },
+              "connectRetryInterval": {
+                "type": "number",
+                "default": 10,
+                "description": "%mssql.connection.connectRetryInterval%"
+              },
+              "applicationName": {
+                "type": "string",
+                "default": "vscode-mssql",
+                "description": "%mssql.connection.applicationName%"
+              },
+              "workstationId": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.workstationId%"
+              },
+              "applicationIntent": {
+                "type": "string",
+                "default": "ReadWrite",
+                "enum": [
+                  "ReadWrite",
+                  "ReadOnly"
+                ],
+                "description": "%mssql.connection.applicationIntent%"
+              },
+              "currentLanguage": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.currentLanguage%"
+              },
+              "pooling": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.pooling%"
+              },
+              "maxPoolSize": {
+                "type": "number",
+                "default": 100,
+                "description": "%mssql.connection.maxPoolSize%"
+              },
+              "minPoolSize": {
+                "type": "number",
+                "default": 0,
+                "description": "%mssql.connection.minPoolSize%"
+              },
+              "loadBalanceTimeout": {
+                "type": "number",
+                "default": 0,
+                "description": "%mssql.connection.loadBalanceTimeout%"
+              },
+              "replication": {
+                "type": "boolean",
+                "default": true,
+                "description": "%mssql.connection.replication%"
+              },
+              "attachDbFilename": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.attachDbFilename%"
+              },
+              "failoverPartner": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.failoverPartner%"
+              },
+              "multiSubnetFailover": {
+                "type": "boolean",
+                "default": true,
+                "description": "%mssql.connection.multiSubnetFailover%"
+              },
+              "multipleActiveResultSets": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.multipleActiveResultSets%"
+              },
+              "packetSize": {
+                "type": "number",
+                "default": 8192,
+                "description": "%mssql.connection.packetSize%"
+              },
+              "typeSystemVersion": {
+                "type": "string",
+                "enum": [
+                  "Latest"
+                ],
+                "description": "%mssql.connection.typeSystemVersion%"
+              },
+              "connectionString": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.connectionString%"
+              },
+              "profileName": {
+                "type": "string",
+                "description": "%mssql.connection.profileName%"
+              },
+              "savePassword": {
+                "type": "boolean",
+                "description": "%mssql.connection.savePassword%"
+              },
+              "emptyPasswordInput": {
+                "type": "boolean",
+                "description": "%mssql.connection.emptyPasswordInput%"
+              }
+            }
+          },
+          "scope": "resource"
+        },
+        "mssql.shortcuts": {
+          "type": "object",
+          "description": "%mssql.shortcuts%",
+          "default": {
+            "_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
+            "event.toggleResultPane": "ctrl+alt+R",
+            "event.focusResultsGrid": "ctrl+alt+G",
+            "event.toggleMessagePane": "ctrl+alt+Y",
+            "event.prevGrid": "ctrl+up",
+            "event.nextGrid": "ctrl+down",
+            "event.copySelection": "ctrl+C",
+            "event.copyWithHeaders": "",
+            "event.copyAllHeaders": "",
+            "event.maximizeGrid": "",
+            "event.selectAll": "ctrl+A",
+            "event.saveAsJSON": "",
+            "event.saveAsCSV": "",
+            "event.saveAsExcel": ""
+          },
+          "scope": "resource"
+        },
+        "mssql.messagesDefaultOpen": {
+          "type": "boolean",
+          "description": "%mssql.messagesDefaultOpen%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.resultsFontFamily": {
+          "type": "string",
+          "description": "%mssql.resultsFontFamily%",
+          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
+          "scope": "resource"
+        },
+        "mssql.resultsFontSize": {
+          "type": "number",
+          "description": "%mssql.resultsFontSize%",
+          "default": 13,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.includeHeaders": {
+          "type": "boolean",
+          "description": "%mssql.saveAsCsv.includeHeaders%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.delimiter": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.delimiter%",
+          "default": ",",
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.lineSeparator": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.lineSeparator%",
+          "default": null,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.textIdentifier": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.textIdentifier%",
+          "default": "\"",
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.encoding": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.encoding%",
+          "default": "utf-8",
+          "scope": "resource"
+        },
+        "mssql.copyIncludeHeaders": {
+          "type": "boolean",
+          "description": "%mssql.copyIncludeHeaders%",
+          "default": false,
+          "scope": "resource"
+        },
+        "mssql.copyRemoveNewLine": {
+          "type": "boolean",
+          "description": "%mssql.copyRemoveNewLine%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.showBatchTime": {
+          "type": "boolean",
+          "description": "%mssql.showBatchTime%",
+          "default": false,
+          "scope": "resource"
+        },
+        "mssql.splitPaneSelection": {
+          "type": "string",
+          "description": "%mssql.splitPaneSelection%",
+          "default": "next",
+          "enum": [
+            "next",
+            "current",
+            "end"
+          ],
+          "scope": "resource"
+        },
+        "mssql.format.alignColumnDefinitionsInColumns": {
+          "type": "boolean",
+          "description": "%mssql.format.alignColumnDefinitionsInColumns%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.format.datatypeCasing": {
+          "type": "string",
+          "description": "%mssql.format.datatypeCasing%",
+          "default": "none",
+          "enum": [
+            "none",
+            "uppercase",
+            "lowercase"
+          ],
+          "scope": "window"
+        },
+        "mssql.format.keywordCasing": {
+          "type": "string",
+          "description": "%mssql.format.keywordCasing%",
+          "default": "none",
+          "enum": [
+            "none",
+            "uppercase",
+            "lowercase"
+          ],
+          "scope": "window"
+        },
+        "mssql.format.placeCommasBeforeNextStatement": {
+          "type": "boolean",
+          "description": "%mssql.format.placeCommasBeforeNextStatement%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.format.placeSelectStatementReferencesOnNewLine": {
+          "type": "boolean",
+          "description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.applyLocalization": {
+          "type": "boolean",
+          "description": "%mssql.applyLocalization%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.query.displayBitAsNumber": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.displayBitAsNumber%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableIntelliSense": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableIntelliSense%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableErrorChecking": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableErrorChecking%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableSuggestions": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableSuggestions%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableQuickInfo": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableQuickInfo%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.lowerCaseSuggestions": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.intelliSense.lowerCaseSuggestions%",
+          "scope": "window"
+        },
+        "mssql.persistQueryResultTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.persistQueryResultTabs%",
+          "scope": "window"
+        },
+        "mssql.queryHistoryLimit": {
+          "type": "number",
+          "default": 20,
+          "description": "%mssql.queryHistoryLimit%",
+          "scope": "window"
+        },
+        "mssql.enableQueryHistoryCapture": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.enableQueryHistoryCapture%",
+          "scope": "window"
+        },
+        "mssql.enableQueryHistoryFeature": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.enableQueryHistoryFeature%",
+          "scope": "window"
+        },
+        "mssql.query.maxXmlCharsToStore": {
+          "type": "number",
+          "default": 2097152,
+          "description": "%mssql.query.maxXmlCharsToStore%"
+        },
+        "mssql.tracingLevel": {
+          "type": "string",
+          "description": "%mssql.tracingLevel%",
+          "default": "Critical",
+          "enum": [
+            "All",
+            "Off",
+            "Critical",
+            "Error",
+            "Warning",
+            "Information",
+            "Verbose"
+          ]
+        },
+        "mssql.logRetentionMinutes": {
+          "type": "number",
+          "default": 10080,
+          "description": "%mssql.logRetentionMinutes%"
+        },
+        "mssql.logFilesRemovalLimit": {
+          "type": "number",
+          "default": 100,
+          "description": "%mssql.logFilesRemovalLimit%"
+        },
+        "mssql.query.rowCount": {
+          "type": "number",
+          "default": 0,
+          "description": "%mssql.query.setRowCount%"
+        },
+        "mssql.query.textSize": {
+          "type": "number",
+          "default": 2147483647,
+          "description": "%mssql.query.textSize%"
+        },
+        "mssql.query.executionTimeout": {
+          "type": "number",
+          "default": 0,
+          "description": "%mssql.query.executionTimeout%"
+        },
+        "mssql.query.noCount": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.noCount%"
+        },
+        "mssql.query.noExec": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.noExec%"
+        },
+        "mssql.query.parseOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.parseOnly%"
+        },
+        "mssql.query.arithAbort": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.arithAbort%"
+        },
+        "mssql.query.statisticsTime": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.statisticsTime%"
+        },
+        "mssql.query.statisticsIO": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.statisticsIO%"
+        },
+        "mssql.query.xactAbortOn": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.xactAbortOn%"
+        },
+        "mssql.query.transactionIsolationLevel": {
+          "enum": [
+            "READ COMMITTED",
+            "READ UNCOMMITTED",
+            "REPEATABLE READ",
+            "SERIALIZABLE"
+          ],
+          "default": "READ COMMITTED",
+          "description": "%mssql.query.transactionIsolationLevel%"
+        },
+        "mssql.query.deadlockPriority": {
+          "enum": [
+            "Normal",
+            "Low"
+          ],
+          "default": "Normal",
+          "description": "%mssql.query.deadlockPriority%"
+        },
+        "mssql.query.lockTimeout": {
+          "type": "number",
+          "default": -1,
+          "description": "%mssql.query.lockTimeout%"
+        },
+        "mssql.query.queryGovernorCostLimit": {
+          "type": "number",
+          "default": -1,
+          "description": "%mssql.query.queryGovernorCostLimit%"
+        },
+        "mssql.query.ansiDefaults": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.ansiDefaults%"
+        },
+        "mssql.query.quotedIdentifier": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.quotedIdentifier%"
+        },
+        "mssql.query.ansiNullDefaultOn": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiNullDefaultOn%"
+        },
+        "mssql.query.implicitTransactions": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.implicitTransactions%"
+        },
+        "mssql.query.cursorCloseOnCommit": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.cursorCloseOnCommit%"
+        },
+        "mssql.query.ansiPadding": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiPadding%"
+        },
+        "mssql.query.ansiWarnings": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiWarnings%"
+        },
+        "mssql.query.ansiNulls": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiNulls%"
+        },
+        "mssql.query.alwaysEncryptedParameterization": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.alwaysEncryptedParameterization%"
+        },
+        "mssql.ignorePlatformWarning": {
+          "type": "boolean",
+          "description": "%mssql.ignorePlatformWarning%",
+          "default": false
+        }
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,1139 +1,1133 @@
 {
-	"name": "mssql",
-	"displayName": "SQL Server (mssql)",
-	"version": "1.16.0",
-	"description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
-	"publisher": "ms-mssql",
-	"preview": false,
-	"license": "SEE LICENSE IN LICENSE.txt",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
-	"icon": "images/sqlserver.png",
-	"galleryBanner": {
-		"color": "#2F2F2F",
-		"theme": "dark"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-mssql.git"
-	},
-	"bugs": {
-		"url": "https://github.com/Microsoft/vscode-mssql/issues"
-	},
-	"homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
-	"engines": {
-		"vscode": "^1.57.0"
-	},
-	"categories": [
-		"Programming Languages",
-		"Azure"
-	],
-	"keywords": [
-		"SQL",
-		"MSSQL",
-		"SQL Server",
-		"Azure SQL Database",
-		"Azure SQL Data Warehouse",
-		"multi-root ready"
-	],
-	"activationEvents": [
-		"onView:objectExplorer",
-		"onLanguage:sql",
-		"onCommand:mssql.connect",
-		"onCommand:mssql.runQuery",
-		"onCommand:mssql.runCurrentStatement",
-		"onCommand:mssql.disconnect",
-		"onCommand:mssql.manageProfiles",
-		"onCommand:mssql.chooseDatabase",
-		"onCommand:mssql.cancelQuery",
-		"onCommand:mssql.showGettingStarted",
-		"onCommand:mssql.newQuery",
-		"onCommand:mssql.rebuildIntelliSenseCache",
-		"onCommand:mssql.addObjectExplorer",
-		"onCommand:mssql.objectExplorerNewQuery",
-		"onCommand:mssql.toggleSqlCmd",
-		"onCommand:mssql.loadCompletionExtension",
-		"onCommand:mssql.removeAadAccount"
-	],
-	"main": "./out/src/extension",
-	"extensionDependencies": [
-		"vscode.sql"
-	],
-	"extensionPack": [
-		"ms-mssql.data-workspace-vscode",
-		"ms-mssql.sql-database-projects-vscode",
-		"ms-mssql.sql-bindings-vscode"
-	],
-	"scripts": {
-		"build": "gulp build",
-		"compile": "gulp ext:compile",
-		"watch": "gulp watch"
-	},
-	"devDependencies": {
-		"@angular/common": "~2.1.2",
-		"@angular/compiler": "~2.1.2",
-		"@angular/core": "~2.1.2",
-		"@angular/forms": "~2.1.2",
-		"@angular/platform-browser": "~2.1.2",
-		"@angular/platform-browser-dynamic": "~2.1.2",
-		"@angular/router": "~3.1.2",
-		"@angular/upgrade": "~2.1.2",
-		"@types/ejs": "^3.1.0",
-		"@types/jquery": "^3.3.31",
-		"@types/jqueryui": "^1.12.7",
-		"@types/keytar": "^4.4.2",
-		"@types/mocha": "^5.2.7",
-		"@types/node": "^14.14.16",
-		"@types/sinon": "^10.0.12",
-		"@types/tmp": "0.0.28",
-		"@types/underscore": "1.8.3",
-		"@types/vscode": "1.57.0",
-		"angular-in-memory-web-api": "0.1.13",
-		"angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
-		"assert": "^1.4.1",
-		"chai": "^3.5.0",
-		"coveralls": "^3.0.2",
-		"decache": "^4.1.0",
-		"del": "^2.2.1",
-		"gulp": "^4.0.2",
-		"gulp-concat": "^2.6.0",
-		"gulp-istanbul-report": "0.0.1",
-		"gulp-json-editor": "^2.2.1",
-		"gulp-rename": "^1.2.2",
-		"gulp-shell": "^0.7.0",
-		"gulp-sourcemaps": "^1.6.0",
-		"gulp-tslint": "^8.1.4",
-		"gulp-typescript": "^5.0.1",
-		"gulp-uglify": "^2.0.0",
-		"istanbul": "^0.4.5",
-		"pm-mocha-jenkins-reporter": "^0.2.6",
-		"remap-istanbul": "^0.6.4",
-		"rxjs": "5.0.0-beta.12",
-		"sinon": "^14.0.0",
-		"slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
-		"systemjs": "0.19.40",
-		"systemjs-builder": "^0.15.32",
-		"systemjs-plugin-json": "^0.2.0",
-		"tslint": "^6.1.3",
-		"tslint-microsoft-contrib": "^5.2.0",
-		"typemoq": "^1.7.0",
-		"typescript": "^3.5.3",
-		"uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
-		"vscode-nls-dev": "2.0.1",
-		"@vscode/test-electron": "^2.1.5",
-		"@xmldom/xmldom": "^0.8.2",
-		"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
-	},
-	"dependencies": {
-		"@azure/arm-resources": "^5.0.0",
-		"@azure/arm-sql": "^9.0.0",
-		"@azure/arm-subscriptions": "^5.0.0",
-		"@microsoft/ads-adal-library": "1.0.15",
-		"core-js": "^2.4.1",
-		"decompress-zip": "^0.2.2",
-		"ejs": "^3.1.7",
-		"error-ex": "^1.3.0",
-		"figures": "^1.4.0",
-		"find-remove": "1.2.1",
-		"getmac": "1.2.1",
-		"http-proxy-agent": "^2.1.0",
-		"https-proxy-agent": "^2.2.1",
-		"jquery": "^3.4.1",
-		"opener": "1.4.2",
-		"plist": "^3.0.5",
-		"pretty-data": "^0.40.0",
-		"rangy": "^1.3.0",
-		"reflect-metadata": "0.1.12",
-		"semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-		"tar": "^6.1.9",
-		"tmp": "^0.0.28",
-		"underscore": "^1.8.3",
-		"vscode-languageclient": "5.2.1",
-		"vscode-nls": "^2.0.2",
-		"zone.js": "^0.6.26"
-	},
-	"capabilities": {
-		"untrustedWorkspaces": {
-			"supported": true
-		}
-	},
-	"contributes": {
-		"viewsContainers": {
-			"activitybar": [
-				{
-					"id": "objectExplorer",
-					"title": "SQL Server",
-					"icon": "./images/server_page_inverse.svg"
-				}
-			]
-		},
-		"views": {
-			"objectExplorer": [
-				{
-					"id": "objectExplorer",
-					"name": "%extension.connections%"
-				},
-				{
-					"id": "queryHistory",
-					"name": "%extension.queryHistory%",
-					"when": "config.mssql.enableQueryHistoryFeature"
-				}
-			]
-		},
-		"languages": [
-			{
-				"id": "sql",
-				"extensions": [
-					".sql"
-				],
-				"aliases": [
-					"SQL"
-				],
-				"configuration": "./syntaxes/sql.configuration.json"
-			}
-		],
-		"grammars": [
-			{
-				"language": "sql",
-				"scopeName": "source.sql",
-				"path": "./syntaxes/SQL.plist"
-			}
-		],
-		"snippets": [
-			{
-				"language": "sql",
-				"path": "./snippets/mssql.json"
-			}
-		],
-		"menus": {
-			"editor/title": [
-				{
-					"command": "mssql.runQuery",
-					"when": "editorLangId == sql",
-					"group": "navigation@1"
-				},
-				{
-					"command": "mssql.cancelQuery",
-					"when": "editorLangId == sql && resourcePath in mssql.runningQueries",
-					"group": "navigation@2"
-				}
-			],
-			"editor/context": [
-				{
-					"command": "mssql.runQuery",
-					"when": "editorLangId == sql"
-				}
-			],
-			"view/title": [
-				{
-					"command": "mssql.addObjectExplorer",
-					"when": "view == objectExplorer",
-					"title": "%mssql.addObjectExplorer%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.startQueryHistoryCapture",
-					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
-					"title": "%mssql.startQueryHistoryCapture%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.pauseQueryHistoryCapture",
-					"when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
-					"title": "%mssql.pauseQueryHistoryCapture%",
-					"group": "navigation"
-				},
-				{
-					"command": "mssql.clearAllQueryHistory",
-					"when": "view == queryHistory",
-					"title": "%mssql.clearAllQueryHistory%",
-					"group": "secondary"
-				}
-			],
-			"view/item/context": [
-				{
-					"command": "mssql.objectExplorerNewQuery",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.removeObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
-					"group": "MS_SQL@4"
-				},
-				{
-					"command": "mssql.refreshObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem != disconnectedServer",
-					"group": "MS_SQL@10"
-				},
-				{
-					"command": "mssql.disconnectObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem == Server",
-					"group": "MS_SQL@3"
-				},
-				{
-					"command": "mssql.scriptSelect",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.scriptCreate",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-					"group": "MS_SQL@2"
-				},
-				{
-					"command": "mssql.scriptDelete",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
-					"group": "MS_SQL@3"
-				},
-				{
-					"command": "mssql.scriptExecute",
-					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
-					"group": "MS_SQL@5"
-				},
-				{
-					"command": "mssql.scriptAlter",
-					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
-					"group": "MS_SQL@4"
-				},
-				{
-					"command": "mssql.openQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@1"
-				},
-				{
-					"command": "mssql.runQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@2"
-				},
-				{
-					"command": "mssql.deleteQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode",
-					"group": "MS_SQL@3"
-				}
-			],
-			"commandPalette": [
-				{
-					"command": "mssql.objectExplorerNewQuery",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
-				},
-				{
-					"command": "mssql.removeObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
-				},
-				{
-					"command": "mssql.refreshObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem != disconnectedServer"
-				},
-				{
-					"command": "mssql.scriptSelect",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
-				},
-				{
-					"command": "mssql.scriptCreate",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-				},
-				{
-					"command": "mssql.scriptDelete",
-					"when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
-				},
-				{
-					"command": "mssql.scriptExecute",
-					"when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
-				},
-				{
-					"command": "mssql.scriptAlter",
-					"when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
-				},
-				{
-					"command": "mssql.disconnectObjectExplorerNode",
-					"when": "view == objectExplorer && viewItem == Server"
-				},
-				{
-					"command": "mssql.toggleSqlCmd",
-					"when": "editorFocus && editorLangId == 'sql'"
-				},
-				{
-					"command": "mssql.startQueryHistoryCapture",
-					"when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
-				},
-				{
-					"command": "mssql.pauseQueryHistoryCapture",
-					"when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
-				},
-				{
-					"command": "mssql.copyObjectName",
-					"when": "view == objectExplorer && viewItem != Folder"
-				},
-				{
-					"command": "mssql.runQueryHistory",
-					"when": "view == queryHistory && viewItem == queryHistoryNode"
-				}
-			]
-		},
-		"commands": [
-			{
-				"command": "mssql.runQuery",
-				"title": "%mssql.runQuery%",
-				"category": "MS SQL",
-				"icon": "$(debug-start)"
-			},
-			{
-				"command": "mssql.runCurrentStatement",
-				"title": "%mssql.runCurrentStatement%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.cancelQuery",
-				"title": "%mssql.cancelQuery%",
-				"category": "MS SQL",
-				"icon": "$(debug-stop)"
-			},
-			{
-				"command": "mssql.connect",
-				"title": "%mssql.connect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.disconnect",
-				"title": "%mssql.disconnect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.manageProfiles",
-				"title": "%mssql.manageProfiles%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.chooseDatabase",
-				"title": "%mssql.chooseDatabase%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.chooseLanguageFlavor",
-				"title": "%mssql.chooseLanguageFlavor%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.showGettingStarted",
-				"title": "%mssql.showGettingStarted%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.newQuery",
-				"title": "%mssql.newQuery%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.rebuildIntelliSenseCache",
-				"title": "%mssql.rebuildIntelliSenseCache%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.toggleSqlCmd",
-				"title": "%mssql.toggleSqlCmd%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.addObjectExplorer",
-				"title": "%mssql.addObjectExplorer%",
-				"category": "MS SQL",
-				"icon": "$(add)"
-			},
-			{
-				"command": "mssql.objectExplorerNewQuery",
-				"title": "%mssql.objectExplorerNewQuery%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.removeObjectExplorerNode",
-				"title": "%mssql.removeObjectExplorerNode%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.refreshObjectExplorerNode",
-				"title": "%mssql.refreshObjectExplorerNode%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.disconnectObjectExplorerNode",
-				"title": "%mssql.disconnect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptSelect",
-				"title": "%mssql.scriptSelect%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptCreate",
-				"title": "%mssql.scriptCreate%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptDelete",
-				"title": "%mssql.scriptDelete%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptExecute",
-				"title": "%mssql.scriptExecute%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.scriptAlter",
-				"title": "%mssql.scriptAlter%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.openQueryHistory",
-				"title": "%mssql.openQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.runQueryHistory",
-				"title": "%mssql.runQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.deleteQueryHistory",
-				"title": "%mssql.deleteQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.clearAllQueryHistory",
-				"title": "%mssql.clearAllQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.startQueryHistoryCapture",
-				"title": "%mssql.startQueryHistoryCapture%",
-				"category": "MS SQL",
-				"icon": "$(debug-start)"
-			},
-			{
-				"command": "mssql.pauseQueryHistoryCapture",
-				"title": "%mssql.pauseQueryHistoryCapture%",
-				"category": "MS SQL",
-				"icon": "$(debug-stop)"
-			},
-			{
-				"command": "mssql.commandPaletteQueryHistory",
-				"title": "%mssql.commandPaletteQueryHistory%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.copyObjectName",
-				"title": "%mssql.copyObjectName%",
-				"category": "MS SQL"
-			},
-			{
-				"command": "mssql.removeAadAccount",
-				"title": "%mssql.removeAadAccount%",
-				"category": "MS SQL"
-			}
-		],
-		"keybindings": [
-			{
-				"command": "mssql.runQuery",
-				"key": "ctrl+shift+e",
-				"mac": "cmd+shift+e",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "mssql.connect",
-				"key": "ctrl+shift+c",
-				"mac": "cmd+shift+c",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "mssql.disconnect",
-				"key": "ctrl+shift+d",
-				"mac": "cmd+shift+d",
-				"when": "editorTextFocus && editorLangId == 'sql'"
-			},
-			{
-				"command": "workbench.view.extension.objectExplorer",
-				"key": "ctrl+alt+d",
-				"mac": "cmd+alt+d"
-			},
-			{
-				"command": "mssql.copyObjectName",
-				"key": "ctrl+c",
-				"mac": "cmd+c",
-				"when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
-			}
-		],
-		"configuration": {
-			"type": "object",
-			"title": "%mssql.Configuration%",
-			"properties": {
-				"mssql.azureActiveDirectory": {
-					"type": "string",
-					"default": "AuthCodeGrant",
-					"description": "%mssql.chooseAuthMethod%",
-					"enum": [
-						"AuthCodeGrant",
-						"DeviceCode"
-					],
-					"enumDescriptions": [
-						"%mssql.authCodeGrant.description%",
-						"%mssql.deviceCode.description%"
-					],
-					"scope": "application"
-				},
-				"mssql.logDebugInfo": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.logDebugInfo%",
-					"scope": "window"
-				},
-				"mssql.maxRecentConnections": {
-					"type": "number",
-					"default": 5,
-					"description": "%mssql.maxRecentConnections%",
-					"scope": "window"
-				},
-				"mssql.connections": {
-					"type": "array",
-					"description": "%mssql.connections%",
-					"items": {
-						"type": "object",
-						"properties": {
-							"server": {
-								"type": "string",
-								"default": "{{put-server-name-here}}",
-								"description": "%mssql.connection.server%"
-							},
-							"database": {
-								"type": "string",
-								"default": "{{put-database-name-here}}",
-								"description": "%mssql.connection.database%"
-							},
-							"user": {
-								"type": "string",
-								"default": "{{put-username-here}}",
-								"description": "%mssql.connection.user%"
-							},
-							"password": {
-								"type": "string",
-								"default": "{{put-password-here}}",
-								"description": "%mssql.connection.password%"
-							},
-							"authenticationType": {
-								"type": "string",
-								"default": "SqlLogin",
-								"enum": [
-									"Integrated",
-									"SqlLogin",
-									"AzureMFA"
-								],
-								"description": "%mssql.connection.authenticationType%"
-							},
-							"port": {
-								"type": "number",
-								"default": 1433,
-								"description": "%mssql.connection.port%"
-							},
-							"encrypt": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.encrypt%"
-							},
-							"trustServerCertificate": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.trustServerCertificate%"
-							},
-							"persistSecurityInfo": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.persistSecurityInfo%"
-							},
-							"connectTimeout": {
-								"type": "number",
-								"default": 15,
-								"description": "%mssql.connection.connectTimeout%"
-							},
-							"connectRetryCount": {
-								"type": "number",
-								"default": 1,
-								"description": "%mssql.connection.connectRetryCount%"
-							},
-							"connectRetryInterval": {
-								"type": "number",
-								"default": 10,
-								"description": "%mssql.connection.connectRetryInterval%"
-							},
-							"applicationName": {
-								"type": "string",
-								"default": "vscode-mssql",
-								"description": "%mssql.connection.applicationName%"
-							},
-							"workstationId": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.workstationId%"
-							},
-							"applicationIntent": {
-								"type": "string",
-								"default": "ReadWrite",
-								"enum": [
-									"ReadWrite",
-									"ReadOnly"
-								],
-								"description": "%mssql.connection.applicationIntent%"
-							},
-							"currentLanguage": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.currentLanguage%"
-							},
-							"pooling": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.pooling%"
-							},
-							"maxPoolSize": {
-								"type": "number",
-								"default": 100,
-								"description": "%mssql.connection.maxPoolSize%"
-							},
-							"minPoolSize": {
-								"type": "number",
-								"default": 0,
-								"description": "%mssql.connection.minPoolSize%"
-							},
-							"loadBalanceTimeout": {
-								"type": "number",
-								"default": 0,
-								"description": "%mssql.connection.loadBalanceTimeout%"
-							},
-							"replication": {
-								"type": "boolean",
-								"default": true,
-								"description": "%mssql.connection.replication%"
-							},
-							"attachDbFilename": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.attachDbFilename%"
-							},
-							"failoverPartner": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.failoverPartner%"
-							},
-							"multiSubnetFailover": {
-								"type": "boolean",
-								"default": true,
-								"description": "%mssql.connection.multiSubnetFailover%"
-							},
-							"multipleActiveResultSets": {
-								"type": "boolean",
-								"default": false,
-								"description": "%mssql.connection.multipleActiveResultSets%"
-							},
-							"packetSize": {
-								"type": "number",
-								"default": 8192,
-								"description": "%mssql.connection.packetSize%"
-							},
-							"typeSystemVersion": {
-								"type": "string",
-								"enum": [
-									"Latest"
-								],
-								"description": "%mssql.connection.typeSystemVersion%"
-							},
-							"connectionString": {
-								"type": "string",
-								"default": "",
-								"description": "%mssql.connection.connectionString%"
-							},
-							"profileName": {
-								"type": "string",
-								"description": "%mssql.connection.profileName%"
-							},
-							"savePassword": {
-								"type": "boolean",
-								"description": "%mssql.connection.savePassword%"
-							},
-							"emptyPasswordInput": {
-								"type": "boolean",
-								"description": "%mssql.connection.emptyPasswordInput%"
-							}
-						}
-					},
-					"scope": "resource"
-				},
-				"mssql.shortcuts": {
-					"type": "object",
-					"description": "%mssql.shortcuts%",
-					"default": {
-						"_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
-						"event.toggleResultPane": "ctrl+alt+R",
-						"event.focusResultsGrid": "ctrl+alt+G",
-						"event.toggleMessagePane": "ctrl+alt+Y",
-						"event.prevGrid": "ctrl+up",
-						"event.nextGrid": "ctrl+down",
-						"event.copySelection": "ctrl+C",
-						"event.copyWithHeaders": "",
-						"event.copyAllHeaders": "",
-						"event.maximizeGrid": "",
-						"event.selectAll": "ctrl+A",
-						"event.saveAsJSON": "",
-						"event.saveAsCSV": "",
-						"event.saveAsExcel": ""
-					},
-					"scope": "resource"
-				},
-				"mssql.messagesDefaultOpen": {
-					"type": "boolean",
-					"description": "%mssql.messagesDefaultOpen%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.resultsFontFamily": {
-					"type": "string",
-					"description": "%mssql.resultsFontFamily%",
-					"default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
-					"scope": "resource"
-				},
-				"mssql.resultsFontSize": {
-					"type": "number",
-					"description": "%mssql.resultsFontSize%",
-					"default": 13,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.includeHeaders": {
-					"type": "boolean",
-					"description": "%mssql.saveAsCsv.includeHeaders%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.delimiter": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.delimiter%",
-					"default": ",",
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.lineSeparator": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.lineSeparator%",
-					"default": null,
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.textIdentifier": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.textIdentifier%",
-					"default": "\"",
-					"scope": "resource"
-				},
-				"mssql.saveAsCsv.encoding": {
-					"type": "string",
-					"description": "%mssql.saveAsCsv.encoding%",
-					"default": "utf-8",
-					"scope": "resource"
-				},
-				"mssql.copyIncludeHeaders": {
-					"type": "boolean",
-					"description": "%mssql.copyIncludeHeaders%",
-					"default": false,
-					"scope": "resource"
-				},
-				"mssql.copyRemoveNewLine": {
-					"type": "boolean",
-					"description": "%mssql.copyRemoveNewLine%",
-					"default": true,
-					"scope": "resource"
-				},
-				"mssql.showBatchTime": {
-					"type": "boolean",
-					"description": "%mssql.showBatchTime%",
-					"default": false,
-					"scope": "resource"
-				},
-				"mssql.splitPaneSelection": {
-					"type": "string",
-					"description": "%mssql.splitPaneSelection%",
-					"default": "next",
-					"enum": [
-						"next",
-						"current",
-						"end"
-					],
-					"scope": "resource"
-				},
-				"mssql.format.alignColumnDefinitionsInColumns": {
-					"type": "boolean",
-					"description": "%mssql.format.alignColumnDefinitionsInColumns%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.format.datatypeCasing": {
-					"type": "string",
-					"description": "%mssql.format.datatypeCasing%",
-					"default": "none",
-					"enum": [
-						"none",
-						"uppercase",
-						"lowercase"
-					],
-					"scope": "window"
-				},
-				"mssql.format.keywordCasing": {
-					"type": "string",
-					"description": "%mssql.format.keywordCasing%",
-					"default": "none",
-					"enum": [
-						"none",
-						"uppercase",
-						"lowercase"
-					],
-					"scope": "window"
-				},
-				"mssql.format.placeCommasBeforeNextStatement": {
-					"type": "boolean",
-					"description": "%mssql.format.placeCommasBeforeNextStatement%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.format.placeSelectStatementReferencesOnNewLine": {
-					"type": "boolean",
-					"description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.applyLocalization": {
-					"type": "boolean",
-					"description": "%mssql.applyLocalization%",
-					"default": false,
-					"scope": "window"
-				},
-				"mssql.query.displayBitAsNumber": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.displayBitAsNumber%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableIntelliSense": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableIntelliSense%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableErrorChecking": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableErrorChecking%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableSuggestions": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableSuggestions%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.enableQuickInfo": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.intelliSense.enableQuickInfo%",
-					"scope": "window"
-				},
-				"mssql.intelliSense.lowerCaseSuggestions": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.intelliSense.lowerCaseSuggestions%",
-					"scope": "window"
-				},
-				"mssql.persistQueryResultTabs": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.persistQueryResultTabs%",
-					"scope": "window"
-				},
-				"mssql.queryHistoryLimit": {
-					"type": "number",
-					"default": 20,
-					"description": "%mssql.queryHistoryLimit%",
-					"scope": "window"
-				},
-				"mssql.enableQueryHistoryCapture": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.enableQueryHistoryCapture%",
-					"scope": "window"
-				},
-				"mssql.enableQueryHistoryFeature": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.enableQueryHistoryFeature%",
-					"scope": "window"
-				},
-				"mssql.query.maxXmlCharsToStore": {
-					"type": "number",
-					"default": 2097152,
-					"description": "%mssql.query.maxXmlCharsToStore%"
-				},
-				"mssql.tracingLevel": {
-					"type": "string",
-					"description": "%mssql.tracingLevel%",
-					"default": "Critical",
-					"enum": [
-						"All",
-						"Off",
-						"Critical",
-						"Error",
-						"Warning",
-						"Information",
-						"Verbose"
-					]
-				},
-				"mssql.logRetentionMinutes": {
-					"type": "number",
-					"default": 10080,
-					"description": "%mssql.logRetentionMinutes%"
-				},
-				"mssql.logFilesRemovalLimit": {
-					"type": "number",
-					"default": 100,
-					"description": "%mssql.logFilesRemovalLimit%"
-				},
-				"mssql.query.rowCount": {
-					"type": "number",
-					"default": 0,
-					"description": "%mssql.query.setRowCount%"
-				},
-				"mssql.query.textSize": {
-					"type": "number",
-					"default": 2147483647,
-					"description": "%mssql.query.textSize%"
-				},
-				"mssql.query.executionTimeout": {
-					"type": "number",
-					"default": 0,
-					"description": "%mssql.query.executionTimeout%"
-				},
-				"mssql.query.noCount": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.noCount%"
-				},
-				"mssql.query.noExec": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.noExec%"
-				},
-				"mssql.query.parseOnly": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.parseOnly%"
-				},
-				"mssql.query.arithAbort": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.arithAbort%"
-				},
-				"mssql.query.statisticsTime": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.statisticsTime%"
-				},
-				"mssql.query.statisticsIO": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.statisticsIO%"
-				},
-				"mssql.query.xactAbortOn": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.xactAbortOn%"
-				},
-				"mssql.query.transactionIsolationLevel": {
-					"enum": [
-						"READ COMMITTED",
-						"READ UNCOMMITTED",
-						"REPEATABLE READ",
-						"SERIALIZABLE"
-					],
-					"default": "READ COMMITTED",
-					"description": "%mssql.query.transactionIsolationLevel%"
-				},
-				"mssql.query.deadlockPriority": {
-					"enum": [
-						"Normal",
-						"Low"
-					],
-					"default": "Normal",
-					"description": "%mssql.query.deadlockPriority%"
-				},
-				"mssql.query.lockTimeout": {
-					"type": "number",
-					"default": -1,
-					"description": "%mssql.query.lockTimeout%"
-				},
-				"mssql.query.queryGovernorCostLimit": {
-					"type": "number",
-					"default": -1,
-					"description": "%mssql.query.queryGovernorCostLimit%"
-				},
-				"mssql.query.ansiDefaults": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.ansiDefaults%"
-				},
-				"mssql.query.quotedIdentifier": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.quotedIdentifier%"
-				},
-				"mssql.query.ansiNullDefaultOn": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiNullDefaultOn%"
-				},
-				"mssql.query.implicitTransactions": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.implicitTransactions%"
-				},
-				"mssql.query.cursorCloseOnCommit": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.cursorCloseOnCommit%"
-				},
-				"mssql.query.ansiPadding": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiPadding%"
-				},
-				"mssql.query.ansiWarnings": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiWarnings%"
-				},
-				"mssql.query.ansiNulls": {
-					"type": "boolean",
-					"default": true,
-					"description": "%mssql.query.ansiNulls%"
-				},
-				"mssql.query.alwaysEncryptedParameterization": {
-					"type": "boolean",
-					"default": false,
-					"description": "%mssql.query.alwaysEncryptedParameterization%"
-				},
-				"mssql.ignorePlatformWarning": {
-					"type": "boolean",
-					"description": "%mssql.ignorePlatformWarning%",
-					"default": false
-				}
-			}
-		}
-	},
-	"__metadata": {
-		"id": "4bf45e86-a448-4531-8c01-ef33f4536306",
-		"publisherDisplayName": "Microsoft",
-		"publisherId": "60b3df88-4640-44d4-a7e5-6ba8004700bb",
-		"isPreReleaseVersion": false
-	}
+  "name": "mssql",
+  "displayName": "SQL Server (mssql)",
+  "version": "1.16.0",
+  "description": "Develop Microsoft SQL Server, Azure SQL Database and SQL Data Warehouse everywhere",
+  "publisher": "ms-mssql",
+  "preview": false,
+  "license": "SEE LICENSE IN LICENSE.txt",
+  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+  "icon": "images/sqlserver.png",
+  "galleryBanner": {
+    "color": "#2F2F2F",
+    "theme": "dark"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-mssql.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-mssql/issues"
+  },
+  "homepage": "https://github.com/Microsoft/vscode-mssql/blob/master/README.md",
+  "engines": {
+    "vscode": "^1.57.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Azure"
+  ],
+  "keywords": [
+    "SQL",
+    "MSSQL",
+    "SQL Server",
+    "Azure SQL Database",
+    "Azure SQL Data Warehouse",
+    "multi-root ready"
+  ],
+  "activationEvents": [
+    "onView:objectExplorer",
+    "onLanguage:sql",
+    "onCommand:mssql.connect",
+    "onCommand:mssql.runQuery",
+    "onCommand:mssql.runCurrentStatement",
+    "onCommand:mssql.disconnect",
+    "onCommand:mssql.manageProfiles",
+    "onCommand:mssql.chooseDatabase",
+    "onCommand:mssql.cancelQuery",
+    "onCommand:mssql.showGettingStarted",
+    "onCommand:mssql.newQuery",
+    "onCommand:mssql.rebuildIntelliSenseCache",
+    "onCommand:mssql.addObjectExplorer",
+    "onCommand:mssql.objectExplorerNewQuery",
+    "onCommand:mssql.toggleSqlCmd",
+    "onCommand:mssql.loadCompletionExtension",
+    "onCommand:mssql.removeAadAccount"
+  ],
+  "main": "./out/src/extension",
+  "extensionDependencies": [
+    "vscode.sql"
+  ],
+  "extensionPack": [
+    "ms-mssql.data-workspace-vscode",
+    "ms-mssql.sql-database-projects-vscode",
+    "ms-mssql.sql-bindings-vscode"
+  ],
+  "scripts": {
+    "build": "gulp build",
+    "compile": "gulp ext:compile",
+    "watch": "gulp watch"
+  },
+  "devDependencies": {
+    "@angular/common": "~2.1.2",
+    "@angular/compiler": "~2.1.2",
+    "@angular/core": "~2.1.2",
+    "@angular/forms": "~2.1.2",
+    "@angular/platform-browser": "~2.1.2",
+    "@angular/platform-browser-dynamic": "~2.1.2",
+    "@angular/router": "~3.1.2",
+    "@angular/upgrade": "~2.1.2",
+    "@types/ejs": "^3.1.0",
+    "@types/jquery": "^3.3.31",
+    "@types/jqueryui": "^1.12.7",
+    "@types/keytar": "^4.4.2",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^14.14.16",
+    "@types/sinon": "^10.0.12",
+    "@types/tmp": "0.0.28",
+    "@types/underscore": "1.8.3",
+    "@types/vscode": "1.57.0",
+    "angular-in-memory-web-api": "0.1.13",
+    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
+    "assert": "^1.4.1",
+    "chai": "^3.5.0",
+    "coveralls": "^3.0.2",
+    "decache": "^4.1.0",
+    "del": "^2.2.1",
+    "gulp": "^4.0.2",
+    "gulp-concat": "^2.6.0",
+    "gulp-istanbul-report": "0.0.1",
+    "gulp-json-editor": "^2.2.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.7.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-tslint": "^8.1.4",
+    "gulp-typescript": "^5.0.1",
+    "gulp-uglify": "^2.0.0",
+    "istanbul": "^0.4.5",
+    "pm-mocha-jenkins-reporter": "^0.2.6",
+    "remap-istanbul": "^0.6.4",
+    "rxjs": "5.0.0-beta.12",
+    "sinon": "^14.0.0",
+    "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
+    "systemjs": "0.19.40",
+    "systemjs-builder": "^0.15.32",
+    "systemjs-plugin-json": "^0.2.0",
+    "tslint": "^6.1.3",
+    "tslint-microsoft-contrib": "^5.2.0",
+    "typemoq": "^1.7.0",
+    "typescript": "^3.5.3",
+    "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
+    "vscode-nls-dev": "2.0.1",
+    "@vscode/test-electron": "^2.1.5",
+    "@xmldom/xmldom": "^0.8.2",
+    "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+  },
+  "dependencies": {
+    "@azure/arm-resources": "^5.0.0",
+    "@azure/arm-sql": "^9.0.0",
+    "@azure/arm-subscriptions": "^5.0.0",
+    "@microsoft/ads-adal-library": "1.0.15",
+    "core-js": "^2.4.1",
+    "decompress-zip": "^0.2.2",
+    "ejs": "^3.1.7",
+    "error-ex": "^1.3.0",
+    "figures": "^1.4.0",
+    "find-remove": "1.2.1",
+    "getmac": "1.2.1",
+    "http-proxy-agent": "^2.1.0",
+    "https-proxy-agent": "^2.2.1",
+    "jquery": "^3.4.1",
+    "opener": "1.4.2",
+    "plist": "^3.0.5",
+    "pretty-data": "^0.40.0",
+    "rangy": "^1.3.0",
+    "reflect-metadata": "0.1.12",
+    "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+    "tar": "^6.1.9",
+    "tmp": "^0.0.28",
+    "underscore": "^1.8.3",
+    "vscode-languageclient": "5.2.1",
+    "vscode-nls": "^2.0.2",
+    "zone.js": "^0.6.26"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "objectExplorer",
+          "title": "SQL Server",
+          "icon": "./images/server_page_inverse.svg"
+        }
+      ]
+    },
+    "views": {
+      "objectExplorer": [
+        {
+          "id": "objectExplorer",
+          "name": "%extension.connections%"
+        },
+        {
+          "id": "queryHistory",
+          "name": "%extension.queryHistory%",
+          "when": "config.mssql.enableQueryHistoryFeature"
+        }
+      ]
+    },
+    "languages": [
+      {
+        "id": "sql",
+        "extensions": [
+          ".sql"
+        ],
+        "aliases": [
+          "SQL"
+        ],
+        "configuration": "./syntaxes/sql.configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "sql",
+        "scopeName": "source.sql",
+        "path": "./syntaxes/SQL.plist"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "sql",
+        "path": "./snippets/mssql.json"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "mssql.runQuery",
+          "when": "editorLangId == sql",
+          "group": "navigation@1"
+        },
+        {
+          "command": "mssql.cancelQuery",
+          "when": "editorLangId == sql && resourcePath in mssql.runningQueries",
+          "group": "navigation@2"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "mssql.runQuery",
+          "when": "editorLangId == sql"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "mssql.addObjectExplorer",
+          "when": "view == objectExplorer",
+          "title": "%mssql.addObjectExplorer%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.startQueryHistoryCapture",
+          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture",
+          "title": "%mssql.startQueryHistoryCapture%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.pauseQueryHistoryCapture",
+          "when": "view == queryHistory && config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture",
+          "title": "%mssql.pauseQueryHistoryCapture%",
+          "group": "navigation"
+        },
+        {
+          "command": "mssql.clearAllQueryHistory",
+          "when": "view == queryHistory",
+          "title": "%mssql.clearAllQueryHistory%",
+          "group": "secondary"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "mssql.objectExplorerNewQuery",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.removeObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/",
+          "group": "MS_SQL@4"
+        },
+        {
+          "command": "mssql.refreshObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem != disconnectedServer",
+          "group": "MS_SQL@10"
+        },
+        {
+          "command": "mssql.disconnectObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem == Server",
+          "group": "MS_SQL@3"
+        },
+        {
+          "command": "mssql.scriptSelect",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.scriptCreate",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+          "group": "MS_SQL@2"
+        },
+        {
+          "command": "mssql.scriptDelete",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType|Trigger|DatabaseTrigger|Index|Key|User|DatabaseRole|ApplicationRole)$/",
+          "group": "MS_SQL@3"
+        },
+        {
+          "command": "mssql.scriptExecute",
+          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/",
+          "group": "MS_SQL@5"
+        },
+        {
+          "command": "mssql.scriptAlter",
+          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/",
+          "group": "MS_SQL@4"
+        },
+        {
+          "command": "mssql.openQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@1"
+        },
+        {
+          "command": "mssql.runQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@2"
+        },
+        {
+          "command": "mssql.deleteQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode",
+          "group": "MS_SQL@3"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "mssql.objectExplorerNewQuery",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server|Database)$/"
+        },
+        {
+          "command": "mssql.removeObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
+        },
+        {
+          "command": "mssql.refreshObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem != disconnectedServer"
+        },
+        {
+          "command": "mssql.scriptSelect",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View)$/"
+        },
+        {
+          "command": "mssql.scriptCreate",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+        },
+        {
+          "command": "mssql.scriptDelete",
+          "when": "view == objectExplorer && viewItem =~ /^(Table|View|AggregateFunction|PartitionFunction|ScalarValuedFunction|Schema|StoredProcedure|TableValuedFunction|User|UserDefinedTableType)$/"
+        },
+        {
+          "command": "mssql.scriptExecute",
+          "when": "view == objectExplorer && viewItem =~ /^(StoredProcedure)$/"
+        },
+        {
+          "command": "mssql.scriptAlter",
+          "when": "view == objectExplorer && viewItem =~ /^(AggregateFunction|PartitionFunction|ScalarValuedFunction|StoredProcedure|TableValuedFunction|View)$/"
+        },
+        {
+          "command": "mssql.disconnectObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem == Server"
+        },
+        {
+          "command": "mssql.toggleSqlCmd",
+          "when": "editorFocus && editorLangId == 'sql'"
+        },
+        {
+          "command": "mssql.startQueryHistoryCapture",
+          "when": "config.mssql.enableQueryHistoryFeature && !config.mssql.enableQueryHistoryCapture"
+        },
+        {
+          "command": "mssql.pauseQueryHistoryCapture",
+          "when": "config.mssql.enableQueryHistoryFeature && config.mssql.enableQueryHistoryCapture"
+        },
+        {
+          "command": "mssql.copyObjectName",
+          "when": "view == objectExplorer && viewItem != Folder"
+        },
+        {
+          "command": "mssql.runQueryHistory",
+          "when": "view == queryHistory && viewItem == queryHistoryNode"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "mssql.runQuery",
+        "title": "%mssql.runQuery%",
+        "category": "MS SQL",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "mssql.runCurrentStatement",
+        "title": "%mssql.runCurrentStatement%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.cancelQuery",
+        "title": "%mssql.cancelQuery%",
+        "category": "MS SQL",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "mssql.connect",
+        "title": "%mssql.connect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.disconnect",
+        "title": "%mssql.disconnect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.manageProfiles",
+        "title": "%mssql.manageProfiles%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.chooseDatabase",
+        "title": "%mssql.chooseDatabase%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.chooseLanguageFlavor",
+        "title": "%mssql.chooseLanguageFlavor%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.showGettingStarted",
+        "title": "%mssql.showGettingStarted%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.newQuery",
+        "title": "%mssql.newQuery%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.rebuildIntelliSenseCache",
+        "title": "%mssql.rebuildIntelliSenseCache%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.toggleSqlCmd",
+        "title": "%mssql.toggleSqlCmd%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.addObjectExplorer",
+        "title": "%mssql.addObjectExplorer%",
+        "category": "MS SQL",
+        "icon": "$(add)"
+      },
+      {
+        "command": "mssql.objectExplorerNewQuery",
+        "title": "%mssql.objectExplorerNewQuery%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.removeObjectExplorerNode",
+        "title": "%mssql.removeObjectExplorerNode%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.refreshObjectExplorerNode",
+        "title": "%mssql.refreshObjectExplorerNode%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.disconnectObjectExplorerNode",
+        "title": "%mssql.disconnect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptSelect",
+        "title": "%mssql.scriptSelect%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptCreate",
+        "title": "%mssql.scriptCreate%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptDelete",
+        "title": "%mssql.scriptDelete%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptExecute",
+        "title": "%mssql.scriptExecute%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.scriptAlter",
+        "title": "%mssql.scriptAlter%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.openQueryHistory",
+        "title": "%mssql.openQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.runQueryHistory",
+        "title": "%mssql.runQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.deleteQueryHistory",
+        "title": "%mssql.deleteQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.clearAllQueryHistory",
+        "title": "%mssql.clearAllQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.startQueryHistoryCapture",
+        "title": "%mssql.startQueryHistoryCapture%",
+        "category": "MS SQL",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "mssql.pauseQueryHistoryCapture",
+        "title": "%mssql.pauseQueryHistoryCapture%",
+        "category": "MS SQL",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "mssql.commandPaletteQueryHistory",
+        "title": "%mssql.commandPaletteQueryHistory%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "title": "%mssql.copyObjectName%",
+        "category": "MS SQL"
+      },
+      {
+        "command": "mssql.removeAadAccount",
+        "title": "%mssql.removeAadAccount%",
+        "category": "MS SQL"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "mssql.runQuery",
+        "key": "ctrl+shift+e",
+        "mac": "cmd+shift+e",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "mssql.connect",
+        "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "mssql.disconnect",
+        "key": "ctrl+shift+d",
+        "mac": "cmd+shift+d",
+        "when": "editorTextFocus && editorLangId == 'sql'"
+      },
+      {
+        "command": "workbench.view.extension.objectExplorer",
+        "key": "ctrl+alt+d",
+        "mac": "cmd+alt+d"
+      },
+      {
+        "command": "mssql.copyObjectName",
+        "key": "ctrl+c",
+        "mac": "cmd+c",
+        "when": "sideBarFocus && activeViewlet == workbench.view.extension.objectExplorer"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "%mssql.Configuration%",
+      "properties": {
+        "mssql.azureActiveDirectory": {
+          "type": "string",
+          "default": "AuthCodeGrant",
+          "description": "%mssql.chooseAuthMethod%",
+          "enum": [
+            "AuthCodeGrant",
+            "DeviceCode"
+          ],
+          "enumDescriptions": [
+            "%mssql.authCodeGrant.description%",
+            "%mssql.deviceCode.description%"
+          ],
+          "scope": "application"
+        },
+        "mssql.logDebugInfo": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.logDebugInfo%",
+          "scope": "window"
+        },
+        "mssql.maxRecentConnections": {
+          "type": "number",
+          "default": 5,
+          "description": "%mssql.maxRecentConnections%",
+          "scope": "window"
+        },
+        "mssql.connections": {
+          "type": "array",
+          "description": "%mssql.connections%",
+          "items": {
+            "type": "object",
+            "properties": {
+              "server": {
+                "type": "string",
+                "default": "{{put-server-name-here}}",
+                "description": "%mssql.connection.server%"
+              },
+              "database": {
+                "type": "string",
+                "default": "{{put-database-name-here}}",
+                "description": "%mssql.connection.database%"
+              },
+              "user": {
+                "type": "string",
+                "default": "{{put-username-here}}",
+                "description": "%mssql.connection.user%"
+              },
+              "password": {
+                "type": "string",
+                "default": "{{put-password-here}}",
+                "description": "%mssql.connection.password%"
+              },
+              "authenticationType": {
+                "type": "string",
+                "default": "SqlLogin",
+                "enum": [
+                  "Integrated",
+                  "SqlLogin",
+                  "AzureMFA"
+                ],
+                "description": "%mssql.connection.authenticationType%"
+              },
+              "port": {
+                "type": "number",
+                "default": 1433,
+                "description": "%mssql.connection.port%"
+              },
+              "encrypt": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.encrypt%"
+              },
+              "trustServerCertificate": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.trustServerCertificate%"
+              },
+              "persistSecurityInfo": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.persistSecurityInfo%"
+              },
+              "connectTimeout": {
+                "type": "number",
+                "default": 15,
+                "description": "%mssql.connection.connectTimeout%"
+              },
+              "connectRetryCount": {
+                "type": "number",
+                "default": 1,
+                "description": "%mssql.connection.connectRetryCount%"
+              },
+              "connectRetryInterval": {
+                "type": "number",
+                "default": 10,
+                "description": "%mssql.connection.connectRetryInterval%"
+              },
+              "applicationName": {
+                "type": "string",
+                "default": "vscode-mssql",
+                "description": "%mssql.connection.applicationName%"
+              },
+              "workstationId": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.workstationId%"
+              },
+              "applicationIntent": {
+                "type": "string",
+                "default": "ReadWrite",
+                "enum": [
+                  "ReadWrite",
+                  "ReadOnly"
+                ],
+                "description": "%mssql.connection.applicationIntent%"
+              },
+              "currentLanguage": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.currentLanguage%"
+              },
+              "pooling": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.pooling%"
+              },
+              "maxPoolSize": {
+                "type": "number",
+                "default": 100,
+                "description": "%mssql.connection.maxPoolSize%"
+              },
+              "minPoolSize": {
+                "type": "number",
+                "default": 0,
+                "description": "%mssql.connection.minPoolSize%"
+              },
+              "loadBalanceTimeout": {
+                "type": "number",
+                "default": 0,
+                "description": "%mssql.connection.loadBalanceTimeout%"
+              },
+              "replication": {
+                "type": "boolean",
+                "default": true,
+                "description": "%mssql.connection.replication%"
+              },
+              "attachDbFilename": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.attachDbFilename%"
+              },
+              "failoverPartner": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.failoverPartner%"
+              },
+              "multiSubnetFailover": {
+                "type": "boolean",
+                "default": true,
+                "description": "%mssql.connection.multiSubnetFailover%"
+              },
+              "multipleActiveResultSets": {
+                "type": "boolean",
+                "default": false,
+                "description": "%mssql.connection.multipleActiveResultSets%"
+              },
+              "packetSize": {
+                "type": "number",
+                "default": 8192,
+                "description": "%mssql.connection.packetSize%"
+              },
+              "typeSystemVersion": {
+                "type": "string",
+                "enum": [
+                  "Latest"
+                ],
+                "description": "%mssql.connection.typeSystemVersion%"
+              },
+              "connectionString": {
+                "type": "string",
+                "default": "",
+                "description": "%mssql.connection.connectionString%"
+              },
+              "profileName": {
+                "type": "string",
+                "description": "%mssql.connection.profileName%"
+              },
+              "savePassword": {
+                "type": "boolean",
+                "description": "%mssql.connection.savePassword%"
+              },
+              "emptyPasswordInput": {
+                "type": "boolean",
+                "description": "%mssql.connection.emptyPasswordInput%"
+              }
+            }
+          },
+          "scope": "resource"
+        },
+        "mssql.shortcuts": {
+          "type": "object",
+          "description": "%mssql.shortcuts%",
+          "default": {
+            "_comment": "Short cuts must follow the format (ctrl)+(shift)+(alt)+[key]",
+            "event.toggleResultPane": "ctrl+alt+R",
+            "event.focusResultsGrid": "ctrl+alt+G",
+            "event.toggleMessagePane": "ctrl+alt+Y",
+            "event.prevGrid": "ctrl+up",
+            "event.nextGrid": "ctrl+down",
+            "event.copySelection": "ctrl+C",
+            "event.copyWithHeaders": "",
+            "event.copyAllHeaders": "",
+            "event.maximizeGrid": "",
+            "event.selectAll": "ctrl+A",
+            "event.saveAsJSON": "",
+            "event.saveAsCSV": "",
+            "event.saveAsExcel": ""
+          },
+          "scope": "resource"
+        },
+        "mssql.messagesDefaultOpen": {
+          "type": "boolean",
+          "description": "%mssql.messagesDefaultOpen%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.resultsFontFamily": {
+          "type": "string",
+          "description": "%mssql.resultsFontFamily%",
+          "default": "-apple-system,BlinkMacSystemFont,Segoe WPC,Segoe UI,HelveticaNeue-Light,Ubuntu,Droid Sans,sans-serif",
+          "scope": "resource"
+        },
+        "mssql.resultsFontSize": {
+          "type": "number",
+          "description": "%mssql.resultsFontSize%",
+          "default": 13,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.includeHeaders": {
+          "type": "boolean",
+          "description": "%mssql.saveAsCsv.includeHeaders%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.delimiter": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.delimiter%",
+          "default": ",",
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.lineSeparator": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.lineSeparator%",
+          "default": null,
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.textIdentifier": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.textIdentifier%",
+          "default": "\"",
+          "scope": "resource"
+        },
+        "mssql.saveAsCsv.encoding": {
+          "type": "string",
+          "description": "%mssql.saveAsCsv.encoding%",
+          "default": "utf-8",
+          "scope": "resource"
+        },
+        "mssql.copyIncludeHeaders": {
+          "type": "boolean",
+          "description": "%mssql.copyIncludeHeaders%",
+          "default": false,
+          "scope": "resource"
+        },
+        "mssql.copyRemoveNewLine": {
+          "type": "boolean",
+          "description": "%mssql.copyRemoveNewLine%",
+          "default": true,
+          "scope": "resource"
+        },
+        "mssql.showBatchTime": {
+          "type": "boolean",
+          "description": "%mssql.showBatchTime%",
+          "default": false,
+          "scope": "resource"
+        },
+        "mssql.splitPaneSelection": {
+          "type": "string",
+          "description": "%mssql.splitPaneSelection%",
+          "default": "next",
+          "enum": [
+            "next",
+            "current",
+            "end"
+          ],
+          "scope": "resource"
+        },
+        "mssql.format.alignColumnDefinitionsInColumns": {
+          "type": "boolean",
+          "description": "%mssql.format.alignColumnDefinitionsInColumns%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.format.datatypeCasing": {
+          "type": "string",
+          "description": "%mssql.format.datatypeCasing%",
+          "default": "none",
+          "enum": [
+            "none",
+            "uppercase",
+            "lowercase"
+          ],
+          "scope": "window"
+        },
+        "mssql.format.keywordCasing": {
+          "type": "string",
+          "description": "%mssql.format.keywordCasing%",
+          "default": "none",
+          "enum": [
+            "none",
+            "uppercase",
+            "lowercase"
+          ],
+          "scope": "window"
+        },
+        "mssql.format.placeCommasBeforeNextStatement": {
+          "type": "boolean",
+          "description": "%mssql.format.placeCommasBeforeNextStatement%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.format.placeSelectStatementReferencesOnNewLine": {
+          "type": "boolean",
+          "description": "%mssql.format.placeSelectStatementReferencesOnNewLine%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.applyLocalization": {
+          "type": "boolean",
+          "description": "%mssql.applyLocalization%",
+          "default": false,
+          "scope": "window"
+        },
+        "mssql.query.displayBitAsNumber": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.displayBitAsNumber%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableIntelliSense": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableIntelliSense%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableErrorChecking": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableErrorChecking%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableSuggestions": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableSuggestions%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.enableQuickInfo": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.intelliSense.enableQuickInfo%",
+          "scope": "window"
+        },
+        "mssql.intelliSense.lowerCaseSuggestions": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.intelliSense.lowerCaseSuggestions%",
+          "scope": "window"
+        },
+        "mssql.persistQueryResultTabs": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.persistQueryResultTabs%",
+          "scope": "window"
+        },
+        "mssql.queryHistoryLimit": {
+          "type": "number",
+          "default": 20,
+          "description": "%mssql.queryHistoryLimit%",
+          "scope": "window"
+        },
+        "mssql.enableQueryHistoryCapture": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.enableQueryHistoryCapture%",
+          "scope": "window"
+        },
+        "mssql.enableQueryHistoryFeature": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.enableQueryHistoryFeature%",
+          "scope": "window"
+        },
+        "mssql.query.maxXmlCharsToStore": {
+          "type": "number",
+          "default": 2097152,
+          "description": "%mssql.query.maxXmlCharsToStore%"
+        },
+        "mssql.tracingLevel": {
+          "type": "string",
+          "description": "%mssql.tracingLevel%",
+          "default": "Critical",
+          "enum": [
+            "All",
+            "Off",
+            "Critical",
+            "Error",
+            "Warning",
+            "Information",
+            "Verbose"
+          ]
+        },
+        "mssql.logRetentionMinutes": {
+          "type": "number",
+          "default": 10080,
+          "description": "%mssql.logRetentionMinutes%"
+        },
+        "mssql.logFilesRemovalLimit": {
+          "type": "number",
+          "default": 100,
+          "description": "%mssql.logFilesRemovalLimit%"
+        },
+        "mssql.query.rowCount": {
+          "type": "number",
+          "default": 0,
+          "description": "%mssql.query.setRowCount%"
+        },
+        "mssql.query.textSize": {
+          "type": "number",
+          "default": 2147483647,
+          "description": "%mssql.query.textSize%"
+        },
+        "mssql.query.executionTimeout": {
+          "type": "number",
+          "default": 0,
+          "description": "%mssql.query.executionTimeout%"
+        },
+        "mssql.query.noCount": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.noCount%"
+        },
+        "mssql.query.noExec": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.noExec%"
+        },
+        "mssql.query.parseOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.parseOnly%"
+        },
+        "mssql.query.arithAbort": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.arithAbort%"
+        },
+        "mssql.query.statisticsTime": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.statisticsTime%"
+        },
+        "mssql.query.statisticsIO": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.statisticsIO%"
+        },
+        "mssql.query.xactAbortOn": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.xactAbortOn%"
+        },
+        "mssql.query.transactionIsolationLevel": {
+          "enum": [
+            "READ COMMITTED",
+            "READ UNCOMMITTED",
+            "REPEATABLE READ",
+            "SERIALIZABLE"
+          ],
+          "default": "READ COMMITTED",
+          "description": "%mssql.query.transactionIsolationLevel%"
+        },
+        "mssql.query.deadlockPriority": {
+          "enum": [
+            "Normal",
+            "Low"
+          ],
+          "default": "Normal",
+          "description": "%mssql.query.deadlockPriority%"
+        },
+        "mssql.query.lockTimeout": {
+          "type": "number",
+          "default": -1,
+          "description": "%mssql.query.lockTimeout%"
+        },
+        "mssql.query.queryGovernorCostLimit": {
+          "type": "number",
+          "default": -1,
+          "description": "%mssql.query.queryGovernorCostLimit%"
+        },
+        "mssql.query.ansiDefaults": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.ansiDefaults%"
+        },
+        "mssql.query.quotedIdentifier": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.quotedIdentifier%"
+        },
+        "mssql.query.ansiNullDefaultOn": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiNullDefaultOn%"
+        },
+        "mssql.query.implicitTransactions": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.implicitTransactions%"
+        },
+        "mssql.query.cursorCloseOnCommit": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.cursorCloseOnCommit%"
+        },
+        "mssql.query.ansiPadding": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiPadding%"
+        },
+        "mssql.query.ansiWarnings": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiWarnings%"
+        },
+        "mssql.query.ansiNulls": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.query.ansiNulls%"
+        },
+        "mssql.query.alwaysEncryptedParameterization": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.query.alwaysEncryptedParameterization%"
+        },
+        "mssql.ignorePlatformWarning": {
+          "type": "boolean",
+          "description": "%mssql.ignorePlatformWarning%",
+          "default": false
+        }
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1129,11 +1129,5 @@
         }
       }
     }
-  },
-  "__metadata": {
-    "id": "4bf45e86-a448-4531-8c01-ef33f4536306",
-    "publisherDisplayName": "Microsoft",
-    "publisherId": "60b3df88-4640-44d4-a7e5-6ba8004700bb",
-    "isPreReleaseVersion": false
   }
 }

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var del = require('del');
 var jeditor = require("gulp-json-editor");
 var istanbulReport = require('gulp-istanbul-report');
+var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 gulp.task('cover:clean', function (done) {
 	return del('coverage', done);
@@ -27,8 +28,14 @@ gulp.task('cover:disable', () => {
 		.pipe(gulp.dest("./out", { 'overwrite': true }));
 });
 
+gulp.task('remap-coverage', function () {
+	return gulp.src('./coverage/coverage.json')
+		.pipe(remapIstanbul())
+		.pipe(gulp.dest('coverage-remapped'));
+});
+
 gulp.task('cover:combine-json', () => {
-	return gulp.src(['./coverage/coverage.json'])
+	return gulp.src(['./coverage-remapped/coverage.json'])
 		.pipe(istanbulReport({
 			reporterOpts: {
 				dir: './coverage'

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var del = require('del');
 var jeditor = require("gulp-json-editor");
 var istanbulReport = require('gulp-istanbul-report');
+var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 gulp.task('cover:clean', function (done) {
 	return del('coverage', done);
@@ -16,6 +17,15 @@ gulp.task('cover:enableconfig', () => {
 		.pipe(gulp.dest("./out", { 'overwrite': true }));
 });
 
+gulp.task('remap-istanbul', () => {
+	return gulp.src('./coverage/coverage.json')
+		.pipe(remapIstanbul({
+			reports: {
+				'json': './coverage/coverage.json',
+			}
+		}));
+});
+
 gulp.task('cover:enable', gulp.series('cover:clean', 'cover:enableconfig'));
 
 gulp.task('cover:disable', () => {
@@ -28,6 +38,7 @@ gulp.task('cover:disable', () => {
 });
 
 gulp.task('cover:combine-json', () => {
+	// return gulp.src(['./coverage/coverage-final.json'])
 	return gulp.src(['./coverage/coverage.json'])
 		.pipe(istanbulReport({
 			reporterOpts: {
@@ -53,4 +64,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-istanbul'));

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -30,13 +30,7 @@ gulp.task('cover:disable', () => {
 
 gulp.task('remap-coverage', function () {
 	return gulp.src('./coverage/coverage.json')
-		// .pipe(remapIstanbul()) TODO prevoius way remapIstanbul function was configured. Uncommented approach below creates an HTML page to confirm easily
-		.pipe(remapIstanbul({
-			reports: {
-				'json': 'coverage.json',
-				'html': 'html-report'
-			}
-		}))
+		.pipe(remapIstanbul())
 		.pipe(gulp.dest('coverage-remapped'));
 });
 

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -38,6 +38,7 @@ gulp.task('cover:disable', () => {
 });
 
 gulp.task('cover:combine-json', () => {
+	// return gulp.src(['./coverage/coverage-final.json'])
 	return gulp.src(['./coverage/coverage.json'])
 		.pipe(istanbulReport({
 			reporterOpts: {

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -38,7 +38,6 @@ gulp.task('cover:disable', () => {
 });
 
 gulp.task('cover:combine-json', () => {
-	// return gulp.src(['./coverage/coverage-final.json'])
 	return gulp.src(['./coverage/coverage.json'])
 		.pipe(istanbulReport({
 			reporterOpts: {

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var del = require('del');
 var jeditor = require("gulp-json-editor");
 var istanbulReport = require('gulp-istanbul-report');
+var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 gulp.task('cover:clean', function (done) {
 	return del('coverage', done);
@@ -14,6 +15,15 @@ gulp.task('cover:enableconfig', () => {
 			return json; // must return JSON object.
 		}))
 		.pipe(gulp.dest("./out", { 'overwrite': true }));
+});
+
+gulp.task('remap-istanbul', () => {
+	return gulp.src('./coverage/coverage.json')
+		.pipe(remapIstanbul({
+			reports: {
+				'json': './coverage/coverage.json',
+			}
+		}));
 });
 
 gulp.task('cover:enable', gulp.series('cover:clean', 'cover:enableconfig'));
@@ -53,4 +63,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-istanbul'));

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -30,7 +30,13 @@ gulp.task('cover:disable', () => {
 
 gulp.task('remap-coverage', function () {
 	return gulp.src('./coverage/coverage.json')
-		.pipe(remapIstanbul())
+		// .pipe(remapIstanbul()) TODO prevoius way remapIstanbul function was configured. Uncommented approach below creates an HTML page to confirm easily
+		.pipe(remapIstanbul({
+			reports: {
+				'json': 'coverage.json',
+				'html': 'html-report'
+			}
+		}))
 		.pipe(gulp.dest('coverage-remapped'));
 });
 
@@ -60,4 +66,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-coverage')); // TODO: Remove 'remap-coverage' from this series.

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -2,7 +2,6 @@ var gulp = require('gulp');
 var del = require('del');
 var jeditor = require("gulp-json-editor");
 var istanbulReport = require('gulp-istanbul-report');
-var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 gulp.task('cover:clean', function (done) {
 	return del('coverage', done);
@@ -15,15 +14,6 @@ gulp.task('cover:enableconfig', () => {
 			return json; // must return JSON object.
 		}))
 		.pipe(gulp.dest("./out", { 'overwrite': true }));
-});
-
-gulp.task('remap-istanbul', () => {
-	return gulp.src('./coverage/coverage.json')
-		.pipe(remapIstanbul({
-			reports: {
-				'json': './coverage/coverage.json',
-			}
-		}));
 });
 
 gulp.task('cover:enable', gulp.series('cover:clean', 'cover:enableconfig'));
@@ -63,4 +53,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-istanbul'));
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -60,4 +60,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-coverage')); // TODO: Remove 'remap-coverage' from this series.
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));

--- a/tasks/covertasks.js
+++ b/tasks/covertasks.js
@@ -2,7 +2,6 @@ var gulp = require('gulp');
 var del = require('del');
 var jeditor = require("gulp-json-editor");
 var istanbulReport = require('gulp-istanbul-report');
-var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 gulp.task('cover:clean', function (done) {
 	return del('coverage', done);
@@ -17,15 +16,6 @@ gulp.task('cover:enableconfig', () => {
 		.pipe(gulp.dest("./out", { 'overwrite': true }));
 });
 
-gulp.task('remap-istanbul', () => {
-	return gulp.src('./coverage/coverage.json')
-		.pipe(remapIstanbul({
-			reports: {
-				'json': './coverage/coverage.json',
-			}
-		}));
-});
-
 gulp.task('cover:enable', gulp.series('cover:clean', 'cover:enableconfig'));
 
 gulp.task('cover:disable', () => {
@@ -38,7 +28,6 @@ gulp.task('cover:disable', () => {
 });
 
 gulp.task('cover:combine-json', () => {
-	// return gulp.src(['./coverage/coverage-final.json'])
 	return gulp.src(['./coverage/coverage.json'])
 		.pipe(istanbulReport({
 			reporterOpts: {
@@ -64,4 +53,4 @@ gulp.task('cover:combine-html', () => {
 });
 
 // for running on the ADO build system
-gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test', 'remap-istanbul'));
+gulp.task('test:cover', gulp.series('cover:clean', 'cover:enableconfig', 'test'));

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--require ts-node/register/transpile-only
+--require source-map-support/register
+--recursive
+**/**.js

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---require ts-node/register/transpile-only
---require source-map-support/register
---recursive
-**/**.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,12 +378,7 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
-amdefine@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.0.tgz#fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
-  integrity sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=
-
-amdefine@>=0.0.4:
+amdefine@>=0.0.4, amdefine@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
@@ -555,7 +550,7 @@ array-each@^1.0.0, array-each@^1.0.1:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+  integrity sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==
 
 array-initial@^1.0.0:
   version "1.1.0"
@@ -1063,7 +1058,7 @@ callsite@^1.0.0:
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
+  integrity sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
@@ -1076,7 +1071,7 @@ camelcase@^1.0.2:
 camelcase@^2.0.0, camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
+  integrity sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -1434,7 +1429,7 @@ css@2.X:
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
-  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
+  integrity sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==
   dependencies:
     array-find-index "^1.0.1"
 
@@ -1461,7 +1456,7 @@ data-uri-to-buffer@0.0.4:
 dateformat@^1.0.11:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"
-  integrity sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=
+  integrity sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==
   dependencies:
     get-stdin "^4.0.1"
     meow "^3.3.0"
@@ -2322,7 +2317,7 @@ get-intrinsic@^1.0.2:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
-  integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+  integrity sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -2614,7 +2609,7 @@ gulp-uglify@^2.0.0:
 gulp-util@3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.7.tgz#78925c4b8f8b49005ac01a011c557e6218941cbb"
-  integrity sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=
+  integrity sha512-Hw0BEAQGwMCCqflSPbWGNuep+/N6m/wLCwzovnuTJ1P7pvfDvUky5v3UisvLCnWSDzbh25dH81AP0l0YOBzW4g==
   dependencies:
     array-differ "^1.0.0"
     array-uniq "^1.0.2"
@@ -2853,7 +2848,7 @@ ieee754@^1.1.13:
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
+  integrity sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==
   dependencies:
     repeating "^2.0.0"
 
@@ -3164,16 +3159,16 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul@0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.3.tgz#5b714ee0ae493ac5ef204b99f3872bceef73d53a"
-  integrity sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=
+istanbul@0.4.5, istanbul@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
+  integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
   dependencies:
     abbrev "1.0.x"
     async "1.x"
     escodegen "1.8.x"
     esprima "2.7.x"
-    fileset "0.2.x"
+    glob "^5.0.15"
     handlebars "^4.0.1"
     js-yaml "3.x"
     mkdirp "0.5.x"
@@ -3194,26 +3189,6 @@ istanbul@^0.3.5:
     escodegen "1.7.x"
     esprima "2.5.x"
     fileset "0.2.x"
-    handlebars "^4.0.1"
-    js-yaml "3.x"
-    mkdirp "0.5.x"
-    nopt "3.x"
-    once "1.x"
-    resolve "1.1.x"
-    supports-color "^3.1.0"
-    which "^1.1.1"
-    wordwrap "^1.0.0"
-
-istanbul@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
-  integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
-  dependencies:
-    abbrev "1.0.x"
-    async "1.x"
-    escodegen "1.8.x"
-    esprima "2.7.x"
-    glob "^5.0.15"
     handlebars "^4.0.1"
     js-yaml "3.x"
     mkdirp "0.5.x"
@@ -3622,7 +3597,7 @@ loose-envify@^1.0.0:
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
+  integrity sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
@@ -3662,7 +3637,7 @@ map-cache@^0.2.0, map-cache@^0.2.2:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+  integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
 
 map-stream@0.0.7, map-stream@~0.0.7:
   version "0.0.7"
@@ -3689,7 +3664,7 @@ matchdep@^2.0.0:
 meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
+  integrity sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==
   dependencies:
     camelcase-keys "^2.0.0"
     decamelize "^1.1.2"
@@ -3752,15 +3727,27 @@ minimatch@2.x:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.1.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass@^3.0.0:
   version "3.1.3"
@@ -4548,7 +4535,7 @@ rechoir@^0.6.2:
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
+  integrity sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
@@ -4571,15 +4558,16 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-remap-istanbul@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/remap-istanbul/-/remap-istanbul-0.6.4.tgz#ac551eff1aa641504b4f318d0303dda61e3bb695"
-  integrity sha1-rFUe/xqmQVBLTzGNAwPdph47tpU=
+remap-istanbul@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/remap-istanbul/-/remap-istanbul-0.9.6.tgz#bbd5a688fe265192f067a0ca5b2b0d7f746c5f4b"
+  integrity sha512-l0WDBsVjaTzP8m3glERJO6bjlAFUahcgfcgvcX+owZw7dKeDLT3CVRpS7UO4L9LfGcMiNsqk223HopwVxlh8Hg==
   dependencies:
-    amdefine "1.0.0"
+    amdefine "^1.0.0"
     gulp-util "3.0.7"
-    istanbul "0.4.3"
-    source-map ">=0.5.6"
+    istanbul "0.4.5"
+    minimatch "^3.0.3"
+    source-map "^0.6.1"
     through2 "2.0.1"
 
 remove-bom-buffer@^3.0.0:
@@ -4960,11 +4948,6 @@ source-map@0.1.32:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@>=0.5.6, source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
 source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -4974,6 +4957,11 @@ source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 source-map@~0.2.0:
   version "0.2.0"
@@ -5154,7 +5142,7 @@ strip-bom@2.X, strip-bom@^2.0.0:
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
+  integrity sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==
   dependencies:
     get-stdin "^4.0.1"
 
@@ -5429,7 +5417,7 @@ traceur@0.0.105:
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+  integrity sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==
 
 trim-right@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,6 +4941,14 @@ source-map-support@^0.4.0, source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@~0.2.8:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.2.10.tgz#ea5a3900a1c1cb25096a0ae8cc5c2b4b10ded3dc"
@@ -4970,7 +4978,7 @@ source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.0:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,14 +4941,6 @@ source-map-support@^0.4.0, source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.21:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-support@~0.2.8:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.2.10.tgz#ea5a3900a1c1cb25096a0ae8cc5c2b4b10ded3dc"
@@ -4978,7 +4970,7 @@ source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
+source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
This PR includes ts files in the coverage report generated for tests.

[Hai Cao edit]:
Coverage task was initially failing in ADO pipeline with `TypeError: sourceMap.originalPositionFor is not a function` error.
Root cause: remap-istanbul was useing >=0.5.6 for the source-map package and later version of source-map included some break changes. Updating remap-istanbul to a newer version fixed this issue.
More info: https://github.com/SitePen/remap-istanbul/issues/160

TS files are still debuggable
![image](https://user-images.githubusercontent.com/21186993/185215436-cdca76d4-2893-492a-aef1-1e625d2623e6.png)
![image](https://user-images.githubusercontent.com/21186993/185241362-481a28ba-c6cb-425b-81ea-4be04fff6143.png)
