### PR TITLE
Fix escape characters inside strings

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -668,32 +668,11 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.sql</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.sql</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
-					<key>match</key>
-					<string>(N)?(')[^']*(')</string>
-					<key>name</key>
-					<string>string.quoted.single.sql</string>
-				</dict>
-				<dict>
 					<key>begin</key>
-					<string>'</string>
+					<string>N?(')</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>0</key>
+						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.begin.sql</string>
@@ -718,27 +697,6 @@
 							<string>#string_escape</string>
 						</dict>
 					</array>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.sql</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.sql</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
-					<key>match</key>
-					<string>(`)[^`\\]*(`)</string>
-					<key>name</key>
-					<string>string.quoted.other.backtick.sql</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -772,27 +730,6 @@
 					</array>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.begin.sql</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.string.end.sql</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
-					<key>match</key>
-					<string>(")[^"#]*(")</string>
-					<key>name</key>
-					<string>string.quoted.double.sql</string>
-				</dict>
-				<dict>
 					<key>begin</key>
 					<string>"</string>
 					<key>beginCaptures</key>
@@ -817,6 +754,10 @@
 					<string>string.quoted.double.sql</string>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>include</key>
+							<string>#string_escape</string>
+						</dict>
 						<dict>
 							<key>include</key>
 							<string>#string_interpolation</string>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/17057

Before:
![image](https://user-images.githubusercontent.com/5701732/132988290-24dc2953-21a3-4833-8fd8-5002ec45d3d6.png)

After:
![image](https://user-images.githubusercontent.com/33529441/176996312-ca3eb0d1-2bdf-41f3-94ef-a32b2ef9c4d3.png)

I am very confused as what this comment means: 
`"comment": "this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines."`
I did some testing and found `begin/end` rules to be no slower than `match`
if anything, `match` was slightly slower due to https://github.com/microsoft/vscode-textmate/issues/167

For some reason double quote strings did not support escape characters what so ever
Does SQL support escape characters inside double quote strings??
```sql
`backtick \` string`
'single quote \' string'
"double quote \" string"
```

should also support the double char escape sequence?
```sql
`backtick `` string`
'single quote '' string'
"double quote "" string"
```