### PR TITLE
Add CI build trigger for release branch

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -1,3 +1,8 @@
+trigger:
+  batch: 'true'
+  branches:
+    include:
+      - release/*
 pool:
   vmImage: "macos-latest"
 


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio-docs/issues/142

Batch up CI builds for changes to release branches so we don't have to manually kick them off each time. 