### PR TITLE
Add YAML schema mapping for pipeline definitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,10 @@
         "**/out/*" : true
     },
 
-    "lcov.path": ["coverage/lcov.info"]
+	"lcov.path": [
+		"coverage/lcov.info"
+	],
+	"yaml.schemas": {
+		"https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json": "build/**/*.yml"
+	},
 }


### PR DESCRIPTION
Add ADO yaml mapping to pipeline definition files

Note that unfortunately there are a number of errors due to issues with the schema. I've tried to follow up with them on getting this fixed but there's little traction. But this still helps with auto-complete for known items and validation of most of the stuff so is still generally useful to have. 