### PR TITLE
Expose getServerInfo API

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -26,9 +26,8 @@ import { ConnectionSummary } from '../models/contracts/connection';
 import { AccountStore } from '../azure/accountStore';
 import { ConnectionProfile } from '../models/connectionProfile';
 import { QuestionTypes, IQuestion } from '../prompts/question';
-import { IAccount } from 'vscode-mssql';
 import { AzureController } from '../azure/azureController';
-import { ConnectionDetails, IConnectionInfo } from 'vscode-mssql';
+import { ConnectionDetails, IConnectionInfo, IAccount, ServerInfo } from 'vscode-mssql';
 import providerSettings from '../azure/providerSettings';
 
 /**
@@ -53,7 +52,7 @@ export class ConnectionInfo {
 	/**
 	 * Information about the SQL Server instance.
 	 */
-	public serverInfo: ConnectionContracts.ServerInfo;
+	public serverInfo: ServerInfo;
 
 	/**
 	 * Whether the connection is in the process of connecting.
@@ -80,7 +79,7 @@ export default class ConnectionManager {
 	private _statusView: StatusView;
 	private _connections: { [fileUri: string]: ConnectionInfo };
 	private _connectionCredentialsToServerInfoMap:
-		Map<IConnectionInfo, ConnectionContracts.ServerInfo>;
+		Map<IConnectionInfo, ServerInfo>;
 	private _uriToConnectionPromiseMap: Map<string, Deferred<boolean>>;
 	private _failedUriToFirewallIpMap: Map<string, string>;
 	private _accountService: AccountService;
@@ -97,7 +96,7 @@ export default class ConnectionManager {
 		private _accountStore?: AccountStore) {
 		this._statusView = statusView;
 		this._connections = {};
-		this._connectionCredentialsToServerInfoMap = new Map<IConnectionInfo, ConnectionContracts.ServerInfo>();
+		this._connectionCredentialsToServerInfoMap = new Map<IConnectionInfo, ServerInfo>();
 		this._uriToConnectionPromiseMap = new Map<string, Deferred<boolean>>();
 
 		if (!this.client) {
@@ -659,7 +658,7 @@ export default class ConnectionManager {
 	 * Get the server info for a connection
 	 * @param connectionCreds
 	 */
-	public getServerInfo(connectionCredentials: IConnectionInfo): ConnectionContracts.ServerInfo {
+	public getServerInfo(connectionCredentials: IConnectionInfo): ServerInfo {
 		if (this._connectionCredentialsToServerInfoMap.has(connectionCredentials)) {
 			return this._connectionCredentialsToServerInfoMap.get(connectionCredentials);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		},
 		sendRequest: async <P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P) => {
 			return await controller.connectionManager.sendRequest(requestType, params);
+		},
+		getServerInfo: (connectionInfo: IConnectionInfo) => {
+			return controller.connectionManager.getServerInfo(connectionInfo);
 		}
 	};
 }

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -7,9 +7,8 @@ import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/localizedConstants';
 import * as Interfaces from './interfaces';
 import { IConnectionProfile } from '../models/interfaces';
-import * as ConnectionContracts from '../models/contracts/connection';
 import * as Utils from './utils';
-import { IConnectionInfo } from 'vscode-mssql';
+import { IConnectionInfo, ServerInfo } from 'vscode-mssql';
 
 /**
  * Sets sensible defaults for key connection properties, especially
@@ -182,7 +181,7 @@ export function getUserNameOrDomainLogin(creds: IConnectionInfo, defaultValue?: 
  * @param {Interfaces.IConnectionCredentials} connCreds connection
  * @returns {string} tooltip
  */
-export function getTooltip(connCreds: IConnectionInfo, serverInfo?: ConnectionContracts.ServerInfo): string {
+export function getTooltip(connCreds: IConnectionInfo, serverInfo?: ServerInfo): string {
 	let tooltip: string =
 		connCreds.connectionString ? 'Connection string: ' + connCreds.connectionString + '\r\n' :
 			('Server name: ' + connCreds.server + '\r\n' +

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from 'vscode-languageclient';
-import { ConnectionDetails } from 'vscode-mssql';
+import { ConnectionDetails, IServerInfo } from 'vscode-mssql';
 
 // ------------------------------- < Connect Request > ----------------------------------------------
 
@@ -42,7 +42,7 @@ export namespace ConnectionCompleteNotification {
 /**
  * Information about a SQL Server instance.
  */
-export class ServerInfo {
+export class ServerInfo implements IServerInfo {
 	/**
 	 * The major version of the SQL Server instance.
 	 */

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from 'vscode-languageclient';
-import { ConnectionDetails, IServerInfo } from 'vscode-mssql';
+import { ConnectionDetails, ServerInfo } from 'vscode-mssql';
 
 // ------------------------------- < Connect Request > ----------------------------------------------
 
@@ -37,61 +37,6 @@ export class ConnectParams {
  */
 export namespace ConnectionCompleteNotification {
 	export const type = new NotificationType<ConnectionCompleteParams, void>('connection/complete');
-}
-
-/**
- * Information about a SQL Server instance.
- */
-export class ServerInfo implements IServerInfo {
-	/**
-	 * The major version of the SQL Server instance.
-	 */
-	public serverMajorVersion: number;
-
-	/**
-	 * The minor version of the SQL Server instance.
-	 */
-	public serverMinorVersion: number;
-
-	/**
-	 * The build of the SQL Server instance.
-	 */
-	public serverReleaseVersion: number;
-
-	/**
-	 * The ID of the engine edition of the SQL Server instance.
-	 */
-	public engineEditionId: number;
-
-	/**
-	 * String containing the full server version text.
-	 */
-	public serverVersion: string;
-
-	/**
-	 * String describing the product level of the server.
-	 */
-	public serverLevel: string;
-
-	/**
-	 * The edition of the SQL Server instance.
-	 */
-	public serverEdition: string;
-
-	/**
-	 * Whether the SQL Server instance is running in the cloud (Azure) or not.
-	 */
-	public isCloud: boolean;
-
-	/**
-	 * The version of Azure that the SQL Server instance is running on, if applicable.
-	 */
-	public azureVersion: number;
-
-	/**
-	 * The Operating System version string of the machine running the SQL Server instance.
-	 */
-	public osVersion: string;
 }
 
 /**

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -10,7 +10,7 @@ import * as ConnInfo from '../models/connectionInfo';
 import * as ConnectionContracts from '../models/contracts/connection';
 import * as Utils from '../models/utils';
 import VscodeWrapper from '../controllers/vscodeWrapper';
-import { IConnectionInfo } from 'vscode-mssql';
+import { IConnectionInfo, ServerInfo } from 'vscode-mssql';
 
 // Status bar element for each file in the editor
 class FileStatusBar {
@@ -155,7 +155,7 @@ export default class StatusView implements vscode.Disposable {
 		this.showProgress(fileUri, LocalizedConstants.connectingLabel, bar.statusConnection);
 	}
 
-	public connectSuccess(fileUri: string, connCreds: IConnectionInfo, serverInfo: ConnectionContracts.ServerInfo): void {
+	public connectSuccess(fileUri: string, connCreds: IConnectionInfo, serverInfo: ServerInfo): void {
 		let bar = this.getStatusBar(fileUri);
 		bar.statusConnection.command = Constants.cmdChooseDatabase;
 		bar.statusConnection.text = ConnInfo.getConnectionDisplayString(connCreds);

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -602,7 +602,7 @@ suite('Per File Connection Tests', () => {
 			databaseName: dbName,
 			userName: connectionCreds.user
 		};
-		const serverInfo: ServerInfo= {
+		const serverInfo: ServerInfo = {
 			engineEditionId: 0,
 			serverMajorVersion: 0,
 			isCloud: false,

--- a/test/perFileConnection.test.ts
+++ b/test/perFileConnection.test.ts
@@ -24,7 +24,7 @@ import VscodeWrapper from '../src/controllers/vscodeWrapper';
 import * as LocalizedConstants from '../src/constants/localizedConstants';
 import { ConnectionUI } from '../src/views/connectionUI';
 import * as Constants from '../src/constants/constants';
-import { IConnectionInfo } from 'vscode-mssql';
+import { IConnectionInfo, ServerInfo } from 'vscode-mssql';
 
 function createTestConnectionResult(ownerUri?: string): ConnectionContracts.ConnectionCompleteParams {
 	let result = new ConnectionContracts.ConnectionCompleteParams();
@@ -571,7 +571,7 @@ suite('Per File Connection Tests', () => {
 		let statusViewMock: TypeMoq.IMock<StatusView> = TypeMoq.Mock.ofType(StatusView);
 		let actualDbName = undefined;
 		statusViewMock.setup(x => x.connectSuccess(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-			.callback((fileUri, creds: IConnectionInfo, server: ConnectionContracts.ServerInfo) => {
+			.callback((fileUri, creds: IConnectionInfo, server: ServerInfo) => {
 				actualDbName = creds.database;
 			});
 
@@ -602,7 +602,19 @@ suite('Per File Connection Tests', () => {
 			databaseName: dbName,
 			userName: connectionCreds.user
 		};
-		myResult.serverInfo = new ConnectionContracts.ServerInfo();
+		const serverInfo: ServerInfo= {
+			engineEditionId: 0,
+			serverMajorVersion: 0,
+			isCloud: false,
+			serverMinorVersion: 0,
+			serverReleaseVersion: 0,
+			serverVersion: '',
+			serverLevel: '',
+			serverEdition: '',
+			azureVersion: 0,
+			osVersion: ''
+		};
+		myResult.serverInfo = serverInfo;
 		return myResult;
 	}
 

--- a/test/scriptingService.test.ts
+++ b/test/scriptingService.test.ts
@@ -30,7 +30,7 @@ suite('Scripting Service Tests', () => {
 		client.setup(c => c.sendRequest(ScriptingRequest.type, TypeMoq.It.isAny())).returns(() => Promise.resolve(mockScriptResult));
 		connectionManager.object.client = client.object;
 		connectionManager.setup(c => c.getServerInfo(TypeMoq.It.isAny())).returns(() => {
-			const serverInfo: ServerInfo= {
+			const serverInfo: ServerInfo = {
 				engineEditionId: 2,
 				serverMajorVersion: 1,
 				isCloud: true,

--- a/test/scriptingService.test.ts
+++ b/test/scriptingService.test.ts
@@ -9,9 +9,8 @@ import SqlToolsServiceClient from '../src/languageservice/serviceclient';
 import { ScriptingService } from '../src/scripting/scriptingService';
 import { ScriptingRequest, IScriptingObject, IScriptingResult, ScriptOperation } from '../src/models/contracts/scripting/scriptingRequest';
 import { TreeNodeInfo } from '../src/objectExplorer/treeNodeInfo';
-import { ServerInfo } from '../src/models/contracts/connection';
 import { assert } from 'chai';
-import { MetadataType, ObjectMetadata } from 'vscode-mssql';
+import { MetadataType, ObjectMetadata, ServerInfo } from 'vscode-mssql';
 import { TestExtensionContext } from './stubs';
 
 suite('Scripting Service Tests', () => {
@@ -31,10 +30,18 @@ suite('Scripting Service Tests', () => {
 		client.setup(c => c.sendRequest(ScriptingRequest.type, TypeMoq.It.isAny())).returns(() => Promise.resolve(mockScriptResult));
 		connectionManager.object.client = client.object;
 		connectionManager.setup(c => c.getServerInfo(TypeMoq.It.isAny())).returns(() => {
-			let serverInfo = new ServerInfo();
-			serverInfo.engineEditionId = 2;
-			serverInfo.serverMajorVersion = 1;
-			serverInfo.isCloud = true;
+			const serverInfo: ServerInfo= {
+				engineEditionId: 2,
+				serverMajorVersion: 1,
+				isCloud: true,
+				serverMinorVersion: 0,
+				serverReleaseVersion: 0,
+				serverVersion: '',
+				serverLevel: '',
+				serverEdition: '',
+				azureVersion: 0,
+				osVersion: ''
+			};
 			return serverInfo;
 		});
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -120,13 +120,13 @@ declare module 'vscode-mssql' {
 		 * @param connectionInfo connection info of the connection
 		 * @returns server information
 	 	*/
-		getServerInfo(connectionInfo: IConnectionInfo): IServerInfo
+		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
 	}
 
 	/**
 	 * Information about a SQL Server instance.
 	 */
-	export interface IServerInfo {
+	export interface ServerInfo {
 		/**
 		 * The major version of the SQL Server instance.
 		 */

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -118,6 +118,7 @@ declare module 'vscode-mssql' {
 		/**
 		 * Get the server info for a connection
 		 * @param connectionInfo connection info of the connection
+		 * @returns server information
 	 	*/
 		getServerInfo(connectionInfo: IConnectionInfo): IServerInfo
 	}

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -114,6 +114,67 @@ declare module 'vscode-mssql' {
 		 * @returns A promise object for when the request receives a response
 		 */
 		sendRequest<P, R, E, R0>(requestType: RequestType<P, R, E, R0>, params?: P): Promise<R>;
+
+		/**
+		 * Get the server info for a connection
+		 * @param connectionInfo connection info of the connection
+	 	*/
+		getServerInfo(connectionInfo: IConnectionInfo): IServerInfo
+	}
+
+	/**
+	 * Information about a SQL Server instance.
+	 */
+	export interface IServerInfo {
+		/**
+		 * The major version of the SQL Server instance.
+		 */
+		serverMajorVersion: number;
+
+		/**
+		 * The minor version of the SQL Server instance.
+		 */
+		serverMinorVersion: number;
+
+		/**
+		 * The build of the SQL Server instance.
+		 */
+		serverReleaseVersion: number;
+
+		/**
+		 * The ID of the engine edition of the SQL Server instance.
+		 */
+		engineEditionId: number;
+
+		/**
+		 * String containing the full server version text.
+		 */
+		serverVersion: string;
+
+		/**
+		 * String describing the product level of the server.
+		 */
+		serverLevel: string;
+
+		/**
+		 * The edition of the SQL Server instance.
+		 */
+		serverEdition: string;
+
+		/**
+		 * Whether the SQL Server instance is running in the cloud (Azure) or not.
+		 */
+		isCloud: boolean;
+
+		/**
+		 * The version of Azure that the SQL Server instance is running on, if applicable.
+		 */
+		azureVersion: number;
+
+		/**
+		 * The Operating System version string of the machine running the SQL Server instance.
+		 */
+		osVersion: string;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #17438 .
By exposing server information, target platform information can be set automatically for the sql database projects that are created from databases.