### PR TITLE
Add Database engine edition information

### DIFF
--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -119,7 +119,7 @@ declare module 'vscode-mssql' {
 		 * Get the server info for a connection
 		 * @param connectionInfo connection info of the connection
 		 * @returns server information
-	 	*/
+		  */
 		getServerInfo(connectionInfo: IConnectionInfo): ServerInfo
 	}
 
@@ -176,6 +176,22 @@ declare module 'vscode-mssql' {
 		 * The Operating System version string of the machine running the SQL Server instance.
 		 */
 		osVersion: string;
+	}
+
+	/**
+	 * The possible values of the server engine edition
+	 */
+	export const enum DatabaseEngineEdition {
+		Unknown = 0,
+		Personal = 1,
+		Standard = 2,
+		Enterprise = 3,
+		Express = 4,
+		SqlDatabase = 5,
+		SqlDataWarehouse = 6,
+		SqlStretchDatabase = 7,
+		SqlManagedInstance = 8,
+		SqlOnDemand = 11
 	}
 
 	/**

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -180,6 +180,7 @@ declare module 'vscode-mssql' {
 
 	/**
 	 * The possible values of the server engine edition
+	 * EngineEdition under https://docs.microsoft.com/sql/t-sql/functions/serverproperty-transact-sql is associated with these values
 	 */
 	export const enum DatabaseEngineEdition {
 		Unknown = 0,


### PR DESCRIPTION
This PR fixes #17448 .

This enum is needed to set target platform appropriately for Sql database projects.