### PR TITLE
add include permissions for create project from db

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.2.0.16",
+    "version": "4.3.0.37",
     "downloadFileNames": {
       "Windows_86": "win-x86-net6.0.zip",
       "Windows_64": "win-x64-net6.0.zip",

--- a/src/services/dacFxService.ts
+++ b/src/services/dacFxService.ts
@@ -66,7 +66,8 @@ export class DacFxService implements mssql.IDacFxService {
 		applicationVersion: string,
 		ownerUri: string,
 		extractTarget: mssql.ExtractTarget,
-		taskExecutionMode: mssql.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+		taskExecutionMode: mssql.TaskExecutionMode,
+		includePermissions?: boolean): Thenable<mssql.DacFxResult> {
 		const params: mssql.ExtractParams = {
 			databaseName: databaseName,
 			packageFilePath: targetFilePath,
@@ -74,7 +75,8 @@ export class DacFxService implements mssql.IDacFxService {
 			applicationVersion: applicationVersion,
 			ownerUri: ownerUri,
 			extractTarget: extractTarget,
-			taskExecutionMode: taskExecutionMode
+			taskExecutionMode: taskExecutionMode,
+			includePermissions: includePermissions
 		};
 		return this._client.sendRequest(dacFxContracts.ExtractRequest.type, params);
 	}

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -385,7 +385,7 @@ declare module 'vscode-mssql' {
 		exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
-		createProjectFromDatabase(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: ExtractTarget, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+		createProjectFromDatabase(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: ExtractTarget, taskExecutionMode: TaskExecutionMode, includePermissions?: boolean): Thenable<DacFxResult>;
 		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
 		generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
@@ -717,6 +717,7 @@ declare module 'vscode-mssql' {
 		ownerUri: string;
 		extractTarget?: ExtractTarget;
 		taskExecutionMode: TaskExecutionMode;
+		includePermissions?: boolean;
 	}
 
 	export interface DeployParams {


### PR DESCRIPTION
Adding "include permissions" as an option for create project in db in vscode for the sql projects extension to use. It was added in ADS in https://github.com/microsoft/azuredatastudio/pull/20823