### PR TITLE
Bumps @xmldom/xmldom package version from 0.8.3 to 0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "@types/tmp": "0.0.28",
     "@types/underscore": "1.8.3",
     "@types/vscode": "1.57.0",
+    "@vscode/test-electron": "^2.1.5",
+    "@xmldom/xmldom": "0.8.4",
     "angular-in-memory-web-api": "0.1.13",
     "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
     "assert": "^1.4.1",
@@ -119,8 +121,6 @@
     "typescript": "^3.5.3",
     "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
     "vscode-nls-dev": "2.0.1",
-    "@vscode/test-electron": "^2.1.5",
-    "@xmldom/xmldom": "^0.8.3",
     "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,10 +325,10 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
-"@xmldom/xmldom@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.3.tgz#beaf980612532aa9a3004aff7e428943aeaa0711"
-  integrity sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==
+"@xmldom/xmldom@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.4.tgz#05b76034d3e09d4b9d309d9b862994de23e7687d"
+  integrity sha512-JIsjTbWBWJHb2t1D4UNZIJ6ohlRYCdoGzeHSzTorMH2zOq3UKlSBzFBMBdFK3xnUD/ANHw/SUzl/vx0z0JrqRw==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
This PR bumps the xmldom package version to 0.8.4. This update resolves an issue around xml DOM's that contain multiple root elements.