### PR TITLE
announce the query execution status change

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -431,6 +431,9 @@
         <trans-unit id="executeQueryLabel">
             <source xml:lang="en">Executing query...</source>
         </trans-unit>
+        <trans-unit id="QueryExecutedLabel">
+            <source xml:lang="en">Query executed</source>
+        </trans-unit>
         <trans-unit id="messagePaneLabel">
             <source xml:lang="en">Messages</source>
         </trans-unit>


### PR DESCRIPTION
for #17451

1. previously the `executing query` status bar item is not showing at all because we were setting the `tooltip` property instead of the `text` property.
2. change the role of the status bar item so that the changes can be announced by screen reader.

normal mode:
![qe-normal](https://user-images.githubusercontent.com/13777222/202037358-a9b3599b-fe5a-4005-8c52-8125a690dfec.gif)

screen reader mode:
![qe-screenreader](https://user-images.githubusercontent.com/13777222/202037379-673442e9-874a-45bc-b4b5-23e70de1483f.gif)
