### PR TITLE
fix accessibility issues with query grid

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -179,13 +179,12 @@ gulp.task('ext:copy-dependencies', (done) => {
 	]).pipe(gulp.dest('out/src/views/htmlcontent/src/js/lib'));
 
 	gulp.src([
-		config.paths.project.root + '/node_modules/angular2-slickgrid/components/css/SlickGrid.css',
+		config.paths.project.root + '/node_modules/angular2-slickgrid/out/css/SlickGrid.css',
 		config.paths.project.root + '/node_modules/slickgrid/slick.grid.css'
 	]).pipe(gulp.dest('out/src/views/htmlcontent/src/css'));
 
 	gulp.src([
-		config.paths.project.root + '/node_modules/angular2-slickgrid/index.js',
-		config.paths.project.root + '/node_modules/angular2-slickgrid/components/**/*.js'
+		config.paths.project.root + '/node_modules/angular2-slickgrid/out/**/*.js'
 	], { base: config.paths.project.root + '/node_modules/angular2-slickgrid' }).pipe(gulp.dest('out/src/views/htmlcontent/src/js/lib/angular2-slickgrid'));
 
 	return gulp.src([config.paths.project.root + '/node_modules/@angular/**/*'])

--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -536,6 +536,15 @@
         <trans-unit id="msgMultipleSelectionModeNotSupported">
             <source xml:lang="en">Running query is not supported when the editor is in multiple selection mode.</source>
         </trans-unit>
+        <trans-unit id="newColumnWidthPrompt">
+            <source xml:lang="en">Enter new column width</source>
+        </trans-unit>
+        <trans-unit id="columnWidthInvalidNumberError">
+            <source xml:lang="en">Invalid column width</source>
+        </trans-unit>
+        <trans-unit id="columnWidthMustBePositiveError">
+            <source xml:lang="en">Width cannot be 0 or negative</source>
+        </trans-unit>
     </body>
   </file>
 </xliff>

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@vscode/test-electron": "^2.1.5",
     "@xmldom/xmldom": "0.8.4",
     "angular-in-memory-web-api": "0.1.13",
-    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.2.2-patch1",
+    "angular2-slickgrid": "github:microsoft/angular2-slickgrid#1.4.6",
     "assert": "^1.4.1",
     "chai": "^3.5.0",
     "coveralls": "^3.0.2",
@@ -111,7 +111,7 @@
     "remap-istanbul": "0.9.6",
     "rxjs": "5.0.0-beta.12",
     "sinon": "^14.0.0",
-    "slickgrid": "github:kburtram/SlickGrid#2.3.23-2",
+    "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.39",
     "systemjs": "0.19.40",
     "systemjs-builder": "^0.15.32",
     "systemjs-plugin-json": "^0.2.0",
@@ -783,7 +783,8 @@
             "event.selectAll": "ctrl+A",
             "event.saveAsJSON": "",
             "event.saveAsCSV": "",
-            "event.saveAsExcel": ""
+            "event.saveAsExcel": "",
+            "event.changeColumnWidth": "ctrl+alt+S"
           },
           "scope": "resource"
         },

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -301,8 +301,13 @@ export enum FieldType {
 
 export interface IColumnDefinition {
 	id?: string;
+	field?: string;
 	name: string;
 	type: FieldType;
+	width?: number;
+	cssClass?: string;
+	focusable?: boolean,
+	selectable?: boolean,
 	asyncPostRender?: (cellRef: string, row: number, dataContext: JSON, colDef: any) => void;
 	formatter?: (row: number, cell: any, value: any, columnDef: any, dataContext: any) => string;
 }

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -306,8 +306,8 @@ export interface IColumnDefinition {
 	type: FieldType;
 	width?: number;
 	cssClass?: string;
-	focusable?: boolean,
-	selectable?: boolean,
+	focusable?: boolean;
+	selectable?: boolean;
 	asyncPostRender?: (cellRef: string, row: number, dataContext: JSON, colDef: any) => void;
 	formatter?: (row: number, cell: any, value: any, columnDef: any, dataContext: any) => string;
 }

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -151,12 +151,15 @@ export class SqlOutputContentProvider {
 
 	private async createWebviewController(uri: string, title: string, queryRunner: QueryRunner): Promise<void> {
 		const proxy: IServerProxy = {
-			getRows: (batchId: number, resultId: number, rowStart: number, numberOfRows: number) => this.rowRequestHandler(uri, batchId, resultId, rowStart, numberOfRows),
-			copyResults: (batchId: number, resultsId: number, selection: ISlickRange[], includeHeaders?: boolean) => this.copyRequestHandler(uri, batchId, resultsId, selection, includeHeaders),
+			getRows: (batchId: number, resultId: number, rowStart: number, numberOfRows: number) =>
+				this.rowRequestHandler(uri, batchId, resultId, rowStart, numberOfRows),
+			copyResults: (batchId: number, resultsId: number, selection: ISlickRange[], includeHeaders?: boolean) =>
+				this.copyRequestHandler(uri, batchId, resultsId, selection, includeHeaders),
 			getConfig: () => this.configRequestHandler(uri),
 			getLocalizedTexts: () => Promise.resolve(LocalizedConstants),
 			openLink: (content: string, columnName: string, linkType: string) => this.openLinkRequestHandler(content, columnName, linkType),
-			saveResults: (batchId: number, resultId: number, format: string, selection: ISlickRange[]) => this.saveResultsRequestHandler(uri, batchId, resultId, format, selection),
+			saveResults: (batchId: number, resultId: number, format: string, selection: ISlickRange[]) =>
+				this.saveResultsRequestHandler(uri, batchId, resultId, format, selection),
 			setEditorSelection: (selection: ISelectionData) => this.editorSelectionRequestHandler(uri, selection),
 			showError: (message: string) => this.showErrorRequestHandler(message),
 			showWarning: (message: string) => this.showWarningRequestHandler(message),
@@ -169,13 +172,13 @@ export class SqlOutputContentProvider {
 					validateInput: async (value: string) => {
 						if (!Number(value)) {
 							return LocalizedConstants.columnWidthInvalidNumberError;
-						} else if (parseInt(value) <= 0) {
+						} else if (parseInt(value, 10) <= 0) {
 							return LocalizedConstants.columnWidthMustBePositiveError;
 						}
 						return undefined;
 					}
 				});
-				return val === undefined ? undefined : parseInt(val);
+				return val === undefined ? undefined : parseInt(val, 10);
 			}
 		};
 		const controller = new WebviewPanelController(this._vscodeWrapper, uri, title, proxy, this.context.extensionPath, this._statusView);

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -151,21 +151,32 @@ export class SqlOutputContentProvider {
 
 	private async createWebviewController(uri: string, title: string, queryRunner: QueryRunner): Promise<void> {
 		const proxy: IServerProxy = {
-			getRows: (batchId: number, resultId: number, rowStart: number, numberOfRows: number) =>
-				this.rowRequestHandler(uri, batchId, resultId, rowStart, numberOfRows),
-			copyResults: (batchId: number, resultsId: number, selection: ISlickRange[], includeHeaders?: boolean) =>
-				this.copyRequestHandler(uri, batchId, resultsId, selection, includeHeaders),
+			getRows: (batchId: number, resultId: number, rowStart: number, numberOfRows: number) => this.rowRequestHandler(uri, batchId, resultId, rowStart, numberOfRows),
+			copyResults: (batchId: number, resultsId: number, selection: ISlickRange[], includeHeaders?: boolean) => this.copyRequestHandler(uri, batchId, resultsId, selection, includeHeaders),
 			getConfig: () => this.configRequestHandler(uri),
 			getLocalizedTexts: () => Promise.resolve(LocalizedConstants),
-			openLink: (content: string, columnName: string, linkType: string) =>
-				this.openLinkRequestHandler(content, columnName, linkType),
-			saveResults: (batchId: number, resultId: number, format: string, selection: ISlickRange[]) =>
-				this.saveResultsRequestHandler(uri, batchId, resultId, format, selection),
+			openLink: (content: string, columnName: string, linkType: string) => this.openLinkRequestHandler(content, columnName, linkType),
+			saveResults: (batchId: number, resultId: number, format: string, selection: ISlickRange[]) => this.saveResultsRequestHandler(uri, batchId, resultId, format, selection),
 			setEditorSelection: (selection: ISelectionData) => this.editorSelectionRequestHandler(uri, selection),
 			showError: (message: string) => this.showErrorRequestHandler(message),
 			showWarning: (message: string) => this.showWarningRequestHandler(message),
 			sendReadyEvent: async () => await this.sendReadyEvent(uri),
-			dispose: () => this._panels.delete(uri)
+			dispose: () => this._panels.delete(uri),
+			getNewColumnWidth: async (current: number): Promise<number | undefined> => {
+				const val = await vscode.window.showInputBox({
+					prompt: LocalizedConstants.newColumnWidthPrompt,
+					value: current.toString(),
+					validateInput: async (value: string) => {
+						if (!Number(value)) {
+							return LocalizedConstants.columnWidthInvalidNumberError;
+						} else if (parseInt(value) <= 0) {
+							return LocalizedConstants.columnWidthMustBePositiveError;
+						}
+						return undefined;
+					}
+				});
+				return val === undefined ? undefined : parseInt(val);
+			}
 		};
 		const controller = new WebviewPanelController(this._vscodeWrapper, uri, title, proxy, this.context.extensionPath, this._statusView);
 		this._panels.set(uri, controller);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -21,6 +21,7 @@ export interface IServerProxy extends Disposable {
 	showError(message: string): void;
 	getLocalizedTexts(): Promise<{ [key: string]: any }>;
 	sendReadyEvent(uri: string): Promise<boolean>;
+	getNewColumnWidth(current: number): Promise<number | undefined>;
 }
 
 export interface IMessageProtocol {

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -61,7 +61,7 @@ const template = `
             <slick-grid #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"
                         [ngClass]="i === activeGrid ? 'active' : ''"
                         [dataRows]="dataSet.dataRows"
-                        (contextMenu)="openContextMenu($event, dataSet.batchId, dataSet.resultId, i)"
+                        (onContextMenu)="openContextMenu($event, dataSet.batchId, dataSet.resultId, i)"
                         enableAsyncPostRender="true"
                         showDataTypeIcon="false"
                         showHeader="true"
@@ -195,14 +195,14 @@ export class AppComponent implements OnInit, AfterViewChecked {
 			} else {
 				let activeGrid = this.activeGrid;
 				let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-				selection = this.tryCombineSelections(selection);
+				selection = this.tryCombineSelectionsForResults(selection);
 				this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId, this.renderedDataSets[activeGrid].resultId);
 			}
 		},
 		'event.copyWithHeaders': () => {
 			let activeGrid = this.activeGrid;
 			let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-			selection = this.tryCombineSelections(selection);
+			selection = this.tryCombineSelectionsForResults(selection);
 			this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId,
 				this.renderedDataSets[activeGrid].resultId, true);
 		},
@@ -220,6 +220,22 @@ export class AppComponent implements OnInit, AfterViewChecked {
 		},
 		'event.saveAsExcel': () => {
 			this.sendSaveRequest('excel');
+		},
+		'event.changeColumnWidth': async () => {
+			const activeGrid = this.slickgrids.toArray()[this.activeGrid]['_grid'];
+			if (activeGrid) {
+				const activeCell = activeGrid.getActiveCell();
+				const columns = activeGrid.getColumns();
+				if (!columns[activeCell.cell]?.resizable) {
+					return;
+				}
+				const newWidth = await this.dataService.getNewColumnWidth(columns[activeCell.cell].width);
+				if (newWidth) {
+					columns[activeCell.cell].width = newWidth;
+					activeGrid.setColumns(columns);
+					activeGrid.setActiveCell(activeCell.row, activeCell.cell);
+				}
+			}
 		}
 	};
 
@@ -246,7 +262,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
 			hoverText: () => { return Constants.saveCSVLabel; },
 			functionality: (batchId, resultId, index) => {
 				let selection = this.slickgrids.toArray()[index].getSelectedRanges();
-				selection = this.tryCombineSelections(selection);
+				selection = this.tryCombineSelectionsForResults(selection);
 				if (selection.length <= 1) {
 					this.handleContextClick({ type: 'savecsv', batchId: batchId, resultId: resultId, index: index, selection: selection });
 				} else {
@@ -260,7 +276,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
 			hoverText: () => { return Constants.saveJSONLabel; },
 			functionality: (batchId, resultId, index) => {
 				let selection = this.slickgrids.toArray()[index].getSelectedRanges();
-				selection = this.tryCombineSelections(selection);
+				selection = this.tryCombineSelectionsForResults(selection);
 				if (selection.length <= 1) {
 					this.handleContextClick({ type: 'savejson', batchId: batchId, resultId: resultId, index: index, selection: selection });
 				} else {
@@ -274,7 +290,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
 			hoverText: () => { return Constants.saveExcelLabel; },
 			functionality: (batchId, resultId, index) => {
 				let selection = this.slickgrids.toArray()[index].getSelectedRanges();
-				selection = this.tryCombineSelections(selection);
+				selection = this.tryCombineSelectionsForResults(selection);
 				if (selection.length <= 1) {
 					this.handleContextClick({ type: 'saveexcel', batchId: batchId, resultId: resultId, index: index, selection: selection });
 				} else {
@@ -381,16 +397,12 @@ export class AppComponent implements OnInit, AfterViewChecked {
 					let resultSet = event.data;
 
 					// Setup a function for generating a promise to lookup result subsets
-					let loadDataFunction = (offset: number, count: number): Promise<IGridDataRow[]> => {
-						return self.dataService.getRows(offset, count, resultSet.batchId, resultSet.id).then(rows => {
-							let gridData: IGridDataRow[] = [];
-							for (let row = 0; row < rows.rows.length; row++) {
-								// Push row values onto end of gridData for slickgrid
-								gridData.push({
-									values: rows.rows[row]
-								});
+					let loadDataFunction = (offset: number, count: number): Promise<any[]> => {
+						return self.dataService.getRows(offset, count, resultSet.batchId, resultSet.id).then(response => {
+							if (!response) {
+								return [];
 							}
-							return gridData;
+							return response.rows;
 						});
 					};
 
@@ -421,6 +433,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
 							let linkType = c.isXml ? 'xml' : 'json';
 							return {
 								id: i.toString(),
+								field: i.toString(),
 								name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 									? 'XML Showplan'
 									: Utils.htmlEntities(c.columnName),
@@ -430,6 +443,16 @@ export class AppComponent implements OnInit, AfterViewChecked {
 							};
 						})
 					};
+					dataSet.columnDefinitions.unshift({
+						id: 'rowNumber',
+						name: '',
+						field: 'rowNumber',
+						width: 22,
+						type: FieldType.Integer,
+						focusable: true,
+						selectable: false,
+						formatter: r => { return `<span class="row-number">${r + 1}</span>`; }
+					});
 					self.dataSets.push(dataSet);
 
 					// Create a dataSet to render without rows to reduce DOM size
@@ -556,10 +579,24 @@ export class AppComponent implements OnInit, AfterViewChecked {
 		}
 	}
 
-	openContextMenu(event: { x: number, y: number }, batchId, resultId, index): void {
-		let selection = this.slickgrids.toArray()[index].getSelectedRanges();
-		selection = this.tryCombineSelections(selection);
-		this.contextMenu.show(event.x, event.y, batchId, resultId, index, selection);
+	openContextMenu(event: MouseEvent, batchId, resultId, index): void {
+		let selection: ISlickRange[] = this.slickgrids.toArray()[index].getSelectedRanges();
+		selection = this.tryCombineSelectionsForResults(selection);
+		this.contextMenu.show(event.clientX, event.clientY, batchId, resultId, index, selection);
+		event.preventDefault();
+		event.stopPropagation();
+	}
+
+	private tryCombineSelectionsForResults(selections: ISlickRange[]): ISlickRange[] {
+		// need to take row number column in to consideration.
+		return this.tryCombineSelections(selections).map(range => {
+			return {
+				fromCell: range.fromCell - 1,
+				fromRow: range.fromRow,
+				toCell: range.toCell - 1,
+				toRow: range.toRow
+			};
+		});
 	}
 
 	private tryCombineSelections(selections: ISlickRange[]): ISlickRange[] {
@@ -598,7 +635,7 @@ export class AppComponent implements OnInit, AfterViewChecked {
 		let batchId = this.renderedDataSets[activeGrid].batchId;
 		let resultId = this.renderedDataSets[activeGrid].resultId;
 		let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-		selection = this.tryCombineSelections(selection);
+		selection = this.tryCombineSelectionsForResults(selection);
 		this.dataService.sendSaveRequest(batchId, resultId, format, selection);
 	}
 

--- a/src/views/htmlcontent/src/js/components/app.component.ts
+++ b/src/views/htmlcontent/src/js/components/app.component.ts
@@ -67,6 +67,7 @@ const template = `
                         showHeader="true"
                         [resized]="dataSet.resized"
                         (mousedown)="navigateToGrid(i)"
+                        (focusin)="setActiveGrid(i)"
                         [selectionModel]="selectionModel"
                         [plugins]="slickgridPlugins"
                         class="boxCol content vertBox slickgrid">
@@ -941,6 +942,27 @@ export class AppComponent implements OnInit, AfterViewChecked {
 	 * @returns A boolean representing if the navigation was successful
 	 */
 	navigateToGrid(targetIndex: number): boolean {
+		const result = this.setActiveGrid(targetIndex);
+		if (!result) { return false; }
+
+		// scrolling logic
+		let resultsWindow = $('#results');
+		let scrollTop = resultsWindow.scrollTop();
+		let scrollBottom = scrollTop + resultsWindow.height();
+		let gridHeight = $(this._el.nativeElement).find('slick-grid').height();
+		if (scrollBottom < gridHeight * (targetIndex + 1)) {
+			scrollTop += (gridHeight * (targetIndex + 1)) - scrollBottom;
+			resultsWindow.scrollTop(scrollTop);
+		}
+		if (scrollTop > gridHeight * targetIndex) {
+			scrollTop = (gridHeight * targetIndex);
+			resultsWindow.scrollTop(scrollTop);
+		}
+
+		return true;
+	}
+
+	setActiveGrid(targetIndex: number): boolean {
 		// check if the target index is valid
 		if (targetIndex >= this.renderedDataSets.length || targetIndex < 0) {
 			return false;
@@ -958,21 +980,6 @@ export class AppComponent implements OnInit, AfterViewChecked {
 		this.slickgrids.toArray()[this.activeGrid].selection = false;
 		this.slickgrids.toArray()[targetIndex].setActive();
 		this.activeGrid = targetIndex;
-
-		// scrolling logic
-		let resultsWindow = $('#results');
-		let scrollTop = resultsWindow.scrollTop();
-		let scrollBottom = scrollTop + resultsWindow.height();
-		let gridHeight = $(this._el.nativeElement).find('slick-grid').height();
-		if (scrollBottom < gridHeight * (targetIndex + 1)) {
-			scrollTop += (gridHeight * (targetIndex + 1)) - scrollBottom;
-			resultsWindow.scrollTop(scrollTop);
-		}
-		if (scrollTop > gridHeight * targetIndex) {
-			scrollTop = (gridHeight * targetIndex);
-			resultsWindow.scrollTop(scrollTop);
-		}
-
 		return true;
 	}
 

--- a/src/views/htmlcontent/src/js/services/data.service.ts
+++ b/src/views/htmlcontent/src/js/services/data.service.ts
@@ -163,4 +163,8 @@ export class DataService implements OnDestroy {
 			});
 		}
 	}
+
+	getNewColumnWidth(currentWidth: number): Promise<number | undefined> {
+		return this._proxy.getNewColumnWidth(currentWidth);
+	}
 }

--- a/src/views/htmlcontent/src/js/slick.dragrowselector.ts
+++ b/src/views/htmlcontent/src/js/slick.dragrowselector.ts
@@ -97,8 +97,7 @@ declare let Slick;
 			if (activeCell.cell > 1) {
 				let isHome = e.which === $.ui.keyCode.HOME;
 				let newActiveCellColumn = isHome ? 1 : activeCell.cell - 1;
-				// Unsure why but for range, must record 1 index less than expected
-				let newRangeColumn = newActiveCellColumn - 1;
+				let newRangeColumn = newActiveCellColumn;
 
 				if (e.shiftKey) {
 					let last = _ranges.pop();
@@ -125,9 +124,8 @@ declare let Slick;
 			let columnLength = _grid.getColumns().length;
 			if (activeCell.cell < columnLength) {
 				let isEnd = e.which === $.ui.keyCode.END;
-				let newActiveCellColumn = isEnd ? columnLength : activeCell.cell + 1;
-				// Unsure why but for range, must record 1 index less than expected
-				let newRangeColumn = newActiveCellColumn - 1;
+				let newActiveCellColumn = isEnd ? columnLength - 1 : activeCell.cell + 1;
+				let newRangeColumn = newActiveCellColumn;
 				if (e.shiftKey) {
 					let last = _ranges.pop();
 
@@ -198,12 +196,12 @@ declare let Slick;
 							if (last.fromRow <= newRangeRow) { last.toRow -= 1; }
 
 							let fromRow = Math.min(activeCell.row - 1, last.fromRow);
-							let fromCell = Math.min(activeCell.cell - 1, last.fromCell);
+							let fromCell = Math.min(activeCell.cell, last.fromCell);
 							let toRow = Math.max(newRangeRow, last.toRow);
-							let toCell = Math.max(activeCell.cell - 1, last.toCell);
+							let toCell = Math.max(activeCell.cell, last.toCell);
 							_ranges = [new Slick.Range(fromRow, fromCell, toRow, toCell)];
 						} else {
-							_ranges = [new Slick.Range(activeCell.row - 1, activeCell.cell - 1, activeCell.row - 1, activeCell.cell - 1)];
+							_ranges = [new Slick.Range(activeCell.row - 1, activeCell.cell, activeCell.row - 1, activeCell.cell)];
 						}
 						_grid.setActiveCell(activeCell.row - 1, activeCell.cell);
 						setSelectedRanges(_ranges);
@@ -228,12 +226,12 @@ declare let Slick;
 							if (newRangeRow <= last.toRow) { last.fromRow += 1; }
 
 							let fromRow = Math.min(activeCell.row + 1, last.fromRow);
-							let fromCell = Math.min(activeCell.cell - 1, last.fromCell);
+							let fromCell = Math.min(activeCell.cell, last.fromCell);
 							let toRow = Math.max(activeCell.row + 1, last.toRow);
-							let toCell = Math.max(activeCell.cell - 1, last.toCell);
+							let toCell = Math.max(activeCell.cell, last.toCell);
 							_ranges = [new Slick.Range(fromRow, fromCell, toRow, toCell)];
 						} else {
-							_ranges = [new Slick.Range(activeCell.row + 1, activeCell.cell - 1, activeCell.row + 1, activeCell.cell - 1)];
+							_ranges = [new Slick.Range(activeCell.row + 1, activeCell.cell, activeCell.row + 1, activeCell.cell)];
 						}
 						_grid.setActiveCell(activeCell.row + 1, activeCell.cell);
 						setSelectedRanges(_ranges);
@@ -256,6 +254,10 @@ declare let Slick;
 			}
 
 			let columnIndex = _grid.getColumnIndex(args.column.id);
+			// do nothing if the row number column header is clicked.
+			if (columnIndex === 0) {
+				return true;
+			}
 			if (e.ctrlKey || e.metaKey) {
 				_ranges.push(new Slick.Range(0, columnIndex, _grid.getDataLength() - 1, columnIndex));
 			} else if (e.shiftKey && _ranges.length) {
@@ -287,7 +289,7 @@ declare let Slick;
 
 			if (!e.ctrlKey && !e.shiftKey && !e.metaKey) {
 				if (cell.cell !== 0) {
-					_ranges = [new Slick.Range(cell.row, cell.cell - 1, cell.row, cell.cell - 1)];
+					_ranges = [new Slick.Range(cell.row, cell.cell, cell.row, cell.cell)];
 					setSelectedRanges(_ranges);
 					_grid.setActiveCell(cell.row, cell.cell);
 					return true;
@@ -303,7 +305,7 @@ declare let Slick;
 						_ranges.push(new Slick.Range(cell.row, 0, cell.row, _grid.getColumns().length - 1));
 						_grid.setActiveCell(cell.row, 1);
 					} else {
-						_ranges.push(new Slick.Range(cell.row, cell.cell - 1, cell.row, cell.cell - 1));
+						_ranges.push(new Slick.Range(cell.row, cell.cell, cell.row, cell.cell));
 						_grid.setActiveCell(cell.row, cell.cell);
 					}
 				} else if (_ranges.length && e.shiftKey) {
@@ -314,9 +316,9 @@ declare let Slick;
 						_ranges = [new Slick.Range(fromRow, 0, toRow, _grid.getColumns().length - 1)];
 					} else {
 						let fromRow = Math.min(cell.row, last.fromRow);
-						let fromCell = Math.min(cell.cell - 1, last.fromCell);
+						let fromCell = Math.min(cell.cell, last.fromCell);
 						let toRow = Math.max(cell.row, last.toRow);
-						let toCell = Math.max(cell.cell - 1, last.toCell);
+						let toCell = Math.max(cell.cell, last.toCell);
 						_ranges = [new Slick.Range(fromRow, fromCell, toRow, toCell)];
 					}
 				}
@@ -341,9 +343,9 @@ declare let Slick;
 			} else if (_ranges.length && e.shiftKey) {
 				let last = _ranges.pop();
 				let fromRow = Math.min(cell.row, last.fromRow);
-				let fromCell = Math.min(cell.cell - 1, last.fromCell);
+				let fromCell = Math.min(cell.cell, last.fromCell);
 				let toRow = Math.max(cell.row, last.toRow);
-				let toCell = Math.max(cell.cell - 1, last.toCell);
+				let toCell = Math.max(cell.cell, last.toCell);
 				_ranges = [new Slick.Range(fromRow, fromCell, toRow, toCell)];
 			} else {
 				_ranges = [new Slick.Range()];
@@ -371,8 +373,8 @@ declare let Slick;
 				} else {
 					let firstRow = Math.min(cell.row, activeCell.row);
 					let lastRow = Math.max(cell.row, activeCell.row);
-					let firstColumn = Math.min(cell.cell - 1, activeCell.cell - 1);
-					let lastColumn = Math.max(cell.cell - 1, activeCell.cell - 1);
+					let firstColumn = Math.min(cell.cell, activeCell.cell);
+					let lastColumn = Math.max(cell.cell, activeCell.cell);
 					_ranges.push(new Slick.Range(firstRow, firstColumn, lastRow, lastColumn));
 				}
 				setSelectedRanges(_ranges);

--- a/src/views/htmlcontent/src/js/slick.dragrowselector.ts
+++ b/src/views/htmlcontent/src/js/slick.dragrowselector.ts
@@ -254,28 +254,30 @@ declare let Slick;
 			}
 
 			let columnIndex = _grid.getColumnIndex(args.column.id);
-			// do nothing if the row number column header is clicked.
+			const newActiveRow = _grid.getViewport()?.top ?? 0;
+			const newActiveColumn = columnIndex === 0 ? 1 : columnIndex;
+			// select all cells if row number header is clicked
 			if (columnIndex === 0) {
-				return true;
-			}
-			if (e.ctrlKey || e.metaKey) {
-				_ranges.push(new Slick.Range(0, columnIndex, _grid.getDataLength() - 1, columnIndex));
-			} else if (e.shiftKey && _ranges.length) {
-				let last = _ranges.pop().fromCell;
-				let from = Math.min(columnIndex, last);
-				let to = Math.max(columnIndex, last);
-				_ranges = [];
-				for (let i = from; i <= to; i++) {
-					if (i !== last) {
-						_ranges.push(new Slick.Range(0, i, _grid.getDataLength() - 1, i));
-					}
-				}
-				_ranges.push(new Slick.Range(0, last, _grid.getDataLength() - 1, last));
+				_ranges = [new Slick.Range(0, 1, _grid.getDataLength() - 1, _grid.getColumns().length - 1)];
 			} else {
-				_ranges = [new Slick.Range(0, columnIndex, _grid.getDataLength() - 1, columnIndex)];
+				if (e.ctrlKey || e.metaKey) {
+					_ranges.push(new Slick.Range(0, columnIndex, _grid.getDataLength() - 1, columnIndex));
+				} else if (e.shiftKey && _ranges.length) {
+					let last = _ranges.pop().fromCell;
+					let from = Math.min(columnIndex, last);
+					let to = Math.max(columnIndex, last);
+					_ranges = [];
+					for (let i = from; i <= to; i++) {
+						if (i !== last) {
+							_ranges.push(new Slick.Range(0, i, _grid.getDataLength() - 1, i));
+						}
+					}
+					_ranges.push(new Slick.Range(0, last, _grid.getDataLength() - 1, last));
+				} else {
+					_ranges = [new Slick.Range(0, columnIndex, _grid.getDataLength() - 1, columnIndex)];
+				}
 			}
-
-			_grid.resetActiveCell();
+			_grid.setActiveCell(newActiveRow, newActiveColumn);
 			setSelectedRanges(_ranges);
 			e.stopImmediatePropagation();
 			return true;
@@ -287,6 +289,11 @@ declare let Slick;
 				return false;
 			}
 
+			if (cell.cell === 0) {
+				e.stopImmediatePropagation();
+				_grid.setActiveCell(cell.row, 1);
+			}
+
 			if (!e.ctrlKey && !e.shiftKey && !e.metaKey) {
 				if (cell.cell !== 0) {
 					_ranges = [new Slick.Range(cell.row, cell.cell, cell.row, cell.cell)];
@@ -294,16 +301,14 @@ declare let Slick;
 					_grid.setActiveCell(cell.row, cell.cell);
 					return true;
 				} else {
-					_ranges = [new Slick.Range(cell.row, 0, cell.row, _grid.getColumns().length - 1)];
+					_ranges = [new Slick.Range(cell.row, 1, cell.row, _grid.getColumns().length - 1)];
 					setSelectedRanges(_ranges);
-					_grid.setActiveCell(cell.row, 1);
 					return true;
 				}
 			} else if (_grid.getOptions().multiSelect) {
 				if (e.ctrlKey || e.metaKey) {
 					if (cell.cell === 0) {
-						_ranges.push(new Slick.Range(cell.row, 0, cell.row, _grid.getColumns().length - 1));
-						_grid.setActiveCell(cell.row, 1);
+						_ranges.push(new Slick.Range(cell.row, 1, cell.row, _grid.getColumns().length - 1));
 					} else {
 						_ranges.push(new Slick.Range(cell.row, cell.cell, cell.row, cell.cell));
 						_grid.setActiveCell(cell.row, cell.cell);
@@ -313,7 +318,7 @@ declare let Slick;
 					if (cell.cell === 0) {
 						let fromRow = Math.min(cell.row, last.fromRow);
 						let toRow = Math.max(cell.row, last.fromRow);
-						_ranges = [new Slick.Range(fromRow, 0, toRow, _grid.getColumns().length - 1)];
+						_ranges = [new Slick.Range(fromRow, 1, toRow, _grid.getColumns().length - 1)];
 					} else {
 						let fromRow = Math.min(cell.row, last.fromRow);
 						let fromCell = Math.min(cell.cell, last.fromCell);
@@ -369,7 +374,7 @@ declare let Slick;
 					let lastCell = _grid.getColumns().length - 1;
 					let firstRow = Math.min(cell.row, activeCell.row);
 					let lastRow = Math.max(cell.row, activeCell.row);
-					_ranges.push(new Slick.Range(firstRow, 0, lastRow, lastCell));
+					_ranges.push(new Slick.Range(firstRow, 1, lastRow, lastCell));
 				} else {
 					let firstRow = Math.min(cell.row, activeCell.row);
 					let lastRow = Math.max(cell.row, activeCell.row);

--- a/src/views/htmlcontent/systemjs.config.js
+++ b/src/views/htmlcontent/systemjs.config.js
@@ -27,7 +27,7 @@
 	var packages = {
 		'app': { main: 'main.js', defaultExtension: 'js' },
 		'': { main: 'views/htmlcontent/src/js/constants.js', defaultExtension: 'js' },
-		'angular2-slickgrid': { main: 'index.js', defaultExtension: 'js' },
+		'angular2-slickgrid': { main: 'out/index.js', defaultExtension: 'js' },
 		'/src/controllers': { defaultExtension: 'js' },
 		'rxjs': { main: 'Rx.js', defaultExtension: 'js' }
 	};

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,9 +388,9 @@ angular-in-memory-web-api@0.1.13:
   resolved "https://registry.yarnpkg.com/angular-in-memory-web-api/-/angular-in-memory-web-api-0.1.13.tgz#24a8abafe8ec647f98ee3269be0832d307ab240f"
   integrity sha1-JKirr+jsZH+Y7jJpvggy0werJA8=
 
-"angular2-slickgrid@github:microsoft/angular2-slickgrid#1.2.2-patch1":
-  version "1.2.2-patch1"
-  resolved "https://codeload.github.com/microsoft/angular2-slickgrid/tar.gz/4027f16251c26d9ac53ecd69a6bd9f823963e075"
+"angular2-slickgrid@github:microsoft/angular2-slickgrid#1.4.6":
+  version "1.4.6"
+  resolved "https://codeload.github.com/microsoft/angular2-slickgrid/tar.gz/09579fdc90b1ec469578ec1040d1515585ce2a11"
 
 ansi-colors@4.1.1:
   version "4.1.1"
@@ -3209,14 +3209,7 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
-jquery-ui@>=1.8.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.2.tgz#de03580ae6604773602f8d786ad1abfb75232034"
-  integrity sha512-wBZPnqWs5GaYJmo1Jj0k/mrSkzdQzKDwhXNtHKcBdAcKVxMM3KNYFq+iJ2i1rwiG53Z8M4mTn3Qxrm17uH1D4Q==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
-
-jquery@>=1.8.0, "jquery@>=1.8.0 <4.0.0", jquery@^3.4.1:
+jquery@^3.4.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
@@ -4874,12 +4867,9 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
-"slickgrid@github:kburtram/SlickGrid#2.3.23-2":
-  version "2.3.23"
-  resolved "https://codeload.github.com/kburtram/SlickGrid/tar.gz/bdf93b113385502f9402170261390dc9065f2715"
-  dependencies:
-    jquery ">=1.8.0"
-    jquery-ui ">=1.8.0"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.39":
+  version "2.3.39"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/4ead9291ec4aab107767940ab0a6eac1455e0627"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
for #17452

1. In order to fix grid not getting the focus issue, I need to use the latest slickgrid but it is not compatible with the implementation as well as the angular2-slickgrid, I had to fix all the compatibility issues.
2. support change column width with keyboard, I followed the same pattern we implemented in ADS a couple weeks ago.
![acc](https://user-images.githubusercontent.com/13777222/202790991-6358b822-6aeb-4b50-8680-453981aa4c63.gif)


tested all the features:
1. selection
2. export
3. navigation with multiple grids