### PR TITLE
Don't package unnecessary files

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,19 +1,23 @@
 .github
 .vscode
 build
+coverage
+coverage-remapped
 lib
 localization
 out/test
+packages
 samples
 src
 tasks
 test
 typings
-packages
+test-reports
 
 .gitignore
 .mention-bot
 coverconfig.json
+extensionlaunched.dat
 gulpfile.js
 tsconfig.json
 tslint*.json


### PR DESCRIPTION
Noticed we were including a few test run artifacts in the final packaged VSIX - removing those to keep the size down

(technically we could probably remove some of the md files too like the changelog since that isn't used by VS Code. But those are small enough that it's fine for now and people might actually want to be able to see that stuff in the unpacked extension directory anyways)

After removal : 

![image](https://user-images.githubusercontent.com/28519865/204597972-b33bff86-5f2f-4a66-97f3-878b9e533d6e.png)
