### PR TITLE
Update ADAL library publishing guide

### DIFF
--- a/lib/ads-adal-library/PUBLISHING.md
+++ b/lib/ads-adal-library/PUBLISHING.md
@@ -1,6 +1,9 @@
 These steps should be followed to publish a new version of the package to npmjs.
 
 1. Bump version if needed
-2. Download ads-adal-library-X.X.X.tgz package from [Official Build Pipeline](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build?definitionId=522) artifacts
-3. Run `npm publish <PATH_TO_PACKAGE>/microsoft-ads-adal-library-X.X.X.tgz`
-   * If you do not have permissions to publish see [Publishing Microsoft scoped packages](https://docs.opensource.microsoft.com/releasing/publish/npm/#publish-microsoft-scoped-packages) to get access
+2. Run the [Official Build Pipeline](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build?definitionId=522) against main
+3. Download ads-adal-library-X.X.X.tgz package from the artifacts of the completed build
+4. Run `npm publish <PATH_TO_PACKAGE>/microsoft-ads-adal-library-X.X.X.tgz`
+   * If you do not have permissions to publish contact the team to get added to the [azure-data-studio](https://www.npmjs.com/settings/microsoft/teams/team/azure-data-studio/users) team on NPM
+   * See [the docs](https://docs.opensource.microsoft.com/releasing/publish-binaries/npm/#publish-microsoft-scoped-packages) for more info about the publishing process
+5. Create a [release](https://github.com/microsoft/vscode-mssql/releases) with a tag pointing to the commit the build is from (should be the latest from main) with a link to the package version that was just released (e.g. https://www.npmjs.com/package/@microsoft/ads-adal-library/v/1.0.15)


### PR DESCRIPTION
Make it a bit clearer

Ideally it'd be nice to have a CD pipeline like I've done in other repos (e.g. https://github.com/microsoft/azdata-test/blob/main/README.md#releasing) that will automatically create the release but that's not something I have time to do currently. 