### PR TITLE
Add SELECT ALL and FULL/NATURAL JOIN syntax to grammar

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -237,7 +237,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(select(\s+(all|distinct))?|insert\s+(ignore\s+)?into|update|delete|from|set|where|group\s+by|or|like|and|union(\s+all)?|having|order\s+by|limit|(inner|cross)\s+join|join|straight_join|full\s+outer\s+join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)</string>
+			<string>(?i:\b(select(\s+(all|distinct))?|insert\s+(ignore\s+)?into|update|delete|from|set|where|group\s+by|or|like|and|union(\s+all)?|having|order\s+by|limit|cross\s+join|join|straight_join|(inner|(left|right|full)(\s+outer)?)\s+join|natural(\s+(inner|(left|right|full)(\s+outer)?))?\s+join)\b)</string>
 			<key>name</key>
 			<string>keyword.other.DML.sql</string>
 		</dict>

--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -237,7 +237,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(select(\s+distinct)?|insert\s+(ignore\s+)?into|update|delete|from|set|where|group\s+by|or|like|and|union(\s+all)?|having|order\s+by|limit|(inner|cross)\s+join|join|straight_join|full\s+outer\s+join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)</string>
+			<string>(?i:\b(select(\s+(all|distinct))?|insert\s+(ignore\s+)?into|update|delete|from|set|where|group\s+by|or|like|and|union(\s+all)?|having|order\s+by|limit|(inner|cross)\s+join|join|straight_join|full\s+outer\s+join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)</string>
 			<key>name</key>
 			<string>keyword.other.DML.sql</string>
 		</dict>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/17507

Before : 

![image](https://user-images.githubusercontent.com/28519865/209245399-b12ad0b9-f180-4d3b-92b4-29f319c8393f.png)

After : 

![image](https://user-images.githubusercontent.com/28519865/209245361-86e110e2-ad8a-41cb-af00-22c7f06f2e25.png)

Note that natural joins aren't valid T-SQL - hence why they're showing up as red. 

We probably shouldn't be even including natural joins in the grammar, but there was already some partial support for it so I decided that for now we'll just add this (since it's just colorization anyways). 

Thanks @hanohrs for the submission and syntax update suggestion!