### PR TITLE
Improve error handling and update profile when returned

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -86,6 +86,7 @@ export default class ConnectionManager {
 		Map<IConnectionInfo, ServerInfo>;
 	private _uriToConnectionPromiseMap: Map<string, Deferred<boolean>>;
 	private _failedUriToFirewallIpMap: Map<string, string>;
+	private _failedUriToSSLMap: Map<string, string>;
 	private _accountService: AccountService;
 	private _firewallService: FirewallService;
 	public azureController: AzureController;
@@ -131,6 +132,7 @@ export default class ConnectionManager {
 		this._accountService = new AccountService(this.client, this._accountStore, this.azureController);
 		this._firewallService = new FirewallService(this._accountService);
 		this._failedUriToFirewallIpMap = new Map<string, string>();
+		this._failedUriToSSLMap = new Map<string, string>();
 
 		if (this.client !== undefined) {
 			this.client.onNotification(ConnectionContracts.ConnectionChangedNotification.type, this.handleConnectionChangedNotification());
@@ -225,6 +227,10 @@ export default class ConnectionManager {
 
 	public get failedUriToFirewallIpMap(): Map<string, string> {
 		return this._failedUriToFirewallIpMap;
+	}
+
+	public get failedUriToSSLMap(): Map<string, string> {
+		return this._failedUriToSSLMap;
 	}
 
 	public get accountService(): AccountService {
@@ -431,10 +437,9 @@ export default class ConnectionManager {
 				connection.errorNumber = result.errorNumber;
 				connection.errorMessage = result.errorMessage;
 			} else if (result.errorNumber === Constants.errorSSLCertificateValidationFailed) {
-				this.showInstructionTextAsWarning(connection.credentials, async updatedConnection => {
-					vscode.commands.executeCommand(Constants.cmdConnectObjectExplorerProfile, updatedConnection);
-				});
-				return;
+				this._failedUriToSSLMap.set(fileUri, result.errorMessage);
+				connection.errorNumber = result.errorNumber;
+				connection.errorMessage = result.errorMessage;
 			} else if (result.errorNumber !== Constants.errorLoginFailed) {
 				Utils.showErrorMsg(Utils.formatString(LocalizedConstants.msgConnectionError, result.errorNumber, result.errorMessage));
 				// check whether it's a firewall rule error
@@ -494,6 +499,16 @@ export default class ConnectionManager {
 			this.vscodeWrapper.openExternal(Constants.encryptionBlogLink);
 			this.showInstructionTextAsWarning(profile, reconnectAction);
 		}
+	}
+
+	public async handleSSLError(uri: string, profile: IConnectionProfile): Promise<IConnectionInfo> {
+		let updatedConn: IConnectionInfo | undefined;
+		this.showInstructionTextAsWarning(profile, async updatedConnection => {
+			vscode.commands.executeCommand(Constants.cmdConnectObjectExplorerProfile, updatedConnection);
+			updatedConn = updatedConnection;
+		});
+		this.failedUriToSSLMap.delete(uri);
+		return updatedConn;
 	}
 
 	private async tryAddMruConnection(connection: ConnectionInfo, newConnection: IConnectionInfo): Promise<void> {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -130,8 +130,6 @@ export class ObjectExplorerService {
 					error += ` : ${result.errorMessage}`;
 				}
 
-				self._connectionManager.vscodeWrapper.showErrorMessage(error);
-
 				if (errorNumber === Constants.errorSSLCertificateValidationFailed) {
 					self._connectionManager.showInstructionTextAsWarning(self._currentNode.connectionInfo,
 						async updatedProfile => {
@@ -147,6 +145,8 @@ export class ObjectExplorerService {
 								self._connectionManager.vscodeWrapper.showErrorMessage(LocalizedConstants.msgPromptProfileUpdateFailed);
 							}
 						});
+				} else{
+					self._connectionManager.vscodeWrapper.showErrorMessage(error);
 				}
 				const promise = self._sessionIdToPromiseMap.get(result.sessionId);
 

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -464,26 +464,32 @@ export class ConnectionUI {
 	 * Validate a connection profile by connecting to it, and save it if we are successful.
 	 */
 	public async validateAndSaveProfile(profile: IConnectionProfile): Promise<IConnectionProfile> {
-		const self = this;
-		let uri = self.vscodeWrapper.activeTextEditorUri;
-		if (!uri || !self.vscodeWrapper.isEditingSqlFile) {
+		let uri = this.vscodeWrapper.activeTextEditorUri;
+		if (!uri || !this.vscodeWrapper.isEditingSqlFile) {
 			uri = ObjectExplorerUtils.getNodeUriFromProfile(profile);
 		}
-		return await self.connectionManager.connect(uri, profile).then(async (result) => {
+		return await this.connectionManager.connect(uri, profile).then(async (result) => {
 			if (result) {
 				// Success! save it
-				return await self.saveProfile(profile);
+				return await this.saveProfile(profile);
 			} else {
 				// Check whether the error was for firewall rule or not
-				if (self.connectionManager.failedUriToFirewallIpMap.has(uri)) {
+				if (this.connectionManager.failedUriToFirewallIpMap.has(uri)) {
 					let success = await this.addFirewallRule(uri, profile);
 					if (success) {
-						return await self.validateAndSaveProfile(profile);
+						return await this.validateAndSaveProfile(profile);
+					}
+					return undefined;
+				} else if(this.connectionManager.failedUriToSSLMap.has(uri)) {
+					// SSL error
+					let updatedConn = await this.connectionManager.handleSSLError(uri, profile);
+					if (updatedConn) {
+						return await this.validateAndSaveProfile(updatedConn as IConnectionProfile);
 					}
 					return undefined;
 				} else {
 					// Normal connection error! Let the user try again, prefilling values that they already entered
-					return await self.promptToRetryAndSaveProfile(profile);
+					return await this.promptToRetryAndSaveProfile(profile);
 				}
 			}
 		});

--- a/test/connectionProfile.test.ts
+++ b/test/connectionProfile.test.ts
@@ -264,6 +264,81 @@ suite('Connection Profile tests', () => {
 		connectionStoreMock.verify(async x => await x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
+	test('Updated Profile is returned when SSL error occurs', async () => {
+		let uri = 'myserver_mydb_undefined';;
+		let server = 'myserver';
+		let database = 'mydb';
+		let encrypt = 'Mandatory';
+		let authType = AuthenticationTypes[AuthenticationTypes.Integrated];
+
+		let updatedProfile = new ConnectionProfile();
+		updatedProfile.server = server;
+		updatedProfile.database = database;
+		updatedProfile.authenticationType = authType;
+		updatedProfile.trustServerCertificate = true;
+		updatedProfile.encrypt = encrypt;
+
+		let contextMock: TypeMoq.IMock<vscode.ExtensionContext> = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
+		let connectionManagerMock: TypeMoq.IMock<ConnectionManager> = TypeMoq.Mock.ofType(ConnectionManager, TypeMoq.MockBehavior.Loose, contextMock.object);
+		connectionManagerMock.setup(async x => await x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
+		connectionManagerMock.setup(x => x.failedUriToFirewallIpMap).returns(() => new Map());
+
+		let sslUriMockMap = new Map<string, string>();
+		sslUriMockMap.set(uri, 'An error occurred while connecting to the server');
+		connectionManagerMock.setup(x => x.failedUriToSSLMap).returns(() => sslUriMockMap);
+		connectionManagerMock.setup(x => x.handleSSLError(uri, TypeMoq.It.isAny())).returns(() =>
+			new Promise<ConnectionProfile>((resolve, reject) => {
+				let obj = connectionManagerMock.object;
+				obj.failedUriToSSLMap.delete(uri);
+				// mock the connection to succeed
+				connectionManagerMock.setup(async x => await x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
+				return resolve(updatedProfile);
+			}));
+
+		let connectionStoreMock = TypeMoq.Mock.ofType(ConnectionStore, TypeMoq.MockBehavior.Loose, contextMock.object);
+		connectionStoreMock.setup(async x => await x.saveProfile(TypeMoq.It.isAny())).returns(() => Promise.resolve(updatedProfile));
+
+		let prompter: TypeMoq.IMock<IPrompter> = TypeMoq.Mock.ofType(TestPrompter);
+		prompter.setup(x => x.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+			.returns(questions => {
+				let answers: { [key: string]: string } = {};
+				answers[LocalizedConstants.serverPrompt] = server;
+				answers[LocalizedConstants.databasePrompt] = database;
+				answers[LocalizedConstants.authTypeName] = authType;
+				answers[LocalizedConstants.profileNamePrompt] = '';
+				for (let key in answers) {
+					if (answers.hasOwnProperty(key)) {
+						questions.map(q => { if (q.name === key) { q.onAnswered(answers[key]); } });
+					}
+				}
+				return Promise.resolve(answers);
+			});
+
+		let vscodeWrapperMock = TypeMoq.Mock.ofType(VscodeWrapper);
+		vscodeWrapperMock.setup(x => x.activeTextEditorUri).returns(() => uri);
+
+		let connectionUI = new ConnectionUI(connectionManagerMock.object, contextMock.object,
+			connectionStoreMock.object, mockAccountStore, prompter.object, vscodeWrapperMock.object);
+
+		// create a new connection profile
+		let connProfile = await connectionUI.createAndSaveProfile();
+
+		// connection is attempted twice
+		connectionManagerMock.verify(async x => await x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.exactly(2));
+
+		// profile is saved
+		connectionStoreMock.verify(async x => await x.saveProfile(TypeMoq.It.isAny()), TypeMoq.Times.once());
+
+		// ssl error is handled
+		connectionManagerMock.verify(async x => await x.handleSSLError(uri, TypeMoq.It.isAny()), TypeMoq.Times.once());
+
+		assert.ok(connProfile, 'Connection profile should be returned.');
+		assert.strictEqual(connProfile.server, server);
+		assert.strictEqual(connProfile.database, database);
+		assert.strictEqual(connProfile.trustServerCertificate, true);
+		assert.strictEqual(connProfile.encrypt, encrypt);
+	});
+
 	test('Profile is not saved when connection validation fails', async () => {
 		let contextMock: TypeMoq.IMock<vscode.ExtensionContext> = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
 		let connectionManagerMock: TypeMoq.IMock<ConnectionManager> = TypeMoq.Mock.ofType(ConnectionManager, TypeMoq.MockBehavior.Loose, contextMock.object);


### PR DESCRIPTION
Improves error handling experience to avoid double prompts and updates profile properly for re-attempted connection.
Fixes issue for SQL Database Projects where profile wasn't updated on return.

**Updated experience:**

![VScode_NewExp](https://user-images.githubusercontent.com/13396919/211253603-618d4c26-bc17-4194-9c0c-e59f890fb7dc.gif)
