### PR TITLE
Fix token refresh and reauthentication with OE connection

### DIFF
--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -66,7 +66,7 @@ export class ConnectionCredentials implements IConnectionInfo {
 		}
 		details.options['database'] = credentials.database;
 		details.options['databaseDisplayName'] = credentials.database;
-		details.options['user'] = credentials.user;
+		details.options['user'] = credentials.user || credentials.email;
 		details.options['password'] = credentials.password;
 		details.options['authenticationType'] = credentials.authenticationType;
 		details.options['azureAccountToken'] = credentials.azureAccountToken;

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -467,9 +467,10 @@ export class ObjectExplorerService {
 							await this._connectionManager.vscodeWrapper.showErrorMessage(
 								errorMessage, LocalizedConstants.refreshTokenLabel).then(async result => {
 									if (result === LocalizedConstants.refreshTokenLabel) {
-										await azureController.populateAccountProperties(
+										let updatedProfile = await azureController.populateAccountProperties(
 											profile, this._connectionManager.accountStore, providerSettings.resources.databaseResource);
-
+										connectionCredentials.azureAccountToken = updatedProfile.azureAccountToken;
+										connectionCredentials.expiresOn = updatedProfile.expiresOn;
 									} else {
 										return undefined;
 									}


### PR DESCRIPTION
Fixes #17468 and fixes #17497

Refreshing credentials wasn't working due to updated profile credentials not being set on connection credentials when opening a session.