### PR TITLE
Disable tslint: no-string-based-set-timeout

### DIFF
--- a/src/azure/msal/httpClient.ts
+++ b/src/azure/msal/httpClient.ts
@@ -83,6 +83,7 @@ const networkRequestViaProxy = <T>(
 	}
 
 	if (timeout) {
+		// tslint:disable-next-line no-string-based-set-timeout
 		tunnelRequestOptions.timeout = timeout;
 	}
 


### PR DESCRIPTION
As per rule definition:

_**no-string-based-set-timeout:** Do not use the version of setTimeout that accepts code as a string argument. However, it is acceptable to use the version of setTimeout where a direct reference to a function is provided as the callback argument._

However, timeout is defined in [ClientRequestArgs](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules__types_node_http_d_._http_.clientrequestargs.html) and is a number, it seems like this rule is a false positive, as many other reports: https://github.com/Microsoft/tslint-microsoft-contrib/issues/355