### PR TITLE
Updating STS to be in sync with ADS

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.5.0.36",
+    "version": "4.5.0.38",
     "downloadFileNames": {
       "Windows_86": "win-x86-net7.0.zip",
       "Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
ADS is currently at 4.5.0.38 so as to release in sync with ADS updating vscode-mssql to also use STS version 4.5.0.38