### PR TITLE
Allow using STS credential store on Linux for encryption keys

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -12,7 +12,7 @@ import { AdalAzureController } from '../azure/adal/adalAzureController';
 import { AzureController } from '../azure/azureController';
 import { MsalAzureController } from '../azure/msal/msalAzureController';
 import providerSettings from '../azure/providerSettings';
-import { getAzureAuthLibraryConfig } from '../azure/utils';
+import { getAzureAuthLibraryConfig, getEnableSqlAuthenticationProviderConfig } from '../azure/utils';
 import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/localizedConstants';
 import { CredentialStore } from '../credentialstore/credentialstore';
@@ -116,8 +116,10 @@ export default class ConnectionManager {
 			this.vscodeWrapper = new VscodeWrapper();
 		}
 
+		const isEnabledSqlAuthProvider = getEnableSqlAuthenticationProviderConfig();
+
 		if (!this._credentialStore) {
-			this._credentialStore = new CredentialStore(context);
+			this._credentialStore = new CredentialStore(context, this.client, isEnabledSqlAuthProvider);
 		}
 
 		if (!this._connectionStore) {

--- a/test/credentialStore.test.ts
+++ b/test/credentialStore.test.ts
@@ -22,7 +22,7 @@ suite('Credential Store Tests', () => {
 		client.setup(c => c.sendRequest(Contracts.SaveCredentialRequest.type, TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
 		client.setup(c => c.sendRequest(Contracts.ReadCredentialRequest.type, TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
 		client.setup(c => c.sendRequest(Contracts.DeleteCredentialRequest.type, TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
-		credentialStore = new CredentialStore(mockContext.object, client.object);
+		credentialStore = new CredentialStore(mockContext.object, client.object, false);
 	});
 
 	test('Read credential should send a ReadCredentialRequest', () => {


### PR DESCRIPTION
Noticed an issue on Linux where Encryption keys are not available in .NET backend when `enableSqlAuthenticationProvider` is enabled. Since we use VS Code secret storage for Linux, STS backend is not able to read these credentials.

Since we need these keys for MSAL cache, the only way it will work is if we store them via STS credential service.
Opening this PR for any feedback before I also open the same in ADS..