### PR TITLE
STS Bump + Notify STS when encryption keys are updated

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.6.0.11",
+    "version": "4.6.0.16",
     "downloadFileNames": {
       "Windows_86": "win-x86-net7.0.zip",
       "Windows_64": "win-x64-net7.0.zip",

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -230,3 +230,25 @@ export class GetConnectionStringParams {
 }
 
 // ------------------------------- </ Connection String Request > --------------------------------------
+
+// ------------------------------- < Encryption IV/KEY updation Event > ------------------------------------
+/**
+ * Parameters for the MSAL cache encryption key notification
+ */
+export class DidChangeEncryptionIVKeyParams {
+	/**
+	 * Buffer encoded IV string for MSAL cache encryption
+	 */
+	public iv: string;
+	/**
+	 * Buffer encoded Key string for MSAL cache encryption
+	 */
+	public key: string;
+}
+
+/**
+ * Notification sent when the encryption keys are changed.
+ */
+export namespace EncryptionKeysChangedNotification {
+	export const type = new NotificationType<DidChangeEncryptionIVKeyParams, void>('connection/encryptionKeysChanged');
+}


### PR DESCRIPTION
Sends notification to backend SqlToolsService to update encryption keys in a cross-platform compatible way.. 
Addresses https://github.com/microsoft/azuredatastudio/issues/22364 paired with https://github.com/microsoft/sqltoolsservice/pull/1955

STS update: https://github.com/microsoft/sqltoolsservice/compare/4.6.0.11...4.6.0.16
![image](https://user-images.githubusercontent.com/13396919/227007044-b1ba6b56-e7c8-41ac-b1bf-8f5504f55a67.png)
