### PR TITLE
update sql projects/dacfx changes in vscode-mssql.d.ts

### DIFF
--- a/src/services/dacFxService.ts
+++ b/src/services/dacFxService.ts
@@ -87,7 +87,7 @@ export class DacFxService implements mssql.IDacFxService {
 		upgradeExisting: boolean,
 		ownerUri: string,
 		taskExecutionMode: mssql.TaskExecutionMode,
-		sqlCommandVariableValues?: Record<string, string>,
+		sqlCommandVariableValues?: Map<string, string>,
 		deploymentOptions?: mssql.DeploymentOptions): Thenable<mssql.DacFxResult> {
 		const params: mssql.DeployParams = {
 			packageFilePath: packageFilePath,
@@ -106,7 +106,7 @@ export class DacFxService implements mssql.IDacFxService {
 		targetDatabaseName: string,
 		ownerUri: string,
 		taskExecutionMode: mssql.TaskExecutionMode,
-		sqlCommandVariableValues?: Record<string, string>,
+		sqlCommandVariableValues?: Map<string, string>,
 		deploymentOptions?: mssql.DeploymentOptions): Thenable<mssql.DacFxResult> {
 		const params: mssql.GenerateDeployScriptParams = {
 			packageFilePath: packageFilePath,
@@ -144,5 +144,9 @@ export class DacFxService implements mssql.IDacFxService {
 			createStreamingJobTsql: createStreamingJobTsql
 		};
 		return this._client.sendRequest(dacFxContracts.ValidateStreamingJobRequest.type, params);
+	}
+
+	savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Map<string, string>, deploymentOptions?: mssql.DeploymentOptions): Thenable<mssql.ResultStatus> {
+		throw new Error('Method not implemented.');
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -26,10 +26,6 @@
     "interface-name": true,
     "jsdoc-format": true,
     "label-position": true,
-    "max-line-length": [
-      true,
-      160
-    ],
     "member-access": false,
     "member-ordering": false,
     "no-any": false,

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -1083,7 +1083,7 @@ declare module 'vscode-mssql' {
 		profilePath: string;
 		databaseName: string;
 		connectionString: string;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 	}
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -432,11 +432,12 @@ declare module 'vscode-mssql' {
 		importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		createProjectFromDatabase(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: ExtractTarget, taskExecutionMode: TaskExecutionMode, includePermissions?: boolean): Thenable<DacFxResult>;
-		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
-		generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
+		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Map<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
+		generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode, sqlCommandVariableValues?: Map<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
 		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 		getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
 		validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
+		savePublishProfile(profilePath: string, databaseName: string, connectionString: string, sqlCommandVariableValues?: Map<string, string>, deploymentOptions?: DeploymentOptions): Thenable<ResultStatus>;
 	}
 
 	/**
@@ -665,37 +666,37 @@ declare module 'vscode-mssql' {
 		moveSqlObjectScript(projectUri: string, destinationPath: string, path: string): Promise<ResultStatus>;
 
 		/**
-		 * getDatabaseReferences
+		 * Get all the database references in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getDatabaseReferences(projectUri: string): Promise<GetDatabaseReferencesResult>;
 
 		/**
-		 * getFolders
+		 * Get all the folders in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getFolders(projectUri: string): Promise<GetFoldersResult>;
 
 		/**
-		 * getPostDeploymentScripts
+		 * Get all the post-deployment scripts in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getPostDeploymentScripts(projectUri: string): Promise<GetScriptsResult>;
 
 		/**
-		 * getPreDeploymentScripts
+		 * Get all the pre-deployment scripts in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getPreDeploymentScripts(projectUri: string): Promise<GetScriptsResult>;
 
 		/**
-		 * getSqlCmdVariables
+		 * Get all the SQLCMD variables in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getSqlCmdVariables(projectUri: string): Promise<GetSqlCmdVariablesResult>;
 
 		/**
-		 * getSqlObjectScripts
+		 * Get all the SQL object scripts in a project
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 */
 		getSqlObjectScripts(projectUri: string): Promise<GetScriptsResult>;
@@ -1041,7 +1042,7 @@ declare module 'vscode-mssql' {
 		packageFilePath: string;
 		databaseName: string;
 		upgradeExisting: boolean;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1050,7 +1051,7 @@ declare module 'vscode-mssql' {
 	export interface GenerateDeployScriptParams {
 		packageFilePath: string;
 		databaseName: string;
-		sqlCommandVariableValues?: Record<string, string>;
+		sqlCommandVariableValues?: Map<string, string>;
 		deploymentOptions?: DeploymentOptions;
 		ownerUri: string;
 		taskExecutionMode: TaskExecutionMode;
@@ -1076,6 +1077,14 @@ declare module 'vscode-mssql' {
 
 	export interface SchemaCompareOptionsResult extends ResultStatus {
 		defaultDeploymentOptions: DeploymentOptions;
+	}
+
+	export interface SavePublishProfileParams {
+		profilePath: string;
+		databaseName: string;
+		connectionString: string;
+		sqlCommandVariableValues?: Record<string, string>;
+		deploymentOptions?: DeploymentOptions;
 	}
 
 	//#region ISqlProjectsService
@@ -1348,7 +1357,7 @@ declare module 'vscode-mssql' {
 	}
 
 	interface UserDatabaseReference extends DatabaseReference {
-		databaseVariable: SqlCmdVariable;
+		databaseVariable?: SqlCmdVariable;
 		serverVariable?: SqlCmdVariable;
 	}
 


### PR DESCRIPTION
I did a diff of the vscode-mssql.d.ts files in ADS and vscode-mssql and found several differences. This brings over the sql projects/dacfx changes that were made in ADS, but weren't brought over to the vscode-mssql repo. After this is merged, I'll make a PR in ADS so that the two files will be the same.