### PR TITLE
Remove LGTM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_apis/build/status/VSCode-MSSQL?branchName=main)](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/latest?definitionId=70&branchName=main)
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/microsoft/vscode-mssql.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/microsoft/vscode-mssql/context:javascript)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-blue.svg)](https://gitter.im/Microsoft/mssql)
 
 


### PR DESCRIPTION
We removed this a while ago and so the badge is not active - removing it to clean up our extension page in VS Code. 

![image](https://user-images.githubusercontent.com/28519865/234675588-35f7a15d-634b-4bc7-aa95-13926b462d29.png)
