### PR TITLE
Improvements in access token flows

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -134,6 +134,9 @@
         <trans-unit id="azureConsentDialogBody">
             <source xml:lang="en">Your tenant '{0} ({1})' requires you to re-authenticate again to access {2} resources. Press Open to start the authentication process.</source>
         </trans-unit>
+        <trans-unit id="azureConsentDialogBodyAccount">
+            <source xml:lang="en">Your account needs re-authentication to access {0} resources. Press Open to start the authentication process.</source>
+        </trans-unit>
         <trans-unit id="azureMicrosoftCorpAccount">
             <source xml:lang="en">Microsoft Corp</source>
         </trans-unit>

--- a/src/azure/constants.ts
+++ b/src/azure/constants.ts
@@ -67,10 +67,21 @@ export const AADSTS50173 = 'AADSTS50173';
  * We have the user sign in again when this error occurs.
  */
 export const AADSTS50020 = 'AADSTS50020';
-
+/**
+ * Error thrown from STS - indicates user account not found in MSAL cache.
+ * We request user to sign in again.
+ */
 export const mdsUserAccountNotFound = `User account '{0}' not found in MSAL cache, please add linked account or refresh account credentials.`;
-
+/**
+ * Error thrown from STS - indicates user account info not received from connection profile.
+ * This is possible when account info is not available when populating user's preferred name in connection profile.
+ * We request user to sign in again, to refresh their account credentials.
+ */
 export const mdsUserAccountNotReceived = 'User account not received.';
+/**
+ * This error is thrown by MSAL when user account is not received in silent authentication request.
+ * Thrown by TS layer, indicates user account hint not provided. We request user to reauthenticate when this error occurs.
+ */
 export const NoAccountInSilentRequestError = 'no_account_in_silent_request';
 
 /** MSAL Account version */

--- a/src/azure/constants.ts
+++ b/src/azure/constants.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ITenant } from "../models/contracts/azure";
+
 export const serviceName = 'Code';
 
 export const httpConfigSectionName = 'http';
@@ -47,6 +49,30 @@ export const azureTenantConfigSection = azureSection + '.' + tenantSection + '.'
 
 export const oldMsalCacheFileName = 'azureTokenCacheMsal-azure_publicCloud';
 
+/////// MSAL ERROR CODES, ref: https://learn.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes
+/**
+ * The refresh token has expired or is invalid due to sign-in frequency checks by conditional access.
+ * The token was issued on {issueDate} and the maximum allowed lifetime for this request is {time}.
+ */
+export const AADSTS70043 = 'AADSTS70043';
+/**
+ * FreshTokenNeeded - The provided grant has expired due to it being revoked, and a fresh auth token is needed.
+ * Either an admin or a user revoked the tokens for this user, causing subsequent token refreshes to fail and
+ * require reauthentication. Have the user sign in again.
+ */
+export const AADSTS50173 = 'AADSTS50173';
+/**
+ * User account 'user@domain.com' from identity provider {IdentityProviderURL} does not exist in tenant {ResourceTenantName}.
+ * This error occurs when account is authenticated without a tenant id, which happens when tenant Id is not available in connection profile.
+ * We have the user sign in again when this error occurs.
+ */
+export const AADSTS50020 = 'AADSTS50020';
+
+export const mdsUserAccountNotFound = `User account '{0}' not found in MSAL cache, please add linked account or refresh account credentials.`;
+
+export const mdsUserAccountNotReceived = 'User account not received.';
+export const NoAccountInSilentRequestError = 'no_account_in_silent_request';
+
 /** MSAL Account version */
 export const accountVersion = '2.0';
 
@@ -59,6 +85,15 @@ export const s256CodeChallengeMethod = 'S256';
 
 export const selectAccount = 'select_account';
 
+export const commonTenant: ITenant = {
+	id: 'common',
+	displayName: 'common'
+};
+
+export const organizationTenant: ITenant = {
+	id: 'organizations',
+	displayName: 'organizations'
+};
 /**
  * Account issuer as received from access token
  */

--- a/src/azure/constants.ts
+++ b/src/azure/constants.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ITenant } from "../models/contracts/azure";
+import { ITenant } from '../models/contracts/azure';
 
 export const serviceName = 'Code';
 
@@ -82,7 +82,7 @@ export const mdsUserAccountNotReceived = 'User account not received.';
  * This error is thrown by MSAL when user account is not received in silent authentication request.
  * Thrown by TS layer, indicates user account hint not provided. We request user to reauthenticate when this error occurs.
  */
-export const NoAccountInSilentRequestError = 'no_account_in_silent_request';
+export const noAccountInSilentRequestError = 'no_account_in_silent_request';
 
 /** MSAL Account version */
 export const accountVersion = '2.0';

--- a/src/azure/msal/msalAzureController.ts
+++ b/src/azure/msal/msalAzureController.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ILoggerCallback, LogLevel as MsalLogLevel } from '@azure/msal-common';
+import { ClientAuthError, ILoggerCallback, LogLevel as MsalLogLevel } from '@azure/msal-common';
 import { Configuration, PublicClientApplication } from '@azure/msal-node';
 import * as Constants from '../../constants/constants';
 import * as LocalizedConstants from '../../constants/localizedConstants';
@@ -19,7 +19,7 @@ import { MsalAzureDeviceCode } from './msalAzureDeviceCode';
 import { MsalCachePluginProvider } from './msalCachePlugin';
 import { promises as fsPromises } from 'fs';
 import * as path from 'path';
-import { oldMsalCacheFileName } from '../constants';
+import * as AzureConstants from '../constants';
 
 export class MsalAzureController extends AzureController {
 	private _authMappings = new Map<AzureAuthType, MsalAzureAuth>();
@@ -69,7 +69,7 @@ export class MsalAzureController extends AzureController {
 	 * Clears old cache file that is no longer needed on system.
 	 */
 	private async clearOldCacheIfExists(): Promise<void> {
-		let filePath = path.join(await this.findOrMakeStoragePath(), oldMsalCacheFileName);
+		let filePath = path.join(await this.findOrMakeStoragePath(), AzureConstants.oldMsalCacheFileName);
 		try {
 			await fsPromises.access(filePath);
 			await fsPromises.rm(filePath);
@@ -134,9 +134,10 @@ export class MsalAzureController extends AzureController {
 
 	public async refreshAccessToken(account: IAccount, accountStore: AccountStore, tenantId: string | undefined,
 		settings: IAADResource): Promise<IToken | undefined> {
+		let newAccount: IAccount;
 		try {
 			let azureAuth = await this.getAzureAuthInstance(getAzureActiveDirectoryConfig());
-			let newAccount = await azureAuth!.refreshAccessToken(account, 'organizations',
+			newAccount = await azureAuth!.refreshAccessToken(account, AzureConstants.organizationTenant.id,
 				this._providerSettings.resources.windowsManagementResource);
 
 			if (newAccount!.isStale === true) {
@@ -145,10 +146,26 @@ export class MsalAzureController extends AzureController {
 
 			await accountStore.addAccount(newAccount!);
 			return await this.getAccountSecurityToken(
-				account, tenantId!, settings
+				account, tenantId ?? account.properties.owningTenant.id, settings
 			);
 		} catch (ex) {
-			this._vscodeWrapper.showErrorMessage(ex);
+			if (ex instanceof ClientAuthError && ex.errorCode === AzureConstants.NoAccountInSilentRequestError) {
+				try {
+					// Account needs re-authentication
+					newAccount = await this.login(account.properties.azureAuthType);
+					if (newAccount!.isStale === true) {
+						return undefined;
+					}
+					await accountStore.addAccount(newAccount!);
+					return await this.getAccountSecurityToken(
+						account, tenantId ?? account.properties.owningTenant.id, settings
+					);
+				} catch (ex) {
+					this._vscodeWrapper.showErrorMessage(ex);
+				}
+			} else {
+				this._vscodeWrapper.showErrorMessage(ex);
+			}
 		}
 	}
 

--- a/src/azure/msal/msalAzureController.ts
+++ b/src/azure/msal/msalAzureController.ts
@@ -149,7 +149,7 @@ export class MsalAzureController extends AzureController {
 				account, tenantId ?? account.properties.owningTenant.id, settings
 			);
 		} catch (ex) {
-			if (ex instanceof ClientAuthError && ex.errorCode === AzureConstants.NoAccountInSilentRequestError) {
+			if (ex instanceof ClientAuthError && ex.errorCode === AzureConstants.noAccountInSilentRequestError) {
 				try {
 					// Account needs re-authentication
 					newAccount = await this.login(account.properties.azureAuthType);

--- a/src/azure/msal/msalCachePlugin.ts
+++ b/src/azure/msal/msalCachePlugin.ts
@@ -122,8 +122,7 @@ export class MsalCachePluginProvider {
 				retryAttempt++;
 				this._logger.verbose(`MsalCachePlugin: Failed to acquire lock on cache file. Retrying in ${retryWait} ms.`);
 
-				// tslint:disable:no-empty
-				await new Promise(resolve => setTimeout(resolve, retryWait));
+				await new Promise(resolve => setTimeout(() => resolve, retryWait));
 			}
 		}
 	}

--- a/src/azure/msal/msalCachePlugin.ts
+++ b/src/azure/msal/msalCachePlugin.ts
@@ -123,7 +123,7 @@ export class MsalCachePluginProvider {
 				this._logger.verbose(`MsalCachePlugin: Failed to acquire lock on cache file. Retrying in ${retryWait} ms.`);
 
 				// tslint:disable:no-empty
-				setTimeout(() => { }, retryWait);
+				await new Promise(resolve => setTimeout(resolve, retryWait));
 			}
 		}
 	}

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -804,23 +804,21 @@ export default class ConnectionManager {
 					connectionCreds.email = account.displayInfo.email;
 					profile.user = account.displayInfo.displayName;
 					profile.email = account.displayInfo.email;
-					if (!this.azureController.isSqlAuthProviderEnabled()) {
-						let azureAccountToken = await this.azureController.refreshAccessToken(account!,
-							this.accountStore, profile.tenantId, providerSettings.resources.databaseResource!);
-						if (!azureAccountToken) {
-							let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
-							let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
-							if (refreshResult === LocalizedConstants.refreshTokenLabel) {
-								await this.azureController.populateAccountProperties(
-									profile, this.accountStore, providerSettings.resources.databaseResource!);
+					let azureAccountToken = await this.azureController.refreshAccessToken(account!,
+						this.accountStore, profile.tenantId, providerSettings.resources.databaseResource!);
+					if (!azureAccountToken) {
+						let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
+						let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
+						if (refreshResult === LocalizedConstants.refreshTokenLabel) {
+							await this.azureController.populateAccountProperties(
+								profile, this.accountStore, providerSettings.resources.databaseResource!);
 
-							} else {
-								throw new Error(LocalizedConstants.cannotConnect);
-							}
 						} else {
-							connectionCreds.azureAccountToken = azureAccountToken.token;
-							connectionCreds.expiresOn = azureAccountToken.expiresOn;
+							throw new Error(LocalizedConstants.cannotConnect);
 						}
+					} else {
+						connectionCreds.azureAccountToken = azureAccountToken.token;
+						connectionCreds.expiresOn = azureAccountToken.expiresOn;
 					}
 				}
 			}

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -799,26 +799,30 @@ export default class ConnectionManager {
 					} else {
 						throw new Error(LocalizedConstants.cannotConnect);
 					}
-					// Always set username
-					connectionCreds.user = account.displayInfo.displayName;
-					connectionCreds.email = account.displayInfo.email;
-					profile.user = account.displayInfo.displayName;
-					profile.email = account.displayInfo.email;
-					let azureAccountToken = await this.azureController.refreshAccessToken(account!,
-						this.accountStore, profile.tenantId, providerSettings.resources.databaseResource!);
-					if (!azureAccountToken) {
-						let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
-						let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
-						if (refreshResult === LocalizedConstants.refreshTokenLabel) {
-							await this.azureController.populateAccountProperties(
-								profile, this.accountStore, providerSettings.resources.databaseResource!);
+					if (account) {
+						// Always set username
+						connectionCreds.user = account.displayInfo.displayName;
+						connectionCreds.email = account.displayInfo.email;
+						profile.user = account.displayInfo.displayName;
+						profile.email = account.displayInfo.email;
+						let azureAccountToken = await this.azureController.refreshAccessToken(account!,
+							this.accountStore, profile.tenantId, providerSettings.resources.databaseResource!);
+						if (!azureAccountToken) {
+							let errorMessage = LocalizedConstants.msgAccountRefreshFailed;
+							let refreshResult = await this.vscodeWrapper.showErrorMessage(errorMessage, LocalizedConstants.refreshTokenLabel);
+							if (refreshResult === LocalizedConstants.refreshTokenLabel) {
+								await this.azureController.populateAccountProperties(
+									profile, this.accountStore, providerSettings.resources.databaseResource!);
 
+							} else {
+								throw new Error(LocalizedConstants.cannotConnect);
+							}
 						} else {
-							throw new Error(LocalizedConstants.cannotConnect);
+							connectionCreds.azureAccountToken = azureAccountToken.token;
+							connectionCreds.expiresOn = azureAccountToken.expiresOn;
 						}
 					} else {
-						connectionCreds.azureAccountToken = azureAccountToken.token;
-						connectionCreds.expiresOn = azureAccountToken.expiresOn;
+						throw new Error(LocalizedConstants.msgAccountNotFound);
 					}
 				}
 			}

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -510,7 +510,7 @@ export class ObjectExplorerService {
 		}
 	}
 
-	private async refreshAccount(account: IAccount, connectionCredentials: ConnectionCredentials) {
+	private async refreshAccount(account: IAccount, connectionCredentials: ConnectionCredentials): Promise<void> {
 		let azureController = this._connectionManager.azureController;
 		let profile = new ConnectionProfile(connectionCredentials);
 		let azureAccountToken = await azureController.refreshAccessToken(


### PR DESCRIPTION
Fixes a few issues when working with 'Sql Authentication Provider' making sure access tokens are available before hitting STS and we can handle errors thrown by STS to provide seamless experience. Handles below errors:
- AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access. The token was issued on {issueDate} and the maximum allowed lifetime for this request is {time}. We request user to sign in again.
- AADSTS50173: FreshTokenNeeded - The provided grant has expired due to it being revoked, and a fresh auth token is needed. Either an admin or a user revoked the tokens for this user, causing subsequent token refreshes to fail and require reauthentication. Have the user sign in again.
- AADSTS50020: User account 'user@domain.com' from identity provider {IdentityProviderURL} does not exist in tenant {ResourceTenantName}. This error occurs when account is authenticated without a tenant id, which happens when tenant Id is not available in connection profile. We have the user sign in again when this error occurs.
- STS error: `User account '{0}' not found in MSAL cache, please add linked account or refresh account credentials.`: Error thrown from STS - indicates user account not found in MSAL cache. We request user to sign in again.
- STS error: `User account not received`: Error thrown from STS - indicates user account info not received from connection profile. This is possible when account info is not available when populating user's preferred name in connection profile. We request user to sign in again, to refresh their account credentials.
- MSAL.js error: `no_account_in_silent_request`: This error is thrown by MSAL when user account is not received in silent authentication request. Thrown by MSAL.js (TS layer), indicates user account hint not provided. We request user to reauthenticate when this error occurs.