### PR TITLE
fix focus style

### DIFF
--- a/src/views/htmlcontent/src/css/color-theme.css
+++ b/src/views/htmlcontent/src/css/color-theme.css
@@ -168,14 +168,12 @@
     --color-cell-bg-grid-selected: rgb(38, 79, 120);
   }
 
-  .vscode-dark a,
-  .vscode-high-contrast a {
-    color: #FF6000;
-  }
-
-  .vscode-dark a:hover,
-  .vscode-high-contrast a:hover{
-    color: #ff8033;
+  .collapsible:focus,
+  a:focus {
+    outline-color: var(--vscode-focusBorder);
+    outline-style: solid;
+    outline-width: 1px;
+    outline-offset: -1px;
   }
 
   /* grid styling */


### PR DESCRIPTION
for: https://github.com/microsoft/vscode-mssql/issues/17612
Use vscode color variable to override the browser defaults.

### BEFORE
![image](https://github.com/microsoft/vscode-mssql/assets/13777222/8de5fe6c-6d9b-4d85-8968-003a65b1ae4a)
![image](https://github.com/microsoft/vscode-mssql/assets/13777222/792b9f81-5584-459a-a4b4-6d322596c1b5)

### AFTER
![image](https://github.com/microsoft/vscode-mssql/assets/13777222/fe112f9a-fc11-43d5-9da1-4673a266e445)
![image](https://github.com/microsoft/vscode-mssql/assets/13777222/339e793d-1a40-4516-b8e9-bb37fd002481)

![image](https://github.com/microsoft/vscode-mssql/assets/13777222/38911a4a-c99f-4223-b8a1-78441808a261)
![image](https://github.com/microsoft/vscode-mssql/assets/13777222/41591de9-8df7-49b4-b4e4-2bb2372c0fa3)

