### PR TITLE
Additional check for connection string

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -788,7 +788,7 @@ export default class ConnectionManager {
 			title: LocalizedConstants.connectProgressNoticationTitle,
 			cancellable: false
 		}, async (_progress, _token) => {
-			if (!connectionCreds.server) {
+			if (!connectionCreds.server && !connectionCreds.connectionString) {
 				throw new Error(LocalizedConstants.serverNameMissing);
 			}
 			// Check if the azure account token is present before sending connect request (only with SQL Auth Provider is not enabled.)


### PR DESCRIPTION
Additional change to PR #17676 to fix https://github.com/microsoft/vscode-mssql/issues/17674
Since we can have profiles without server name that only contain connection string.
Addresses https://github.com/microsoft/vscode-mssql/issues/17698