### PR TITLE
Ignore trailing blank lines when folding regions

### DIFF
--- a/syntaxes/sql.configuration.json
+++ b/syntaxes/sql.configuration.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "vscode://schemas/language-configuration",
     "comments": {
         "lineComment": "--",
         "blockComment": [
@@ -58,6 +59,7 @@
         }
     ],
     "folding": {
+        "offSide": true,
         "markers": {
             "start": "^\\s*--\\s*#region\\s*.*$",
             "end": "^\\s*--\\s*#endregion\\s*.*$"


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/23167

`A language adheres to the off-side rule if blocks in that language are expressed by their indentation. If set, empty lines belong to the subsequent block.`

While T-SQL isn't defined by indentation, having empty lines belong to the subsequent blocks makes sense to me.

I also added the schema definition to this file so we get auto-complete (VS Code defines it by default for files named `language-configuration.json` only)

![SqlFoldingIndent](https://github.com/microsoft/vscode-mssql/assets/28519865/61b1da2d-44ce-47ea-b418-0690e411927c)
