### PR TITLE
Add surroundingPairs section to language configuration

### DIFF
--- a/syntaxes/sql.configuration.json
+++ b/syntaxes/sql.configuration.json
@@ -1,68 +1,90 @@
 {
-    "$schema": "vscode://schemas/language-configuration",
-    "comments": {
-        "lineComment": "--",
-        "blockComment": [
-            "/*",
-            "*/"
-        ]
+  "$schema": "vscode://schemas/language-configuration",
+  "comments": {
+    "lineComment": "--",
+    "blockComment": [
+      "/*",
+      "*/"
+    ]
+  },
+  "brackets": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ]
+  ],
+  "autoClosingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [
+        "string"
+      ]
     },
-    "brackets": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ]
-    ],
-    "autoClosingPairs": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ],
-        {
-            "open": "\"",
-            "close": "\"",
-            "notIn": [
-                "string"
-            ]
-        },
-        {
-            "open": "N'",
-            "close": "'",
-            "notIn": [
-                "string",
-                "comment"
-            ]
-        },
-        {
-            "open": "'",
-            "close": "'",
-            "notIn": [
-                "string",
-                "comment"
-            ]
-        }
-    ],
-    "folding": {
-        "offSide": true,
-        "markers": {
-            "start": "^\\s*--\\s*#region\\s*.*$",
-            "end": "^\\s*--\\s*#endregion\\s*.*$"
-        }
+    {
+      "open": "N'",
+      "close": "'",
+      "notIn": [
+        "string",
+        "comment"
+      ]
+    },
+    {
+      "open": "'",
+      "close": "'",
+      "notIn": [
+        "string",
+        "comment"
+      ]
     }
+  ],
+  "surroundingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    [
+      "\"",
+      "\""
+    ],
+    [
+      "'",
+      "'"
+    ]
+  ],
+  "folding": {
+    "offSide": true,
+    "markers": {
+      "start": "^\\s*--\\s*#region\\s*.*$",
+      "end": "^\\s*--\\s*#endregion\\s*.*$"
+    }
+  }
 }


### PR DESCRIPTION
This was added a long time back in VS Code (and thus inherited by ADS) but never added here. https://github.com/microsoft/vscode/commit/630be960713700a7627a174d84f2ada74ca04d7b

More general info : https://code.visualstudio.com/api/language-extensions/language-configuration-guide#autosurrounding

It doesn't seem to actually make a difference which is interesting (even with the MSSQL extension installed & activated it still auto-surrounds the characters specified here). But that might be because VS Code comes with its own configuration built-in. 

Regardless, this seems reasonable to have - so in order to keep everything in sync adding that section here.

(also formatted the file while I was at it)