### PR TITLE
Fix nested comment colorization

### DIFF
--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -675,20 +675,32 @@
 					</array>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>/\*</string>
-					<key>captures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.comment.sql</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\*/</string>
+					<key>include</key>
+					<string>#comment-block</string>
+				</dict>
+			</array>
+		</dict>
+		<key>comment-block</key>
+		<dict>
+			<key>begin</key>
+			<string>/\*</string>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
 					<key>name</key>
-					<string>comment.block.c</string>
+					<string>punctuation.definition.comment.sql</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment-block</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1014 and https://github.com/microsoft/azuredatastudio/issues/19205 (will close ADS one when I port it over there)

Fix here is to take what was suggested in https://github.com/microsoft/vscode-mssql/issues/1014#issuecomment-1172876040 -split out comment blocks into their own section and add themselves as possible children. Thank you @RedCmd for the fix suggestion!

I renamed the section to just comment-block, I don't see why the .c was added in the first place and it seems to work just fine without it. 

Before:
![image](https://github.com/microsoft/vscode-mssql/assets/28519865/9812f304-b1c8-46f1-8f74-25df61631122)

After:
![image](https://github.com/microsoft/vscode-mssql/assets/28519865/e4fba76b-b198-47fe-a029-e858bebaf662)
