### PR TITLE
Add support for system db package references

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.8.0.15",
+    "version": "4.8.0.18",
     "downloadFileNames": {
       "Windows_86": "win-x86-net7.0.zip",
       "Windows_64": "win-x64-net7.0.zip",

--- a/src/services/sqlProjectsService.ts
+++ b/src/services/sqlProjectsService.ts
@@ -74,6 +74,7 @@ export class SqlProjectsService implements mssql.ISqlProjectsService {
 	 * @param projectUri Absolute path of the project, including .sqlproj
 	 * @param systemDatabase Type of system database
 	 * @param suppressMissingDependencies Whether to suppress missing dependencies
+	 * @param referencetype Type of reference - ArtifactReference or PackageReference
 	 * @param databaseLiteral Literal name used to reference another database in the same server, if not using SQLCMD variables
 	 */
 	public async addSystemDatabaseReference(

--- a/src/services/sqlProjectsService.ts
+++ b/src/services/sqlProjectsService.ts
@@ -80,11 +80,13 @@ export class SqlProjectsService implements mssql.ISqlProjectsService {
 		projectUri: string,
 		systemDatabase: mssql.SystemDatabase,
 		suppressMissingDependencies: boolean,
+		systemDbReferenceType: mssql.SystemDbReferenceType,
 		databaseLiteral?: string): Promise<mssql.ResultStatus> {
 		const params: mssql.AddSystemDatabaseReferenceParams = {
 			projectUri: projectUri,
 			systemDatabase: systemDatabase,
 			suppressMissingDependencies: suppressMissingDependencies,
+			referenceType: systemDbReferenceType,
 			databaseLiteral: databaseLiteral
 		};
 		return this._client.sendRequest(contracts.AddSystemDatabaseReferenceRequest.type, params);

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -482,9 +482,10 @@ declare module 'vscode-mssql' {
 		 * @param projectUri Absolute path of the project, including .sqlproj
 		 * @param systemDatabase Type of system database
 		 * @param suppressMissingDependencies Whether to suppress missing dependencies
+		 * @param referenceType Type of reference - ArtifactReference or PackageReference
 		 * @param databaseLiteral Literal name used to reference another database in the same server, if not using SQLCMD variables
 		 */
-		addSystemDatabaseReference(projectUri: string, systemDatabase: SystemDatabase, suppressMissingDependencies: boolean, databaseLiteral?: string): Promise<ResultStatus>;
+		addSystemDatabaseReference(projectUri: string, systemDatabase: SystemDatabase, suppressMissingDependencies: boolean, referenceType: SystemDbReferenceType, databaseLiteral?: string): Promise<ResultStatus>;
 
 		/**
 		 * Add a nuget package database reference to a project
@@ -1209,6 +1210,11 @@ declare module 'vscode-mssql' {
 		 * Type of system database
 		 */
 		systemDatabase: SystemDatabase;
+
+		/**
+	 * Type of reference - ArtifactReference or PackageReference
+	 */
+		referenceType: SystemDbReferenceType;
 	}
 
 	export interface AddNugetPackageReferenceParams extends AddUserDatabaseReferenceParams {
@@ -1411,6 +1417,11 @@ declare module 'vscode-mssql' {
 	export const enum SystemDatabase {
 		Master = 0,
 		MSDB = 1
+	}
+
+	export const enum SystemDbReferenceType {
+		ArtifactReference = 0,
+		PackageReference = 1
 	}
 
 	export interface DatabaseReference {


### PR DESCRIPTION
These changes expose the option for adding system db references as package references for SDK-style projects in vscode for the sql-database-projects-vscode extension to use.