### PR TITLE
Add ADAL deprecation message upon startup

### DIFF
--- a/localization/xliff/enu/constants/localizedConstants.enu.xlf
+++ b/localization/xliff/enu/constants/localizedConstants.enu.xlf
@@ -653,8 +653,14 @@
         <trans-unit id="reloadChoice">
             <source xml:lang="en">Reload Visual Studio Code</source>
         </trans-unit>
-         <trans-unit id="deprecatedMessage">
-            <source xml:lang="en">Warning: ADAL has been deprecated, and is scheduled to be removed in a future release. Please use MSAL instead.</source>
+        <trans-unit id="deprecatedMessage">
+            <source xml:lang="en">Warning: ADAL has been deprecated, and is scheduled to be removed in the next release. Please use MSAL instead.</source>
+        </trans-unit>
+        <trans-unit id="switchToMsal">
+            <source xml:lang="en">Switch to MSAL</source>
+        </trans-unit>
+        <trans-unit id="dismiss">
+            <source xml:lang="en">Dismiss</source>
         </trans-unit>
     </body>
   </file>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 
 	// Exposed for testing purposes
 	vscode.commands.registerCommand('mssql.getControllerForTests', () => controller);
+	if (config.get('azureAuthenticationLibrary') === 'ADAL') {
+		vscode.window.showWarningMessage(LocalizedConstants.deprecatedMessage, LocalizedConstants.switchToMsal, LocalizedConstants.dismiss).then(async (value) => {
+			if (value === LocalizedConstants.switchToMsal) {
+				await config.update('azureAuthenticationLibrary', 'MSAL', vscode.ConfigurationTarget.Global);
+			}
+		});
+	}
 	await controller.activate();
 	return {
 		sqlToolsServicePath: SqlToolsServerClient.instance.sqlToolsServicePath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import SqlToolsServerClient from './languageservice/serviceclient';
 import { ConnectionProfile } from './models/connectionProfile';
 import { FirewallRuleError } from './languageservice/interfaces';
 import { RequestType } from 'vscode-languageclient';
+import { AuthLibrary } from './models/contracts/azure';
 
 let controller: MainController = undefined;
 
@@ -37,7 +38,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	if (config.get('azureAuthenticationLibrary') === 'ADAL') {
 		vscode.window.showWarningMessage(LocalizedConstants.deprecatedMessage, LocalizedConstants.switchToMsal, LocalizedConstants.dismiss).then(async (value) => {
 			if (value === LocalizedConstants.switchToMsal) {
-				await config.update('azureAuthenticationLibrary', 'MSAL', vscode.ConfigurationTarget.Global);
+				await config.update(Constants.azureAuthLibrary, AuthLibrary.MSAL, vscode.ConfigurationTarget.Global);
 			}
 		});
 	}


### PR DESCRIPTION
Added this warning message that will show every time a user starts vscode-mssql extension:

![Screenshot 2023-06-23 at 3 22 37 PM](https://github.com/microsoft/vscode-mssql/assets/18150417/d285a735-dba6-426f-ae33-a2fad72acf7a)
