### PR TITLE
Use case sensitive location name as used by Azure auth

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Collection of Non-localizable Constants
-export const vscodeAppName = 'code';
 export const languageId = 'sql';
 export const extensionName = 'mssql';
 export const extensionConfigSectionName = 'mssql';

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -28,6 +28,7 @@ import { exists } from '../utils/utils';
 import { env } from 'process';
 import { getAppDataPath, getAzureAuthLibraryConfig, getEnableConnectionPoolingConfig, getEnableSqlAuthenticationProviderConfig } from '../azure/utils';
 import { AuthLibrary } from '../models/contracts/azure';
+import { serviceName } from '../azure/constants';
 
 const STS_OVERRIDE_ENV_VAR = 'MSSQL_SQLTOOLSSERVICE';
 
@@ -405,7 +406,7 @@ export default class SqlToolsServiceClient {
 			}
 
 			// Send application name and path to determine MSAL cache location
-			serverArgs.push('--application-name', 'code');
+			serverArgs.push('--application-name', serviceName);
 			serverArgs.push('--data-path', getAppDataPath());
 
 			// Enable SQL Auth Provider registration for Azure MFA Authentication


### PR DESCRIPTION
Fix application name to build correct path for MSAL cache, as per documentation: https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations

Addresses issue #17744 

Verified on Debian 12

![image](https://github.com/microsoft/vscode-mssql/assets/13396919/8ea93b8e-1390-41c3-b544-1ac9f8647f8b)
