### PR TITLE
Add no-invalid-this linting

### DIFF
--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -19,7 +19,7 @@ function ensureExtensionIsActive(): Promise<any> {
 function waitForExtensionToBeActive(resolve): void {
 	if (typeof (vscode.extensions.getExtension('ms-mssql.mssql')) === 'undefined' ||
 		!vscode.extensions.getExtension('ms-mssql.mssql').isActive) {
-		// tslint:disable-next-line no-invalid-this
+		// tslint:disable-next-line no-invalid-this Bind to the mocha context so it resolves properly
 		setTimeout(waitForExtensionToBeActive.bind(this, resolve), 50);
 	} else {
 		resolve();

--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -19,7 +19,8 @@ function ensureExtensionIsActive(): Promise<any> {
 function waitForExtensionToBeActive(resolve): void {
 	if (typeof (vscode.extensions.getExtension('ms-mssql.mssql')) === 'undefined' ||
 		!vscode.extensions.getExtension('ms-mssql.mssql').isActive) {
-		setTimeout(() => waitForExtensionToBeActive(resolve), 50);
+		// tslint:disable-next-line no-invalid-this
+		setTimeout(waitForExtensionToBeActive.bind(this, resolve), 50);
 	} else {
 		resolve();
 	}

--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -19,7 +19,7 @@ function ensureExtensionIsActive(): Promise<any> {
 function waitForExtensionToBeActive(resolve): void {
 	if (typeof (vscode.extensions.getExtension('ms-mssql.mssql')) === 'undefined' ||
 		!vscode.extensions.getExtension('ms-mssql.mssql').isActive) {
-		setTimeout(waitForExtensionToBeActive.bind(this, resolve), 50);
+		setTimeout(() => waitForExtensionToBeActive(resolve), 50);
 	} else {
 		resolve();
 	}

--- a/test/serviceInstallerUtils.test.ts
+++ b/test/serviceInstallerUtils.test.ts
@@ -11,11 +11,13 @@ suite('Stub Status View tests', function (): void {
 	let stubStatusView: StubStatusView;
 	let logStub: sinon.SinonSpy;
 
+	// tslint:disable-next-line no-invalid-this Mocha injects the Suite as the this context
 	this.beforeAll(function (): void {
 		logStub = sinon.stub();
 		stubStatusView = new StubStatusView(logStub);
 	});
 
+	// tslint:disable-next-line no-invalid-this Mocha injects the Suite as the this context
 	this.afterAll(function (): void {
 		sinon.restore();
 	});
@@ -46,11 +48,13 @@ suite('Stub Logger tests', function (): void {
 	let stubLogger: StubLogger;
 	let logStub: sinon.SinonSpy;
 
+	// tslint:disable-next-line no-invalid-this Mocha injects the Suite as the this context
 	this.beforeEach(function (): void {
 		logStub = sinon.stub();
 		stubLogger = new StubLogger(logStub);
 	});
 
+	// tslint:disable-next-line no-invalid-this Mocha injects the Suite as the this context
 	this.afterEach(function (): void {
 		sinon.restore();
 	});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -50,8 +50,6 @@ function createWorkspaceConfiguration(items: { [key: string]: any }, workspaceIt
 			};
 		},
 		update(section: string, value: any, global?: boolean): Thenable<void> {
-			items[section] = value;
-
 			global = global === undefined ? true : global;
 			if (!global) {
 				if (workspaceItems === undefined) {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -50,6 +50,9 @@ function createWorkspaceConfiguration(items: { [key: string]: any }, workspaceIt
 			};
 		},
 		update(section: string, value: any, global?: boolean): Thenable<void> {
+			// tslint:disable-next-line no-invalid-this Test currently expects the object to contain the property values, so allowing this until further investigation can be done
+			this[section] = value;
+
 			global = global === undefined ? true : global;
 			if (!global) {
 				if (workspaceItems === undefined) {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -50,9 +50,6 @@ function createWorkspaceConfiguration(items: { [key: string]: any }, workspaceIt
 			};
 		},
 		update(section: string, value: any, global?: boolean): Thenable<void> {
-			// tslint:disable-next-line no-invalid-this Test currently expects the object to contain the property values, so allowing this until further investigation can be done
-			this[section] = value;
-
 			global = global === undefined ? true : global;
 			if (!global) {
 				if (workspaceItems === undefined) {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -50,7 +50,7 @@ function createWorkspaceConfiguration(items: { [key: string]: any }, workspaceIt
 			};
 		},
 		update(section: string, value: any, global?: boolean): Thenable<void> {
-			this[section] = value;
+			items[section] = value;
 
 			global = global === undefined ? true : global;
 			if (!global) {

--- a/tslint.json
+++ b/tslint.json
@@ -48,6 +48,7 @@
     "no-empty": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
+    "no-invalid-this": true,
     "no-null-keyword": true,
     "no-require-imports": true,
     "no-shadowed-variable": true,


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-mssql/pull/17757 - this will fail linting if an invalid call to this is made like was broken there. This will prevent such issues from happening again in the future.

@cssuh @cheenamalhotra I definitely recommend looking at tslint/eslint rules every time you come across a bug like this. There's a lot of really useful rules out there and while enabling every single one isn't super feasible, it's still good to at least check if one exists so we can verify other instances of the issue don't exist. (luckily in this case there weren't any such other issues outside of test code, although the fact that they weren't failing before might indicate some issues with what the tests are doing themselves, I didn't investigate that far since the tests are passing as is)

https://palantir.github.io/tslint/rules/no-invalid-this/