### PR TITLE
Remove unused task in build pipeline

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -121,11 +121,6 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish Artifact: drop"
 
-  - task: gulp@0
-    displayName: "gulp ext:install-service"
-    inputs:
-      targets: "ext:install-service"
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: "Component Detection"
     inputs:


### PR DESCRIPTION
This doesn't seem to be doing anything - it's ran after everything is already build + published (and it's already done as part of the build anyways). 