### PR TITLE
Change telemetry package name

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -11,7 +11,7 @@ import { TelemetryActions, TelemetryViews } from './telemetryInterfaces';
 const packageJson = vscode.extensions.getExtension(vscodeMssql.extension.name).packageJSON;
 
 let packageInfo = {
-	name: packageJson.name,
+	name: 'vscode-mssql', // Differentiate this from the mssql extension in ADS
 	version: packageJson.version,
 	aiKey: packageJson.aiKey
 };


### PR DESCRIPTION
The package name (mssql) conflicts with the mssql extension in ADS, so changing this directly to make it so we can differentiate events from each.