### PR TITLE
Add null check for account info

### DIFF
--- a/src/azure/msal/msalAzureAuth.ts
+++ b/src/azure/msal/msalAzureAuth.ts
@@ -103,7 +103,7 @@ export abstract class MsalAzureAuth {
 	 * @returns The authentication result, including the access token
 	 */
 	public async getToken(account: IAccount, tenantId: string, settings: IAADResource): Promise<AuthenticationResult | null> {
-		let accountInfo: AccountInfo | null
+		let accountInfo: AccountInfo | null;
 		try {
 			accountInfo = await this.getAccountFromMsalCache(account.key.id);
 		} catch (e) {
@@ -231,7 +231,7 @@ export abstract class MsalAzureAuth {
 			account = await cache.getAccountByLocalId(accountId);
 		}
 		if (!account) {
-			throw new Error('Error: Could not find account from MSAL Cache.')
+			throw new Error('Error: Could not find account from MSAL Cache.');
 		}
 		return account;
 	}


### PR DESCRIPTION
Before: If the account is not found in the account cache, there is no error handling and the process just fails.

After: If the account is not found in the account cache, we prompt the user to re-authenticate
<img width="261" alt="Screenshot 2023-09-11 at 2 22 31 PM" src="https://github.com/microsoft/vscode-mssql/assets/18150417/55fbd188-e6a3-4560-91ab-1ee66fc4b093">

Fixes #17798