### PR TITLE
Optimize getting account sessions

### DIFF
--- a/src/azure/azureController.ts
+++ b/src/azure/azureController.ts
@@ -121,7 +121,7 @@ export abstract class AzureController {
 	 * Returns Azure sessions with subscriptions, tenant and token for each given account
 	 */
 	public async getAccountSessions(account: IAccount): Promise<IAzureAccountSession[]> {
-		let sessions: IAzureAccountSession[] = [];
+		const sessions: IAzureAccountSession[] = [];
 		const tenants = <ITenant[]>account.properties.tenants;
 		for (const tenant of tenants) {
 			const tenantId = tenant.id;

--- a/src/azure/azureController.ts
+++ b/src/azure/azureController.ts
@@ -123,7 +123,8 @@ export abstract class AzureController {
 	public async getAccountSessions(account: IAccount): Promise<IAzureAccountSession[]> {
 		let sessions: IAzureAccountSession[] = [];
 		const tenants = <ITenant[]>account.properties.tenants;
-		for (const tenantId of tenants.map(t => t.id)) {
+		for (const tenant of tenants) {
+			const tenantId = tenant.id;
 			const token = await this.getAccountSecurityToken(account, tenantId, providerSettings.resources.azureManagementResource);
 			const subClient = this._subscriptionClientFactory(token!);
 			const newSubPages = await subClient.subscriptions.list();
@@ -135,7 +136,7 @@ export abstract class AzureController {
 					token: token
 				};
 			});
-			sessions = sessions.concat(array);
+			sessions.push(...array);
 		}
 
 		return sessions.sort((a, b) => (a.subscription.displayName || '').localeCompare(b.subscription.displayName || ''));


### PR DESCRIPTION
I did a little optimization to avoid needless `map` iteration and reuse `sessions` array(`push` instead of `concat`)