### PR TITLE
Simplify getting unix timestamp

### DIFF
--- a/src/azure/azureController.ts
+++ b/src/azure/azureController.ts
@@ -176,7 +176,7 @@ export abstract class AzureController {
 		if (!expiresOn) {
 			return true;
 		}
-		const currentTime = new Date().getTime() / 1000;
+		const currentTime = Date.now() / 1000;
 		const maxTolerance = 2 * 60; // two minutes
 		return (expiresOn - currentTime < maxTolerance);
 	}

--- a/src/azure/simpleWebServer.ts
+++ b/src/azure/simpleWebServer.ts
@@ -37,7 +37,7 @@ export class SimpleWebServer {
 	}
 
 	private bumpLastUsed(): void {
-		this.lastUsed = new Date().getTime();
+		this.lastUsed = Date.now();
 	}
 
 	public async shutdown(): Promise<void> {
@@ -99,7 +99,7 @@ export class SimpleWebServer {
 
 	private autoShutoff(): void {
 		this.shutoffInterval = setInterval(() => {
-			const time = new Date().getTime();
+			const time = Date.now();
 
 			if (time - this.lastUsed > this.autoShutoffTimer) {
 				console.log('Shutting off webserver...');

--- a/test/azureController.test.ts
+++ b/test/azureController.test.ts
@@ -8,7 +8,7 @@ import * as assert from 'assert';
 
 suite('Azure Controller Tests', () => {
 
-	const currentTime = new Date().getTime() / 1000;
+	const currentTime = Date.now() / 1000;
 
 	test('isTokenInValid should return true for undefined token', () => {
 		const actual = AzureController.isTokenInValid(undefined, currentTime);

--- a/test/istanbultestrunner.ts
+++ b/test/istanbultestrunner.ts
@@ -39,7 +39,7 @@ function mkDirIfExists(dir: string): void {
 
 class CoverageRunner {
 
-	private coverageVar: string = '$$cov_' + new Date().getTime() + '$$';
+	private coverageVar: string = '$$cov_' + Date.now() + '$$';
 	private transformer: any = undefined;
 	private matchFn: any = undefined;
 	private instrumenter: any = undefined;


### PR DESCRIPTION
To obtain a Unix timestamp, you can use a static method from `Date`. There is no need to create a `new Date` instance.