### PR TITLE
[release/1.22] Update STS version to 4.10.2.1

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.10.1.1",
+    "version": "4.10.2.1",
     "downloadFileNames": {
       "Windows_86": "win-x86-net7.0.zip",
       "Windows_64": "win-x64-net7.0.zip",


### PR DESCRIPTION
Updating STS to get MDS update. ADS was on 4.10.1.3, but the other fixes since 4.10.1.1 were for features not available in vscode-mssql

![image](https://github.com/microsoft/vscode-mssql/assets/31145923/b975d2fd-d8e4-4299-a740-4fb00a5d43e2)
