### PR TITLE
Update to sqltoolsservice 5.0.0.4 and remove specific Linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,7 @@ Currently this extension supports the following operating systems:
 
 * Windows (x64 | x86 | arm64)
 * macOS (x64 | arm64)
-* Ubuntu 14.04 / Linux Mint 17 / Linux Mint 18 / Elementary OS 0.3
-* Ubuntu 16.04 / Elementary OS 0.4
-* Debian 8.2
-* CentOS 7.1 / Oracle Linux 7
-* Red Hat Enterprise Linux (RHEL)
-* Fedora 23
-* OpenSUSE 13.2
-* Linux arm64
+* Linux (x64 | arm64)
 
 ## Offline Installation
 The extension will download and install a required SqlToolsService package during activation. For machines with no Internet access, you can still use the extension by choosing the

--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -16,6 +16,9 @@
       "RHEL_7": "rhel-x64-net7.0.tar.gz",
       "Ubuntu_14": "rhel-x64-net7.0.tar.gz",
       "Ubuntu_16": "rhel-x64-net7.0.tar.gz",
+      "Ubuntu_18": "rhel-x64-net7.0.tar.gz",
+      "Ubuntu_20": "rhel-x64-net7.0.tar.gz",
+      "Ubuntu_22": "rhel-x64-net7.0.tar.gz",
       "Linux_ARM64": "linux-arm64-net7.0.tar.gz"
     },
     "installDir": "../sqltoolsservice/{#version#}/{#platform#}",

--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,53 +1,21 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "4.11.0.2",
+    "version": "5.0.0.4",
     "downloadFileNames": {
-      "Windows_86": "win-x86-net7.0.zip",
-      "Windows_64": "win-x64-net7.0.zip",
-      "Windows_ARM64": "win-arm64-net7.0.zip",
-      "OSX_10_11_64": "osx-x64-net7.0.tar.gz",
-      "OSX_ARM64": "osx-arm64-net7.0.tar.gz",
-      "CentOS_7": "rhel-x64-net7.0.tar.gz",
-      "Debian_8": "rhel-x64-net7.0.tar.gz",
-      "Fedora_23": "rhel-x64-net7.0.tar.gz",
-      "OpenSUSE_13_2": "rhel-x64-net7.0.tar.gz",
-      "SLES_12_2": "rhel-x64-net7.0.tar.gz",
-      "RHEL_7": "rhel-x64-net7.0.tar.gz",
-      "Ubuntu_14": "rhel-x64-net7.0.tar.gz",
-      "Ubuntu_16": "rhel-x64-net7.0.tar.gz",
-      "Ubuntu_18": "rhel-x64-net7.0.tar.gz",
-      "Ubuntu_20": "rhel-x64-net7.0.tar.gz",
-      "Ubuntu_22": "rhel-x64-net7.0.tar.gz",
-      "Linux_ARM64": "linux-arm64-net7.0.tar.gz"
+      "Windows_86": "win-x86-net8.0.zip",
+      "Windows_64": "win-x64-net8.0.zip",
+      "Windows_ARM64": "win-arm64-net8.0.zip",
+      "OSX_64": "osx-x64-net8.0.tar.gz",
+      "OSX_ARM64": "osx-arm64-net8.0.tar.gz",
+      "Linux_64": "linux-x64-net8.0.tar.gz",
+      "Linux_ARM64": "linux-arm64-net8.0.tar.gz"
     },
     "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
     "executableFiles": [
       "MicrosoftSqlToolsServiceLayer.exe",
       "MicrosoftSqlToolsServiceLayer",
       "MicrosoftSqlToolsServiceLayer.dll"
-    ]
-  },
-  "v1Service": {
-    "downloadUrl": "https://download.microsoft.com/download/3/A/E/3AE0DD0F-86A1-46CD-BFE2-E106E7CC8508/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "1.0.0",
-    "downloadFileNames": {
-      "Windows_86": "win-x86-netcoreapp1.0.zip",
-      "Windows_64": "win-x64-netcoreapp1.0.zip",
-      "OSX_10_11_64": "osx-x64-netcoreapp1.0.tar.gz",
-      "CentOS_7": "centos-x64-netcoreapp1.0.tar.gz",
-      "Debian_8": "debian-x64-netcoreapp1.0.tar.gz",
-      "Fedora_23": "fedora-x64-netcoreapp1.0.tar.gz",
-      "OpenSUSE_13_2": "opensuse-x64-netcoreapp1.0.tar.gz",
-      "RHEL_7": "rhel-x64-netcoreapp1.0.tar.gz",
-      "Ubuntu_14": "ubuntu14-x64-netcoreapp1.0.tar.gz",
-      "Ubuntu_16": "ubuntu16-x64-netcoreapp1.0.tar.gz"
-    },
-    "installDir": "../sqltoolsservice/{#version#}/{#platform#}",
-    "executableFiles": [
-      "Microsoft.SqlTools.ServiceLayer.exe",
-      "Microsoft.SqlTools.ServiceLayer",
-      "Microsoft.SqlTools.ServiceLayer.dll"
     ]
   }
 }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -475,7 +475,7 @@ export default class ConnectionManager {
 				if (action && action === LocalizedConstants.macOpenSslHelpButton) {
 					await vscode.env.openExternal(vscode.Uri.parse(Constants.integratedAuthHelpLink));
 				}
-			} else if (platformInfo.runtimeId === Runtime.OSX_10_11_64 &&
+			} else if (platformInfo.runtimeId === Runtime.OSX_64 &&
 				result.messages.indexOf('Unable to load DLL \'System.Security.Cryptography.Native\'') !== -1) {
 				const action = await this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.msgConnectionError2,
 					LocalizedConstants.macOpenSslErrorMessage), LocalizedConstants.macOpenSslHelpButton);

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -16,19 +16,9 @@ export enum Runtime {
 	Windows_86 = 'Windows_86',
 	Windows_64 = 'Windows_64',
 	Windows_ARM64 = 'Windows_ARM64',
-	OSX_10_11_64 = 'OSX_10_11_64',
+	OSX_64 = 'OSX_64',
 	OSX_ARM64 = 'OSX_ARM64',
-	CentOS_7 = 'CentOS_7',
-	Debian_8 = 'Debian_8',
-	Fedora_23 = 'Fedora_23',
-	OpenSUSE_13_2 = 'OpenSUSE_13_2',
-	SLES_12_2 = 'SLES_12_2',
-	RHEL_7 = 'RHEL_7',
-	Ubuntu_14 = 'Ubuntu_14',
-	Ubuntu_16 = 'Ubuntu_16',
-	Ubuntu_18 = 'Ubuntu_18',
-	Ubuntu_20 = 'Ubuntu_20',
-	Ubuntu_22 = 'Ubuntu_22',
+	Linux_64 = 'Linux_64',
 	Linux_ARM64 = 'Linux_ARM64'
 }
 
@@ -38,31 +28,10 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
 		case Runtime.Windows_86:
 		case Runtime.Windows_ARM64:
 			return 'Windows';
-		case Runtime.OSX_10_11_64:
+		case Runtime.OSX_64:
 		case Runtime.OSX_ARM64:
 			return 'OSX';
-		case Runtime.CentOS_7:
-			return 'CentOS';
-		case Runtime.Debian_8:
-			return 'Debian';
-		case Runtime.Fedora_23:
-			return 'Fedora';
-		case Runtime.OpenSUSE_13_2:
-			return 'OpenSUSE';
-		case Runtime.SLES_12_2:
-			return 'SLES';
-		case Runtime.RHEL_7:
-			return 'RHEL';
-		case Runtime.Ubuntu_14:
-			return 'Ubuntu14';
-		case Runtime.Ubuntu_16:
-			return 'Ubuntu16';
-		case Runtime.Ubuntu_18:
-			return 'Ubuntu18';
-		case Runtime.Ubuntu_20:
-			return 'Ubuntu20';
-		case Runtime.Ubuntu_22:
-			return 'Ubuntu22';
+		case Runtime.Linux_64:
 		case Runtime.Linux_ARM64:
 			return 'Linux';
 		default:
@@ -308,8 +277,7 @@ export class PlatformInformation {
 
 			case 'darwin':
 				switch (architecture) {
-					// Note: We return the El Capitan RID for Sierra
-					case 'x86_64': return Runtime.OSX_10_11_64;
+					case 'x86_64': return Runtime.OSX_64;
 					case 'arm64': return Runtime.OSX_ARM64;
 					default:
 				}
@@ -317,106 +285,18 @@ export class PlatformInformation {
 				throw new Error(`Unsupported macOS architecture: ${architecture}`);
 
 			case 'linux':
-				if (architecture === 'x86_64') {
-
-					// First try the distribution name
-					let runtimeId = PlatformInformation.getRuntimeIdHelper(distribution.name, distribution.version);
-
-					// If the distribution isn't one that we understand, but the 'ID_LIKE' field has something that we understand, use that
-					//
-					// NOTE: 'ID_LIKE' doesn't specify the version of the 'like' OS. So we will use the 'VERSION_ID' value. This will restrict
-					// how useful ID_LIKE will be since it requires the version numbers to match up, but it is the best we can do.
-					if (runtimeId === Runtime.UnknownRuntime && distribution.idLike && distribution.idLike.length > 0) {
-						for (let id of distribution.idLike) {
-							runtimeId = PlatformInformation.getRuntimeIdHelper(id, distribution.version);
-							if (runtimeId !== Runtime.UnknownRuntime) {
-								break;
-							}
-						}
-					}
-
-					if (runtimeId !== Runtime.UnknownRuntime) {
-						return runtimeId;
-					}
-				} else if (architecture === 'aarch64') {
-					return Runtime.Linux_ARM64;
+				switch (architecture) {
+					case 'x86_64': return Runtime.Linux_64;
+					case 'aarch64': return Runtime.Linux_ARM64;
+					default:
 				}
 
 				// If we got here, this is not a Linux distro or architecture that we currently support.
-				throw new Error(`Unsupported Linux distro: ${distribution.name}, ${distribution.version}, ${architecture}`);
+				throw new Error(`Unsupported Linux architecture: ${architecture}`);
 			default:
 				// If we got here, we've ended up with a platform we don't support  like 'freebsd' or 'sunos'.
 				// Chances are, VS Code doesn't support these platforms either.
 				throw Error('Unsupported platform ' + platform);
 		}
 	}
-
-	private static getRuntimeIdHelper(distributionName: string, distributionVersion: string): Runtime {
-		switch (distributionName) {
-			case 'arch':
-			case 'antergos':
-				// NOTE: currently Arch Linux seems to be compatible enough with Ubuntu 16 that this works,
-				// though in the future this may need to change as Arch follows a rolling release model.
-				return Runtime.Ubuntu_16;
-			case 'ubuntu':
-				if (distributionVersion.startsWith('14')) {
-					// This also works for Linux Mint
-					return Runtime.Ubuntu_14;
-				} else if (distributionVersion.startsWith('16')) {
-					return Runtime.Ubuntu_16;
-				} else if (distributionVersion.startsWith('18')) {
-					return Runtime.Ubuntu_18;
-				} else if (distributionVersion.startsWith('20')) {
-					return Runtime.Ubuntu_20;
-				} else if (distributionVersion.startsWith('22')) {
-					return Runtime.Ubuntu_22;
-				}
-				break;
-			case 'elementary':
-			case 'elementary OS':
-				if (distributionVersion.startsWith('0.3')) {
-					// Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04
-					return Runtime.Ubuntu_14;
-				} else if (distributionVersion.startsWith('0.4')) {
-					// Elementary OS 0.4 Loki is binary compatible with Ubuntu 16.04
-					return Runtime.Ubuntu_16;
-				}
-
-				break;
-			case 'linuxmint':
-				if (distributionVersion.startsWith('18') || distributionVersion.startsWith('19')) {
-					// Linux Mint 18 is binary compatible with Ubuntu 16.04
-					return Runtime.Ubuntu_16;
-				}
-
-				break;
-			case 'centos':
-			case 'ol':
-				// Oracle Linux is binary compatible with CentOS
-				return Runtime.CentOS_7;
-			case 'fedora':
-				return Runtime.Fedora_23;
-			case 'opensuse':
-				return Runtime.OpenSUSE_13_2;
-			case 'sles':
-				return Runtime.SLES_12_2;
-			case 'rhel':
-				return Runtime.RHEL_7;
-			case 'debian':
-			case 'deepin':
-				return Runtime.Debian_8;
-			case 'galliumos':
-				if (distributionVersion.startsWith('2.0')) {
-					return Runtime.Ubuntu_16;
-				}
-				break;
-			case 'neon':
-				return Runtime.Ubuntu_16
-			default:
-				return Runtime.Ubuntu_22;
-		}
-
-		return Runtime.Ubuntu_22;
-	}
 }
-

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -26,6 +26,9 @@ export enum Runtime {
 	RHEL_7 = 'RHEL_7',
 	Ubuntu_14 = 'Ubuntu_14',
 	Ubuntu_16 = 'Ubuntu_16',
+	Ubuntu_18 = 'Ubuntu_18',
+	Ubuntu_20 = 'Ubuntu_20',
+	Ubuntu_22 = 'Ubuntu_22',
 	Linux_ARM64 = 'Linux_ARM64'
 }
 
@@ -54,6 +57,12 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
 			return 'Ubuntu14';
 		case Runtime.Ubuntu_16:
 			return 'Ubuntu16';
+		case Runtime.Ubuntu_18:
+			return 'Ubuntu18';
+		case Runtime.Ubuntu_20:
+			return 'Ubuntu20';
+		case Runtime.Ubuntu_22:
+			return 'Ubuntu22';
 		case Runtime.Linux_ARM64:
 			return 'Linux';
 		default:
@@ -355,8 +364,13 @@ export class PlatformInformation {
 					return Runtime.Ubuntu_14;
 				} else if (distributionVersion.startsWith('16')) {
 					return Runtime.Ubuntu_16;
+				} else if (distributionVersion.startsWith('18')) {
+					return Runtime.Ubuntu_18;
+				} else if (distributionVersion.startsWith('20')) {
+					return Runtime.Ubuntu_20;
+				} else if (distributionVersion.startsWith('22')) {
+					return Runtime.Ubuntu_22;
 				}
-
 				break;
 			case 'elementary':
 			case 'elementary OS':
@@ -396,11 +410,13 @@ export class PlatformInformation {
 					return Runtime.Ubuntu_16;
 				}
 				break;
+			case 'neon':
+				return Runtime.Ubuntu_16
 			default:
-				return Runtime.Ubuntu_16;
+				return Runtime.Ubuntu_22;
 		}
 
-		return Runtime.Ubuntu_16;
+		return Runtime.Ubuntu_22;
 	}
 }
 

--- a/tasks/packagetasks.js
+++ b/tasks/packagetasks.js
@@ -69,6 +69,9 @@ gulp.task('package:offline', () => {
 	packages.push({ rid: 'rhel.7.2-x64', runtime: Runtime.RHEL_7 });
 	packages.push({ rid: 'ubuntu.14.04-x64', runtime: Runtime.Ubuntu_14 });
 	packages.push({ rid: 'ubuntu.16.04-x64', runtime: Runtime.Ubuntu_16 });
+	packages.push({ rid: 'ubuntu.18.04-x64', runtime: Runtime.Ubuntu_18 });
+	packages.push({ rid: 'ubuntu.20.04-x64', runtime: Runtime.Ubuntu_20 });
+	packages.push({ rid: 'ubuntu.22.04-x64', runtime: Runtime.Ubuntu_22 });
 	packages.push({ rid: 'linux-arm64', runtime: Runtime.Linux_ARM64 });
 	var promise = Promise.resolve();
 	cleanServiceInstallFolder().then(() => {

--- a/tasks/packagetasks.js
+++ b/tasks/packagetasks.js
@@ -60,18 +60,9 @@ gulp.task('package:offline', () => {
 	packages.push({ rid: 'win-x64', runtime: Runtime.Windows_64 });
 	packages.push({ rid: 'win-x86', runtime: Runtime.Windows_86 });
 	packages.push({ rid: 'win-arm64', runtime: Runtime.Windows_ARM64 });
-	packages.push({ rid: 'osx.10.11-x64', runtime: Runtime.OSX_10_11_64 });
+	packages.push({ rid: 'osx-x64', runtime: Runtime.OSX_64 });
 	packages.push({ rid: 'osx-arm64', runtime: Runtime.OSX_ARM64 });
-	packages.push({ rid: 'centos.7-x64', runtime: Runtime.CentOS_7 });
-	packages.push({ rid: 'debian.8-x64', runtime: Runtime.Debian_8 });
-	packages.push({ rid: 'fedora.23-x64', runtime: Runtime.Fedora_23 });
-	packages.push({ rid: 'opensuse.13.2-x64', runtime: Runtime.OpenSUSE_13_2 });
-	packages.push({ rid: 'rhel.7.2-x64', runtime: Runtime.RHEL_7 });
-	packages.push({ rid: 'ubuntu.14.04-x64', runtime: Runtime.Ubuntu_14 });
-	packages.push({ rid: 'ubuntu.16.04-x64', runtime: Runtime.Ubuntu_16 });
-	packages.push({ rid: 'ubuntu.18.04-x64', runtime: Runtime.Ubuntu_18 });
-	packages.push({ rid: 'ubuntu.20.04-x64', runtime: Runtime.Ubuntu_20 });
-	packages.push({ rid: 'ubuntu.22.04-x64', runtime: Runtime.Ubuntu_22 });
+	packages.push({ rid: 'linux-x64', runtime: Runtime.Linux_64 });
 	packages.push({ rid: 'linux-arm64', runtime: Runtime.Linux_ARM64 });
 	var promise = Promise.resolve();
 	cleanServiceInstallFolder().then(() => {

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -46,7 +46,7 @@ suite('ServiceDownloadProvider Tests', () => {
 		config.setup(x => x.getSqlToolsPackageVersion()).returns(() => expectedVersionFromConfig);
 		let downloadProvider = new ServiceDownloadProvider(config.object, undefined, testStatusView.object,
 			testHttpClient.object, testDecompressProvider.object);
-		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_10_11_64);
+		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_64);
 		assert.equal(expected, actual);
 	});
 
@@ -58,7 +58,7 @@ suite('ServiceDownloadProvider Tests', () => {
 		config.setup(x => x.getSqlToolsPackageVersion()).returns(() => expectedVersionFromConfig);
 		let downloadProvider = new ServiceDownloadProvider(config.object, undefined, testStatusView.object,
 			testHttpClient.object, testDecompressProvider.object);
-		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_10_11_64);
+		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_64);
 		assert.equal(expected, actual);
 	});
 
@@ -70,7 +70,7 @@ suite('ServiceDownloadProvider Tests', () => {
 		config.setup(x => x.getSqlToolsPackageVersion()).returns(() => expectedVersionFromConfig);
 		let downloadProvider = new ServiceDownloadProvider(config.object, undefined, testStatusView.object,
 			testHttpClient.object, testDecompressProvider.object);
-		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_10_11_64);
+		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_64);
 		assert.equal(expected, actual);
 	});
 
@@ -82,7 +82,7 @@ suite('ServiceDownloadProvider Tests', () => {
 		config.setup(x => x.getSqlToolsPackageVersion()).returns(() => expectedVersionFromConfig);
 		let downloadProvider = new ServiceDownloadProvider(config.object, undefined, testStatusView.object,
 			testHttpClient.object, testDecompressProvider.object);
-		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_10_11_64);
+		let actual = await downloadProvider.getOrMakeInstallDirectory(Runtime.OSX_64);
 		assert.equal(expected, actual);
 	});
 

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -81,7 +81,7 @@ suite('Platform Tests', () => {
 	test('Compute correct RID for MacOS Intel', () => {
 		const platformInfo = new PlatformInformation('darwin', 'x86_64');
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.OSX_10_11_64.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.OSX_64.toString());
 	});
 
 	test('Compute correct RID for MacOS ARM', () => {
@@ -99,31 +99,31 @@ suite('Platform Tests', () => {
 	test('Compute correct RID for Ubuntu 14.04', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_ubuntu_14_04());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_14.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 
 	test('Compute correct RID for Fedora 23', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_fedora_23());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Fedora_23.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 
 	test('Compute correct RID for Debian 8', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_debian_8());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Debian_8.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 
 	test('Compute correct RID for CentOS 7', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_centos_7());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.CentOS_7.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 
 	test('Compute correct RID for KDE neon', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_kde_neon_5_8());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_16.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 
 	test('Compute no RID for CentOS 7 with 32-bit architecture', () => {
@@ -132,10 +132,10 @@ suite('Platform Tests', () => {
 		expect(platformInfo.runtimeId).to.equal(undefined);
 	});
 
-	test('Compute default (Ubuntu_22) RID for fake distro with no ID_LIKE', () => {
+	test('Compute default RID for fake distro with no ID_LIKE', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_unknown_no_id_like());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_22.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Linux_64.toString());
 	});
 });
 

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -132,10 +132,10 @@ suite('Platform Tests', () => {
 		expect(platformInfo.runtimeId).to.equal(undefined);
 	});
 
-	test('Compute default (Ubuntu_16) RID for fake distro with no ID_LIKE', () => {
+	test('Compute default (Ubuntu_22) RID for fake distro with no ID_LIKE', () => {
 		const platformInfo = new PlatformInformation('linux', 'x86_64', distro_unknown_no_id_like());
 
-		expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_16.toString());
+		expect(platformInfo.runtimeId).to.equal(Runtime.Ubuntu_22.toString());
 	});
 });
 


### PR DESCRIPTION
Currently, the most recent Ubuntu version is 16. This PR adds those LTS versions up to the most recently released one (22).