### PR TITLE
Switch loc config to use feed instead of PAT

### DIFF
--- a/build/Localization.yml
+++ b/build/Localization.yml
@@ -23,8 +23,8 @@ jobs:
     inputs:
       locProj: 'localization/LocProject.json'
       outDir: '$(Build.ArtifactStagingDirectory)'
+      dependencyPackageSource: 'https://pkgs.dev.azure.com/msdata/_packaging/SQLDS_SSMS/nuget/v3/index.json'
       packageSourceAuth: patAuth
-      patVariable: '$(OneLocBuildPat)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
This PR updates the localization task config to use the feed instead of the loc PAT.