### PR TITLE
Fix changing timestamp issue when switching query result tabs

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -307,7 +307,6 @@ export default class QueryRunner {
 			const batchSet = this.batchSets[batchId];
 			this.eventEmitter.emit('batchStart', batchSet);
 			let executionTime = <number>(Utils.parseTimeString(batchSet.executionElapsed) || 0);
-			this._totalElapsedMilliseconds += executionTime;
 			if (executionTime > 0) {
 				// send a time message in the format used for query complete
 				this.sendBatchTimeMessage(batchSet.id, Utils.parseNumAsTimeString(executionTime));

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -219,13 +219,18 @@ export class SqlOutputContentProvider {
 				this._panels.get(uri).proxy.sendEvent('resultSet', resultSet);
 			});
 			queryRunner.eventEmitter.on('batchStart', (batch) => {
+				let time = new Date().toLocaleTimeString();
+				if (batch.executionElapsed && batch.executionEnd) {
+					time = new Date(batch.executionStart).toLocaleTimeString();
+				}
+
 				// Build a message for the selection and send the message
 				// from the webview
 				let message = {
 					message: LocalizedConstants.runQueryBatchStartMessage,
 					selection: batch.selection,
 					isError: false,
-					time: new Date().toLocaleTimeString(),
+					time: time,
 					link: {
 						text: Utils.formatString(LocalizedConstants.runQueryBatchStartLine, batch.selection.startLine + 1)
 					}


### PR DESCRIPTION
This PR fixes #17916

The PR stops the timestamp and total elapsed time measurements from changing when the query results tab is changed to another.