### PR TITLE
Updating Color contrast of success queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,3 @@ This extension is [licensed under the MIT License]. Please see the [third-party 
 [opencode@microsoft.com]:mailto:opencode@microsoft.com
 [#669]:https://github.com/Microsoft/vscode-mssql/issues/669
 
-this is a test to see if I have access to this repo

--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ This extension is [licensed under the MIT License]. Please see the [third-party 
 [opencode@microsoft.com]:mailto:opencode@microsoft.com
 [#669]:https://github.com/Microsoft/vscode-mssql/issues/669
 
+this is a test to see if I have access to this repo

--- a/src/queryHistory/icons/status_success.svg
+++ b/src/queryHistory/icons/status_success.svg
@@ -1,1 +1,1 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#3bb44a;}</style></defs><title>success_16x16</title><path class="cls-1" d="M16,3.16,5.48,13.69,0,8.2l.89-.89,4.6,4.59,9.63-9.62Z"/></svg>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#2ca03b;}</style></defs><title>success_16x16</title><path class="cls-1" d="M16,3.16,5.48,13.69,0,8.2l.89-.89,4.6,4.59,9.63-9.62Z"/></svg>


### PR DESCRIPTION
Color contrast between tick and background is less under 'Query History' section, so I updated it to be correct

bug: https://github.com/microsoft/vscode-mssql/issues/17878