### PR TITLE
Rename preview to experimental and hide settings flag

### DIFF
--- a/localization/xliff/enu/localizedPackage.json.enu.xlf
+++ b/localization/xliff/enu/localizedPackage.json.enu.xlf
@@ -425,9 +425,6 @@
         <trans-unit id="mssql.objectExplorer.expandTimeout">
             <source xml:lang="en">The timeout in seconds for expanding a node in Object Explorer. The default value is 45 seconds.</source>
         </trans-unit>
-        <trans-unit id="mssql.enablePreviewFeaturesDescription">
-            <source xml:lang="en">Enable preview features in the extension. Requires a restart of VS Code to take effect.</source>
-        </trans-unit>
         <trans-unit id="mssql.newTable">
             <source xml:lang="en">New Table</source>
         </trans-unit>

--- a/package.json
+++ b/package.json
@@ -349,12 +349,12 @@
         },
         {
           "command": "mssql.newTable",
-          "when": "view == objectExplorer && viewItem == TablesFolder && config.mssql.enablePreviewFeatures",
+          "when": "view == objectExplorer && viewItem == TablesFolder && config.mssql.enableExperimentalFeatures",
           "group": "inline"
         },
         {
           "command": "mssql.editTable",
-          "when": "view == objectExplorer && viewItem == Table && config.mssql.enablePreviewFeatures",
+          "when": "view == objectExplorer && viewItem == Table && config.mssql.enableExperimentalFeatures",
           "group": "inline"
         }
       ],
@@ -673,11 +673,6 @@
       "type": "object",
       "title": "%mssql.Configuration%",
       "properties": {
-        "mssql.enablePreviewFeatures": {
-          "type": "boolean",
-          "default": false,
-          "description": "%mssql.enablePreviewFeaturesDescription%"
-        },
         "mssql.azureActiveDirectory": {
           "type": "string",
           "default": "AuthCodeGrant",

--- a/package.nls.json
+++ b/package.nls.json
@@ -140,7 +140,6 @@
 "mssql.objectExplorer.enableGroupBySchema":"Enable Group By Schema",
 "mssql.objectExplorer.disableGroupBySchema":"Disable Group By Schema",
 "mssql.objectExplorer.expandTimeout":"The timeout in seconds for expanding a node in Object Explorer. The default value is 45 seconds.",
-"mssql.enablePreviewFeaturesDescription":"Enable preview features in the extension. Requires a restart of VS Code to take effect.",
 "mssql.newTable":"New Table",
 "mssql.editTable":"Edit Table"
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -155,7 +155,7 @@ export const configPersistQueryResultTabs = 'persistQueryResultTabs';
 export const configQueryHistoryLimit = 'queryHistoryLimit';
 export const configEnableQueryHistoryCapture = 'enableQueryHistoryCapture';
 export const configEnableQueryHistoryFeature = 'enableQueryHistoryFeature';
-export const configEnablePreviewFeatures = 'enablePreviewFeatures';
+export const configEnableExperimentalFeatures = 'enableExperimentalFeatures';
 
 // ToolsService Constants
 export const serviceInstallingTo = 'Installing SQL tools service to';

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -125,7 +125,7 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	public get isPreviewEnabled(): boolean {
-		return this.configuration.get(Constants.configEnablePreviewFeatures);
+		return this.configuration.get(Constants.configEnableExperimentalFeatures);
 	}
 
 	/**


### PR DESCRIPTION
Hiding the flag so people cannot enable it from the settings UI.

To enable experimental features this flag needs to be added to `settings.json`
```js
"mssql.enableExperimentalFeatures": true
```