### PR TITLE
Start gulp watch before launching the extension for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "quick-build",
+			"preLaunchTask": "watch",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
@@ -55,7 +55,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "quick-build",
+			"preLaunchTask": "watch",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
+			"preLaunchTask": "build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
@@ -54,6 +55,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
+			"preLaunchTask": "build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,6 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
@@ -55,7 +54,6 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "build",
+			"preLaunchTask": "quick-build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
@@ -55,7 +55,7 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "build",
+			"preLaunchTask": "quick-build",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,26 +7,5 @@
         "--no-color"
     ],
     "tasks": [
-        {
-            "label": "build",
-            "type": "gulp",
-            "task": "build",
-            "problemMatcher": [
-                "$lessCompile",
-                "$tsc",
-                "$jshint"
-            ],
-            "group": {
-                "_id": "build",
-                "isDefault": false
-            }
-        },
-        {
-            "type": "npm",
-            "script": "lint",
-            "problemMatcher": [],
-            "label": "npm: lint",
-            "detail": "eslint ."
-        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,5 +7,26 @@
         "--no-color"
     ],
     "tasks": [
+        {
+            "label": "build",
+            "type": "gulp",
+            "task": "build",
+            "problemMatcher": [
+                "$lessCompile",
+                "$tsc",
+                "$jshint"
+            ],
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "npm",
+            "script": "lint",
+            "problemMatcher": [],
+            "label": "npm: lint",
+            "detail": "eslint ."
+        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,12 +32,7 @@
                 "$jshint",
                 {
                     "owner": "custom",
-                    "pattern": {
-                        "regexp": ".",
-                        "file": 1,
-                        "location": 2,
-                        "message": 3
-                    },
+                    "base": "$tsc",
                     "background": {
                         "activeOnStart": true,
                         "beginsPattern": "Starting 'watch'...",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,20 @@
             }
         },
         {
+            "label": "quick-build",
+            "type": "gulp",
+            "task": "quick-build",
+            "problemMatcher": [
+                "$lessCompile",
+                "$tsc",
+                "$jshint"
+            ],
+            "group": {
+                "_id": "quick-build",
+                "isDefault": false
+            }
+        },
+        {
             "type": "npm",
             "script": "lint",
             "problemMatcher": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,16 +22,31 @@
             }
         },
         {
-            "label": "quick-build",
+            "label": "watch",
             "type": "gulp",
-            "task": "quick-build",
+            "task": "watch",
+            "isBackground": true,
             "problemMatcher": [
                 "$lessCompile",
                 "$tsc",
-                "$jshint"
+                "$jshint",
+                {
+                    "owner": "custom",
+                    "pattern": {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    },
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": "Starting 'watch'...",
+                        "endsPattern": "Starting 'watch-reactviews'...",
+                    }
+                }
             ],
             "group": {
-                "_id": "quick-build",
+                "_id": "watch",
                 "isDefault": false
             }
         },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,7 +434,7 @@ gulp.task('build', gulp.series('clean', 'ext:build', 'ext:install-service'));
 
 gulp.task('quick-build', function(done) {
 	if (!require('fs').existsSync('out')) {
-		return run('gulp build')();
+		run('gulp build')();
 	}
 
 	done();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -432,14 +432,6 @@ gulp.task('clean', function (done) {
 
 gulp.task('build', gulp.series('clean', 'ext:build', 'ext:install-service'));
 
-gulp.task('quick-build', function(done) {
-	if (!require('fs').existsSync('out')) {
-		run('gulp build')();
-	}
-
-	done();
-});
-
 gulp.task('watch-src', function () {
 	return gulp.watch('./src/**/*.ts', gulp.series('ext:compile-src'))
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -432,6 +432,14 @@ gulp.task('clean', function (done) {
 
 gulp.task('build', gulp.series('clean', 'ext:build', 'ext:install-service'));
 
+gulp.task('quick-build', function(done) {
+	if (!require('fs').existsSync('out')) {
+		return run('gulp build')();
+	}
+
+	done();
+});
+
 gulp.task('watch-src', function () {
 	return gulp.watch('./src/**/*.ts', gulp.series('ext:compile-src'))
 });


### PR DESCRIPTION
This PR starts gulp watch before the MSSQL extension is launched. This allows refreshes to load the latest changes without needing to do a complete build like it does currently.

![watch_and_launch_extension](https://github.com/user-attachments/assets/893f0370-c823-4207-abfd-90b1b3789e62)
