### PR TITLE
Fixing add connection when OE is empty in experimental

### DIFF
--- a/package.json
+++ b/package.json
@@ -390,6 +390,10 @@
           "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
         },
         {
+          "command": "mssql.editConnection",
+          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
+        },
+        {
           "command": "mssql.refreshObjectExplorerNode",
           "when": "view == objectExplorer && viewItem != disconnectedServer"
         },

--- a/package.json
+++ b/package.json
@@ -268,13 +268,7 @@
       "view/title": [
         {
           "command": "mssql.addObjectExplorer",
-          "when": "view == objectExplorer && !config.mssql.enableExperimentalFeatures",
-          "title": "%mssql.addObjectExplorer%",
-          "group": "navigation"
-        },
-        {
-          "command": "mssql.addObjectExplorer2",
-          "when": "view == objectExplorer && config.mssql.enableExperimentalFeatures",
+          "when": "view == objectExplorer",
           "title": "%mssql.addObjectExplorer%",
           "group": "navigation"
         },
@@ -393,10 +387,6 @@
         },
         {
           "command": "mssql.removeObjectExplorerNode",
-          "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
-        },
-        {
-          "command": "mssql.editConnection",
           "when": "view == objectExplorer && viewItem =~ /^(disconnectedServer|Server)$/"
         },
         {
@@ -541,12 +531,6 @@
       },
       {
         "command": "mssql.addObjectExplorer",
-        "title": "%mssql.addObjectExplorer%",
-        "category": "MS SQL",
-        "icon": "$(add)"
-      },
-      {
-        "command": "mssql.addObjectExplorer2",
         "title": "%mssql.addObjectExplorer%",
         "category": "MS SQL",
         "icon": "$(add)"

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -434,16 +434,24 @@ export default class MainController implements vscode.Disposable {
 		}));
 
 		// Old style Add connection when experimental features are not enabled
-		if (!this.isExperimentalEnabled) {
-			// Add Object Explorer Node
-			this.registerCommand(Constants.cmdAddObjectExplorer);
-			this._event.on(Constants.cmdAddObjectExplorer, async () => {
+
+		// Add Object Explorer Node
+		this.registerCommand(Constants.cmdAddObjectExplorer);
+		this._event.on(Constants.cmdAddObjectExplorer, async () => {
+			if (!this.isExperimentalEnabled) {
 				if (!self._objectExplorerProvider.objectExplorerExists) {
 					self._objectExplorerProvider.objectExplorerExists = true;
 				}
 				await self.createObjectExplorerSession();
-			});
-		}
+			} else {
+				const connDialog = new ConnectionDialogWebViewController(
+					this._context,
+					this,
+					this._objectExplorerProvider
+				);
+				connDialog.revealToForeground();
+			}
+		});
 
 
 		// Object Explorer New Query
@@ -509,16 +517,6 @@ export default class MainController implements vscode.Disposable {
 				}));
 
 		if (this.isExperimentalEnabled) {
-			this.registerCommand(Constants.cmdAddObjectExplorer2);
-			this._event.on(Constants.cmdAddObjectExplorer2, async () => {
-				const connDialog = new ConnectionDialogWebViewController(
-					this._context,
-					this,
-					this._objectExplorerProvider
-				);
-				connDialog.revealToForeground();
-			});
-
 			this._context.subscriptions.push(
 				vscode.commands.registerCommand(
 					Constants.cmdEditConnection, async (node: TreeNodeInfo) => {


### PR DESCRIPTION
This fixes #17962 

This merges the new and old command into one so we don't have to worry about it being referenced throughout the code. 