### PR TITLE
Using one bundle file for all webviews

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -219,8 +219,7 @@ async function generateReactWebviewsBundle() {
 		 * for each entry point, to be used by the webview's HTML content.
 		 */
 		entryPoints: {
-			tableDesigner: 'src/reactviews/pages/TableDesigner/index.tsx',
-			connectionDialog: 'src/reactviews/pages/ConnectionDialog/index.tsx',
+			mssqlwebview: 'src/reactviews/index.tsx'
 		},
 		bundle: true,
 		outdir: 'out/src/reactviews/assets',

--- a/src/connectionconfig/connectionDialogWebViewController.ts
+++ b/src/connectionconfig/connectionDialogWebViewController.ts
@@ -11,6 +11,7 @@ import MainController from '../controllers/mainController';
 import { getConnectionDisplayName } from '../models/connectionInfo';
 import { AzureController } from '../azure/azureController';
 import { ObjectExplorerProvider } from '../objectExplorer/objectExplorerProvider';
+import { WebviewRoute } from '../sharedInterfaces/webviewRoutes';
 
 export class ConnectionDialogWebViewController extends ReactWebViewPanelController<ConnectionDialogWebviewState, ConnectionDialogReducers> {
 	private _connectionToEditCopy: IConnectionDialogProfile | undefined;
@@ -23,8 +24,7 @@ export class ConnectionDialogWebViewController extends ReactWebViewPanelControll
 		super(
 			context,
 			'Connection Dialog',
-			'connectionDialog.js',
-			'connectionDialog.css',
+			WebviewRoute.connectionDialog,
 			{
 				recentConnections: [],
 				selectedFormTab: FormTabs.Parameters,

--- a/src/controllers/reactWebviewController.ts
+++ b/src/controllers/reactWebviewController.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { WebviewRoute } from '../sharedInterfaces/webviewRoutes';
 
 /**
  * ReactWebViewPanelController is a class that manages a vscode.WebviewPanel and provides
@@ -33,8 +34,7 @@ export class ReactWebViewPanelController<State, Reducers> implements vscode.Disp
 	constructor(
 		protected _context: vscode.ExtensionContext,
 		title: string,
-		private _srcFile: string,
-		private _styleFile: string,
+		private _route: WebviewRoute,
 		initialData: State,
 		viewColumn: vscode.ViewColumn = vscode.ViewColumn.One,
 		private _iconPath?: vscode.Uri | {
@@ -75,8 +75,8 @@ export class ReactWebViewPanelController<State, Reducers> implements vscode.Disp
 
 	private _getHtmlTemplate() {
 		const nonce = getNonce();
-		const scriptUri = this.resourceUrl([this._srcFile]);
-		const styleUri = this.resourceUrl([this._styleFile]);
+		const scriptUri = this.resourceUrl(['mssqlwebview.js']);
+		const styleUri = this.resourceUrl(['mssqlwebview.css']);
 		return `
 		<!DOCTYPE html>
 				<html lang="en">
@@ -124,6 +124,9 @@ export class ReactWebViewPanelController<State, Reducers> implements vscode.Disp
 		};
 		this._webViewRequestHandlers['getTheme'] = () => {
 			return vscode.window.activeColorTheme.kind;
+		};
+		this._webViewRequestHandlers['getRoute'] = () => {
+			return this._route;
 		};
 	}
 

--- a/src/reactviews/index.tsx
+++ b/src/reactviews/index.tsx
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import { useVscodeWebview, VscodeWebViewProvider } from './common/vscodeWebViewProvider'
+import { TableDesignerStateProvider } from './pages/TableDesigner/tableDesignerStateProvider';
+import { TableDesigner } from './pages/TableDesigner/tableDesignerPage';
+import { WebviewRoute } from '../sharedInterfaces/webviewRoutes';
+import { ConnectionDialogStateProvider } from './pages/ConnectionDialog/connectionDialogStateProvider';
+import { ConnectionPage } from './pages/ConnectionDialog/connectionPage';
+
+const Router = () => {
+	const vscodeWebviewState = useVscodeWebview<unknown, unknown>();
+	if (!vscodeWebviewState) {
+		return null;
+	}
+	const routes = vscodeWebviewState.route;
+
+	switch (routes) {
+		case WebviewRoute.tableDesigner:
+			return (
+				<TableDesignerStateProvider>
+					<TableDesigner />
+				</TableDesignerStateProvider>
+			);
+		case WebviewRoute.connectionDialog:
+			return (
+				<ConnectionDialogStateProvider>
+					<ConnectionPage />
+				</ConnectionDialogStateProvider>
+			);
+		default: (
+			<div>Route not found</div>
+		);
+	}
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+	<VscodeWebViewProvider>
+		<Router />
+	</VscodeWebViewProvider>
+)

--- a/src/sharedInterfaces/webviewRoutes.ts
+++ b/src/sharedInterfaces/webviewRoutes.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum WebviewRoute {
+	tableDesigner = 'tableDesigner',
+	connectionDialog = 'connectionDialog',
+}

--- a/src/tableDesigner/tableDesignerWebViewController.ts
+++ b/src/tableDesigner/tableDesignerWebViewController.ts
@@ -11,6 +11,7 @@ import * as designer from '../sharedInterfaces/tableDesigner';
 import UntitledSqlDocumentService from '../controllers/untitledSqlDocumentService';
 import { getDesignerView } from './tableDesignerTabDefinition';
 import { TreeNodeInfo } from '../objectExplorer/treeNodeInfo';
+import { WebviewRoute } from '../sharedInterfaces/webviewRoutes';
 
 export class TableDesignerWebViewController extends ReactWebViewPanelController<designer.TableDesignerWebViewState, designer.TableDesignerReducers> {
 	private _isEdit: boolean = false;
@@ -21,7 +22,7 @@ export class TableDesignerWebViewController extends ReactWebViewPanelController<
 		private _untitledSqlDocumentService: UntitledSqlDocumentService,
 		private _targetNode?: TreeNodeInfo
 	) {
-		super(context, 'Table Designer', 'tableDesigner.js', 'tableDesigner.css', {
+		super(context, 'Table Designer', WebviewRoute.tableDesigner, {
 			apiState: {
 				editState: designer.LoadState.NotStarted,
 				generateScriptState: designer.LoadState.NotStarted,


### PR DESCRIPTION
Previously we had one bundle file for each webview. This was not a good approach as each bundle file repeated a lot of libraries like react, fluent-react and fluent-react-icons. I am modifying the code to have only one bundle file which has all the web views. This prevents repetition 

Previous js files:

TableDesigner: 16.7MB
Connection Dialog: 13.1 MB

New combined file:
mssqlWebview: 17.1MB