### PR TITLE
 Fixing race condition in getting initial state for web views

### DIFF
--- a/src/reactviews/common/vscodeWebViewProvider.tsx
+++ b/src/reactviews/common/vscodeWebViewProvider.tsx
@@ -67,7 +67,13 @@ export function VscodeWebViewProvider<State, Reducers>({ children }: VscodeWebVi
 			}
 		}
 
+		async function getState() {
+			const state = await extensionRpc.call('getState');
+			setState(state as State);
+		}
+
 		getTheme();
+		getState();
 	});
 
 	extensionRpc.subscribe('onDidChangeTheme', (params) => {


### PR DESCRIPTION
This fixes #17969 and also initial loading screen not showing for table designer. 

I am making an explicit call to get the state for the webview after the component is initialized. Previously, the webview controller was trying to set the state for the webview. However, since the webview wasn't completely initialized, the handler in the webview wasn't registered and the webview didn't get the initial state. This fix prevents that from happening. 

Loading screen for designer:
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/b440eada-23ea-47a2-96f3-61f7b17f6568">
