### PR TITLE
Fixing size of webviews in prod vsix files

### DIFF
--- a/.github/workflows/daily-build-and-test.yml
+++ b/.github/workflows/daily-build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build extension
         run: |
-          yarn build
+          yarn build --prod
 
       - name: Run lint
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ package.nls.*.json
 /blob-report/
 /playwright/.cache/
 .env
+webviews-metafile.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,3 +23,4 @@ tsconfig.json
 tslint*.json
 **/*.map
 **/*.ts
+webviews-metafile.json

--- a/build/templates/build.yml
+++ b/build/templates/build.yml
@@ -33,6 +33,7 @@ steps:
     inputs:
       targets: build
       gulpFile: ${{ parameters.gulpfile }}
+      arguments: '--prod'
     env:
       BUILDMACHINE: true
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "lint": "gulp lint",
     "localization": "gulp ext:localization",
     "smoketest": "gulp ext:smoke",
-    "test": "gulp test:cover --log"
+    "test": "gulp test:cover --log",
+    "package": "vsce package"
   },
   "devDependencies": {
     "@angular/common": "~2.1.2",
@@ -67,7 +68,9 @@
     "@angular/upgrade": "~2.1.2",
     "@eslint/compat": "^1.1.0",
     "@eslint/js": "^9.5.0",
+    "@fluentui/react-components": "^9.54.3",
     "@jgoz/esbuild-plugin-typecheck": "^4.0.0",
+    "@monaco-editor/react": "^4.6.0",
     "@playwright/test": "^1.45.0",
     "@types/azdata": "^1.44.0",
     "@types/ejs": "^3.1.0",
@@ -120,6 +123,11 @@
     "istanbul": "^0.4.5",
     "npm-run-all": "^4.1.5",
     "pm-mocha-jenkins-reporter": "^0.2.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "react-resizable": "^3.0.5",
+    "react-router-dom": "^6.24.1",
     "remap-istanbul": "0.9.6",
     "rxjs": "5.0.0-beta.12",
     "sinon": "^14.0.0",
@@ -132,14 +140,7 @@
     "typescript-eslint": "^7.13.1",
     "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
     "vscode-nls-dev": "2.0.1",
-    "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-    "@fluentui/react-components": "^9.54.3",
-    "@monaco-editor/react": "^4.6.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-markdown": "^9.0.1",
-    "react-resizable": "^3.0.5",
-    "react-router-dom": "^6.24.1"
+    "yargs": "^17.7.2"
   },
   "dependencies": {
     "@azure/arm-resources": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,6 +2969,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -9091,6 +9100,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.matchall@^4.0.11:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz#1092a72c59268d2abaad76582dccc687c0297e0a"
@@ -10469,6 +10487,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs-parser@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.1.tgz#7ede329c1d8cdbbe209bd25cdb990e9b1ebbb394"
@@ -10499,6 +10522,19 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yargs@^3.32.0:
   version "3.32.0"
@@ -10531,18 +10567,6 @@ yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.1"
-
-"yargs@https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz":
-  version "3.32.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
The large size of the webviews was due to including source maps in the bundled JavaScript files. While source maps are useful for debugging, they significantly increase the bundle size. To address this, I've added a `prod` flag that skips the inclusion of source maps in the production version of the extension. This allows us to avoid shipping the bulky source maps. 

I am also creating a metafile in debugging envs so that we can analyze the bundle structure by uploading the metafile file to https://esbuild.github.io/analyze/ and getting the vis I have added below. 

Before: Current file: (16.9MB)
![image](https://github.com/user-attachments/assets/323d7e21-16bc-414e-902a-29d54531ec53)

After: Removing source maps: (1.1MB)
![image](https://github.com/user-attachments/assets/599c145e-5c83-411d-8204-43386ee811a8)

