### PR TITLE
Adding back source maps to debug web views

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,7 @@
 {
 	"version": "0.1.0",
 	"configurations": [
+
 		{
 			"type": "node",
 			"request": "launch",
@@ -32,7 +33,15 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "watch",
+			"rendererDebugOptions": {
+				"pauseForSourceMap": true,
+				"sourceMapRenames": true,
+				"sourceMaps": true,
+				"webRoot": "${workspaceRoot}/src/reactviews"
+			},
+			"sourceMapRenames": true,
+			"pauseForSourceMap": true,
+      		"debugWebviews": true,
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,12 +33,14 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
+			"preLaunchTask": "watch",
 			"rendererDebugOptions": {
 				"pauseForSourceMap": true,
 				"sourceMapRenames": true,
 				"sourceMaps": true,
 				"webRoot": "${workspaceRoot}/src/reactviews"
 			},
+			"debugWebWorkerHost": true,
 			"sourceMapRenames": true,
 			"pauseForSourceMap": true,
       		"debugWebviews": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,6 @@
 			"debugWebWorkerHost": true,
 			"sourceMapRenames": true,
 			"pauseForSourceMap": true,
-      		"debugWebviews": true,
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -236,7 +236,7 @@ async function generateReactWebviewsBundle() {
 			esbuildProblemMatcherPlugin('React App'),
 			typecheckPlugin()
 		],
-		sourcemap: prod ? undefined : 'inline',
+		sourcemap: prod ? false : 'inline',
 		metafile: !prod,
 		minify: prod,
 		minifyWhitespace: prod,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -42,7 +42,6 @@ export const cmdManageConnectionProfiles = 'mssql.manageProfiles';
 export const cmdClearPooledConnections = 'mssql.clearPooledConnections';
 export const cmdRebuildIntelliSenseCache = 'mssql.rebuildIntelliSenseCache';
 export const cmdAddObjectExplorer = 'mssql.addObjectExplorer';
-export const cmdAddObjectExplorer2 = 'mssql.addObjectExplorer2';
 export const cmdObjectExplorerNewQuery = 'mssql.objectExplorerNewQuery';
 export const cmdRemoveObjectExplorerNode = 'mssql.removeObjectExplorerNode';
 export const cmdRefreshObjectExplorerNode = 'mssql.refreshObjectExplorerNode';

--- a/src/controllers/reactWebviewController.ts
+++ b/src/controllers/reactWebviewController.ts
@@ -49,7 +49,8 @@ export class ReactWebViewPanelController<State, Reducers> implements vscode.Disp
 			viewColumn,
 			{
 				enableScripts: true,
-				retainContextWhenHidden: true
+				retainContextWhenHidden: true,
+				localResourceRoots: [vscode.Uri.file(this._context.extensionPath)]
 			}
 		);
 


### PR DESCRIPTION
This doesn't have seem to affected the load times when we load many web views.

<img width="625" alt="image" src="https://github.com/user-attachments/assets/b7d70bee-2e22-493c-b052-474ca6c0057b">
