### PR TITLE
Remove accounts in account store with no keys

### DIFF
--- a/src/azure/accountStore.ts
+++ b/src/azure/accountStore.ts
@@ -41,7 +41,13 @@ export class AccountStore {
 			this._logger.error('Azure Account key not received for removal request.');
 		}
 		let configValues = this.getAccounts();
-		configValues = configValues.filter(val => val.key.id !== key);
+		configValues = configValues.filter((val) => {
+			if (val.key) {
+				return val.key.id !== key;
+			} else {
+				return false;
+			}
+		});
 		this._context.globalState.update(Constants.configAzureAccount, configValues);
 		return;
 	}

--- a/src/azure/accountStore.ts
+++ b/src/azure/accountStore.ts
@@ -41,13 +41,7 @@ export class AccountStore {
 			this._logger.error('Azure Account key not received for removal request.');
 		}
 		let configValues = this.getAccounts();
-		configValues = configValues.filter((val) => {
-			if (val.key) {
-				return val.key.id !== key;
-			} else {
-				return false;
-			}
-		});
+		configValues = configValues.filter(val => val.key.id !== key);
 		this._context.globalState.update(Constants.configAzureAccount, configValues);
 		return;
 	}
@@ -72,6 +66,19 @@ export class AccountStore {
 		} else {
 			this._logger.error('Empty Azure Account cannot be added to account store.');
 		}
+	}
+
+	public async pruneAccounts(): Promise<void> {
+		let configValues = this.getAccounts();
+		configValues = configValues.filter((val) => {
+			if (val.key) {
+				return true;
+			} else {
+				return false;
+			}
+		});
+		await this._context.globalState.update(Constants.configAzureAccount, configValues);
+		return;
 	}
 
 	public async clearAccounts(): Promise<void> {

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1158,11 +1158,11 @@ export default class ConnectionManager {
 					try {
 						if (answers.account.key) {
 							this._accountStore.removeAccount(answers.account.key.id);
-							this.azureController.removeAccount(answers.account);
-							this.vscodeWrapper.showInformationMessage(LocalizedConstants.accountRemovedSuccessfully);
 						} else {
 							await this._accountStore.pruneAccounts();
 						}
+						this.azureController.removeAccount(answers.account);
+						this.vscodeWrapper.showInformationMessage(LocalizedConstants.accountRemovedSuccessfully);
 
 					} catch (e) {
 						this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.accountRemovalFailed, e.message));

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1156,9 +1156,14 @@ export default class ConnectionManager {
 			return prompter.prompt<IAccount>(questions, true).then(async answers => {
 				if (answers?.account) {
 					try {
-						this._accountStore.removeAccount(answers.account.key.id);
-						this.azureController.removeAccount(answers.account);
-						this.vscodeWrapper.showInformationMessage(LocalizedConstants.accountRemovedSuccessfully);
+						if (answers.account.key) {
+							this._accountStore.removeAccount(answers.account.key.id);
+							this.azureController.removeAccount(answers.account);
+							this.vscodeWrapper.showInformationMessage(LocalizedConstants.accountRemovedSuccessfully);
+						} else {
+							await this._accountStore.pruneAccounts();
+						}
+
 					} catch (e) {
 						this.vscodeWrapper.showErrorMessage(Utils.formatString(LocalizedConstants.accountRemovalFailed, e.message));
 					}


### PR DESCRIPTION
Adds a null check on the account.key field, so we can filter out any stale/broken account objects in extensionContext.globalState.  

Previously, attempting to remove an account with no key resulted in this error: `An error occurred while removing Microsoft Entra account: Cannot read properties of undefined (reading 'id')`

fixes: #18019