### PR TITLE
Adding checks for loc strings 

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Check for changes in english xlf files
         run: |
           cd pr
-          if git diff --quiet --exit-code src/localization/xliff/vscode-mssql.xlf; then
+          if git diff --quiet --exit-code ./src/localization/xliff/vscode-mssql.xlf; then
             echo "Changes found in english xlf files"
             echo "loc_update_required=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,8 +148,7 @@ jobs:
       - name: Check for changes in english xlf files
         run: |
           cd pr
-          if git diff --exit-code --name-only origin/main -- src/localization/xliff/vscode-mssql.xlf
-          then
+          if git diff --quiet --exit-code src/localization/xliff/vscode-mssql.xlf; then
             echo "No changes in english xlf files"
             echo "loc_check=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,9 @@
-name: File Size Check
-# Trigger the workflow on PRs to the main branch. It builds the extension in prod mode and checks the size of the
-# vsix file and webview bundle file and compares it with the main branch. It fails if the size has increased by more than 10%.
-# For vsix, we also check if the size is greater than 25MB.
+name: PR Checks
+# Trigger the workflow on PRs to the main branch.
+# It performs the following checks:
+# 1. Calculate the size difference between the webview bundles of the main branch and the PR branch.
+# 2. Calculate the size difference between the VSIX files of the main branch and the PR branch.
+# 3. Does a check if the PR has properly localized strings.
 
 on:
   pull_request:
@@ -119,21 +121,14 @@ jobs:
           body-includes: |
             ### VSIX Size Comparison
 
-      - name: Create comment
+      - name: Create or update comment
         if: steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: ./results.md
-
-      - name: Update comment
-        if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
-          body-path: ./results.md
           edit-mode: replace
 
       - name: Fail if vsix size is increased by 5% or size is above 25mb
@@ -142,6 +137,63 @@ jobs:
 
       - name: Fail if bundle size is increased by 5%
         if: ${{ env.webview_bundle_percentage_change > 5 }}
+        run: exit 1
+
+      - name: Check for localized strings
+        run: |
+          cd pr
+          yarn localization
+
+      # Check if there are git changes in english xlf files
+      - name: Check for changes in english xlf files
+        run: |
+          cd pr
+          if git diff --exit-code --name-only origin/main -- src/localization/xliff/vscode-mssql.xlf
+          then
+            echo "No changes in english xlf files"
+            echo "loc_check=true" >> $GITHUB_ENV
+          else
+            echo "Changes in english xlf files"
+            echo "loc_check=false" >> $GITHUB_ENV
+          fi
+
+      - name: Find comment
+        if: ${{ env.loc_check == 'false' }}
+        uses: peter-evans/find-comment@v3
+        id: loc-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: |
+            ### Updates to localized strings required
+
+      - name: Create or update comment
+        if: ${{ env.loc_check == 'false' }} && steps.loc-comment.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.loc-comment.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+          # Updates to localized strings required
+            Please update the localized strings in the PR with following steps:
+            1. Run `yarn localization` in the PR branch.
+            1. Based on the changes,
+                * If there are changes in localized strings in source code, make sure that `src/localization/xliff/vscode-mssql.xlf` and `src/l10n/bundle.l10n.json` files are updated.
+                * If there are changes in localized strings in `package.nls.json`, make sure that `src/localization/xliff/vscode-mssql.xlf` is updated.
+          edit-mode: replace
+
+      - name: Delete comment
+        if: ${{ env.loc_check == 'true' }} && steps.loc-comment.outputs.comment-id != ''
+        run: |
+          curl -X DELETE \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ steps.loc-comment.outputs.comment-id }}
+
+
+      - name: Fail if there are changes in english xlf files
+        if: ${{ env.loc_check == 'false' }}
         run: exit 1
 
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,12 +175,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-          # Updates to localized strings required
-            Please update the localized strings in the PR with following steps:
-            1. Run `yarn localization` in the PR branch.
-            1. Based on the changes,
-                * If there are changes in localized strings in source code, make sure that `src/localization/xliff/vscode-mssql.xlf` and `src/l10n/bundle.l10n.json` files are updated.
-                * If there are changes in localized strings in `package.nls.json`, make sure that `src/localization/xliff/vscode-mssql.xlf` is updated.
+            # Updates to localized strings required
+              Please update the localized strings in the PR with following steps:
+              1. Run `yarn localization` in the PR branch.
+              1. Based on the changes,
+                  * If there are changes in localized strings in source code, make sure that `src/localization/xliff/vscode-mssql.xlf` and `src/l10n/bundle.l10n.json` files are updated.
+                  * If there are changes in localized strings in `package.nls.json`, make sure that `src/localization/xliff/vscode-mssql.xlf` is updated.
           edit-mode: replace
 
       - name: Delete comment

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,12 +148,12 @@ jobs:
       - name: Check for changes in english xlf files
         run: |
           cd pr
-          if git diff --quiet --exit-code ./src/localization/xliff/vscode-mssql.xlf; then
-            echo "Changes found in english xlf files"
-            echo "loc_update_required=true" >> $GITHUB_ENV
-          else
+          if git diff --quiet --exit-code ./localization/xliff/vscode-mssql.xlf; then
             echo "Changes not found in english xlf files"
             echo "loc_update_required=false" >> $GITHUB_ENV
+          else
+            echo "Changes found in english xlf files"
+            echo "loc_update_required=true" >> $GITHUB_ENV
           fi
 
       - name: Find comment

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 jobs:
-  size-check:
+  pr-checks:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -149,15 +149,14 @@ jobs:
         run: |
           cd pr
           if git diff --quiet --exit-code src/localization/xliff/vscode-mssql.xlf; then
-            echo "No changes in english xlf files"
-            echo "loc_check=true" >> $GITHUB_ENV
+            echo "Changes found in english xlf files"
+            echo "loc_update_required=true" >> $GITHUB_ENV
           else
-            echo "Changes in english xlf files"
-            echo "loc_check=false" >> $GITHUB_ENV
+            echo "Changes not found in english xlf files"
+            echo "loc_update_required=false" >> $GITHUB_ENV
           fi
 
       - name: Find comment
-        if: ${{ env.loc_check == 'false' }}
         uses: peter-evans/find-comment@v3
         id: loc-comment
         with:
@@ -167,7 +166,7 @@ jobs:
             ### Updates to localized strings required
 
       - name: Create or update comment
-        if: ${{ env.loc_check == 'false' }} && steps.loc-comment.outputs.comment-id == ''
+        if: ${{ env.loc_update_required == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}
@@ -183,7 +182,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete comment
-        if: ${{ env.loc_check == 'true' }} && steps.loc-comment.outputs.comment-id != ''
+        if: ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != ''
         run: |
           curl -X DELETE \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -191,8 +190,8 @@ jobs:
           https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ steps.loc-comment.outputs.comment-id }}
 
 
-      - name: Fail if there are changes in english xlf files
-        if: ${{ env.loc_check == 'false' }}
+      - name: Fail if there are changes required in english xlf files
+        if: ${{ env.loc_update_required == 'true' }}
         run: exit 1
 
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -189,12 +189,6 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ steps.loc-comment.outputs.comment-id }}
 
-
       - name: Fail if there are changes required in english xlf files
         if: ${{ env.loc_update_required == 'true' }}
         run: exit 1
-
-
-
-
-

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -139,7 +139,7 @@ jobs:
         if: ${{ env.webview_bundle_percentage_change > 5 }}
         run: exit 1
 
-      - name: Check for localized strings
+      - name: Generate xliff files in PR branch
         run: |
           cd pr
           yarn localization

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -163,7 +163,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: |
-            ### Updates to localized strings required
+            # Updates to localized strings required
 
       - name: Create or update comment
         if: ${{ env.loc_update_required == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ coverage
 coverage-remapped
 test-reports
 .vscode-test
-localization/i18n/
 src/constants/localizedConstants.ts
 package.nls.*.json
 /test-results/

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1046,6 +1046,9 @@
     <trans-unit id="mssql.queryHistoryLimit">
       <source xml:lang="en">Number of query history entries to show in the Query History view</source>
     </trans-unit>
+    <trans-unit id="mssql.openExecutionPlanFile">
+      <source xml:lang="en">Open Execution Plan File</source>
+    </trans-unit>
     <trans-unit id="mssql.openQueryHistory">
       <source xml:lang="en">Open Query</source>
     </trans-unit>

--- a/src/objectExplorer/addConnectionTreeNode.ts
+++ b/src/objectExplorer/addConnectionTreeNode.ts
@@ -10,7 +10,6 @@ import * as LocalizedConstants from '../constants/locConstants';
 import { ObjectExplorerUtils } from './objectExplorerUtils';
 
 export class AddConnectionTreeNode extends vscode.TreeItem {
-	private _test = vscode.l10n.t('test');
 
 	constructor() {
 		super(LocalizedConstants.msgAddConnection, vscode.TreeItemCollapsibleState.None);
@@ -22,6 +21,5 @@ export class AddConnectionTreeNode extends vscode.TreeItem {
 			light: path.join(ObjectExplorerUtils.rootPath, 'add_light.svg'),
 			dark: path.join(ObjectExplorerUtils.rootPath, 'add_dark.svg')
 		};
-		console.log(this._test);
 	}
 }

--- a/src/objectExplorer/addConnectionTreeNode.ts
+++ b/src/objectExplorer/addConnectionTreeNode.ts
@@ -10,7 +10,7 @@ import * as LocalizedConstants from '../constants/locConstants';
 import { ObjectExplorerUtils } from './objectExplorerUtils';
 
 export class AddConnectionTreeNode extends vscode.TreeItem {
-	private test = vscode.l10n.t('test');
+	private _test = vscode.l10n.t('test');
 
 	constructor() {
 		super(LocalizedConstants.msgAddConnection, vscode.TreeItemCollapsibleState.None);
@@ -22,6 +22,6 @@ export class AddConnectionTreeNode extends vscode.TreeItem {
 			light: path.join(ObjectExplorerUtils.rootPath, 'add_light.svg'),
 			dark: path.join(ObjectExplorerUtils.rootPath, 'add_dark.svg')
 		};
-		console.log(test);
+		console.log(this._test);
 	}
 }

--- a/src/objectExplorer/addConnectionTreeNode.ts
+++ b/src/objectExplorer/addConnectionTreeNode.ts
@@ -10,6 +10,7 @@ import * as LocalizedConstants from '../constants/locConstants';
 import { ObjectExplorerUtils } from './objectExplorerUtils';
 
 export class AddConnectionTreeNode extends vscode.TreeItem {
+	private test = vscode.l10n.t('test');
 
 	constructor() {
 		super(LocalizedConstants.msgAddConnection, vscode.TreeItemCollapsibleState.None);
@@ -21,5 +22,6 @@ export class AddConnectionTreeNode extends vscode.TreeItem {
 			light: path.join(ObjectExplorerUtils.rootPath, 'add_light.svg'),
 			dark: path.join(ObjectExplorerUtils.rootPath, 'add_dark.svg')
 		};
+		console.log(test);
 	}
 }


### PR DESCRIPTION
I've added checks for new localization strings in a PR. If any localization strings are found without corresponding entries in the .xlf file, we request the PR owner to run yarn localization and submit the updated .xlf files.

If there bot detects that xlf files are not updated, it adds this comments and fails. 

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/59c28a0f-5e8b-4c2d-b54b-70a608b240b4">

It will delete the comment and succeed after the xlf file is updated.