### PR TITLE
Lewissanchez/feat/add language service switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1197,6 +1197,12 @@
           "description": "%mssql.intelliSense.lowerCaseSuggestions%",
           "scope": "window"
         },
+        "mssql.intelliSense.setQueryEditorLanguageToNone": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.intelliSense.setQueryEditorLanguageToNone%",
+          "scope": "window"
+        },
         "mssql.persistQueryResultTabs": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,6 +100,7 @@
 "mssql.intelliSense.enableQuickInfo":"Should IntelliSense quick info be enabled",
 "mssql.enableQueryHistoryFeature":"Should Query History feature be enabled",
 "mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase",
+"mssql.intelliSense.setQueryEditorLanguageToNone":"Should the editor language be set to None when a query editor is opened.",
 "mssql.persistQueryResultTabs":"Should query result selections and scroll positions be saved when switching tabs (may impact performance)",
 "mssql.queryHistoryLimit":"Number of query history entries to show in the Query History view",
 "mssql.createAzureFunction":"Create Azure Function with SQL binding",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -162,6 +162,7 @@ export const configQueryHistoryLimit = 'queryHistoryLimit';
 export const configEnableQueryHistoryCapture = 'enableQueryHistoryCapture';
 export const configEnableQueryHistoryFeature = 'enableQueryHistoryFeature';
 export const configEnableExperimentalFeatures = 'mssql.enableExperimentalFeatures';
+export const configIntelliSense = 'intelliSense';
 
 // ToolsService Constants
 export const serviceInstallingTo = 'Installing SQL tools service to';

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -880,12 +880,13 @@ export default class ConnectionManager {
 					this.statusView.connecting(fileUri, connectionCreds);
 					this.statusView.languageFlavorChanged(fileUri, flavor);
 
+					// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles
 					if (flavor === Constants.noneProviderName) {
 						SqlToolsServerClient.instance.sendNotification(LanguageServiceContracts.LanguageFlavorChangedNotification.type,
 							<LanguageServiceContracts.DidChangeLanguageFlavorParams>{
 								uri: fileUri,
 								language: 'sql',
-								flavor: flavor
+								flavor: Constants.noneProviderName
 							})
 					}
 				}

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -875,7 +875,7 @@ export default class ConnectionManager {
 					 // lewissanchez flag: May need to check intellisense enabled setting here
 					const configuration = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
 					const intelliSenseConfig = configuration.get<IntelliSenseConfig>(Constants.configIntelliSense);
-					const flavor = intelliSenseConfig.enableIntelliSense ? Constants.mssqlProviderName : Constants.noneProviderName;
+					const flavor = intelliSenseConfig.setQueryEditorLanguageToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 					this.statusView.languageFlavorChanged(fileUri, flavor);
 					this.statusView.connecting(fileUri, connectionCreds);
 					this.statusView.languageFlavorChanged(fileUri, flavor);

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -23,7 +23,7 @@ import { IAccount } from '../models/contracts/azure';
 import * as ConnectionContracts from '../models/contracts/connection';
 import { ClearPooledConnectionsRequest, ConnectionSummary } from '../models/contracts/connection';
 import * as LanguageServiceContracts from '../models/contracts/languageService';
-import { EncryptOptions, IConnectionProfile } from '../models/interfaces';
+import { EncryptOptions, IConnectionProfile, IntelliSenseConfig } from '../models/interfaces';
 import { PlatformInformation, Runtime } from '../models/platform';
 import * as Utils from '../models/utils';
 import { IPrompter, IQuestion, QuestionTypes } from '../prompts/question';
@@ -872,9 +872,22 @@ export default class ConnectionManager {
 
 				// Note: must call flavor changed before connecting, or the timer showing an animation doesn't occur
 				if (this.statusView) {
-					this.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+					 // lewissanchez flag: May need to check intellisense enabled setting here
+					const configuration = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+					const intelliSenseConfig = configuration.get<IntelliSenseConfig>(Constants.configIntelliSense);
+					const flavor = intelliSenseConfig.enableIntelliSense ? Constants.mssqlProviderName : Constants.noneProviderName;
+					this.statusView.languageFlavorChanged(fileUri, flavor);
 					this.statusView.connecting(fileUri, connectionCreds);
-					this.statusView.languageFlavorChanged(fileUri, Constants.mssqlProviderName);
+					this.statusView.languageFlavorChanged(fileUri, flavor);
+
+					if (flavor === Constants.noneProviderName) {
+						SqlToolsServerClient.instance.sendNotification(LanguageServiceContracts.LanguageFlavorChangedNotification.type,
+							<LanguageServiceContracts.DidChangeLanguageFlavorParams>{
+								uri: fileUri,
+								language: 'sql',
+								flavor: flavor
+							})
+					}
 				}
 				this.vscodeWrapper.logToOutputChannel(
 					LocalizedConstants.msgConnecting(connectionCreds.server, fileUri)

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -13,7 +13,7 @@ import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/locConstants';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import * as ConnInfo from '../models/connectionInfo';
-import { CompletionExtensionParams, CompletionExtLoadRequest, DidChangeLanguageFlavorParams, LanguageFlavorChangedNotification, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
+import { CompletionExtensionParams, CompletionExtLoadRequest, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
 import { ScriptOperation } from '../models/contracts/scripting/scriptingRequest';
 import { SqlOutputContentProvider } from '../models/sqlOutputContentProvider';
 import * as Utils from '../models/utils';
@@ -1288,20 +1288,8 @@ export default class MainController implements vscode.Disposable {
 		this._connectionMgr.onDidOpenTextDocument(doc);
 
 		if (doc && doc.languageId === Constants.languageId) {
-			const isLanguageSetToNone = this.configuration.get('mssql.intelliSense.setQueryEditorLanguageToNone');
-			const flavor = isLanguageSetToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 			// set encoding to false
-			this._statusview.languageFlavorChanged(doc.uri.toString(true), flavor);
-
-			// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles.
-			if (flavor === Constants.noneProviderName) {
-				SqlToolsServerClient.instance.sendNotification(LanguageFlavorChangedNotification.type,
-					<DidChangeLanguageFlavorParams>{
-						uri: doc.uri.toString(true),
-						language: 'sql',
-						flavor: Constants.noneProviderName
-					});
-			}
+			this._statusview.languageFlavorChanged(doc.uri.toString(true), Constants.mssqlProviderName);
 		}
 
 		if (doc && doc.languageId === Constants.sqlPlanLanguageId) {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -13,7 +13,7 @@ import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/locConstants';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import * as ConnInfo from '../models/connectionInfo';
-import { CompletionExtensionParams, CompletionExtLoadRequest, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
+import { CompletionExtensionParams, CompletionExtLoadRequest, DidChangeLanguageFlavorParams, LanguageFlavorChangedNotification, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
 import { ScriptOperation } from '../models/contracts/scripting/scriptingRequest';
 import { SqlOutputContentProvider } from '../models/sqlOutputContentProvider';
 import * as Utils from '../models/utils';
@@ -1288,8 +1288,20 @@ export default class MainController implements vscode.Disposable {
 		this._connectionMgr.onDidOpenTextDocument(doc);
 
 		if (doc && doc.languageId === Constants.languageId) {
+			const isLanguageSetToNone = this.configuration.get('mssql.intelliSense.setQueryEditorLanguageToNone');
+			const flavor = isLanguageSetToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 			// set encoding to false
-			this._statusview.languageFlavorChanged(doc.uri.toString(true), Constants.mssqlProviderName);
+			this._statusview.languageFlavorChanged(doc.uri.toString(true), flavor);
+
+			// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles.
+			if (flavor === Constants.noneProviderName) {
+				SqlToolsServerClient.instance.sendNotification(LanguageFlavorChangedNotification.type,
+					<DidChangeLanguageFlavorParams>{
+						uri: doc.uri.toString(true),
+						language: 'sql',
+						flavor: Constants.noneProviderName
+					});
+			}
 		}
 
 		if (doc && doc.languageId === Constants.sqlPlanLanguageId) {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -10,6 +10,10 @@ import * as vscodeMssql from 'vscode-mssql';
 import { AzureAuthType } from './contracts/azure';
 
 // interfaces
+export interface IntelliSenseConfig {
+	enableIntelliSense: boolean;
+}
+
 export enum ContentType {
 	Root = 0,
 	Messages = 1,

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -11,7 +11,7 @@ import { AzureAuthType } from './contracts/azure';
 
 // interfaces
 export interface IntelliSenseConfig {
-	enableIntelliSense: boolean;
+	setQueryEditorLanguageToNone: boolean;
 }
 
 export enum ContentType {


### PR DESCRIPTION
This PR fixes #17298

This PR adds a new setting to the MSSQL extension that allows users to have the language mode set to none by default
![image](https://github.com/user-attachments/assets/2f0b6f81-79bf-45ba-a089-2ada11759b1f)

New query editors that are opened when this setting is enabled, will have "None" as the chosen language
![image](https://github.com/user-attachments/assets/2e9d583f-26b5-4b20-8d58-0152ba0c5f75)

Previously saved query files that are opened when this setting is enabled, will also have "None" as the chosen language
![image](https://github.com/user-attachments/assets/af421d44-ca81-4502-a018-313d93c132f2)


