### PR TITLE
Adds lang service switch

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1142,6 +1142,9 @@
     <trans-unit id="mssql.format.placeSelectStatementReferencesOnNewLine">
       <source xml:lang="en">Should references to objects in a select statements be split into separate lines? E.g. for &apos;SELECT C1, C2 FROM T1&apos; both C1 and C2 will be on separate lines</source>
     </trans-unit>
+    <trans-unit id="mssql.intelliSense.defaultQueryEditorLanguageToNone">
+      <source xml:lang="en">Should the default editor language be set to None when a query editor is opened.</source>
+    </trans-unit>
     <trans-unit id="mssql.startQueryHistoryCapture">
       <source xml:lang="en">Start Query History Capture</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -1197,6 +1197,12 @@
           "description": "%mssql.intelliSense.lowerCaseSuggestions%",
           "scope": "window"
         },
+		"mssql.intelliSense.setQueryEditorLanguageToNone": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mssql.intelliSense.setQueryEditorLanguageToNone%",
+          "scope": "window"
+        },
         "mssql.persistQueryResultTabs": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -1197,10 +1197,10 @@
           "description": "%mssql.intelliSense.lowerCaseSuggestions%",
           "scope": "window"
         },
-		"mssql.intelliSense.setQueryEditorLanguageToNone": {
+        "mssql.intelliSense.defaultQueryEditorLanguageToNone": {
           "type": "boolean",
           "default": false,
-          "description": "%mssql.intelliSense.setQueryEditorLanguageToNone%",
+          "description": "%mssql.intelliSense.defaultQueryEditorLanguageToNone%",
           "scope": "window"
         },
         "mssql.persistQueryResultTabs": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -101,7 +101,7 @@
 "mssql.enableQueryHistoryFeature":"Should Query History feature be enabled",
 "mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase",
 "mssql.persistQueryResultTabs":"Should query result selections and scroll positions be saved when switching tabs (may impact performance)",
-"mssql.intelliSense.setQueryEditorLanguageToNone":"Should the editor language be set to None when a query editor is opened.",
+"mssql.intelliSense.defaultQueryEditorLanguageToNone":"Should the default editor language be set to None when a query editor is opened.",
 "mssql.queryHistoryLimit":"Number of query history entries to show in the Query History view",
 "mssql.createAzureFunction":"Create Azure Function with SQL binding",
 "mssql.query.maxXmlCharsToStore":"Maximum number of characters to store for each value in XML columns after running a query. Default value: 2,097,152. Valid value range: 1 to 2,147,483,647.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -101,6 +101,7 @@
 "mssql.enableQueryHistoryFeature":"Should Query History feature be enabled",
 "mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase",
 "mssql.persistQueryResultTabs":"Should query result selections and scroll positions be saved when switching tabs (may impact performance)",
+"mssql.intelliSense.setQueryEditorLanguageToNone":"Should the editor language be set to None when a query editor is opened.",
 "mssql.queryHistoryLimit":"Number of query history entries to show in the Query History view",
 "mssql.createAzureFunction":"Create Azure Function with SQL binding",
 "mssql.query.maxXmlCharsToStore":"Maximum number of characters to store for each value in XML columns after running a query. Default value: 2,097,152. Valid value range: 1 to 2,147,483,647.",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -162,6 +162,7 @@ export const configQueryHistoryLimit = 'queryHistoryLimit';
 export const configEnableQueryHistoryCapture = 'enableQueryHistoryCapture';
 export const configEnableQueryHistoryFeature = 'enableQueryHistoryFeature';
 export const configEnableExperimentalFeatures = 'mssql.enableExperimentalFeatures';
+export const configIntelliSense = 'intelliSense';
 
 // ToolsService Constants
 export const serviceInstallingTo = 'Installing SQL tools service to';

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -882,11 +882,11 @@ export default class ConnectionManager {
 					// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles
 					if (flavor === Constants.noneProviderName) {
 						SqlToolsServerClient.instance.sendNotification(LanguageServiceContracts.LanguageFlavorChangedNotification.type,
-							<LanguageServiceContracts.DidChangeLanguageFlavorParams>{
+							{
 								uri: fileUri,
 								language: 'sql',
 								flavor: Constants.noneProviderName
-							});
+							} as LanguageServiceContracts.DidChangeLanguageFlavorParams);
 					}
 				}
 				this.vscodeWrapper.logToOutputChannel(

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -874,7 +874,7 @@ export default class ConnectionManager {
 				if (this.statusView) {
 					const configuration = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
 					const intelliSenseConfig = configuration.get<IntelliSenseConfig>(Constants.configIntelliSense);
-					const flavor = intelliSenseConfig.setQueryEditorLanguageToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
+					const flavor = intelliSenseConfig.defaultQueryEditorLanguageToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 					this.statusView.languageFlavorChanged(fileUri, flavor);
 					this.statusView.connecting(fileUri, connectionCreds);
 					this.statusView.languageFlavorChanged(fileUri, flavor);

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1288,8 +1288,8 @@ export default class MainController implements vscode.Disposable {
 		this._connectionMgr.onDidOpenTextDocument(doc);
 
 		if (doc && doc.languageId === Constants.languageId) {
-			const isLanguageSetToNone = this.configuration.get('mssql.intelliSense.setQueryEditorLanguageToNone');
-			const flavor = isLanguageSetToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
+			const isQueryEditorLanguageDefaultNone = this.configuration.get('mssql.intelliSense.defaultQueryEditorLanguageToNone');
+			const flavor = isQueryEditorLanguageDefaultNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 			// set encoding to false
 			this._statusview.languageFlavorChanged(doc.uri.toString(true), flavor);
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -35,7 +35,7 @@ import { SqlProjectsService } from '../services/sqlProjectsService';
 import { SchemaCompareService } from '../services/schemaCompareService';
 import { SqlTasksService } from '../services/sqlTasksService';
 import StatusView from '../views/statusView';
-import { IConnectionProfile, ISelectionData } from './../models/interfaces';
+import { IConnectionProfile, IntelliSenseConfig, ISelectionData } from './../models/interfaces';
 import ConnectionManager from './connectionManager';
 import UntitledSqlDocumentService from './untitledSqlDocumentService';
 import VscodeWrapper from './vscodeWrapper';
@@ -1288,8 +1288,9 @@ export default class MainController implements vscode.Disposable {
 		this._connectionMgr.onDidOpenTextDocument(doc);
 
 		if (doc && doc.languageId === Constants.languageId) {
-			const isQueryEditorLanguageDefaultNone = this.configuration.get('mssql.intelliSense.defaultQueryEditorLanguageToNone');
-			const flavor = isQueryEditorLanguageDefaultNone ? Constants.noneProviderName : Constants.mssqlProviderName;
+			const configuration = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+			const intelliSenseConfig = configuration.get<IntelliSenseConfig>(Constants.configIntelliSense);
+			const flavor = intelliSenseConfig.defaultQueryEditorLanguageToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 			// set encoding to false
 			this._statusview.languageFlavorChanged(doc.uri.toString(true), flavor);
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1297,11 +1297,11 @@ export default class MainController implements vscode.Disposable {
 			// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles.
 			if (flavor === Constants.noneProviderName) {
 				SqlToolsServerClient.instance.sendNotification(LanguageFlavorChangedNotification.type,
-					<DidChangeLanguageFlavorParams>{
+					{
 						uri: doc.uri.toString(true),
 						language: 'sql',
 						flavor: Constants.noneProviderName
-					});
+					} as DidChangeLanguageFlavorParams);
 			}
 		}
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -13,7 +13,7 @@ import * as Constants from '../constants/constants';
 import * as LocalizedConstants from '../constants/locConstants';
 import SqlToolsServerClient from '../languageservice/serviceclient';
 import * as ConnInfo from '../models/connectionInfo';
-import { CompletionExtensionParams, CompletionExtLoadRequest, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
+import { CompletionExtensionParams, CompletionExtLoadRequest, DidChangeLanguageFlavorParams, LanguageFlavorChangedNotification, RebuildIntelliSenseNotification } from '../models/contracts/languageService';
 import { ScriptOperation } from '../models/contracts/scripting/scriptingRequest';
 import { SqlOutputContentProvider } from '../models/sqlOutputContentProvider';
 import * as Utils from '../models/utils';
@@ -1288,8 +1288,20 @@ export default class MainController implements vscode.Disposable {
 		this._connectionMgr.onDidOpenTextDocument(doc);
 
 		if (doc && doc.languageId === Constants.languageId) {
+			const isLanguageSetToNone = this.configuration.get('mssql.intelliSense.setQueryEditorLanguageToNone');
+			const flavor = isLanguageSetToNone ? Constants.noneProviderName : Constants.mssqlProviderName;
 			// set encoding to false
-			this._statusview.languageFlavorChanged(doc.uri.toString(true), Constants.mssqlProviderName);
+			this._statusview.languageFlavorChanged(doc.uri.toString(true), flavor);
+
+			// Notify the language service that the editor with the specified URI doesn't have a language flavor to avoid error squiggles.
+			if (flavor === Constants.noneProviderName) {
+				SqlToolsServerClient.instance.sendNotification(LanguageFlavorChangedNotification.type,
+					<DidChangeLanguageFlavorParams>{
+						uri: doc.uri.toString(true),
+						language: 'sql',
+						flavor: Constants.noneProviderName
+					});
+			}
 		}
 
 		if (doc && doc.languageId === Constants.sqlPlanLanguageId) {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -11,7 +11,7 @@ import { AzureAuthType } from './contracts/azure';
 
 // interfaces
 export interface IntelliSenseConfig {
-	setQueryEditorLanguageToNone: boolean;
+	defaultQueryEditorLanguageToNone: boolean;
 }
 
 export enum ContentType {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -10,6 +10,10 @@ import * as vscodeMssql from 'vscode-mssql';
 import { AzureAuthType } from './contracts/azure';
 
 // interfaces
+export interface IntelliSenseConfig {
+	setQueryEditorLanguageToNone: boolean;
+}
+
 export enum ContentType {
 	Root = 0,
 	Messages = 1,


### PR DESCRIPTION
This PR fixes #17298

This PR adds a new setting to the MSSQL extension that allows users to have the language mode set to none by default
![image](https://github.com/user-attachments/assets/2f0b6f81-79bf-45ba-a089-2ada11759b1f)

New query editors that are opened when this setting is enabled, will have "None" as the chosen language
![image](https://github.com/user-attachments/assets/2e9d583f-26b5-4b20-8d58-0152ba0c5f75)

Previously saved query files that are opened when this setting is enabled, will also have "None" as the chosen language
![image](https://github.com/user-attachments/assets/af421d44-ca81-4502-a018-313d93c132f2)

To enable the MSSQL language mode for an editor, first click on "None" in the status bar, and then choose MSSQL as the language
![image](https://github.com/user-attachments/assets/eb125f75-bfdc-40a5-a8e0-e80f2ba25ae7)

