### PR TITLE
Fix extension icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
         {
           "id": "objectExplorer",
           "title": "SQL Server",
-          "icon": "./images/server_page_dark.svg"
+          "icon": "media/server_page_dark.svg"
         }
       ]
     },


### PR DESCRIPTION
The extension icon was moved to `media` but the path is not updated, leading to a missing icon.
Now:
<img width="95" alt="image" src="https://github.com/user-attachments/assets/20ef59e1-41c1-431e-aa11-99c454051751">
<img width="641" alt="image" src="https://github.com/user-attachments/assets/f75cd876-aee6-4b81-addf-0f38c687021c">
After the fix:
<img width="69" alt="image" src="https://github.com/user-attachments/assets/6da84371-2bb0-4003-a26f-c118e73b57cb">
