### PR TITLE
Fixing pre-commit hooks and running yarn localization in precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 yarn lint
+yarn localization

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,7 +14,7 @@ tasks
 test
 typings
 test-reports
-
+.husky
 .gitignore
 .mention-bot
 coverconfig.json

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "localization": "gulp ext:extract-localization-strings",
     "smoketest": "gulp ext:smoke",
     "test": "gulp test:cover --log",
-    "package": "vsce package"
+    "package": "vsce package",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@angular/common": "~2.1.2",


### PR DESCRIPTION
The `prepare` command is a reserved `npm` command that runs automatically after `yarn install`. I'm configuring Husky within the prepare script so that whenever someone runs yarn install, Husky will set up the pre-commit hook. This pre-commit hook runs `yarn lint` and `yarn localization` before allowing code to be committed. While this might slow down the commit process slightly, it ensures that code checks are performed upfront, saving time compared to waiting for checks to pass after submitting a pull request.