### PR TITLE
Making loc pipeline push in xlf files changes after we get new translations

### DIFF
--- a/build/Localization.yml
+++ b/build/Localization.yml
@@ -25,6 +25,12 @@ jobs:
       outDir: '$(Build.ArtifactStagingDirectory)'
       dependencyPackageSource: 'https://pkgs.dev.azure.com/msdata/_packaging/SQLDS_SSMS/nuget/v3/index.json'
       packageSourceAuth: patAuth
+      repoType: gitHub
+      isCreatePrSelected: True
+      prSourceBranchPrefix: 'locfiles'
+      isAutoCompletePrSelected: true
+      gitHubPrMergeMethod: squash
+
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
Currently the loc pipeline was not checking in the new xlf files generated after we received new translations in LCL files. This makes the pipeline automatically check in the new xlf files. 

After the localization pipeline runs, it will create and merge in xlf files in the main branch automatically. The PR will looks something like this
https://github.com/microsoft/vscode-mssql/pull/18078