### PR TITLE
Stop loc pipeline deleting PR branch

### DIFF
--- a/build/Localization.yml
+++ b/build/Localization.yml
@@ -25,6 +25,7 @@ jobs:
       outDir: '$(Build.ArtifactStagingDirectory)'
       dependencyPackageSource: 'https://pkgs.dev.azure.com/msdata/_packaging/SQLDS_SSMS/nuget/v3/index.json'
       packageSourceAuth: patAuth
+      isDeletePrSourceBranchSelected: true
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'

--- a/build/Localization.yml
+++ b/build/Localization.yml
@@ -25,7 +25,7 @@ jobs:
       outDir: '$(Build.ArtifactStagingDirectory)'
       dependencyPackageSource: 'https://pkgs.dev.azure.com/msdata/_packaging/SQLDS_SSMS/nuget/v3/index.json'
       packageSourceAuth: patAuth
-      isDeletePrSourceBranchSelected: true
+      isDeletePrSourceBranchSelected: false
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
Since this branch is automatically deleted when we the pipeline merges in the PR, it leads to the build step failing as it cannot find any branch to delete