### PR TITLE
Improving Azure server loading experience and performance

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -659,6 +659,7 @@
     ]
   },
   "Azure sign in failed.": "Azure sign in failed.",
+  "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",
   "No subscriptions set in VS Code's Azure account filter.": "No subscriptions set in VS Code's Azure account filter.",
   "Error loading Azure databases.": "Error loading Azure databases."
 }

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -418,6 +418,9 @@
     <trans-unit id="++CODE++4eca430ed6ea02cdcd0e956ce27d238e2659997f15a4f580b0fd3385cfd815a0">
       <source xml:lang="en">Error loading Azure databases.</source>
     </trans-unit>
+    <trans-unit id="++CODE++5b149b9da8f7cd0bdae05ad12cd9e4f650db61436fb31c868a6568695dce21f2">
+      <source xml:lang="en">Error loading Azure subscriptions.</source>
+    </trans-unit>
     <trans-unit id="++CODE++f6d7eb5fe821427ad07a3bf9a3cc35423ddc3ccd3a745b1f09584fbf26f377fe">
       <source xml:lang="en">Error loading designer</source>
     </trans-unit>

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -19,7 +19,6 @@ import { FormItemSpec } from "../../common/forms/form";
 import { IConnectionDialogProfile } from "../../../sharedInterfaces/connectionDialog";
 import { AdvancedOptionsDrawer } from "./components/advancedOptionsDrawer.component";
 import { locConstants as Loc } from "../../common/locConstants";
-import { TestConnectionButton } from "./components/testConnectionButton.component";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
 
 function removeDuplicates<T>(array: T[]): T[] {
@@ -61,7 +60,6 @@ export const AzureBrowsePage = () => {
     >(undefined);
 
     useEffect(() => {
-        console.log("===: subscriptions dropdown effect");
         const subs = removeDuplicates(
             context.state.azureSubscriptions.map(
                 (sub) => `${sub.name} (${sub.id})`,
@@ -75,7 +73,6 @@ export const AzureBrowsePage = () => {
     }, [context.state.azureSubscriptions]);
 
     useEffect(() => {
-        console.log("===: resource group dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -97,7 +94,6 @@ export const AzureBrowsePage = () => {
     }, [subscriptions, selectedSubscription, context.state.azureServers]);
 
     useEffect(() => {
-        console.log("===: locations dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -126,7 +122,6 @@ export const AzureBrowsePage = () => {
     }, [resourceGroups, selectedResourceGroup, context.state.azureServers]);
 
     useEffect(() => {
-        console.log("===: server dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -160,7 +155,6 @@ export const AzureBrowsePage = () => {
     }, [locations, selectedLocation, context.state.azureServers]);
 
     useEffect(() => {
-        console.log("===: database dropdown effect");
         if (!selectedServer) {
             return; // should not be visible if no server is selected
         }
@@ -286,6 +280,7 @@ export const AzureBrowsePage = () => {
                     />
                     {context.state.connectionComponents.mainOptions
                         .filter(
+                            // filter out inputs that are manually placed above
                             (opt) =>
                                 ![
                                     "server",
@@ -332,9 +327,6 @@ export const AzureBrowsePage = () => {
                     {Loc.connectionDialog.advancedSettings}
                 </Button>
                 <div className={formStyles.formNavTrayRight}>
-                    <TestConnectionButton
-                        className={formStyles.formNavTrayButton}
-                    />
                     <ConnectButton className={formStyles.formNavTrayButton} />
                 </div>
             </div>
@@ -375,46 +367,43 @@ const AzureBrowseDropdown = ({
     };
 
     return (
-        <>
-            <div className={formStyles.formComponentDiv}>
-                <Field
-                    label={
-                        <span className={loadableStyles.loadable}>
-                            {label}
-                            {loadState === ApiStatus.Loading && (
-                                <Spinner size="tiny" />
-                            )}
-                        </span>
+        <div className={formStyles.formComponentDiv}>
+            <Field
+                label={
+                    <div className={loadableStyles.loadable}>
+                        {label}
+                        {loadState === ApiStatus.Loading && (
+                            <Spinner size="tiny" />
+                        )}
+                    </div>
+                }
+                orientation="horizontal"
+                required={required}
+            >
+                <Combobox
+                    value={content.currentValue ?? ""}
+                    selectedOptions={
+                        content.currentValue ? [content.currentValue] : []
                     }
-                    orientation="horizontal"
-                    required={required}
-                >
-                    <Combobox
-                        style={{ width: "100%" }}
-                        value={content.currentValue ?? ""}
-                        selectedOptions={
-                            content.currentValue ? [content.currentValue] : []
+                    clearable={clearable}
+                    onInput={onInput}
+                    onOptionSelect={(_event, data) => {
+                        if (data.optionValue === content.currentValue) {
+                            return;
                         }
-                        clearable={clearable}
-                        onInput={onInput}
-                        onOptionSelect={(_event, data) => {
-                            if (data.optionValue === content.currentValue) {
-                                return;
-                            }
 
-                            content.setValue(data.optionValue);
-                        }}
-                    >
-                        {content.valueList.map((val, idx) => {
-                            return (
-                                <Option key={idx} value={val}>
-                                    {val}
-                                </Option>
-                            );
-                        })}
-                    </Combobox>
-                </Field>
-            </div>
-        </>
+                        content.setValue(data.optionValue);
+                    }}
+                >
+                    {content.valueList.map((val, idx) => {
+                        return (
+                            <Option key={idx} value={val}>
+                                {val}
+                            </Option>
+                        );
+                    })}
+                </Combobox>
+            </Field>
+        </div>
     );
 };

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -61,6 +61,7 @@ export const AzureBrowsePage = () => {
     >(undefined);
 
     useEffect(() => {
+        console.log("===: subscriptions dropdown effect");
         const subs = removeDuplicates(
             context.state.azureSubscriptions.map(
                 (sub) => `${sub.name} (${sub.id})`,
@@ -74,6 +75,7 @@ export const AzureBrowsePage = () => {
     }, [context.state.azureSubscriptions]);
 
     useEffect(() => {
+        console.log("===: resource group dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -95,6 +97,7 @@ export const AzureBrowsePage = () => {
     }, [subscriptions, selectedSubscription, context.state.azureServers]);
 
     useEffect(() => {
+        console.log("===: locations dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -123,6 +126,7 @@ export const AzureBrowsePage = () => {
     }, [resourceGroups, selectedResourceGroup, context.state.azureServers]);
 
     useEffect(() => {
+        console.log("===: server dropdown effect");
         let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
@@ -156,6 +160,7 @@ export const AzureBrowsePage = () => {
     }, [locations, selectedLocation, context.state.azureServers]);
 
     useEffect(() => {
+        console.log("===: database dropdown effect");
         if (!selectedServer) {
             return; // should not be visible if no server is selected
         }

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -54,17 +54,19 @@ export const AzureBrowsePage = () => {
 
     useEffect(() => {
         const subs = removeDuplicates(
-            context.state.azureDatabases.map((server) => server.subscription),
+            context.state.azureSubscriptions.map(
+                (sub) => `${sub.name} (${sub.id})`,
+            ),
         );
         setSubscriptions(subs.sort());
 
         if (!selectedSubscription && subs.length === 1) {
             setSelectedSubscription(subs[0]);
         }
-    }, [context.state.azureDatabases]);
+    }, [context.state.azureSubscriptions]);
 
     useEffect(() => {
-        let activeServers = context.state.azureDatabases;
+        let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
             activeServers = activeServers.filter(
@@ -82,10 +84,10 @@ export const AzureBrowsePage = () => {
         if (selectedResourceGroup && !rgs.includes(selectedResourceGroup)) {
             setSelectedResourceGroup(rgs.length === 1 ? rgs[0] : undefined);
         }
-    }, [subscriptions, selectedSubscription]);
+    }, [subscriptions, selectedSubscription, context.state.azureServers]);
 
     useEffect(() => {
-        let activeServers = context.state.azureDatabases;
+        let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
             activeServers = activeServers.filter(
@@ -110,10 +112,10 @@ export const AzureBrowsePage = () => {
         if (selectedLocation && !locs.includes(selectedLocation)) {
             setSelectedLocation(locs.length === 1 ? locs[0] : undefined);
         }
-    }, [resourceGroups, selectedResourceGroup]);
+    }, [resourceGroups, selectedResourceGroup, context.state.azureServers]);
 
     useEffect(() => {
-        let activeServers = context.state.azureDatabases;
+        let activeServers = context.state.azureServers;
 
         if (selectedSubscription) {
             activeServers = activeServers.filter(
@@ -143,14 +145,14 @@ export const AzureBrowsePage = () => {
         if (selectedServer && !srvs.includes(selectedServer)) {
             setSelectedServer(srvs.length === 1 ? srvs[0] : undefined);
         }
-    }, [locations, selectedLocation]);
+    }, [locations, selectedLocation, context.state.azureServers]);
 
     useEffect(() => {
         if (!selectedServer) {
             return; // should not be visible if no server is selected
         }
 
-        const dbs = context.state.azureDatabases.find(
+        const dbs = context.state.azureServers.find(
             (server) => server.server === selectedServer,
         )!.databases;
 
@@ -324,10 +326,10 @@ const AzureBrowseDropdown = ({
                         content.setValue(data.optionValue);
                     }}
                 >
-                    {content.valueList.map((loc, idx) => {
+                    {content.valueList.map((val, idx) => {
                         return (
-                            <Option key={idx} value={loc}>
-                                {loc}
+                            <Option key={idx} value={val}>
+                                {val}
                             </Option>
                         );
                     })}

--- a/src/reactviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
@@ -59,6 +59,11 @@ const ConnectionDialogStateProvider: React.FC<
                 connect: function (): void {
                     webviewState?.extensionRpc.action("connect");
                 },
+                loadAzureServers: function (subscriptionId: string): void {
+                    webviewState?.extensionRpc.action("loadAzureServers", {
+                        subscriptionId: subscriptionId,
+                    });
+                },
             }}
         >
             {children}

--- a/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
@@ -12,7 +12,6 @@ import { IConnectionDialogProfile } from "../../../sharedInterfaces/connectionDi
 import { ConnectButton } from "./components/connectButton.component";
 import { locConstants } from "../../common/locConstants";
 import { AdvancedOptionsDrawer } from "./components/advancedOptionsDrawer.component";
-import { TestConnectionButton } from "./components/testConnectionButton.component";
 
 export const ConnectionFormPage = () => {
     const context = useContext(ConnectionDialogContext);
@@ -63,9 +62,6 @@ export const ConnectionFormPage = () => {
                     {locConstants.connectionDialog.advancedSettings}
                 </Button>
                 <div className={formStyles.formNavTrayRight}>
-                    <TestConnectionButton
-                        className={formStyles.formNavTrayButton}
-                    />
                     <ConnectButton className={formStyles.formNavTrayButton} />
                 </div>
             </div>

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -37,19 +37,23 @@ export class ConnectionDialogWebviewState
             (keyof IConnectionDialogProfile)[]
         >;
     };
-    public azureDatabases: AzureSqlDatabaseInfo[];
+    public azureSubscriptions: AzureSubscriptionInfo[];
+    public azureServers: AzureSqlServerInfo[];
     public recentConnections: IConnectionDialogProfile[];
     public connectionStatus: ApiStatus;
     public formError: string;
+    public loadingAzureSubscriptionsStatus: ApiStatus;
 
     constructor({
         connectionProfile,
         selectedInputMode,
         connectionComponents,
-        azureDatabases,
+        azureSubscriptions,
+        azureServers,
         recentConnections,
         connectionStatus,
         formError,
+        loadingAzureSubscriptionsStatus,
     }: {
         connectionProfile: IConnectionDialogProfile;
         selectedInputMode: ConnectionInputMode;
@@ -65,22 +69,32 @@ export class ConnectionDialogWebviewState
                 (keyof IConnectionDialogProfile)[]
             >;
         };
-        azureDatabases: AzureSqlDatabaseInfo[];
+        azureServers: AzureSqlServerInfo[];
+        azureSubscriptions: AzureSubscriptionInfo[];
         recentConnections: IConnectionDialogProfile[];
         connectionStatus: ApiStatus;
         formError: string;
+        loadingAzureSubscriptionsStatus: ApiStatus;
     }) {
         this.formState = connectionProfile;
         this.selectedInputMode = selectedInputMode;
         this.connectionComponents = connectionComponents;
-        this.azureDatabases = azureDatabases;
+        this.azureSubscriptions = azureSubscriptions;
+        this.azureServers = azureServers;
         this.recentConnections = recentConnections;
         this.connectionStatus = connectionStatus;
         this.formError = formError;
+        this.loadingAzureSubscriptionsStatus = loadingAzureSubscriptionsStatus;
     }
 }
 
-export interface AzureSqlDatabaseInfo {
+export interface AzureSubscriptionInfo {
+    name: string;
+    id: string;
+    loaded: boolean;
+}
+
+export interface AzureSqlServerInfo {
     server: string;
     databases: string[];
     location: string;

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -43,6 +43,7 @@ export class ConnectionDialogWebviewState
     public connectionStatus: ApiStatus;
     public formError: string;
     public loadingAzureSubscriptionsStatus: ApiStatus;
+    public loadingAzureServersStatus: ApiStatus;
 
     constructor({
         connectionProfile,
@@ -54,6 +55,7 @@ export class ConnectionDialogWebviewState
         connectionStatus,
         formError,
         loadingAzureSubscriptionsStatus,
+        loadingAzureServersStatus,
     }: {
         connectionProfile: IConnectionDialogProfile;
         selectedInputMode: ConnectionInputMode;
@@ -75,6 +77,7 @@ export class ConnectionDialogWebviewState
         connectionStatus: ApiStatus;
         formError: string;
         loadingAzureSubscriptionsStatus: ApiStatus;
+        loadingAzureServersStatus: ApiStatus;
     }) {
         this.formState = connectionProfile;
         this.selectedInputMode = selectedInputMode;
@@ -85,6 +88,7 @@ export class ConnectionDialogWebviewState
         this.connectionStatus = connectionStatus;
         this.formError = formError;
         this.loadingAzureSubscriptionsStatus = loadingAzureSubscriptionsStatus;
+        this.loadingAzureServersStatus = loadingAzureServersStatus;
     }
 }
 
@@ -133,6 +137,7 @@ export interface ConnectionDialogContextProps
     loadConnection: (connection: IConnectionDialogProfile) => void;
     setConnectionInputType: (inputType: ConnectionInputMode) => void;
     connect: () => void;
+    loadAzureServers: (subscriptionId: string) => void;
 }
 
 export enum AuthenticationType {
@@ -152,4 +157,7 @@ export interface ConnectionDialogReducers {
         connection: IConnectionDialogProfile;
     };
     connect: {};
+    loadAzureServers: {
+        subscriptionId: string;
+    };
 }


### PR DESCRIPTION
* adds loading spinners for subscription and server calls
* switches server call to load from all subscriptions in parallelish (not awaiting until all promises have started)
* adds shortcut to immediately load servers for a subscription if the user selects that subscription before it's been populated in its turn

Note: there's a known bug where the user is prevented from typing in the "server" combobox; will fix in a later iteration/PR: #18102 