### PR TITLE
Always launching nps dialog through registered command

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -57,7 +57,7 @@ import { ExecutionPlanWebviewController } from "./executionPlanWebviewController
 import { QueryResultWebviewController } from "../queryResult/queryResultWebViewController";
 import { MssqlProtocolHandler } from "../mssqlProtocolHandler";
 import { isIConnectionInfo } from "../utils/utils";
-import { UserSurvey } from "../nps/userSurvey";
+import { getStandardNPSQuestions, UserSurvey } from "../nps/userSurvey";
 
 /**
  * The main controller class that initializes the extension
@@ -214,7 +214,10 @@ export default class MainController implements vscode.Disposable {
             });
             this.registerCommand(Constants.cmdLaunchUserFeedback);
             this._event.on(Constants.cmdLaunchUserFeedback, async () => {
-                await UserSurvey.getInstance().promptUserForNPSFeedback();
+                await UserSurvey.getInstance().launchSurvey(
+                    "nps",
+                    getStandardNPSQuestions(),
+                );
             });
             this.registerCommand(Constants.cmdCancelQuery);
             this._event.on(Constants.cmdCancelQuery, () => {

--- a/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
+++ b/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles({
         display: "flex",
         flexDirection: "column",
         width: "800px",
-        maxWidth: "100%",
+        maxWidth: "calc(100% - 20px)",
         "> *": {
             marginBottom: "15px",
         },


### PR DESCRIPTION
Previously, I accidentally plugged in the wrong function in case of "Give feedback" command. Due to which it was following the NPS selection logic and not always showing the NPS dialog. This PR corrects that behavior. 