### PR TITLE
Upgrading floating promises to require explicit `void`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -125,7 +125,7 @@ export default [
       ],
       "deprecation/deprecation": "warn",
       "@typescript-eslint/no-floating-promises": [
-        "warn",
+        "error",
         {
           ignoreVoid: true,
         },

--- a/src/azure/msal/msalAzureAuth.ts
+++ b/src/azure/msal/msalAzureAuth.ts
@@ -272,7 +272,7 @@ export abstract class MsalAzureAuth {
 
     public async loadTokenCache(): Promise<void> {
         let tokenCache = this.clientApplication.getTokenCache();
-        tokenCache.getAllAccounts();
+        void tokenCache.getAllAccounts();
     }
 
     public async getAccountFromMsalCache(

--- a/src/azure/msal/msalAzureController.ts
+++ b/src/azure/msal/msalAzureController.ts
@@ -74,7 +74,7 @@ export class MsalAzureController extends AzureController {
 
         let azureAuth = await this.getAzureAuthInstance(authType!);
         await this.clearOldCacheIfExists();
-        azureAuth.loadTokenCache();
+        void azureAuth.loadTokenCache();
     }
 
     public async clearTokenCache(): Promise<void> {

--- a/src/azure/simpleWebServer.ts
+++ b/src/azure/simpleWebServer.ts
@@ -93,7 +93,7 @@ export class SimpleWebServer {
             clearTimeout(portTimeout);
         };
 
-        portPromise.finally(clearPortTimeout);
+        void portPromise.finally(clearPortTimeout);
 
         return portPromise;
     }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1657,7 +1657,9 @@ export default class ConnectionManager {
                             } else {
                                 await this._accountStore.pruneAccounts();
                             }
-                            this.azureController.removeAccount(answers.account);
+                            void this.azureController.removeAccount(
+                                answers.account,
+                            );
                             this.vscodeWrapper.showInformationMessage(
                                 LocalizedConstants.accountRemovedSuccessfully,
                             );

--- a/src/controllers/executionPlanWebviewController.ts
+++ b/src/controllers/executionPlanWebviewController.ts
@@ -55,7 +55,7 @@ export class ExecutionPlanWebviewController extends ReactWebviewPanelController<
                 ),
             },
         );
-        this.initialize();
+        void this.initialize();
     }
 
     private async initialize() {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -141,7 +141,7 @@ export default class MainController implements vscode.Disposable {
      * Disposes the controller
      */
     dispose(): void {
-        this.deactivate();
+        void this.deactivate();
     }
 
     /**
@@ -177,16 +177,16 @@ export default class MainController implements vscode.Disposable {
             // register VS Code commands
             this.registerCommand(Constants.cmdConnect);
             this._event.on(Constants.cmdConnect, () => {
-                this.runAndLogErrors(this.onNewConnection());
+                void this.runAndLogErrors(this.onNewConnection());
             });
             this.registerCommand(Constants.cmdDisconnect);
             this._event.on(Constants.cmdDisconnect, () => {
-                this.runAndLogErrors(this.onDisconnect());
+                void this.runAndLogErrors(this.onDisconnect());
             });
             this.registerCommand(Constants.cmdRunQuery);
             this._event.on(Constants.cmdRunQuery, () => {
-                UserSurvey.getInstance().promptUserForNPSFeedback();
-                this.onRunQuery();
+                void UserSurvey.getInstance().promptUserForNPSFeedback();
+                void this.onRunQuery();
             });
             this.registerCommand(Constants.cmdManageConnectionProfiles);
             this._event.on(Constants.cmdManageConnectionProfiles, async () => {
@@ -198,19 +198,19 @@ export default class MainController implements vscode.Disposable {
             });
             this.registerCommand(Constants.cmdRunCurrentStatement);
             this._event.on(Constants.cmdRunCurrentStatement, () => {
-                this.onRunCurrentStatement();
+                void this.onRunCurrentStatement();
             });
             this.registerCommand(Constants.cmdChangeDatabase);
             this._event.on(Constants.cmdChangeDatabase, () => {
-                this.runAndLogErrors(this.onChooseDatabase());
+                void this.runAndLogErrors(this.onChooseDatabase());
             });
             this.registerCommand(Constants.cmdChooseDatabase);
             this._event.on(Constants.cmdChooseDatabase, () => {
-                this.runAndLogErrors(this.onChooseDatabase());
+                void this.runAndLogErrors(this.onChooseDatabase());
             });
             this.registerCommand(Constants.cmdChooseLanguageFlavor);
             this._event.on(Constants.cmdChooseLanguageFlavor, () => {
-                this.runAndLogErrors(this.onChooseLanguageFlavor());
+                void this.runAndLogErrors(this.onChooseLanguageFlavor());
             });
             this.registerCommand(Constants.cmdLaunchUserFeedback);
             this._event.on(Constants.cmdLaunchUserFeedback, async () => {
@@ -536,7 +536,7 @@ export default class MainController implements vscode.Disposable {
 
         // Shows first time notifications on extension installation or update
         // This call is intentionally not awaited to avoid blocking extension activation
-        this.showFirstLaunchPrompts();
+        void this.showFirstLaunchPrompts();
 
         // Handle case where SQL file is the 1st opened document
         const activeTextEditor = this._vscodeWrapper.activeTextEditor;
@@ -1269,7 +1269,7 @@ export default class MainController implements vscode.Disposable {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
             const fileUri = this._vscodeWrapper.activeTextEditorUri;
             if (fileUri && this._vscodeWrapper.isEditingSqlFile) {
-                this._connectionMgr.onChooseLanguageFlavor();
+                void this._connectionMgr.onChooseLanguageFlavor();
             } else {
                 this._vscodeWrapper.showWarningMessage(
                     LocalizedConstants.msgOpenSqlFile,
@@ -1997,7 +1997,7 @@ export default class MainController implements vscode.Disposable {
                 (await this._objectExplorerProvider.getChildren()).forEach(
                     (n: TreeNodeInfo) => {
                         try {
-                            this._objectExplorerProvider.refreshNode(n);
+                            void this._objectExplorerProvider.refreshNode(n);
                         } catch (e) {
                             errorFoundWhileRefreshing = true;
                             this._connectionMgr.client.logger.error(e);
@@ -2079,11 +2079,11 @@ export default class MainController implements vscode.Disposable {
     }
 
     public removeAadAccount(prompter: IPrompter): void {
-        this.connectionManager.removeAccount(prompter);
+        void this.connectionManager.removeAccount(prompter);
     }
 
     public addAadAccount(): void {
-        this.connectionManager.addAccount();
+        void this.connectionManager.addAccount();
     }
 
     public onClearAzureTokenCache(): void {

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -515,7 +515,7 @@ export default class QueryRunner {
             this._vscodeWrapper.showErrorMessage(
                 "Something went wrong getting more rows: " + error.message,
             );
-            Promise.reject(error);
+            void Promise.reject(error);
         }
     }
 
@@ -536,7 +536,7 @@ export default class QueryRunner {
             this._vscodeWrapper.showErrorMessage(
                 "Failed disposing query: " + error.message,
             );
-            Promise.reject(error);
+            void Promise.reject(error);
         }
     }
 

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -453,7 +453,7 @@ export default class SqlToolsServiceClient {
             serverOptions,
             clientOptions,
         );
-        client.onReady().then(() => {
+        void client.onReady().then(() => {
             client.onNotification(
                 LanguageServiceContracts.StatusChangedNotification.type,
                 this.handleLanguageServiceStatusNotification(),

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -123,7 +123,7 @@ export class SqlOutputContentProvider {
         selection: Interfaces.ISlickRange[],
         includeHeaders?: boolean,
     ): void {
-        this._queryResultsMap
+        void this._queryResultsMap
             .get(uri)
             .queryRunner.copyResults(
                 selection,
@@ -137,7 +137,7 @@ export class SqlOutputContentProvider {
         uri: string,
         selection: ISelectionData,
     ): void {
-        this._queryResultsMap
+        void this._queryResultsMap
             .get(uri)
             .queryRunner.setEditorSelection(selection);
     }
@@ -617,7 +617,7 @@ export class SqlOutputContentProvider {
                     this.cancelQuery(queryRunnerState.queryRunner);
                 } else {
                     // We need to explicitly dispose the query
-                    queryRunnerState.queryRunner.dispose();
+                    void queryRunnerState.queryRunner.dispose();
                 }
             } else {
                 queryRunnerState.timeout = this.setRunnerDeletionTimeout(uri);

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -222,10 +222,10 @@ export class ObjectExplorerService {
                     errorNumber ===
                     Constants.errorSSLCertificateValidationFailed
                 ) {
-                    self._connectionManager.showInstructionTextAsWarning(
+                    void self._connectionManager.showInstructionTextAsWarning(
                         self._currentNode.connectionInfo,
                         async (updatedProfile) => {
-                            self.reconnectProfile(
+                            void self.reconnectProfile(
                                 self._currentNode,
                                 updatedProfile,
                             );
@@ -251,7 +251,7 @@ export class ObjectExplorerService {
                             self._currentNode.connectionInfo
                         );
                         self.updateNode(self._currentNode);
-                        self._connectionManager.connectionUI.handleFirewallError(
+                        void self._connectionManager.connectionUI.handleFirewallError(
                             nodeUri,
                             profile,
                             handleFirewallResult.ipAddress,
@@ -273,7 +273,7 @@ export class ObjectExplorerService {
                     await this.refreshAccount(account, profile);
                     // Do not await when performing reconnect to allow
                     // OE node to expand after connection is established.
-                    this.reconnectProfile(self._currentNode, profile);
+                    void this.reconnectProfile(self._currentNode, profile);
                 } else {
                     self._connectionManager.vscodeWrapper.showErrorMessage(
                         error,
@@ -311,7 +311,7 @@ export class ObjectExplorerService {
                     profile,
                 )
             ) {
-                this.refreshNode(node);
+                void this.refreshNode(node);
             }
         } else {
             this._connectionManager.vscodeWrapper.showErrorMessage(
@@ -765,7 +765,10 @@ export class ObjectExplorerService {
                         (!azureController.isSqlAuthProviderEnabled() ||
                             needsRefresh)
                     ) {
-                        this.refreshAccount(account, connectionCredentials);
+                        void this.refreshAccount(
+                            account,
+                            connectionCredentials,
+                        );
                     }
                 }
             }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -153,7 +153,7 @@ class MessageProxy implements Disposable {
                 deferred.resolve(message.response);
             }
         } else {
-            Promise.resolve(
+            void Promise.resolve(
                 this.handler[message.method].apply(
                     this.handler,
                     message.passArguments,

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -24,7 +24,8 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 resultPaneTab: qr.QueryResultPaneTabs.Messages,
             },
         });
-        this.initialize();
+
+        void this.initialize();
     }
 
     private async initialize() {

--- a/src/reactviews/common/rpc.ts
+++ b/src/reactviews/common/rpc.ts
@@ -83,7 +83,7 @@ export class WebviewRpc<Reducers> {
         method: MethodName,
         payload?: Reducers[MethodName],
     ) {
-        this.call("action", { type: method, payload });
+        void this.call("action", { type: method, payload });
     }
 
     public subscribe(method: string, callback: (params: unknown) => void) {
@@ -94,10 +94,10 @@ export class WebviewRpc<Reducers> {
     }
 
     public sendActionEvent(event: WebviewTelemetryActionEvent) {
-        this.call("sendActionEvent", event);
+        void this.call("sendActionEvent", event);
     }
 
     public sendErrorEvent(event: WebviewTelemetryErrorEvent) {
-        this.call("sendErrorEvent", event);
+        void this.call("sendErrorEvent", event);
     }
 }

--- a/src/reactviews/common/vscodeWebviewProvider.tsx
+++ b/src/reactviews/common/vscodeWebviewProvider.tsx
@@ -115,10 +115,10 @@ export function VscodeWebviewProvider<State, Reducers>({
             setLocalization(true);
         }
 
-        getTheme();
-        getState();
-        loadStats();
-        getLocalization();
+        void getTheme();
+        void getState();
+        void loadStats();
+        void getLocalization();
     }, []);
 
     extensionRpc.subscribe("onDidChangeTheme", (params) => {

--- a/src/reactviews/pages/ExecutionPlan/properties.tsx
+++ b/src/reactviews/pages/ExecutionPlan/properties.tsx
@@ -455,7 +455,7 @@ export const PropertiesPane: React.FC<PropertiesPaneProps> = ({
                     }
                     onChange={(e) => {
                         setInputValue(e.target.value);
-                        handleFilter(e.target.value);
+                        void handleFilter(e.target.value);
                     }}
                 />
             </Toolbar>

--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -45,7 +45,7 @@ const CommandBar = (props: CommandBarProps) => {
     const classes = useStyles();
 
     const saveResults = (buttonLabel: string) => {
-        webViewState.extensionRpc.call("saveResults", {
+        void webViewState.extensionRpc.call("saveResults", {
             uri: props.uri,
             batchId: props.resultSetSummary?.batchId,
             resultId: props.resultSetSummary?.id,

--- a/src/reactviews/pages/QueryResult/table/hybridDataProvider.ts
+++ b/src/reactviews/pages/QueryResult/table/hybridDataProvider.ts
@@ -108,12 +108,12 @@ export class HybridDataProvider<T extends Slick.SlickData>
 
     public async filter(columns: FilterableColumn<T>[]) {
         await this.initializeCacheIfNeeded();
-        this.provider.filter(columns);
+        void this.provider.filter(columns);
     }
 
     public async sort(options: Slick.OnSortEventArgs<T>) {
         await this.initializeCacheIfNeeded();
-        this.provider.sort(options);
+        void this.provider.sort(options);
     }
 
     private get thresholdReached(): boolean {

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -165,7 +165,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
             "click",
             "#sort-ascending",
             (_e: JQuery.ClickEvent) => {
-                this.handleMenuItemClick("sort-asc", this.columnDef);
+                void this.handleMenuItemClick("sort-asc", this.columnDef);
                 closePopup($popup);
             },
         );
@@ -173,7 +173,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
             "click",
             "#sort-descending",
             (_e: JQuery.ClickEvent) => {
-                this.handleMenuItemClick("sort-desc", this.columnDef);
+                void this.handleMenuItemClick("sort-desc", this.columnDef);
                 closePopup($popup);
             },
         );

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -60,7 +60,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                 ),
             },
         );
-        this.initialize();
+        void this.initialize();
     }
 
     private async initialize() {

--- a/test/unit/adapter.test.ts
+++ b/test/unit/adapter.test.ts
@@ -71,10 +71,10 @@ suite("Code Adapter Tests", () => {
     });
 
     test("promptSingle and promptCallback should call prompt", () => {
-        adapter.promptSingle(testQuestion);
+        void adapter.promptSingle(testQuestion);
         adapter.promptCallback([testQuestion], () => true);
         // Error case
-        adapter.prompt([{ type: "test", message: "test", name: "test" }]);
+        void adapter.prompt([{ type: "test", message: "test", name: "test" }]);
     });
 
     test("prompting a checkbox question should call fixQuestion", () => {
@@ -84,9 +84,9 @@ suite("Code Adapter Tests", () => {
             name: "test_checkbox",
             choices: [{ name: "test_choice", value: "test_choice" }],
         };
-        adapter.promptSingle(formattedQuestion);
+        void adapter.promptSingle(formattedQuestion);
         let question: any = Object.assign({}, formattedQuestion);
         question.choices[0] = "test";
-        adapter.promptSingle(question);
+        void adapter.promptSingle(question);
     });
 });

--- a/test/unit/connectionCredentials.test.ts
+++ b/test/unit/connectionCredentials.test.ts
@@ -139,7 +139,7 @@ suite("ConnectionCredentials Tests", () => {
                     answers[LocalizedConstants.passwordPrompt] = emptyPassword
                         ? ""
                         : "newPassword";
-                    passwordQuestion[0].onAnswered(
+                    void passwordQuestion[0].onAnswered(
                         answers[LocalizedConstants.passwordPrompt],
                     );
                 })
@@ -315,7 +315,7 @@ suite("ConnectionCredentials Tests", () => {
         )[0];
 
         let connectionString = "server=some-server";
-        serverQuestion.onAnswered(connectionString);
+        void serverQuestion.onAnswered(connectionString);
 
         // Verify that the remaining questions will not prompt
         let otherQuestions = questions.filter(
@@ -336,14 +336,14 @@ suite("ConnectionCredentials Tests", () => {
         )[0];
 
         let connectionString = "server=some-server";
-        serverQuestion.onAnswered(connectionString);
+        void serverQuestion.onAnswered(connectionString);
 
         // Verify that the question updated the connection string
         assert.equal(credentials.connectionString, connectionString);
         assert.notEqual(credentials.server, connectionString);
 
         let serverName = "some-server";
-        serverQuestion.onAnswered(serverName);
+        void serverQuestion.onAnswered(serverName);
         assert.equal(credentials.server, serverName);
         assert.notEqual(credentials.connectionString, serverName);
     });

--- a/test/unit/connectionUI.test.ts
+++ b/test/unit/connectionUI.test.ts
@@ -317,7 +317,7 @@ suite("Connection UI tests", () => {
         prompter
             .setup((p) => p.promptSingle(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(true));
-        connectionUI.promptToManageProfiles();
+        void connectionUI.promptToManageProfiles();
         prompter.verify(
             (p) => p.promptSingle(TypeMoq.It.isAny()),
             TypeMoq.Times.once(),

--- a/test/unit/credentialStore.test.ts
+++ b/test/unit/credentialStore.test.ts
@@ -52,7 +52,7 @@ suite("Credential Store Tests", () => {
     });
 
     test("Read credential should send a ReadCredentialRequest", () => {
-        credentialStore.readCredential("test_credential").then(() => {
+        void credentialStore.readCredential("test_credential").then(() => {
             client.verify(
                 (c) =>
                     c.sendRequest(
@@ -65,7 +65,7 @@ suite("Credential Store Tests", () => {
     });
 
     test("Save credential should send a SaveCredentialRequest", () => {
-        credentialStore
+        void credentialStore
             .saveCredential("test_credential", "test_password")
             .then(() => {
                 client.verify(
@@ -80,7 +80,7 @@ suite("Credential Store Tests", () => {
     });
 
     test("Delete credential should send a DeleteCredentialRequest", () => {
-        credentialStore.deleteCredential("test_credential").then(() => {
+        void credentialStore.deleteCredential("test_credential").then(() => {
             client.verify(
                 (c) =>
                     c.sendRequest(

--- a/test/unit/initialization.test.ts
+++ b/test/unit/initialization.test.ts
@@ -32,7 +32,7 @@ function waitForExtensionToBeActive(resolve): void {
 suite("Initialization Tests", () => {
     test("Connection manager is initialized properly", (done) => {
         // Wait for the extension to activate
-        ensureExtensionIsActive().then(async () => {
+        void ensureExtensionIsActive().then(async () => {
             // Verify that the connection manager was initialized properly
             let controller: MainController = await Extension.getController();
             let connectionManager: ConnectionManager =

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -100,7 +100,7 @@ suite("MainController Tests", () => {
 
     // Standard closed document event test
     test("onDidCloseTextDocument should propogate onDidCloseTextDocument to connectionManager", () => {
-        mainController.onDidCloseTextDocument(document);
+        void mainController.onDidCloseTextDocument(document);
         try {
             connectionManager.verify(
                 (x) => x.onDidCloseTextDocument(TypeMoq.It.isAny()),
@@ -125,7 +125,7 @@ suite("MainController Tests", () => {
 
         // A save untitled doc constitutes an saveDoc event directly followed by a closeDoc event
         mainController.onDidSaveTextDocument(newDocument);
-        mainController.onDidCloseTextDocument(document2);
+        void mainController.onDidCloseTextDocument(document2);
         try {
             connectionManager.verify(
                 (x) =>
@@ -147,7 +147,7 @@ suite("MainController Tests", () => {
     test("onDidCloseTextDocument should call renamedDoc function when rename occurs", (done) => {
         // A renamed doc constitutes an openDoc event directly followed by a closeDoc event
         mainController.onDidOpenTextDocument(newDocument);
-        mainController.onDidCloseTextDocument(document);
+        void mainController.onDidCloseTextDocument(document);
 
         // Verify renameDoc function was called
         try {
@@ -175,7 +175,7 @@ suite("MainController Tests", () => {
 
         // Cause event time out (above 10 ms should work)
         setTimeout(() => {
-            mainController.onDidCloseTextDocument(document);
+            void mainController.onDidCloseTextDocument(document);
             try {
                 connectionManager.verify(
                     (x) =>
@@ -250,7 +250,7 @@ suite("MainController Tests", () => {
         // None of the TextDocument events should throw exceptions, they should cleanly exit instead.
         controller.onDidOpenTextDocument(document);
         controller.onDidSaveTextDocument(document);
-        controller.onDidCloseTextDocument(document);
+        void controller.onDidCloseTextDocument(document);
         done();
     });
 

--- a/test/unit/objectExplorerProvider.test.ts
+++ b/test/unit/objectExplorerProvider.test.ts
@@ -96,7 +96,7 @@ suite("Object Explorer Provider Tests", () => {
                     );
                 });
             });
-        objectExplorerProvider
+        void objectExplorerProvider
             .createSession(promise, undefined)
             .then(async () => {
                 expect(
@@ -123,11 +123,14 @@ suite("Object Explorer Provider Tests", () => {
         objectExplorerService
             .setup((s) => s.refreshNode(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(TypeMoq.It.isAny()));
-        objectExplorerProvider.refreshNode(treeNode.object).then((node) => {
-            expect(node, "Refreshed node should not be undefined").is.not.equal(
-                undefined,
-            );
-        });
+        void objectExplorerProvider
+            .refreshNode(treeNode.object)
+            .then((node) => {
+                expect(
+                    node,
+                    "Refreshed node should not be undefined",
+                ).is.not.equal(undefined);
+            });
         done();
     });
 
@@ -179,7 +182,7 @@ suite("Object Explorer Provider Tests", () => {
         objectExplorerService
             .setup((s) => s.getChildren(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve([childTreeNode.object]));
-        objectExplorerProvider
+        void objectExplorerProvider
             .getChildren(parentTreeNode.object)
             .then((children) => {
                 children.forEach((child) =>
@@ -317,7 +320,7 @@ suite("Object Explorer Provider Tests", () => {
         let node: any = {
             connectionCredentials: undefined,
         };
-        objectExplorerProvider.expandNode(node, "test_session", undefined);
+        void objectExplorerProvider.expandNode(node, "test_session", undefined);
         objectExplorerService.verify(
             (s) =>
                 s.expandNode(
@@ -362,7 +365,7 @@ suite("Object Explorer Provider Tests", () => {
             s.removeConnectionNodes(TypeMoq.It.isAny()),
         );
         let connections: any[] = [{ server: "test_server" }];
-        objectExplorerProvider.removeConnectionNodes(connections);
+        void objectExplorerProvider.removeConnectionNodes(connections);
         objectExplorerService.verify(
             (s) => s.removeConnectionNodes(connections),
             TypeMoq.Times.once(),

--- a/test/unit/perFileConnection.test.ts
+++ b/test/unit/perFileConnection.test.ts
@@ -829,7 +829,7 @@ suite("Per File Connection Tests", () => {
         );
 
         // Attempt to run a query without connecting
-        controller.onRunQuery();
+        void controller.onRunQuery();
         connectionManagerMock.verify(
             (x) => x.onNewConnection(),
             TypeMoq.Times.once(),
@@ -869,38 +869,42 @@ suite("Per File Connection Tests", () => {
         // Open a connection using the connection manager
         let connectionCreds = createTestCredentials();
 
-        connectionManager.connect(testFile, connectionCreds).then((result) => {
-            assert.equal(result, true);
+        void connectionManager
+            .connect(testFile, connectionCreds)
+            .then((result) => {
+                assert.equal(result, true);
 
-            // Check that the connection was established
-            assert.equal(connectionManager.isConnected(testFile), true);
-            assert.equal(
-                connectionManager.getConnectionInfo(testFile).credentials
-                    .database,
-                connectionCreds.database,
-            );
+                // Check that the connection was established
+                assert.equal(connectionManager.isConnected(testFile), true);
+                assert.equal(
+                    connectionManager.getConnectionInfo(testFile).credentials
+                        .database,
+                    connectionCreds.database,
+                );
 
-            // Simulate a connection changed notification
-            let parameters = new ConnectionContracts.ConnectionChangedParams();
-            parameters.ownerUri = testFile;
-            parameters.connection = new ConnectionContracts.ConnectionSummary();
-            parameters.connection.serverName = connectionCreds.server;
-            parameters.connection.databaseName = "myOtherDatabase";
-            parameters.connection.userName = connectionCreds.user;
+                // Simulate a connection changed notification
+                let parameters =
+                    new ConnectionContracts.ConnectionChangedParams();
+                parameters.ownerUri = testFile;
+                parameters.connection =
+                    new ConnectionContracts.ConnectionSummary();
+                parameters.connection.serverName = connectionCreds.server;
+                parameters.connection.databaseName = "myOtherDatabase";
+                parameters.connection.userName = connectionCreds.user;
 
-            let notificationObject =
-                connectionManager.handleConnectionChangedNotification();
-            notificationObject.call(connectionManager, parameters);
+                let notificationObject =
+                    connectionManager.handleConnectionChangedNotification();
+                notificationObject.call(connectionManager, parameters);
 
-            // Verify that the connection changed to the other database for the file
-            assert.equal(
-                connectionManager.getConnectionInfo(testFile).credentials
-                    .database,
-                "myOtherDatabase",
-            );
+                // Verify that the connection changed to the other database for the file
+                assert.equal(
+                    connectionManager.getConnectionInfo(testFile).credentials
+                        .database,
+                    "myOtherDatabase",
+                );
 
-            done();
-        });
+                done();
+            });
     });
 
     test("Should use actual database name instead of <default>", (done) => {

--- a/test/unit/platform.test.ts
+++ b/test/unit/platform.test.ts
@@ -19,7 +19,7 @@ function getPlatform(): Promise<Runtime> {
 
 suite("Platform Tests", () => {
     test("getCurrentPlatform should return valid value", (done) => {
-        getPlatform().then((platform) => {
+        void getPlatform().then((platform) => {
             assert.notEqual(platform, Runtime.UnknownRuntime);
             done();
         });

--- a/test/unit/queryRunner.test.ts
+++ b/test/unit/queryRunner.test.ts
@@ -886,7 +886,7 @@ suite("Query Runner tests", () => {
                 testVscodeWrapper.object,
             );
             queryRunner.uri = testuri;
-            queryRunner.copyResults(testRange, 0, 0).then(() => {
+            void queryRunner.copyResults(testRange, 0, 0).then(() => {
                 testVscodeWrapper.verify<void>(
                     (x) => x.clipboardWriteText(TypeMoq.It.isAnyString()),
                     TypeMoq.Times.once(),

--- a/test/unit/serverStatus.test.ts
+++ b/test/unit/serverStatus.test.ts
@@ -33,7 +33,7 @@ suite("Server Status View Tests", () => {
                 resolve();
             }, 300);
         });
-        p.then(() => done());
+        void p.then(() => done());
     });
 
     test("Test update service download progress status", () => {

--- a/test/unit/serviceClient.test.ts
+++ b/test/unit/serviceClient.test.ts
@@ -72,7 +72,7 @@ suite("Service Client tests", () => {
             vscodeWrapper.object,
         );
 
-        serviceClient
+        void serviceClient
             .initializeForPlatform(fixture.platformInfo, undefined)
             .then((result) => {
                 assert.notEqual(result, undefined);
@@ -98,7 +98,7 @@ suite("Service Client tests", () => {
             vscodeWrapper.object,
         );
 
-        serviceClient
+        void serviceClient
             .initializeForPlatform(fixture.platformInfo, undefined)
             .then((result) => {
                 assert.notEqual(result, undefined);
@@ -165,7 +165,7 @@ suite("Service Client tests", () => {
             vscodeWrapper.object,
         );
 
-        serviceClient
+        void serviceClient
             .initializeForPlatform(fixture.platformInfo, undefined)
             .then((result) => {
                 assert.equal(serviceVersion, 1);
@@ -213,7 +213,7 @@ suite("Service Client tests", () => {
             vscodeWrapper.object,
         );
 
-        serviceClient
+        void serviceClient
             .initializeForPlatform(fixture.platformInfo, undefined)
             .then((result) => {
                 assert.equal(serviceVersion, 0);

--- a/test/unit/sqlOutputContentProvider.test.ts
+++ b/test/unit/sqlOutputContentProvider.test.ts
@@ -194,7 +194,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
             startColumn: 0,
             startLine: 0,
         };
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -204,7 +204,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         // Run function with properties declared below
         let title2 = "Test_Title2";
         let uri2 = "Test_URI2";
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri2,
             querySelection,
@@ -230,7 +230,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -239,7 +239,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
 
         // Ensure all side effects occurred as intended
         assert.equal(mockMap.get(uri).queryRunner.isExecutingQuery, true);
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -263,7 +263,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -294,7 +294,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -333,7 +333,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -343,7 +343,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         // Ensure all side effects occured as intended
         assert.equal(mockMap.has(testUri), true);
 
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -373,7 +373,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -384,7 +384,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         // Ensure all side effects occured as intended
         assert.equal(mockMap.has(resultUri), true);
 
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -416,7 +416,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -427,7 +427,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         // Ensure all side effects occured as intended
         assert.equal(mockMap.has(testUri), true);
 
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,
@@ -456,7 +456,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         };
 
         // Setup the function to call base and run it
-        mockContentProvider.object.runQuery(
+        void mockContentProvider.object.runQuery(
             statusView.object,
             uri,
             querySelection,

--- a/test/unit/untitledSqlDocumentService.test.ts
+++ b/test/unit/untitledSqlDocumentService.test.ts
@@ -78,7 +78,7 @@ suite("UntitledSqlDocumentService Tests", () => {
         };
         fixture = createUntitledSqlDocumentService(fixture);
 
-        fixture.service.newQuery().then((result) => {
+        void fixture.service.newQuery().then((_) => {
             fixture.vscodeWrapper.verify(
                 (x) => x.openMsSqlTextDocument(),
                 TypeMoq.Times.once(),

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -139,7 +139,7 @@ suite.skip("Utility tests - Timer Class", () => {
                 resolve();
             }, 100);
         });
-        p.then(() => done());
+        void p.then(() => done());
     });
 
     test("timer should end when ended", (done) => {
@@ -152,6 +152,6 @@ suite.skip("Utility tests - Timer Class", () => {
                 resolve();
             }, 100);
         });
-        p.then(() => done());
+        void p.then(() => done());
     });
 });

--- a/test/unit/webviewPanelController.test.ts
+++ b/test/unit/webviewPanelController.test.ts
@@ -43,7 +43,7 @@ suite("Webview Panel Controller Tests", () => {
 
     test("Initializing a controller should create and open a new webview panel", (done) => {
         assert.equal(webviewPanel, undefined);
-        mockWebviewPanelController.object.init();
+        void mockWebviewPanelController.object.init();
         assert.notEqual(webviewPanel, undefined);
         assert.equal(mockWebviewPanelController.object.isDisposed, false);
         mockWebviewPanelController.object.dispose();
@@ -51,7 +51,7 @@ suite("Webview Panel Controller Tests", () => {
     });
 
     test("Closing the Webview Panel should dispose the webview", (done) => {
-        mockWebviewPanelController.object.init();
+        void mockWebviewPanelController.object.init();
         assert.notEqual(webviewPanel, undefined);
         assert.equal(mockWebviewPanelController.object.isDisposed, false);
         mockWebviewPanelController.object.dispose();


### PR DESCRIPTION
Making this change to head off bugs; every async call now requires either an `await` or a `void` in front of it to be explicit which behavior is intended.