### PR TITLE
Adding inline refresh button for all OE nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,6 +417,11 @@
           "group": "MS_SQL@10"
         },
         {
+          "command": "mssql.refreshObjectExplorerNode",
+          "when": "view == objectExplorer && viewItem =~ /\\btype=(?!disconnectedServer\\b)[^,]+/ ",
+          "group": "inline@9999"
+        },
+        {
           "command": "mssql.disconnectObjectExplorerNode",
           "when": "view == objectExplorer && viewItem =~ /\\btype=(Server)\\b/",
           "group": "MS_SQL@3"
@@ -686,7 +691,8 @@
       {
         "command": "mssql.refreshObjectExplorerNode",
         "title": "%mssql.refreshObjectExplorerNode%",
-        "category": "MS SQL"
+        "category": "MS SQL",
+        "icon": "$(refresh)"
       },
       {
         "command": "mssql.disconnectObjectExplorerNode",


### PR DESCRIPTION
This PR fixes #18158 

the group is set to inline@9999 because I want the refresh icon to always appear as the last icon.
<img width="508" alt="image" src="https://github.com/user-attachments/assets/0e1dc94d-1ed6-4957-9139-820c56aa7032">

