### PR TITLE
Add basic telemetry to query result pane

### DIFF
--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -7,6 +7,12 @@ import * as vscode from "vscode";
 import * as qr from "../sharedInterfaces/queryResult";
 import { ReactWebviewViewController } from "../controllers/reactWebviewViewController";
 import { SqlOutputContentProvider } from "../models/sqlOutputContentProvider";
+import { sendActionEvent } from "../telemetry/telemetry";
+import {
+    TelemetryActions,
+    TelemetryViews,
+} from "../sharedInterfaces/telemetry";
+import { randomUUID } from "crypto";
 
 export class QueryResultWebviewController extends ReactWebviewViewController<
     qr.QueryResultWebviewState,
@@ -15,6 +21,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
     private _queryResultStateMap: Map<string, qr.QueryResultWebviewState> =
         new Map<string, qr.QueryResultWebviewState>();
     private _sqlOutputContentProvider: SqlOutputContentProvider;
+    private _correlationId: string = randomUUID();
 
     constructor(context: vscode.ExtensionContext) {
         super(context, "queryResult", {
@@ -49,6 +56,13 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             );
         });
         this.registerRequestHandler("saveResults", async (message) => {
+            sendActionEvent(
+                TelemetryViews.QueryResult,
+                TelemetryActions.SaveResults,
+                {
+                    correlationId: this._correlationId,
+                },
+            );
             return await this._sqlOutputContentProvider.saveResultsRequestHandler(
                 message.uri,
                 message.batchId,

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -61,6 +61,9 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 TelemetryActions.SaveResults,
                 {
                     correlationId: this._correlationId,
+                    format: message.format,
+                    // TODO: add selection to telemetry when it's supported
+                    // TODO: add action origin (context/toolbar) to telemetry
                 },
             );
             return await this._sqlOutputContentProvider.saveResultsRequestHandler(

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -8,6 +8,7 @@ export enum TelemetryViews {
     CommandPalette = "CommandPalette",
     SqlProjects = "SqlProjects",
     QueryEditor = "QueryEditor",
+    QueryResult = "QueryResult",
     ResultsGrid = "ResultsGrid",
     ConnectionPrompt = "ConnectionPrompt",
     WebviewController = "WebviewController",
@@ -41,4 +42,5 @@ export enum TelemetryActions {
     ContinueEditing = "ContinueEditing",
     Close = "Close",
     SurverySubmit = "SurveySubmit",
+    SaveResults = "SaveResults",
 }

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -8,8 +8,8 @@ export enum TelemetryViews {
     CommandPalette = "CommandPalette",
     SqlProjects = "SqlProjects",
     QueryEditor = "QueryEditor",
-    QueryResult = "QueryResult",
-    ResultsGrid = "ResultsGrid",
+    QueryResult = "QueryResult", // react query result pane
+    ResultsGrid = "ResultsGrid", // angular results grid
     ConnectionPrompt = "ConnectionPrompt",
     WebviewController = "WebviewController",
     ObjectExplorerFilter = "ObjectExplorerFilter",


### PR DESCRIPTION
We only need to add telemetry to the query result page, the query execution already has its own telemetry.

Follow up items:
1. Add selection info and origin info once save from context menu is implemented https://github.com/microsoft/vscode-mssql/issues/18061
2. Add telemetry event for copy feature once it's implemented https://github.com/microsoft/vscode-mssql/issues/18060
3. Add telemetry event for maximize button once it's implemented https://github.com/microsoft/vscode-mssql/issues/18144
