### PR TITLE
Fixing a bunch of Table designer bugs. 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1,15 +1,11 @@
 {
-  "The name of the table object.": "The name of the table object.",
-  "Table name": "Table name",
-  "The schema that contains the table.": "The schema that contains the table.",
-  "Schema": "Schema",
   "Description for the table.": "Description for the table.",
   "Description": "Description",
   "The name of the column object.": "The name of the column object.",
   "Name": "Name",
   "Displays the description of the column": "Displays the description of the column",
   "Displays the unified data type (including length, scale and precision) for the column": "Displays the unified data type (including length, scale and precision) for the column",
-  "Advanced Type": "Advanced Type",
+  "Data Type": "Data Type",
   "Displays the data type name for the column": "Displays the data type name for the column",
   "Type": "Type",
   "The maximum length (in characters) that can be stored in this database object.": "The maximum length (in characters) that can be stored in this database object.",
@@ -60,7 +56,7 @@
   "Check Constraints": "Check Constraints",
   "Check Constraint": "Check Constraint",
   "New Check Constraint": "New Check Constraint",
-  "General": "General",
+  "Advanced Options": "Advanced Options",
   "{0} issue/{0} is the number of issues": {
     "message": "{0} issue",
     "comment": [
@@ -174,12 +170,14 @@
       "{0} is the object type"
     ]
   },
+  "Table name": "Table name",
   "Remove {0}/{0} is the object type": {
     "message": "Remove {0}",
     "comment": [
       "{0} is the object type"
     ]
   },
+  "Schema": "Schema",
   "Connect": "Connect",
   "Advanced Connection Settings": "Advanced Connection Settings",
   "Advanced": "Advanced",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -51,8 +51,8 @@
     <trans-unit id="++CODE++d2cab259e6e6da600d35907f2b627f8bf69c49ab40f8f129b9d9f206f149a8f9">
       <source xml:lang="en">Advanced Connection Settings</source>
     </trans-unit>
-    <trans-unit id="++CODE++232bbbc747fa6709e2940f4d0eec4b819b3b007acfdacaec8f3e2e1536799bd7">
-      <source xml:lang="en">Advanced Type</source>
+    <trans-unit id="++CODE++dfa2817fb2221c8b89c47c4fe8326d07c119b7c32e89e509d1061fc596fdf801">
+      <source xml:lang="en">Advanced Options</source>
     </trans-unit>
     <trans-unit id="++CODE++ab4db1a876378f718e4073baa75897c34c0e7d2608d68cda6461e01de42fa962">
       <source xml:lang="en">Allow Nulls</source>
@@ -317,6 +317,9 @@
     <trans-unit id="++CODE++3cc30692596cf10ca4319a818741998997632cce895dbf138cb3299b1314d37f">
       <source xml:lang="en">Custom Zoom</source>
     </trans-unit>
+    <trans-unit id="++CODE++68cd154732021d9684d0dcad6276e99d675f962c9b08774f23f5de9398e19290">
+      <source xml:lang="en">Data Type</source>
+    </trans-unit>
     <trans-unit id="++CODE++fa7fe67124e94375d97e50896e0c32f44b03bb7ed5e9fb026341b55da724126b">
       <source xml:lang="en">Database</source>
     </trans-unit>
@@ -552,9 +555,6 @@
     <trans-unit id="++CODE++463124bedefc986e5dc0c3e34607c881ba0337297037552decc1df70945e57e8">
       <source xml:lang="en">Found pending reconnect promise for uri {0}, waiting.</source>
       <note>{0} is the uri</note>
-    </trans-unit>
-    <trans-unit id="++CODE++c910d474dcd724bff83ddedeb06bf1eceaf9fb3af7c76bb282be057f36e6dffa">
-      <source xml:lang="en">General</source>
     </trans-unit>
     <trans-unit id="++CODE++e7789e4d6916633a7461743194a10f2bc4d20b06c2e329b35c7a2da87aa8cbae">
       <source xml:lang="en">Generate Script</source>
@@ -1185,14 +1185,8 @@
     <trans-unit id="++CODE++644a28f160d2df093fab1a8c94e5176f21c1af3bee1915315edd409d14397021">
       <source xml:lang="en">The name of the index.</source>
     </trans-unit>
-    <trans-unit id="++CODE++289db14dbc3d213c4ac28f356bcfc37eb02f473e07ee63bcea2fa7075c888822">
-      <source xml:lang="en">The name of the table object.</source>
-    </trans-unit>
     <trans-unit id="++CODE++13549c97f0b3baa43655bd41e05e3bb60918ded05df9e7e94186ecc6ba53c3d1">
       <source xml:lang="en">The recent connections list has been cleared but there were errors while deleting some associated credentials. View the errors in the MSSQL output channel.</source>
-    </trans-unit>
-    <trans-unit id="++CODE++c9d2c41f4eeba094c6db66ab88d3c5190e34865d80fe230483b6fdcaddf79e8a">
-      <source xml:lang="en">The schema that contains the table.</source>
     </trans-unit>
     <trans-unit id="++CODE++ea13943c4f06ddf0a81173991d20e8cf8252b636b94c0c2476e58098d9fbc1f3">
       <source xml:lang="en">The second value must be set for the {0} operator in the {1} filter</source>

--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "5.0.20240918.1",
+    "version": "5.0.20241010.3",
     "downloadFileNames": {
       "Windows_86": "win-x86-net8.0.zip",
       "Windows_64": "win-x64-net8.0.zip",

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -132,6 +132,7 @@ export class LocConstants {
                     args: [objectType],
                     comment: ["{0} is the object type"],
                 }),
+            schema: l10n.t("Schema"),
         };
     }
 

--- a/src/reactviews/pages/TableDesigner/designerCheckbox.tsx
+++ b/src/reactviews/pages/TableDesigner/designerCheckbox.tsx
@@ -41,7 +41,12 @@ export const DesignerCheckbox = ({
             size="small"
             label={
                 showLabel ? (
-                    <Label size="small">
+                    <Label
+                        size="small"
+                        style={{
+                            lineHeight: "22px", // Used to align the label with the checkbox
+                        }}
+                    >
                         {component.componentProperties.title!}
                     </Label>
                 ) : undefined
@@ -52,7 +57,7 @@ export const DesignerCheckbox = ({
                     (component.componentProperties.width ??
                     UiArea === "PropertiesView")
                         ? "100%"
-                        : "300px",
+                        : "400px",
             }}
         >
             <Checkbox
@@ -72,6 +77,7 @@ export const DesignerCheckbox = ({
                 style={{
                     fontSize: "12px",
                 }}
+                size="medium"
                 disabled={model.enabled === undefined ? false : !model.enabled}
             />
         </Field>

--- a/src/reactviews/pages/TableDesigner/designerMainPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerMainPane.tsx
@@ -6,16 +6,20 @@
 import { Tab, TabList } from "@fluentui/react-tabs";
 import {
     CounterBadge,
+    Dropdown,
+    Field,
     Input,
+    Option,
     Text,
     makeStyles,
     shorthands,
 } from "@fluentui/react-components";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import {
     DesignerEditType,
     DesignerMainPaneTabs,
+    DropDownProperties,
     InputBoxProperties,
 } from "../../../sharedInterfaces/tableDesigner";
 import { DesignerMainPaneTab } from "./designerMainPaneTab";
@@ -31,6 +35,13 @@ const useStyles = makeStyles({
     },
     title: {
         ...shorthands.margin("10px", "5px", "5px", "5px"),
+        gap: "10px",
+        width: "400px",
+        maxWidth: "100%",
+        padding: "10px",
+        "> *": {
+            marginBottom: "10px",
+        },
     },
     separator: {
         ...shorthands.margin("0px", "-20px", "0px", "0px"),
@@ -63,6 +74,15 @@ export const DesignerMainPane = () => {
     const [tableName, setTableName] = useState(
         (metadata.model!["name"] as InputBoxProperties).value,
     );
+    const [schema, setSchema] = useState(
+        (metadata.model!["schema"] as InputBoxProperties).value,
+    );
+
+    useEffect(() => {
+        setTableName((metadata.model!["name"] as InputBoxProperties).value);
+        setSchema((metadata.model!["schema"] as InputBoxProperties).value);
+    }, [metadata.model]);
+
     const getCurrentTabIssuesCount = (tabId: string) => {
         const tabComponents = metadata.view?.tabs.find(
             (tab) => tab.id === tabId,
@@ -128,24 +148,53 @@ export const DesignerMainPane = () => {
     return (
         <div className={classes.root}>
             <div className={classes.title}>
-                <Text className={classes.title} size={300} weight="semibold">
-                    {locConstants.tableDesigner.tableName}
-                </Text>
-                <Input
-                    size="medium"
-                    value={tableName}
-                    onChange={(_event, data) => {
-                        setTableName(data.value);
-                    }}
-                    onBlur={(_event) => {
-                        state.provider.processTableEdit({
-                            source: "TabsView",
-                            type: DesignerEditType.Update,
-                            path: ["name"],
-                            value: tableName,
-                        });
-                    }}
-                />
+                <Field
+                    label={locConstants.tableDesigner.tableName}
+                    orientation="horizontal"
+                >
+                    <Input
+                        size="medium"
+                        value={tableName}
+                        onChange={(_event, data) => {
+                            setTableName(data.value);
+                        }}
+                        onBlur={(_event) => {
+                            state.provider.processTableEdit({
+                                source: "TabsView",
+                                type: DesignerEditType.Update,
+                                path: ["name"],
+                                value: tableName,
+                            });
+                        }}
+                    />
+                </Field>
+                <Field
+                    label={locConstants.tableDesigner.schema}
+                    orientation="horizontal"
+                >
+                    <Dropdown
+                        size="medium"
+                        value={schema}
+                        onOptionSelect={(_event, data) => {
+                            if (!data.optionValue) {
+                                return;
+                            }
+                            setSchema(data?.optionValue);
+                            state.provider.processTableEdit({
+                                source: "TabsView",
+                                type: DesignerEditType.Update,
+                                path: ["schema"],
+                                value: data.optionValue,
+                            });
+                        }}
+                    >
+                        {(
+                            metadata.model?.["schema"] as DropDownProperties
+                        )?.values.map((option) => {
+                            return <Option>{option}</Option>;
+                        })}
+                    </Dropdown>
+                </Field>
             </div>
             <TabList
                 size="small"

--- a/src/reactviews/pages/TableDesigner/designerMainPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerMainPane.tsx
@@ -158,6 +158,7 @@ export const DesignerMainPane = () => {
                         onChange={(_event, data) => {
                             setTableName(data.value);
                         }}
+                        autoFocus // initial focus
                         onBlur={(_event) => {
                             state.provider.processTableEdit({
                                 source: "TabsView",

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -260,7 +260,7 @@ export const DesignerPropertiesPane = () => {
                 />
             </div>
             <div className={classes.stack}>
-                <Accordion multiple collapsible defaultOpenItems={groups}>
+                <Accordion multiple collapsible defaultOpenItems={[groups[0]]}>
                     {data &&
                         groups?.map((group) => {
                             const groupItems = parentTableProperties

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -21,6 +21,7 @@ import { DesignerDropdown } from "./designerDropdown";
 import { DesignerTable } from "./designerTable";
 import {
     CheckBoxProperties,
+    DesignerDataPropertyInfo,
     DesignerTableProperties,
     DropDownProperties,
     InputBoxProperties,
@@ -113,7 +114,10 @@ export const DesignerPropertiesPane = () => {
         );
     }
 
-    const renderAccordionItem = (group: string | undefined) => {
+    const renderAccordionItem = (
+        group: string | undefined,
+        groupItem: DesignerDataPropertyInfo[],
+    ) => {
         if (!group) {
             return undefined;
         }
@@ -122,93 +126,81 @@ export const DesignerPropertiesPane = () => {
                 <AccordionHeader>{group}</AccordionHeader>
                 <AccordionPanel>
                     <div className={classes.group}>
-                        {parentTableProperties
-                            .itemProperties!.filter(
-                                (i) =>
-                                    (group === "General" && !i.group) ||
-                                    group === i.group,
-                            )
-                            .filter(
-                                (item) => item.showInPropertiesView !== false,
-                            )
-                            .map((item) => {
-                                if (!data) {
-                                    return undefined;
-                                }
-                                const modelValue = data![item.propertyName];
-                                if (!modelValue) {
-                                    return undefined;
-                                }
-                                switch (item.componentType) {
-                                    case "checkbox":
-                                        return (
-                                            <DesignerCheckbox
-                                                UiArea="PropertiesView"
-                                                component={item}
-                                                model={
-                                                    modelValue as CheckBoxProperties
-                                                }
-                                                componentPath={[
-                                                    ...propertiesPaneData!
-                                                        .componentPath,
-                                                    item.propertyName,
-                                                ]}
-                                                key={`${group}-${item.propertyName}`}
-                                            />
-                                        );
-                                    case "input":
-                                        return (
-                                            <DesignerInputBox
-                                                UiArea="PropertiesView"
-                                                component={item}
-                                                model={
-                                                    modelValue as InputBoxProperties
-                                                }
-                                                componentPath={[
-                                                    ...propertiesPaneData!
-                                                        .componentPath,
-                                                    item.propertyName,
-                                                ]}
-                                                horizontal
-                                                key={`${group}-${item.propertyName}`}
-                                            />
-                                        );
-                                    case "dropdown":
-                                        return (
-                                            <DesignerDropdown
-                                                UiArea="PropertiesView"
-                                                component={item}
-                                                model={
-                                                    modelValue as DropDownProperties
-                                                }
-                                                componentPath={[
-                                                    ...propertiesPaneData!
-                                                        .componentPath,
-                                                    item.propertyName,
-                                                ]}
-                                                horizontal
-                                                key={`${group}-${item.propertyName}`}
-                                            />
-                                        );
-                                    case "table":
-                                        return (
-                                            <DesignerTable
-                                                UiArea="PropertiesView"
-                                                component={item}
-                                                model={
-                                                    modelValue as DesignerTableProperties
-                                                }
-                                                componentPath={[
-                                                    ...propertiesPaneData!
-                                                        .componentPath,
-                                                    item.propertyName,
-                                                ]}
-                                                loadPropertiesTabData={false}
-                                                key={`${group}-${item.propertyName}`}
-                                            />
-                                        );
-                                }
-                            })}
+                        {groupItem.map((item) => {
+                            if (!data) {
+                                return undefined;
+                            }
+                            const modelValue = data![item.propertyName];
+                            switch (item.componentType) {
+                                case "checkbox":
+                                    return (
+                                        <DesignerCheckbox
+                                            UiArea="PropertiesView"
+                                            component={item}
+                                            model={
+                                                modelValue as CheckBoxProperties
+                                            }
+                                            componentPath={[
+                                                ...propertiesPaneData!
+                                                    .componentPath,
+                                                item.propertyName,
+                                            ]}
+                                            key={`${group}-${item.propertyName}`}
+                                        />
+                                    );
+                                case "input":
+                                    return (
+                                        <DesignerInputBox
+                                            UiArea="PropertiesView"
+                                            component={item}
+                                            model={
+                                                modelValue as InputBoxProperties
+                                            }
+                                            componentPath={[
+                                                ...propertiesPaneData!
+                                                    .componentPath,
+                                                item.propertyName,
+                                            ]}
+                                            horizontal
+                                            key={`${group}-${item.propertyName}`}
+                                        />
+                                    );
+                                case "dropdown":
+                                    return (
+                                        <DesignerDropdown
+                                            UiArea="PropertiesView"
+                                            component={item}
+                                            model={
+                                                modelValue as DropDownProperties
+                                            }
+                                            componentPath={[
+                                                ...propertiesPaneData!
+                                                    .componentPath,
+                                                item.propertyName,
+                                            ]}
+                                            horizontal
+                                            key={`${group}-${item.propertyName}`}
+                                        />
+                                    );
+                                case "table":
+                                    return (
+                                        <DesignerTable
+                                            UiArea="PropertiesView"
+                                            component={item}
+                                            model={
+                                                modelValue as DesignerTableProperties
+                                            }
+                                            componentPath={[
+                                                ...propertiesPaneData!
+                                                    .componentPath,
+                                                item.propertyName,
+                                            ]}
+                                            loadPropertiesTabData={false}
+                                            key={`${group}-${item.propertyName}`}
+                                        />
+                                    );
+                            }
+                        })}
                     </div>
                 </AccordionPanel>
             </AccordionItem>
@@ -271,7 +263,36 @@ export const DesignerPropertiesPane = () => {
                 <Accordion multiple collapsible defaultOpenItems={groups}>
                     {data &&
                         groups?.map((group) => {
-                            return renderAccordionItem(group);
+                            const groupItems = parentTableProperties
+                                .itemProperties!.filter(
+                                    (i) =>
+                                        (group === "General" && !i.group) ||
+                                        group === i.group,
+                                )
+                                .filter((item) => {
+                                    if (item.showInPropertiesView === false) {
+                                        return false;
+                                    }
+                                    const modelValue = data![item.propertyName];
+                                    if (!modelValue) {
+                                        return false;
+                                    }
+                                    if (
+                                        (
+                                            modelValue as
+                                                | InputBoxProperties
+                                                | CheckBoxProperties
+                                                | DropDownProperties
+                                        )?.enabled === false
+                                    ) {
+                                        return false;
+                                    }
+                                    return true;
+                                });
+                            if (groupItems.length === 0) {
+                                return undefined;
+                            }
+                            return renderAccordionItem(group, groupItems);
                         })}
                 </Accordion>
             </div>

--- a/src/sharedInterfaces/tableDesigner.ts
+++ b/src/sharedInterfaces/tableDesigner.ts
@@ -150,6 +150,7 @@ export enum TableColumnProperty {
     IsPrimaryKey = "isPrimaryKey",
     Precision = "precision",
     Scale = "scale",
+    IsIdentity = "isIdentity",
 }
 
 /**

--- a/src/tableDesigner/tableDesignerTabDefinition.ts
+++ b/src/tableDesigner/tableDesignerTabDefinition.ts
@@ -6,31 +6,13 @@
 import * as designer from "../sharedInterfaces/tableDesigner";
 import * as vscode from "vscode";
 
-export function getAboutTableComponents(
+export function getAdvancedOptionsComponents(
     viewDefinition: designer.TableDesignerView | undefined,
 ): designer.DesignerDataPropertyInfo[] {
     if (!viewDefinition) {
         return [];
     }
     const tabComponents: designer.DesignerDataPropertyInfo[] = [
-        {
-            componentType: "input",
-            propertyName: designer.TableColumnProperty.Name,
-            description: vscode.l10n.t("The name of the table object."),
-            componentProperties: {
-                title: vscode.l10n.t("Table name"),
-                width: 350,
-            },
-        },
-        {
-            componentType: "dropdown",
-            propertyName: designer.TableProperty.Schema,
-            description: vscode.l10n.t("The schema that contains the table."),
-            componentProperties: {
-                title: vscode.l10n.t("Schema"),
-                width: 350,
-            },
-        },
         {
             componentType: "textarea",
             propertyName: designer.TableProperty.Description,
@@ -86,7 +68,7 @@ export function getColumnsTabComponents(
                 "Displays the unified data type (including length, scale and precision) for the column",
             ),
             componentProperties: {
-                title: vscode.l10n.t("Advanced Type"),
+                title: vscode.l10n.t("Data Type"),
                 width: 120,
                 isEditable: true,
             },
@@ -175,6 +157,7 @@ export function getColumnsTabComponents(
         designer.TableColumnProperty.Name,
         designer.TableColumnProperty.Type,
         designer.TableColumnProperty.IsPrimaryKey,
+        designer.TableColumnProperty.IsIdentity,
         designer.TableColumnProperty.AllowNulls,
         designer.TableColumnProperty.DefaultValue,
     ]);
@@ -687,9 +670,9 @@ export function getDesignerView(
                 components: getCheckConstraintsTabComponents(view),
             },
             {
-                title: vscode.l10n.t("General"),
+                title: vscode.l10n.t("Advanced Options"),
                 id: designer.DesignerMainPaneTabs.AboutTable,
-                components: getAboutTableComponents(view),
+                components: getAdvancedOptionsComponents(view),
             },
         ],
     };

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -203,12 +203,6 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     correlationId: this._correlationId,
                 },
             );
-            if (editResponse.inputValidationError) {
-                void vscode.window.showErrorMessage(
-                    editResponse.inputValidationError,
-                );
-                return state;
-            }
             if (editResponse.issues?.length === 0) {
                 state.tabStates.resultPaneTab =
                     designer.DesignerResultPaneTabs.Script;

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -203,6 +203,12 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     correlationId: this._correlationId,
                 },
             );
+            if (editResponse.inputValidationError) {
+                void vscode.window.showErrorMessage(
+                    editResponse.inputValidationError,
+                );
+                return state;
+            }
             if (editResponse.issues?.length === 0) {
                 state.tabStates.resultPaneTab =
                     designer.DesignerResultPaneTabs.Script;


### PR DESCRIPTION
Fixes #18163 
1. Renamed `General` tab to `Advanced Options` in the Table designer main panel. 
![image](https://github.com/user-attachments/assets/5e825fba-0333-4875-bb16-2315e940e149)

2. Moved `table name` and `schema` out of the tab to the top of the designer 
![image](https://github.com/user-attachments/assets/bad451a3-0a21-4cbd-b0fa-c780e66d92b5)

3. Renamed `System versioning Enabled` to `System Versioning`.
![image](https://github.com/user-attachments/assets/2c7e0c31-3e18-41de-bfca-d101d151010e)

Fixes #18160 
1. Moved Is Identity to columns table
2. Leaving identity enabled for first column and also making it primary key
3. Naming first column 'Id
![image](https://github.com/user-attachments/assets/1dcdc67d-d02e-4557-9645-23238881b8b7)


Fixes #18161 
1. Leaving all panels collapsed except 'General'
![image](https://github.com/user-attachments/assets/183dae77-ba3c-4fc0-8b0a-1f5709a15931)
2. Chaning Advanced Type prop to Data Type
![image](https://github.com/user-attachments/assets/0758e14f-9ffb-49c3-909f-1f0a38fa76d9)
3. Precision and Scale are only visible for applicable data types now
int
![image](https://github.com/user-attachments/assets/b8444def-ce38-4b62-9578-abaadd6207e9)
numberic/decimal
![image](https://github.com/user-attachments/assets/4b3a324d-5569-4383-b08e-1d32220c609f)
4. Hiding not 'Grayed out' props
![image](https://github.com/user-attachments/assets/d6e5f245-1853-467f-ace5-043f3fbc5a8d)

Fixes #18159 partially
Things fixed: 
1. Focusing on table name property first.
2. First column name is 'id'. Primary key and identity is enabled by default.
3. Schema is below table name field.
![image](https://github.com/user-attachments/assets/922a77a2-fdaf-44da-b986-518f31a86d12)

Things not fixed:
Leaving default name Empty as it is not so simple to do from the backend (Will require DacFx update).



Companion PR in STS: https://github.com/microsoft/sqltoolsservice/pull/2404
