### PR TITLE
Cleans up open protocol handler and adds unit tests

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -350,12 +350,14 @@ export default class MainController implements vscode.Disposable {
 
             const self = this;
             const uriHandler: vscode.UriHandler = {
-                handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+                async handleUri(uri: vscode.Uri): Promise<void> {
                     if (self.isExperimentalEnabled) {
-                        const mssqlProtocolHandler = new MssqlProtocolHandler();
+                        const mssqlProtocolHandler = new MssqlProtocolHandler(
+                            self._connectionMgr.client,
+                        );
 
                         const connectionInfo =
-                            mssqlProtocolHandler.handleUri(uri);
+                            await mssqlProtocolHandler.handleUri(uri);
 
                         vscode.commands.executeCommand(
                             Constants.cmdAddObjectExplorer,

--- a/src/mssqlProtocolHandler.ts
+++ b/src/mssqlProtocolHandler.ts
@@ -80,14 +80,14 @@ export class MssqlProtocolHandler {
     private async readProfileFromArgs(
         query: string,
     ): Promise<IConnectionInfo | undefined> {
+        if (!query) {
+            return undefined;
+        }
+
         const capabilitiesResult: CapabilitiesResult =
             await this.client.sendRequest(GetCapabilitiesRequest.type, {});
         const connectionOptions =
             capabilitiesResult.capabilities.connectionProvider.options;
-
-        if (!query) {
-            return undefined;
-        }
 
         const connectionInfo = {};
         const args = new URLSearchParams(query);

--- a/src/mssqlProtocolHandler.ts
+++ b/src/mssqlProtocolHandler.ts
@@ -97,6 +97,11 @@ export class MssqlProtocolHandler {
             return connectionInfo as IConnectionInfo;
         }
 
+        const profileName = args.get("profileName");
+        if (profileName) {
+            connectionInfo["profileName"] = profileName;
+        }
+
         const connectionOptionProperties: ConnectionOptionProperty[] =
             connectionOptions.map(
                 (option) =>

--- a/src/mssqlProtocolHandler.ts
+++ b/src/mssqlProtocolHandler.ts
@@ -6,17 +6,27 @@
 import * as vscode from "vscode";
 import * as Utils from "./models/utils";
 import { IConnectionInfo } from "vscode-mssql";
+import SqlToolsServiceClient from "./languageservice/serviceclient";
+import {
+    CapabilitiesResult,
+    GetCapabilitiesRequest,
+} from "./models/contracts/connection";
 
 enum Command {
     connect = "/connect",
     openConnectionDialog = "/openConnectionDialog",
 }
 
+interface ConnectionOptionProperty {
+    name: keyof IConnectionInfo;
+    type: "string" | "number" | "boolean" | "category";
+}
+
 /**
  * Handles MSSQL protocol URIs.
  */
 export class MssqlProtocolHandler {
-    constructor() {}
+    constructor(private client: SqlToolsServiceClient) {}
 
     /**
      * Handles the given URI and returns connection information if applicable. Examples of URIs handled:
@@ -26,7 +36,7 @@ export class MssqlProtocolHandler {
      * @param uri - The URI to handle.
      * @returns The connection information or undefined if not applicable.
      */
-    public handleUri(uri: vscode.Uri): IConnectionInfo | undefined {
+    public handleUri(uri: vscode.Uri): Promise<IConnectionInfo | undefined> {
         Utils.logDebug(
             `[MssqlProtocolHandler][handleUri] URI: ${uri.toString()}`,
         );
@@ -57,7 +67,7 @@ export class MssqlProtocolHandler {
      * @param uri - The URI containing connection information.
      * @returns The connection information or undefined if not applicable.
      */
-    private connect(uri: vscode.Uri): IConnectionInfo | undefined {
+    private connect(uri: vscode.Uri): Promise<IConnectionInfo | undefined> {
         return this.readProfileFromArgs(uri.query);
     }
 
@@ -67,201 +77,66 @@ export class MssqlProtocolHandler {
      * @param query - The query string containing connection information.
      * @returns The connection information object or undefined if the query is empty.
      */
-    private readProfileFromArgs(query: string): IConnectionInfo | undefined {
+    private async readProfileFromArgs(
+        query: string,
+    ): Promise<IConnectionInfo | undefined> {
+        const capabilitiesResult: CapabilitiesResult =
+            await this.client.sendRequest(GetCapabilitiesRequest.type, {});
+        const connectionOptions =
+            capabilitiesResult.capabilities.connectionProvider.options;
+
         if (!query) {
             return undefined;
         }
 
+        const connectionInfo = {};
         const args = new URLSearchParams(query);
-
-        const connectionString = args.get("connectionString") ?? undefined;
-        if (connectionString !== undefined) {
-            return {
-                connectionString,
-            } as IConnectionInfo;
+        const connectionString = args.get("connectionString");
+        if (connectionString) {
+            connectionInfo["connectionString"] = connectionString;
+            return connectionInfo as IConnectionInfo;
         }
 
-        const server = args.get("server") ?? "";
-        const database = args.get("database") ?? "";
-        const user = args.get("user") ?? "";
-        const email = args.get("email") ?? "";
-        const accountId = args.get("accountId") ?? "";
-        const tenantId = args.get("tenantId") ?? "";
+        const connectionOptionProperties: ConnectionOptionProperty[] =
+            connectionOptions.map(
+                (option) =>
+                    ({
+                        name: option.name as keyof IConnectionInfo,
+                        type: option.valueType,
+                    }) as ConnectionOptionProperty,
+            );
 
-        const portValue = parseInt(args.get("port"));
-        const port = isNaN(portValue) ? 0 : portValue;
+        for (const property of connectionOptionProperties) {
+            const propName = property.name as string;
+            const propValue: string | undefined = args.get(propName);
 
-        /*
-            Authentication Type:
-            1. Take --authenticationType, if not
-            2. Take --integrated, if not
-            3. take --aad, if not
-            4. If user exists, and user has @, then it's azureMFA
-            5. If user exists but doesn't have @, then its SqlLogin
-            6. If user doesn't exist, then integrated
-        */
-        const authenticationType = args.get("authenticationType")
-            ? args.get("authenticationType")
-            : args.get("integrated")
-              ? "Integrated"
-              : args.get("aad")
-                ? "AzureMFA"
-                : user && user.length > 0
-                  ? user.includes("@")
-                      ? "AzureMFA"
-                      : "SqlLogin"
-                  : "Integrated";
+            if (propValue === undefined || propValue === null) {
+                continue;
+            }
 
-        const azureAccountToken = args.get("azureAccountToken") ?? undefined;
+            switch (property.type) {
+                case "string":
+                case "category":
+                    connectionInfo[propName] = propValue;
+                    break;
 
-        const expiresOnValue = parseInt(args.get("expiresOn"));
-        const expiresOn = isNaN(expiresOnValue) ? undefined : expiresOnValue;
+                case "number":
+                    const numericalValue = parseInt(propValue);
+                    if (!isNaN(numericalValue)) {
+                        connectionInfo[propName] = numericalValue;
+                    }
+                    break;
 
-        const encryptValueFlag = parseInt(args.get("encrypt"));
-        const encryptValueStr = args.get("encrypt") ?? "Mandatory"; // default to Mandatory
-        const encrypt = isNaN(encryptValueFlag)
-            ? encryptValueStr
-            : encryptValueFlag === 1;
+                case "boolean":
+                    connectionInfo[propName] =
+                        propValue === "true" || propValue === "1";
+                    break;
 
-        const trustServerCertificateValue = parseInt(
-            args.get("trustServerCertificate"),
-        );
-        const trustServerCertificate = isNaN(trustServerCertificateValue)
-            ? undefined
-            : trustServerCertificateValue === 1;
+                default:
+                    break;
+            }
+        }
 
-        const hostNameInCertificate =
-            args.get("hostNameInCertificate") ?? undefined;
-
-        const persistSecurityInfoValue = parseInt(
-            args.get("persistSecurityInfo"),
-        );
-        const persistSecurityInfo = isNaN(persistSecurityInfoValue)
-            ? undefined
-            : persistSecurityInfoValue === 1;
-
-        const columnEncryptionSetting =
-            args.get("columnEncryptionSetting") ?? undefined;
-        const attestationProtocol =
-            args.get("attestationProtocol") ?? undefined;
-        const enclaveAttestationUrl =
-            args.get("enclaveAttestationUrl") ?? undefined;
-
-        const connectTimeoutValue = parseInt(args.get("connectTimeout"));
-        const connectTimeout = isNaN(connectTimeoutValue)
-            ? undefined
-            : connectTimeoutValue;
-
-        const commandTimeoutValue = parseInt(args.get("commandTimeout"));
-        const commandTimeout = isNaN(commandTimeoutValue)
-            ? undefined
-            : commandTimeoutValue;
-
-        const connectRetryCountValue = parseInt(args.get("connectRetryCount"));
-        const connectRetryCount = isNaN(connectRetryCountValue)
-            ? undefined
-            : connectRetryCountValue;
-
-        const connectRetryIntervalValue = parseInt(
-            args.get("connectRetryInterval"),
-        );
-        const connectRetryInterval = isNaN(connectRetryIntervalValue)
-            ? undefined
-            : connectRetryIntervalValue;
-
-        const applicationName = args.get("applicationName")
-            ? `${args.get("applicationName")}-azdata`
-            : "azdata";
-
-        const workstationId = args.get("workstationId") ?? undefined;
-        const applicationIntent = args.get("applicationIntent") ?? undefined;
-        const currentLanguage = args.get("currentLanguage") ?? undefined;
-
-        const poolingValue = parseInt(args.get("pooling"));
-        const pooling = isNaN(poolingValue) ? undefined : poolingValue === 1;
-
-        const maxPoolSizeValue = parseInt(args.get("maxPoolSize"));
-        const maxPoolSize = isNaN(maxPoolSizeValue)
-            ? undefined
-            : maxPoolSizeValue;
-
-        const minPoolSizeValue = parseInt(args.get("minPoolSize"));
-        const minPoolSize = isNaN(minPoolSizeValue)
-            ? undefined
-            : minPoolSizeValue;
-
-        const loadBalanceTimeoutValue = parseInt(
-            args.get("loadBalanceTimeout"),
-        );
-        const loadBalanceTimeout = isNaN(loadBalanceTimeoutValue)
-            ? undefined
-            : loadBalanceTimeoutValue;
-
-        const replicationValue = parseInt(args.get("replication"));
-        const replication = isNaN(replicationValue)
-            ? undefined
-            : replicationValue === 1;
-
-        const attachDbFilename = args.get("attachDbFilename") ?? undefined;
-        const failoverPartner = args.get("failoverPartner") ?? undefined;
-
-        const multiSubnetFailoverValue = parseInt(
-            args.get("multiSubnetFailover"),
-        );
-        const multiSubnetFailover = isNaN(multiSubnetFailoverValue)
-            ? undefined
-            : multiSubnetFailoverValue === 1;
-
-        const multipleActiveResultSetsValue = parseInt(
-            args.get("multipleActiveResultSets"),
-        );
-        const multipleActiveResultSets = isNaN(multipleActiveResultSetsValue)
-            ? undefined
-            : multipleActiveResultSetsValue === 1;
-
-        const packetSizeValue = parseInt(args.get("packetSize"));
-        const packetSize = isNaN(packetSizeValue) ? undefined : packetSizeValue;
-
-        const typeSystemVersion = args.get("typeSystemVersion") ?? undefined;
-
-        return {
-            server,
-            database,
-            user,
-            email,
-            accountId,
-            tenantId,
-            port,
-            authenticationType,
-            azureAccountToken,
-            expiresOn,
-            encrypt,
-            trustServerCertificate,
-            hostNameInCertificate,
-            persistSecurityInfo,
-            columnEncryptionSetting,
-            attestationProtocol,
-            enclaveAttestationUrl,
-            connectTimeout,
-            commandTimeout,
-            connectRetryCount,
-            connectRetryInterval,
-            applicationName,
-            workstationId,
-            applicationIntent,
-            currentLanguage,
-            pooling,
-            maxPoolSize,
-            minPoolSize,
-            loadBalanceTimeout,
-            replication,
-            attachDbFilename,
-            failoverPartner,
-            multiSubnetFailover,
-            multipleActiveResultSets,
-            packetSize,
-            typeSystemVersion,
-            connectionString,
-        } as IConnectionInfo;
+        return connectionInfo as IConnectionInfo;
     }
 }

--- a/test/unit/mssqlProtocolHandler.test.ts
+++ b/test/unit/mssqlProtocolHandler.test.ts
@@ -186,4 +186,45 @@ suite("MssqlProtocolHandler Tests", () => {
         assert.equal(connInfo.connectTimeout, 15);
         assert.isTrue(connInfo.trustServerCertificate);
     });
+
+    test("handleUri - with connect command and query with invalid bool value for trust server cert - trust server cert is false and parses valid params", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse(
+                "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&trustServerCertificate=yes",
+            ),
+        );
+
+        assert.isDefined(connInfo);
+        assert.equal(connInfo.server, "myServer");
+        assert.equal(connInfo.database, "dbName");
+        assert.isFalse(connInfo.trustServerCertificate);
+    });
+
+    test("handleUri - with connect command and query with invalid numerical value for connect timeout - timeout is undefined and parses valid params", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse(
+                "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&connectTimeout=twenty",
+            ),
+        );
+
+        assert.isDefined(connInfo);
+        assert.equal(connInfo.server, "myServer");
+        assert.equal(connInfo.database, "dbName");
+        assert.isUndefined(connInfo.connectTimeout);
+    });
+
+    test("handleUri - with connect command and query invalid parameter - invalid param is undefined", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse(
+                "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&madeUpParam=great",
+            ),
+        );
+
+        assert.isDefined(connInfo);
+        assert.equal(connInfo.server, "myServer");
+        assert.equal(connInfo.database, "dbName");
+
+        const madeUpParam = "madeUpParam";
+        assert.isUndefined(connInfo[madeUpParam]);
+    });
 });

--- a/test/unit/mssqlProtocolHandler.test.ts
+++ b/test/unit/mssqlProtocolHandler.test.ts
@@ -142,7 +142,6 @@ suite("MssqlProtocolHandler Tests", () => {
         );
     });
 
-    // "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&authenticationType=SqlLogin"
     test("handleUri - with no command and empty query - returns undefined", async () => {
         const connInfo = await mssqlProtocolHandler.handleUri(
             Uri.parse("vscode://ms-mssql.mssql/"),

--- a/test/unit/mssqlProtocolHandler.test.ts
+++ b/test/unit/mssqlProtocolHandler.test.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as TypeMoq from "typemoq";
+import { /*expect,*/ assert } from "chai";
+import { MssqlProtocolHandler } from "../../src/mssqlProtocolHandler";
+import SqlToolsServiceClient from "../../src/languageservice/serviceclient";
+import { Uri } from "vscode";
+
+suite("MssqlProtocolHandler Tests", () => {
+    let mssqlProtocolHandler: MssqlProtocolHandler;
+    let sqlToolsServiceClientMock: TypeMoq.IMock<SqlToolsServiceClient>;
+
+    setup(() => {
+        sqlToolsServiceClientMock = TypeMoq.Mock.ofType(
+            SqlToolsServiceClient,
+            TypeMoq.MockBehavior.Loose,
+        );
+
+        sqlToolsServiceClientMock
+            .setup((x) => x.sendRequest(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() =>
+                Promise.resolve({
+                    capabilities: {
+                        connectionProvider: {
+                            options: [
+                                {
+                                    specialValueType: "serverName",
+                                    isIdentity: true,
+                                    name: "server",
+                                    displayName: "Server name",
+                                    description:
+                                        "Name of the SQL Server instance",
+                                    groupName: "Source",
+                                    valueType: "string",
+                                    defaultValue: null,
+                                    objectType: null,
+                                    categoryValues: null,
+                                    isRequired: true,
+                                    isArray: false,
+                                },
+                                {
+                                    specialValueType: "databaseName",
+                                    isIdentity: true,
+                                    name: "database",
+                                    displayName: "Database name",
+                                    description:
+                                        "The name of the initial catalog or database in the data source",
+                                    groupName: "Source",
+                                    valueType: "string",
+                                    defaultValue: null,
+                                    objectType: null,
+                                    categoryValues: null,
+                                    isRequired: false,
+                                    isArray: false,
+                                },
+                                {
+                                    specialValueType: "userName",
+                                    isIdentity: true,
+                                    name: "user",
+                                    displayName: "User name",
+                                    description:
+                                        "Indicates the user ID to be used when connecting to the data source",
+                                    groupName: "Security",
+                                    valueType: "string",
+                                    defaultValue: null,
+                                    objectType: null,
+                                    categoryValues: null,
+                                    isRequired: true,
+                                    isArray: false,
+                                },
+                                {
+                                    specialValueType: "authType",
+                                    isIdentity: true,
+                                    name: "authenticationType",
+                                    displayName: "Authentication type",
+                                    description:
+                                        "Specifies the method of authenticating with SQL Server",
+                                    groupName: "Security",
+                                    valueType: "category",
+                                    defaultValue: null,
+                                    objectType: null,
+                                    categoryValues: [
+                                        {
+                                            displayName: "SQL Login",
+                                            name: "SqlLogin",
+                                        },
+                                        {
+                                            displayName:
+                                                "Windows Authentication",
+                                            name: "Integrated",
+                                        },
+                                        {
+                                            displayName:
+                                                "Microsoft Entra ID - Universal with MFA support",
+                                            name: "AzureMFA",
+                                        },
+                                    ],
+                                    isRequired: true,
+                                    isArray: false,
+                                },
+                                {
+                                    specialValueType: null,
+                                    isIdentity: false,
+                                    name: "connectTimeout",
+                                    displayName: "Connect timeout",
+                                    description:
+                                        "The length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error",
+                                    groupName: "Initialization",
+                                    valueType: "number",
+                                    defaultValue: "15",
+                                    objectType: null,
+                                    categoryValues: null,
+                                    isRequired: false,
+                                    isArray: false,
+                                },
+                                {
+                                    specialValueType: null,
+                                    isIdentity: false,
+                                    name: "trustServerCertificate",
+                                    displayName: "Trust server certificate",
+                                    description:
+                                        "When true (and encrypt=true), SQL Server uses SSL encryption for all data sent between the client and server without validating the server certificate",
+                                    groupName: "Security",
+                                    valueType: "boolean",
+                                    defaultValue: null,
+                                    objectType: null,
+                                    categoryValues: null,
+                                    isRequired: false,
+                                    isArray: false,
+                                },
+                            ],
+                        },
+                    },
+                }),
+            );
+
+        mssqlProtocolHandler = new MssqlProtocolHandler(
+            sqlToolsServiceClientMock.object,
+        );
+    });
+
+    // "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&authenticationType=SqlLogin"
+    test("handleUri - with no command and empty query - returns undefined", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse("vscode://ms-mssql.mssql/"),
+        );
+
+        assert.isUndefined(connInfo);
+    });
+
+    test("handleUri - with connect command and no query - doesn't parse query and returns undefined", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse("vscode://ms-mssql.mssql/connect"),
+        );
+
+        assert.isUndefined(connInfo);
+    });
+
+    test("handleUri - with connect command and connection string - parses connection string and returns connection info object", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse(
+                "vscode://ms-mssql.mssql/connect?connectionString=Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;",
+            ),
+        );
+
+        assert.isDefined(connInfo);
+        assert.equal(
+            connInfo.connectionString,
+            "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;",
+        );
+    });
+
+    test("handleUri - with connect command and query - parses query and returns connection info object", async () => {
+        const connInfo = await mssqlProtocolHandler.handleUri(
+            Uri.parse(
+                "vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&authenticationType=SqlLogin&connectTimeout=15&trustServerCertificate=true",
+            ),
+        );
+
+        assert.isDefined(connInfo);
+        assert.equal(connInfo.server, "myServer");
+        assert.equal(connInfo.database, "dbName");
+        assert.equal(connInfo.authenticationType, "SqlLogin");
+        assert.equal(connInfo.connectTimeout, 15);
+        assert.isTrue(connInfo.trustServerCertificate);
+    });
+});

--- a/test/unit/mssqlProtocolHandler.test.ts
+++ b/test/unit/mssqlProtocolHandler.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as TypeMoq from "typemoq";
-import { /*expect,*/ assert } from "chai";
+import { assert } from "chai";
 import { MssqlProtocolHandler } from "../../src/mssqlProtocolHandler";
 import SqlToolsServiceClient from "../../src/languageservice/serviceclient";
 import { Uri } from "vscode";


### PR DESCRIPTION
This PR cleans up the open protocol handler logic and adds unit tests.

The cleaned up logic continues to handle MSSQL protocol URIs as before. A connection string like:

`vscode://ms-mssql.mssql/connect?server=(localdb)\MssqlLocalDb&database=msdb&user=lewis&authenticationType=SqlLogin&profileName=profile1`

The URi can be entered into a browser. Once submitted, VS Code will prompt the user if they would like to open the URI:
![image](https://github.com/user-attachments/assets/16de5825-95d2-440a-89ab-1bb52047ab9f)

Clicking on "Open" in the prompt will open the connection dialog for users to make any additional adjustments to connect to their target connection.
![image](https://github.com/user-attachments/assets/d81ccef5-7b0c-438c-a681-28ef67e528d8)

