### PR TITLE
Adding a prompt to restore closed webviews (Table Designer in this case)

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -713,8 +713,8 @@
       "{0} is the feature name"
     ]
   },
-  "The {0} has been close. Would you like to restore it?/{0} is the webview name": {
-    "message": "The {0} has been close. Would you like to restore it?",
+  "The {0} has been closed. Would you like to restore it?/{0} is the webview name": {
+    "message": "The {0} has been closed. Would you like to restore it?",
     "comment": [
       "{0} is the webview name"
     ]

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -713,6 +713,12 @@
       "{0} is the feature name"
     ]
   },
+  "The {0} has been close. Would you like to restore it?/{0} is the webview name": {
+    "message": "The {0} has been close. Would you like to restore it?",
+    "comment": [
+      "{0} is the webview name"
+    ]
+  },
   "Azure sign in failed.": "Azure sign in failed.",
   "Select subscriptions": "Select subscriptions",
   "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -713,8 +713,8 @@
       "{0} is the feature name"
     ]
   },
-  "The {0} has been closed. Would you like to restore it?/{0} is the webview name": {
-    "message": "The {0} has been closed. Would you like to restore it?",
+  "{0} has been closed. Would you like to restore it?/{0} is the webview name": {
+    "message": "{0} has been closed. Would you like to restore it?",
     "comment": [
       "{0} is the webview name"
     ]

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1223,8 +1223,8 @@
     <trans-unit id="++CODE++d7f9cfdbfc45384b7521ed4b8082d476a2d3cae5cbb8c57eec64003513cacbf2">
       <source xml:lang="en">The table which contains the primary or unique key column.</source>
     </trans-unit>
-    <trans-unit id="++CODE++faed4cb00fef13c83cb76d001570fe70be89cfce627e317a9391f17f9a0d452d">
-      <source xml:lang="en">The {0} has been close. Would you like to restore it?</source>
+    <trans-unit id="++CODE++ac94ff0eb69149fc72ac5b94b2e54a3d65e5ddb07b45dd4ba9324e33e6c33666">
+      <source xml:lang="en">The {0} has been closed. Would you like to restore it?</source>
       <note>{0} is the webview name</note>
     </trans-unit>
     <trans-unit id="++CODE++2b8198974f44b4a37d366cb6535153e3646f2c9de308f0ca05bf90513b0a4630">

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1223,10 +1223,6 @@
     <trans-unit id="++CODE++d7f9cfdbfc45384b7521ed4b8082d476a2d3cae5cbb8c57eec64003513cacbf2">
       <source xml:lang="en">The table which contains the primary or unique key column.</source>
     </trans-unit>
-    <trans-unit id="++CODE++ac94ff0eb69149fc72ac5b94b2e54a3d65e5ddb07b45dd4ba9324e33e6c33666">
-      <source xml:lang="en">The {0} has been closed. Would you like to restore it?</source>
-      <note>{0} is the webview name</note>
-    </trans-unit>
     <trans-unit id="++CODE++2b8198974f44b4a37d366cb6535153e3646f2c9de308f0ca05bf90513b0a4630">
       <source xml:lang="en">This setting requires Visual Studio Code to be relaunched, please reload Visual Studio Code.</source>
     </trans-unit>
@@ -1356,6 +1352,10 @@
     </trans-unit>
     <trans-unit id="++CODE++d4781f8681d947d6d8eb589d9a93c7bd093110ab1b826da373b7e1e6b6cf080f">
       <source xml:lang="en">{0} (filtered)</source>
+    </trans-unit>
+    <trans-unit id="++CODE++16885df9a4767fe04d26b997deabc5a36f96f34bf58bbed4b4a87d029f25209b">
+      <source xml:lang="en">{0} has been closed. Would you like to restore it?</source>
+      <note>{0} is the webview name</note>
     </trans-unit>
     <trans-unit id="++CODE++e3620e8a37371c6057d768faed05a7608c6e5ee783372a58b137b047300e8b7a">
       <source xml:lang="en">{0} issue</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1223,6 +1223,10 @@
     <trans-unit id="++CODE++d7f9cfdbfc45384b7521ed4b8082d476a2d3cae5cbb8c57eec64003513cacbf2">
       <source xml:lang="en">The table which contains the primary or unique key column.</source>
     </trans-unit>
+    <trans-unit id="++CODE++faed4cb00fef13c83cb76d001570fe70be89cfce627e317a9391f17f9a0d452d">
+      <source xml:lang="en">The {0} has been close. Would you like to restore it?</source>
+      <note>{0} is the webview name</note>
+    </trans-unit>
     <trans-unit id="++CODE++2b8198974f44b4a37d366cb6535153e3646f2c9de308f0ca05bf90513b0a4630">
       <source xml:lang="en">This setting requires Visual Studio Code to be relaunched, please reload Visual Studio Code.</source>
     </trans-unit>

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import { ReactWebviewPanelController } from "../controllers/reactWebviewController";
+
 import {
     AuthenticationType,
     AzureSqlServerInfo,
@@ -15,43 +15,45 @@ import {
     ConnectionInputMode,
     IConnectionDialogProfile,
 } from "../sharedInterfaces/connectionDialog";
-import { IConnectionInfo } from "vscode-mssql";
-import MainController from "../controllers/mainController";
-import { getConnectionDisplayName } from "../models/connectionInfo";
-import { AzureController } from "../azure/azureController";
-import { ObjectExplorerProvider } from "../objectExplorer/objectExplorerProvider";
 import {
     CapabilitiesResult,
     GetCapabilitiesRequest,
 } from "../models/contracts/connection";
-import { ConnectionOption } from "azdata";
-import { Logger } from "../models/logger";
-import VscodeWrapper from "../controllers/vscodeWrapper";
+import {
+    FormItemActionButton,
+    FormItemOptions,
+    FormItemSpec,
+    FormItemType,
+} from "../reactviews/common/forms/form";
+import {
+    GenericResourceExpanded,
+    ResourceManagementClient,
+} from "@azure/arm-resources";
 import {
     ConnectionDialog as Loc,
     refreshTokenLabel,
 } from "../constants/locConstants";
 import {
-    FormItemSpec,
-    FormItemActionButton,
-    FormItemOptions,
-    FormItemType,
-} from "../reactviews/common/forms/form";
-import { ApiStatus } from "../sharedInterfaces/webview";
-import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
-import {
-    GenericResourceExpanded,
-    ResourceManagementClient,
-} from "@azure/arm-resources";
-import { getErrorMessage, listAllIterator } from "../utils/utils";
-import { l10n } from "vscode";
-import { UserSurvey } from "../nps/userSurvey";
-import {
     azureSubscriptionFilterConfigKey,
     confirmVscodeAzureSignin,
     promptForAzureSubscriptionFilter,
 } from "./azureHelper";
+import { getErrorMessage, listAllIterator } from "../utils/utils";
+
+import { ApiStatus } from "../sharedInterfaces/webview";
+import { AzureController } from "../azure/azureController";
+import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
+import { ConnectionOption } from "azdata";
+import { IConnectionInfo } from "vscode-mssql";
+import { Logger } from "../models/logger";
+import MainController from "../controllers/mainController";
+import { ObjectExplorerProvider } from "../objectExplorer/objectExplorerProvider";
+import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
+import { UserSurvey } from "../nps/userSurvey";
+import VscodeWrapper from "../controllers/vscodeWrapper";
 import { connectionCertValidationFailedErrorCode } from "./connectionConstants";
+import { getConnectionDisplayName } from "../models/connectionInfo";
+import { l10n } from "vscode";
 
 export class ConnectionDialogWebviewController extends ReactWebviewPanelController<
     ConnectionDialogWebviewState,
@@ -70,7 +72,6 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
     ) {
         super(
             context,
-            Loc.connectionDialog,
             "connectionDialog",
             new ConnectionDialogWebviewState({
                 connectionProfile: {} as IConnectionDialogProfile,
@@ -91,18 +92,21 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                 loadingAzureServersStatus: ApiStatus.NotStarted,
                 trustServerCertError: undefined,
             }),
-            vscode.ViewColumn.Active,
             {
-                dark: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "connectionDialogEditor_dark.svg",
-                ),
-                light: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "connectionDialogEditor_light.svg",
-                ),
+                title: Loc.connectionDialog,
+                viewColumn: vscode.ViewColumn.Active,
+                iconPath: {
+                    dark: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "connectionDialogEditor_dark.svg",
+                    ),
+                    light: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "connectionDialogEditor_light.svg",
+                    ),
+                },
             },
         );
 

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -718,7 +718,7 @@ export class UserSurvey {
 export class Webview {
     public static webviewRestorePrompt = (webviewName: string) =>
         l10n.t({
-            message: "The {0} has been close. Would you like to restore it?",
+            message: "The {0} has been closed. Would you like to restore it?",
             args: [webviewName],
             comment: ["{0} is the webview name"],
         });

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -718,7 +718,7 @@ export class UserSurvey {
 export class Webview {
     public static webviewRestorePrompt = (webviewName: string) =>
         l10n.t({
-            message: "The {0} has been closed. Would you like to restore it?",
+            message: "{0} has been closed. Would you like to restore it?",
             args: [webviewName],
             comment: ["{0} is the webview name"],
         });

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -714,3 +714,13 @@ export class UserSurvey {
             comment: ["{0} is the feature name"],
         });
 }
+
+export class Webview {
+    public static webviewRestorePrompt = (webviewName: string) =>
+        l10n.t({
+            message: "The {0} has been close. Would you like to restore it?",
+            args: [webviewName],
+            comment: ["{0} is the webview name"],
+        });
+    public static Restore = l10n.t("Restore");
+}

--- a/src/controllers/executionPlanWebviewController.ts
+++ b/src/controllers/executionPlanWebviewController.ts
@@ -3,14 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
-import { ReactWebviewPanelController } from "./reactWebviewController";
 import * as ep from "../reactviews/pages/ExecutionPlan/executionPlanInterfaces";
-import { homedir } from "os";
-import { exists } from "../utils/utils";
-import UntitledSqlDocumentService from "../controllers/untitledSqlDocumentService";
 import * as path from "path";
+import * as vscode from "vscode";
+
 import { ApiStatus } from "../sharedInterfaces/webview";
+import { ReactWebviewPanelController } from "./reactWebviewPanelController";
+import UntitledSqlDocumentService from "../controllers/untitledSqlDocumentService";
+import { exists } from "../utils/utils";
+import { homedir } from "os";
 
 export class ExecutionPlanWebviewController extends ReactWebviewPanelController<
     ep.ExecutionPlanWebviewState,
@@ -27,7 +28,6 @@ export class ExecutionPlanWebviewController extends ReactWebviewPanelController<
     ) {
         super(
             context,
-            `${xmlPlanFileName}`, // Sets the webview title
             "executionPlan",
             {
                 sqlPlanContent: executionPlanContents,
@@ -41,18 +41,21 @@ export class ExecutionPlanWebviewController extends ReactWebviewPanelController<
                 executionPlanGraphs: [],
                 totalCost: 0,
             },
-            vscode.ViewColumn.Active,
             {
-                dark: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "executionPlan_dark.svg",
-                ),
-                light: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "executionPlan_light.svg",
-                ),
+                title: `${xmlPlanFileName}`, // Sets the webview title
+                viewColumn: vscode.ViewColumn.Active, // Sets the view column of the webview
+                iconPath: {
+                    dark: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "executionPlan_dark.svg",
+                    ),
+                    light: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "executionPlan_light.svg",
+                    ),
+                },
             },
         );
         void this.initialize();

--- a/src/controllers/reactWebviewPanelController.ts
+++ b/src/controllers/reactWebviewPanelController.ts
@@ -118,4 +118,8 @@ export class ReactWebviewPanelController<
             },
         );
     }
+
+    public set showRestorePromptAfterClose(value: boolean) {
+        this._options.showRestorePromptAfterClose = value;
+    }
 }

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -3,19 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
 import * as constants from "../constants/constants";
-import { ReactWebviewPanelController } from "../controllers/reactWebviewController";
-import {
-    UserSurveyReducers,
-    UserSurveyState,
-} from "../sharedInterfaces/userSurvey";
 import * as locConstants from "../constants/locConstants";
-import { sendActionEvent } from "../telemetry/telemetry";
+import * as vscode from "vscode";
+
 import {
     TelemetryActions,
     TelemetryViews,
 } from "../sharedInterfaces/telemetry";
+import {
+    UserSurveyReducers,
+    UserSurveyState,
+} from "../sharedInterfaces/userSurvey";
+
+import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
+import { sendActionEvent } from "../telemetry/telemetry";
 
 const PROBABILITY = 0.15;
 const SESSION_COUNT_KEY = "nps/sessionCount";
@@ -190,13 +192,10 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
     public readonly onCancel: vscode.Event<void> = this._onCancel.event;
 
     constructor(context: vscode.ExtensionContext, state?: UserSurveyState) {
-        super(
-            context,
-            locConstants.UserSurvey.mssqlFeedback,
-            "userSurvey",
-            state,
-            undefined,
-            {
+        super(context, "userSurvey", state, {
+            title: locConstants.UserSurvey.mssqlFeedback,
+            viewColumn: vscode.ViewColumn.Active,
+            iconPath: {
                 dark: vscode.Uri.joinPath(
                     context.extensionUri,
                     "media",
@@ -208,7 +207,7 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
                     "feedback_light.svg",
                 ),
             },
-        );
+        });
 
         this.registerReducer("submit", async (state, payload) => {
             this._onSubmit.fire(payload.answers);

--- a/src/objectExplorer/objectExplorerFilter.ts
+++ b/src/objectExplorer/objectExplorerFilter.ts
@@ -3,20 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ReactWebviewPanelController } from "../controllers/reactWebviewController";
-import * as vscodeMssql from "vscode-mssql";
 import * as vscode from "vscode";
-import { TreeNodeInfo } from "./treeNodeInfo";
+import * as vscodeMssql from "vscode-mssql";
+
 import {
     ObjectExplorerFilterState,
     ObjectExplorerReducers,
 } from "../sharedInterfaces/objectExplorerFilter";
-import { sendActionEvent } from "../telemetry/telemetry";
 import {
     TelemetryActions,
     TelemetryViews,
 } from "../sharedInterfaces/telemetry";
+
+import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
+import { TreeNodeInfo } from "./treeNodeInfo";
 import { randomUUID } from "crypto";
+import { sendActionEvent } from "../telemetry/telemetry";
 
 export class ObjectExplorerFilterReactWebviewController extends ReactWebviewPanelController<
     ObjectExplorerFilterState,
@@ -37,25 +39,27 @@ export class ObjectExplorerFilterReactWebviewController extends ReactWebviewPane
     ) {
         super(
             context,
-            vscode.l10n.t("Object Explorer Filter"),
             "objectExplorerFilter",
             data ?? {
                 filterProperties: [],
                 existingFilters: [],
                 nodePath: "",
             },
-            vscode.ViewColumn.Beside,
             {
-                dark: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "filter_dark.svg",
-                ),
-                light: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "filter_light.svg",
-                ),
+                title: vscode.l10n.t("Object Explorer Filter"),
+                viewColumn: vscode.ViewColumn.Beside,
+                iconPath: {
+                    dark: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "filter_dark.svg",
+                    ),
+                    light: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "filter_light.svg",
+                    ),
+                },
             },
         );
 

--- a/src/sharedInterfaces/webview.ts
+++ b/src/sharedInterfaces/webview.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from "vscode";
+
 import { TelemetryActions, TelemetryViews } from "./telemetry";
 
 export enum ApiStatus {
@@ -64,4 +66,36 @@ export interface WebviewTelemetryErrorEvent {
      * Additional measurements to include in the telemetry event.
      */
     additionalMeasurements?: Record<string, number>;
+}
+
+/**
+ * Options for customizing a webview panel. Since vscode has an interface with the same name, this
+ * interface is prefixed with Mssql to avoid conflicts.
+ */
+export interface MssqlWebviewPanelOptions {
+    /**
+     * The title of the webview panel.
+     */
+    title: string;
+    /**
+     * The view column in which the webview panel should be displayed.
+     */
+    viewColumn: vscode.ViewColumn;
+    /**
+     * The icon path for the webview panel tab icon.
+     */
+    iconPath?:
+        | vscode.Uri
+        | {
+              readonly light: vscode.Uri;
+              readonly dark: vscode.Uri;
+          };
+    /**
+     * When the webview panel is disposed, there is a prompt shown to restore it.
+     * This option is useful when the user accidentally closes the webview panel.
+     * By default, the webview panel is disposed when it is closed.
+     * Note: Use this option with caution and only on webview panels that have a significant amount of state.
+     * As it can be frustrating for users to see the restore prompt for every webview panel.
+     */
+    showRestorePromptAfterClose?: boolean;
 }

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -6,7 +6,7 @@
 import * as vscode from "vscode";
 import ConnectionManager from "../controllers/connectionManager";
 import { randomUUID } from "crypto";
-import { ReactWebviewPanelController } from "../controllers/reactWebviewController";
+import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
 import * as designer from "../sharedInterfaces/tableDesigner";
 import UntitledSqlDocumentService from "../controllers/untitledSqlDocumentService";
 import { getDesignerView } from "./tableDesignerTabDefinition";
@@ -35,7 +35,6 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
     ) {
         super(
             context,
-            "Table Designer",
             "tableDesigner",
             {
                 apiState: {
@@ -46,18 +45,22 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     initializeState: designer.LoadState.Loading,
                 },
             },
-            vscode.ViewColumn.Active,
             {
-                dark: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "tableDesignerEditor_dark.svg",
-                ),
-                light: vscode.Uri.joinPath(
-                    context.extensionUri,
-                    "media",
-                    "tableDesignerEditor_light.svg",
-                ),
+                title: "Table Designer",
+                viewColumn: vscode.ViewColumn.Active,
+                iconPath: {
+                    dark: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "tableDesignerEditor_dark.svg",
+                    ),
+                    light: vscode.Uri.joinPath(
+                        context.extensionUri,
+                        "media",
+                        "tableDesignerEditor_light.svg",
+                    ),
+                },
+                showRestorePromptAfterClose: true,
             },
         );
         void this.initialize();
@@ -181,6 +184,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
     }
 
     public override dispose() {
+        this._tableDesignerService.disposeTableDesigner(this.state.tableInfo);
         super.dispose();
         sendActionEvent(TelemetryViews.TableDesigner, TelemetryActions.Close, {
             correlationId: this._correlationId,

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -264,6 +264,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     },
                 };
                 this.panel.title = state.tableInfo.title;
+                this.showRestorePromptAfterClose = false;
                 await UserSurvey.getInstance().promptUserForNPSFeedback();
             } catch (e) {
                 state = {
@@ -398,6 +399,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
 
         this.registerReducer("continueEditing", async (state) => {
             this.state.apiState.publishState = designer.LoadState.NotStarted;
+            this.showRestorePromptAfterClose = true;
             sendActionEvent(
                 TelemetryViews.TableDesigner,
                 TelemetryActions.ContinueEditing,


### PR DESCRIPTION
Unfortunately, VS Code doesn't allow us to prevent a webview panel from being closed. However, we can listen for when the panel is closed and attempt to restore it, which is what this PR implements.
This feature should be used with caution, as it may frustrate users. However, for the table designer, it’s crucial since users may have a significant amount of unsaved data.

**Limitations: If the user decide to close vscode, they can bypass this modal and lose the edits.** 


Modal Dialog:
<img width="269" alt="image" src="https://github.com/user-attachments/assets/c28099a8-507c-4125-9dca-ea4ed28f4d35">


