### PR TITLE
profile name query param is processed with connection strings

### DIFF
--- a/src/mssqlProtocolHandler.ts
+++ b/src/mssqlProtocolHandler.ts
@@ -91,15 +91,16 @@ export class MssqlProtocolHandler {
 
         const connectionInfo = {};
         const args = new URLSearchParams(query);
-        const connectionString = args.get("connectionString");
-        if (connectionString) {
-            connectionInfo["connectionString"] = connectionString;
-            return connectionInfo as IConnectionInfo;
-        }
 
         const profileName = args.get("profileName");
         if (profileName) {
             connectionInfo["profileName"] = profileName;
+        }
+
+        const connectionString = args.get("connectionString");
+        if (connectionString) {
+            connectionInfo["connectionString"] = connectionString;
+            return connectionInfo as IConnectionInfo;
         }
 
         const connectionOptionProperties: ConnectionOptionProperty[] =


### PR DESCRIPTION
This PR fixes an issue where the profileName was previously not being included when the URI contained a connection string.

A URI with a connection string and a profileName like this:
`vscode://ms-mssql.mssql/connect?connectionString=Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;&profileName=profile1`

Results in the connection dialog opening with the correct fields filled in:
![image](https://github.com/user-attachments/assets/801e7c28-b108-4117-957b-08aac4e5f6e9)

![image](https://github.com/user-attachments/assets/9b35316b-db8c-4382-9e8f-6713809f0177)

