### PR TITLE
Porting Not collapsing all properties by default (#18202)

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -83,8 +83,6 @@
       "{1} is the number of issues"
     ]
   },
-  "Properties": "Properties",
-  "No data": "No data",
   "Move Up": "Move Up",
   "Move Down": "Move Down",
   "Delete": "Delete",
@@ -227,6 +225,7 @@
   "Find Node": "Find Node",
   "Highlight Expensive Operation": "Highlight Expensive Operation",
   "Toggle Tooltips": "Toggle Tooltips",
+  "Properties": "Properties",
   "Importance": "Importance",
   "Alphabetical": "Alphabetical",
   "Reverse Alphabetical": "Reverse Alphabetical",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -770,9 +770,6 @@
     <trans-unit id="++CODE++87a122216f22b55fd29964cf75c886ef5da5cd8369e2a6e24c73ec0ad22227ba">
       <source xml:lang="en">No connection was found. Please connect to a server first.</source>
     </trans-unit>
-    <trans-unit id="++CODE++3b41ba9c7cb8c5d6530c12eec5000c4e2ad0c48b2d4b9149a3ef6d2a23802819">
-      <source xml:lang="en">No data</source>
-    </trans-unit>
     <trans-unit id="++CODE++c933cd0d45861a20699df513967542bc9b448f409d362d9bec4e7443dd96f403">
       <source xml:lang="en">No need to refresh Microsoft Entra acccount token for connection {0} with uri {1}</source>
       <note>{0} is the connection id

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -31,7 +31,6 @@ import {
     ChevronLeftFilled,
     DismissRegular,
 } from "@fluentui/react-icons";
-import * as l10n from "@vscode/l10n";
 import { locConstants } from "../../common/locConstants";
 
 const useStyles = makeStyles({
@@ -98,20 +97,8 @@ export const DesignerPropertiesPane = () => {
     );
     groups?.unshift("General");
 
-    const PROPERTIES = l10n.t("Properties");
-    const NO_DATA = l10n.t("No data");
-
     if (!data) {
-        return (
-            <div className={classes.root}>
-                <Text className={classes.title} size={500}>
-                    {PROPERTIES}
-                </Text>
-                <div className={classes.stack}>
-                    <Text>{NO_DATA}</Text>
-                </div>
-            </div>
-        );
+        return undefined;
     }
 
     const renderAccordionItem = (
@@ -260,7 +247,7 @@ export const DesignerPropertiesPane = () => {
                 />
             </div>
             <div className={classes.stack}>
-                <Accordion multiple collapsible defaultOpenItems={[groups[0]]}>
+                <Accordion multiple collapsible defaultOpenItems={groups}>
                     {data &&
                         groups?.map((group) => {
                             const groupItems = parentTableProperties


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-mssql/issues/18204
PR to main Branch #18202 


Context copied from main branch PR

Collapsing all properties by default was hiding some essential properties for foreign keys and index items. Ideally we will have to reorder stuff to make sure that if we decide to collapse additional properties the main ones are not hidden. 


Before:
Index:
![image](https://github.com/user-attachments/assets/e7085fa1-d3aa-4648-b982-0177b89d339c)
Foreign Keys:
![image](https://github.com/user-attachments/assets/d2734207-280f-42ab-821f-4350c46b7a47)

After:
Index:
![image](https://github.com/user-attachments/assets/bf548269-4341-4b00-8a08-e83a40ffb750)

Foreign Keys:
![image](https://github.com/user-attachments/assets/c1b39e2b-b3a6-433c-a673-e6d51158a3f8)
