### PR TITLE
Adding some telemetry events

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1680,7 +1680,13 @@ export default class MainController implements vscode.Disposable {
             LocalizedConstants.Common.learnMore,
             LocalizedConstants.Common.dontShowAgain,
         );
-
+        await sendActionEvent(
+            TelemetryViews.General,
+            TelemetryActions.EnableRichExperiencesPrompt,
+            {
+                response,
+            },
+        );
         if (response === LocalizedConstants.enableRichExperiences) {
             await this._vscodeWrapper
                 .getConfiguration()

--- a/src/controllers/reactWebviewPanelController.ts
+++ b/src/controllers/reactWebviewPanelController.ts
@@ -6,8 +6,14 @@
 import * as locConstants from "../constants/locConstants";
 import * as vscode from "vscode";
 
+import {
+    TelemetryActions,
+    TelemetryViews,
+} from "../sharedInterfaces/telemetry";
+
 import { MssqlWebviewPanelOptions } from "../sharedInterfaces/webview";
 import { ReactWebviewBaseController } from "./reactWebviewBaseController";
+import { sendActionEvent } from "../telemetry/telemetry";
 
 /**
  * ReactWebviewPanelController is a class that manages a vscode.WebviewPanel and provides
@@ -112,6 +118,12 @@ export class ReactWebviewPanelController<
             {
                 title: locConstants.Webview.Restore,
                 run: async () => {
+                    sendActionEvent(
+                        TelemetryViews.WebviewController,
+                        TelemetryActions.Restore,
+                        {},
+                        {},
+                    );
                     await this.createWebviewPanel();
                     this._panel.reveal(this._options.viewColumn);
                 },

--- a/src/objectExplorer/objectExplorerFilter.ts
+++ b/src/objectExplorer/objectExplorerFilter.ts
@@ -122,17 +122,20 @@ export class ObjectExplorerFilter {
             }
             this._filterWebviewController.revealToForeground();
             this._filterWebviewController.onSubmit((e) => {
-                sendActionEvent(
-                    TelemetryViews.ObjectExplorerFilter,
-                    TelemetryActions.Submit,
-                    {
-                        nodeType: treeNode.nodeType,
-                        correlationId,
-                    },
-                    {
-                        filterCount: e.length,
-                    },
-                );
+                if (e) {
+                    sendActionEvent(
+                        TelemetryViews.ObjectExplorerFilter,
+                        TelemetryActions.Submit,
+                        {
+                            nodeType: treeNode.nodeType,
+                            correlationId,
+                            filters: JSON.stringify(e.map((e) => e.name)),
+                        },
+                        {
+                            filterCount: e.length,
+                        },
+                    );
+                }
                 resolve(e);
             });
             this._filterWebviewController.onCancel(() => {

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -15,6 +15,7 @@ export enum TelemetryViews {
     ObjectExplorerFilter = "ObjectExplorerFilter",
     TableDesigner = "TableDesigner",
     UserSurvey = "UserSurvey",
+    General = "General",
 }
 
 export enum TelemetryActions {
@@ -43,4 +44,6 @@ export enum TelemetryActions {
     Close = "Close",
     SurverySubmit = "SurveySubmit",
     SaveResults = "SaveResults",
+    EnableRichExperiencesPrompt = "EnableRichExperiencesPrompt",
+    Restore = "Restore",
 }

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -275,6 +275,14 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     },
                     publishingError: e.toString(),
                 };
+                sendActionEvent(
+                    TelemetryViews.TableDesigner,
+                    TelemetryActions.Publish,
+                    {
+                        correlationId: this._correlationId,
+                        error: "true",
+                    },
+                );
             }
             return state;
         });


### PR DESCRIPTION
1. Adds telemetry for how many users enable rich experiences in the prompt dialog.
2. Adds telemetry for table designer error
3. Adds which filters are used in OE filtering.
4. Table Designer publish errors
5. Adds event for table designer webview restoring. 