### PR TITLE
Porting hid execution plan button under rich feature flag (#18219) and Query Plan Bugs (#18215)

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
         },
         {
           "command": "mssql.showExecutionPlanInResults",
-          "when": "editorLangId == sql",
+          "when": "editorLangId == sql && config.mssql.enableRichExperiences",
           "group": "navigation@4"
         }
       ],

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -55,6 +55,7 @@ export class SqlOutputContentProvider {
     >();
     private _panels = new Map<string, WebviewPanelController>();
     private _queryResultWebviewController: QueryResultWebviewController;
+    private _executionPlanOptions: ExecutionPlanOptions = {};
 
     // CONSTRUCTOR /////////////////////////////////////////////////////////
     constructor(
@@ -248,9 +249,15 @@ export class SqlOutputContentProvider {
                 await this.createWebviewController(uri, title, queryRunner);
             }
         } else {
+            if (executionPlanOptions) {
+                this._executionPlanOptions = executionPlanOptions;
+            } else {
+                this._executionPlanOptions = {};
+            }
             this._queryResultWebviewController.addQueryResultState(
                 uri,
-                executionPlanOptions?.includeEstimatedExecutionPlanXml ?? false,
+                this._executionPlanOptions?.includeEstimatedExecutionPlanXml ??
+                    false,
             );
         }
         if (queryRunner) {
@@ -388,7 +395,11 @@ export class SqlOutputContentProvider {
                 if (!this.isRichExperiencesEnabled) {
                     this._panels.get(uri).proxy.sendEvent("start", panelUri);
                 } else {
-                    this._queryResultWebviewController.addQueryResultState(uri);
+                    this._queryResultWebviewController.addQueryResultState(
+                        uri,
+                        this._executionPlanOptions
+                            ?.includeEstimatedExecutionPlanXml ?? false,
+                    );
                     await vscode.commands.executeCommand("queryResult.focus");
                     this._queryResultWebviewController.getQueryResultState(
                         uri,

--- a/src/reactviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/src/reactviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -110,7 +110,9 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({
         if (!executionPlanState || isExecutionPlanLoaded) return;
 
         setContainerHeight(
-            executionPlanState!.executionPlanGraphs!.length > 1
+            executionPlanState!.executionPlanGraphs!.length > 1 &&
+                graphIndex !==
+                    executionPlanState!.executionPlanGraphs!.length - 1
                 ? "500px"
                 : "100%",
         );

--- a/src/reactviews/pages/ExecutionPlan/executionPlanPage.tsx
+++ b/src/reactviews/pages/ExecutionPlan/executionPlanPage.tsx
@@ -9,7 +9,6 @@ import { makeStyles, Spinner, Text } from "@fluentui/react-components";
 import { ExecutionPlanGraph } from "./executionPlanGraph";
 import { ErrorCircleRegular } from "@fluentui/react-icons";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
-import { QueryResultState } from "../QueryResult/queryResultStateProvider";
 
 const useStyles = makeStyles({
     outerDiv: {
@@ -34,15 +33,9 @@ const useStyles = makeStyles({
     },
 });
 
-interface ExecutionPlanPageProps {
-    context?: QueryResultState;
-}
-
-export const ExecutionPlanPage: React.FC<ExecutionPlanPageProps> = ({
-    context,
-}) => {
+export const ExecutionPlanPage = () => {
     const classes = useStyles();
-    const provider = context ? context : useContext(ExecutionPlanContext);
+    const provider = useContext(ExecutionPlanContext);
     const executionPlanState = provider?.state?.executionPlanState;
     const loadState = executionPlanState?.loadState ?? ApiStatus.Loading;
     const renderMainContent = () => {

--- a/src/reactviews/pages/ExecutionPlan/findNodes.tsx
+++ b/src/reactviews/pages/ExecutionPlan/findNodes.tsx
@@ -37,15 +37,19 @@ const useStyles = makeStyles({
         gap: "2px",
         opacity: 1,
     },
-    combobox: {
-        minWidth: "50px",
-        width: "100px",
-        maxWidth: "100px",
-        overflow: "hidden",
+    inputs: {
+        minWidth: "unset",
+        maxWidth: "unset",
     },
-    dropdown: {
-        minWidth: "50px",
-        width: "100px",
+    option: {
+        fontSize: "12px",
+        whiteSpace: "nowrap",
+        textAlign: "left",
+        marginLeft: "0px",
+        paddingLeft: "0px",
+    },
+    spacer: {
+        padding: "1px",
     },
 });
 
@@ -146,10 +150,14 @@ export const FindNode: React.FC<FindNodeProps> = ({
                 background: theme.colorNeutralBackground1,
             }}
         >
-            <div>{locConstants.executionPlan.findNodes}</div>
+            {locConstants.executionPlan.findNodes}
+            <div style={{ paddingRight: "12px" }} />
             <Combobox
                 id="findNodeDropdown"
-                className={classes.combobox}
+                className={classes.inputs}
+                size="small"
+                input={{ style: { width: "130px", textOverflow: "ellipsis" } }}
+                listbox={{ style: { minWidth: "fit-content" } }}
                 defaultValue={findNodeOptions[0]}
                 onOptionSelect={(_, data) => {
                     setFindNodeSelection(data.optionText ?? findNodeOptions[0]);
@@ -157,15 +165,22 @@ export const FindNode: React.FC<FindNodeProps> = ({
                     setFindNodeResults([]);
                 }}
             >
-                <div style={{ maxHeight: "250px", maxWidth: "100px" }}>
-                    {findNodeOptions.map((option) => (
-                        <Option key={option}>{option}</Option>
-                    ))}
-                </div>
+                {findNodeOptions.map((option) => (
+                    <Option key={option} className={classes.option}>
+                        {option}
+                    </Option>
+                ))}
             </Combobox>
+            <div className={classes.spacer}></div>
             <Dropdown
                 id="findNodeComparisonDropdown"
-                className={classes.dropdown}
+                size="small"
+                className={classes.inputs}
+                style={{
+                    width: "80px",
+                    textOverflow: "ellipsis",
+                    height: "24px",
+                }}
                 defaultValue={findNodeComparisonOptions[0]}
                 onOptionSelect={(_, data) => {
                     setFindNodeComparisonSelection(
@@ -176,30 +191,42 @@ export const FindNode: React.FC<FindNodeProps> = ({
                 }}
             >
                 {findNodeComparisonOptions.map((option) => (
-                    <Option key={option}>{option}</Option>
+                    <Option key={option} className={classes.option}>
+                        {option}
+                    </Option>
                 ))}
             </Dropdown>
+            <div className={classes.spacer}></div>
             <Input
                 id="findNodeInputBox"
+                size="small"
                 type="text"
-                className={classes.combobox}
+                className={classes.inputs}
+                input={{ style: { width: "85px", textOverflow: "ellipsis" } }}
                 onChange={(e) => {
                     setFindNodeSearchValue(e.target.value);
                     setFindNodeResultsIndex(-1);
                     setFindNodeResults([]);
                 }}
             />
+            <div className={classes.spacer}></div>
             <Button
                 onClick={() => handleFoundNode(-1)}
+                size="small"
+                appearance="subtle"
                 icon={<ArrowUp20Regular />}
             />
             <Button
                 onClick={() => handleFoundNode(1)}
+                size="small"
+                appearance="subtle"
                 icon={<ArrowDown20Regular />}
             />
             <Button
-                icon={<Dismiss20Regular />}
                 onClick={() => setFindNodeClicked(false)}
+                size="small"
+                appearance="subtle"
+                icon={<Dismiss20Regular />}
             />
         </div>
     );


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/18114
Fixes https://github.com/microsoft/vscode-mssql/issues/18113

Also hides the execution plan generation button behind the rich feature flag.

Context copied from main branch PR

Fixes a regression that appeared after this pr (https://github.com/microsoft/vscode-mssql/pull/18192), where query plans stopped working after the context for them was dropped

find nodes style changes: 
![image](https://github.com/user-attachments/assets/6f9c212f-926a-4192-891c-466fe585ffa3)
![Screenshot 2024-10-15 142207](https://github.com/user-attachments/assets/6219ac46-7f76-4cd0-a1ed-5f6ae85c57c8)