### PR TITLE
Improving first-run prompt flow

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -693,8 +693,13 @@
   "Execution Plan": "Execution Plan",
   "Script copied to clipboard": "Script copied to clipboard",
   "Copied": "Copied",
-  "The MSSQL extension has some new GUI-based experiences! Would you like to enable them?": "The MSSQL extension has some new GUI-based experiences! Would you like to enable them?",
-  "Enable Rich Experiences": "Enable Rich Experiences",
+  "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})/{0} is a url to learn more about the new features": {
+    "message": "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})",
+    "comment": [
+      "{0} is a url to learn more about the new features"
+    ]
+  },
+  "Enable Experiences & Reload": "Enable Experiences & Reload",
   "Connection Dialog": "Connection Dialog",
   "Azure Account": "Azure Account",
   "Azure Account is required": "Azure Account is required",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -396,8 +396,8 @@
     <trans-unit id="++CODE++1e71b5c8f3211f1f01b27341d3ddc6a2ad651800264b495c12b50867f998662c">
       <source xml:lang="en">Enable &apos;Trust Server Certificate&apos;</source>
     </trans-unit>
-    <trans-unit id="++CODE++952bc2eaca6c7bdfa690c327fa623692420a6821a4e386af25f6e333e31e30b2">
-      <source xml:lang="en">Enable Rich Experiences</source>
+    <trans-unit id="++CODE++fab99ae162d8056598a1ab43c81a2a5a296873c0868800c4f092697d8470720a">
+      <source xml:lang="en">Enable Experiences &amp; Reload</source>
     </trans-unit>
     <trans-unit id="++CODE++45e33ceba31737f1cb793c231fafc9dd99074ca1f26476a70b0c830ef155c9d3">
       <source xml:lang="en">Enable Trust Server Certificate</source>
@@ -1180,8 +1180,9 @@
     <trans-unit id="++CODE++90c8505baad739c0925471e0d594ba9d83f84d3a96dbdfa16a47ae7a3ad95d91">
       <source xml:lang="en">Testing connection profile...</source>
     </trans-unit>
-    <trans-unit id="++CODE++bf0625b7472379f6e2c58de0495e3375908927e805a30b25fcc0052af4539bc6">
-      <source xml:lang="en">The MSSQL extension has some new GUI-based experiences! Would you like to enable them?</source>
+    <trans-unit id="++CODE++acd64111965ff7af14fb0dc101deb52a5e3e7cfc6aae4d0fa9bf7a65ed37870a">
+      <source xml:lang="en">The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})</source>
+      <note>{0} is a url to learn more about the new features</note>
     </trans-unit>
     <trans-unit id="++CODE++3eacf5cf678e2285cae1276d29f034aa0e7ceb3f8940239c1d67a2d486649719">
       <source xml:lang="en">The behavior when a user tries to delete a row with data that is involved in a foreign key relationship.</source>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -643,10 +643,15 @@ export let executionPlan = l10n.t("Execution Plan");
 export let scriptCopiedToClipboard = l10n.t("Script copied to clipboard");
 export let copied = l10n.t("Copied");
 
-export let enableRichExperiencesPrompt = l10n.t(
-    "The MSSQL extension has some new GUI-based experiences! Would you like to enable them?",
-);
-export let enableRichExperiences = l10n.t("Enable Rich Experiences");
+export function enableRichExperiencesPrompt(learnMoreUrl: string) {
+    return l10n.t({
+        message:
+            "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})",
+        args: [learnMoreUrl],
+        comment: ["{0} is a url to learn more about the new features"],
+    });
+}
+export let enableRichExperiences = l10n.t("Enable Experiences & Reload");
 
 export class ConnectionDialog {
     public static connectionDialog = l10n.t("Connection Dialog");

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1653,15 +1653,16 @@ export default class MainController implements vscode.Disposable {
 
     private async showOnLaunchPrompts(): Promise<void> {
         // All prompts should be async and _not_ awaited so that we don't block the rest of the extension
-        void this.showFirstLaunchPrompts();
-        void this.showEnableRichExperiencesPrompt();
+
+        if (this.shouldShowEnableRichExperiencesPrompt()) {
+            void this.showEnableRichExperiencesPrompt();
+        } else {
+            void this.showFirstLaunchPrompts();
+        }
     }
 
-    /**
-     * Prompts the user to enable rich experiences
-     */
-    private async showEnableRichExperiencesPrompt(): Promise<void> {
-        if (
+    private shouldShowEnableRichExperiencesPrompt(): boolean {
+        return !(
             this._vscodeWrapper
                 .getConfiguration()
                 .get<boolean>(
@@ -1670,16 +1671,26 @@ export default class MainController implements vscode.Disposable {
             this._vscodeWrapper
                 .getConfiguration()
                 .get<boolean>(Constants.configEnableRichExperiences)
-        ) {
+        );
+    }
+
+    /**
+     * Prompts the user to enable rich experiences
+     */
+    private async showEnableRichExperiencesPrompt(): Promise<void> {
+        if (!this.shouldShowEnableRichExperiencesPrompt()) {
             return;
         }
 
         const response = await this._vscodeWrapper.showInformationMessage(
-            LocalizedConstants.enableRichExperiencesPrompt,
+            LocalizedConstants.enableRichExperiencesPrompt(
+                Constants.richFeaturesLearnMoreLink,
+            ),
             LocalizedConstants.enableRichExperiences,
-            LocalizedConstants.Common.learnMore,
             LocalizedConstants.Common.dontShowAgain,
         );
+
+        this.doesExtensionLaunchedFileExist(); // create the "extensionLaunched" file since this takes the place of the release notes prompt
 
         if (response === LocalizedConstants.enableRichExperiences) {
             await this._vscodeWrapper
@@ -1689,9 +1700,10 @@ export default class MainController implements vscode.Disposable {
                     true,
                     vscode.ConfigurationTarget.Global,
                 );
-        } else if (response === LocalizedConstants.Common.learnMore) {
-            await vscode.env.openExternal(
-                vscode.Uri.parse(Constants.richFeaturesLearnMoreLink),
+
+            // reload immediately
+            await vscode.commands.executeCommand(
+                "workbench.action.reloadWindow",
             );
         } else if (response === LocalizedConstants.Common.dontShowAgain) {
             await this._vscodeWrapper


### PR DESCRIPTION
Fixes #18210

vscode now reloads the extensions immediately after the users accepts the prompt to enable the new UX

Users should now see a maximum of one prompt at launch, with the prompt to enable new features taking the place of the typical release notes prompt if users have neither enabled or suppressed it.  Users will be prompted to enable the new UX each launch until they pick one, but the release notes prompt will (still) only be shown once per extension update.

Once the new UX is GAed, the new prompt will be removed and the behavior will be reverted.