### PR TITLE
Porting Fixing bug where profile name isn't displayed immediately after new connectionString connection (#18223)

### DIFF
--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -776,6 +776,17 @@ export class ObjectExplorerService {
                 ConnectionCredentials.createConnectionDetails(
                     connectionCredentials,
                 );
+
+            if ((connectionCredentials as IConnectionProfile).profileName) {
+                this._nodePathToNodeLabelMap.set(
+                    // using the server name as the key because that's what the rest of the OE service expects.
+                    // TODO: this service should be refactored to use something guaranteed to be unique across all connections,
+                    // but that likely involves a larger refactor of connection management.
+                    connectionCredentials.server,
+                    (connectionCredentials as IConnectionProfile).profileName,
+                );
+            }
+
             const response: CreateSessionResponse =
                 await this._connectionManager.client.sendRequest(
                     CreateSessionRequest.type,


### PR DESCRIPTION
Original PR: #18223 

Bug: https://github.com/microsoft/vscode-mssql/issues/18156

Sets a cache entry that was missed during the connection dialog save flow

Before:
![image](https://github.com/user-attachments/assets/65d4dbfe-d53c-4d03-954c-2397e69a66fa)

After:
![image](https://github.com/user-attachments/assets/14dbd379-9226-4378-8ce1-111d231c5fb0)
