### PR TITLE
Fix query plan flickering bug

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -285,7 +285,7 @@ export const QueryResultPane = () => {
 
     const renderGridPanel = () => {
         const grids = [];
-        gridRefs.current.forEach((r) => r?.refreshGrid());
+        // gridRefs.current.forEach((r) => r?.refreshGrid());
         let totalResultCount = 0;
         Object.values(metadata?.resultSetSummaries ?? []).forEach((v) => {
             totalResultCount += Object.keys(v).length;

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -285,7 +285,9 @@ export const QueryResultPane = () => {
 
     const renderGridPanel = () => {
         const grids = [];
-        // gridRefs.current.forEach((r) => r?.refreshGrid());
+        if (!metadata?.isExecutionPlan) {
+            gridRefs.current.forEach((r) => r?.refreshGrid());
+        }
         let totalResultCount = 0;
         Object.values(metadata?.resultSetSummaries ?? []).forEach((v) => {
             totalResultCount += Object.keys(v).length;

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -285,6 +285,10 @@ export const QueryResultPane = () => {
 
     const renderGridPanel = () => {
         const grids = [];
+        // execution plans only load after reading the resulting xml showplan
+        // of the query. therefore, it updates the state once the results
+        // are loaded, which causes a rendering loop if the grid
+        // gets refreshed
         if (!metadata?.isExecutionPlan) {
             gridRefs.current.forEach((r) => r?.refreshGrid());
         }


### PR DESCRIPTION
Fixed the flickering bug by preventing grid refreshes if the query is an execution plan

issue: https://github.com/microsoft/vscode-mssql/issues/18254

eventually, I'll move the state change responsible for the query plan rendering to the extension side rather than the client side: https://github.com/microsoft/vscode-mssql/issues/18257
