### PR TITLE
Fix event subscription in webview

### DIFF
--- a/src/reactviews/common/rpc.ts
+++ b/src/reactviews/common/rpc.ts
@@ -22,7 +22,7 @@ export class WebviewRpc<Reducers> {
         };
     } = {};
     private _methodSubscriptions: {
-        [method: string]: ((params: unknown) => void)[];
+        [method: string]: Record<string, (params: unknown) => void>;
     } = {};
     private static _instance: WebviewRpc<any>;
     public static getInstance<Reducers>(
@@ -51,8 +51,8 @@ export class WebviewRpc<Reducers> {
             if (message.type === "notification") {
                 const { method, params } = message;
                 if (this._methodSubscriptions[method]) {
-                    this._methodSubscriptions[method].forEach((callback) =>
-                        callback(params),
+                    Object.values(this._methodSubscriptions[method]).forEach(
+                        (cb) => cb(params),
                     );
                 }
             }
@@ -86,11 +86,15 @@ export class WebviewRpc<Reducers> {
         void this.call("action", { type: method, payload });
     }
 
-    public subscribe(method: string, callback: (params: unknown) => void) {
+    public subscribe(
+        callerId: string,
+        method: string,
+        callback: (params: unknown) => void,
+    ) {
         if (!this._methodSubscriptions[method]) {
-            this._methodSubscriptions[method] = [];
+            this._methodSubscriptions[method] = {};
         }
-        this._methodSubscriptions[method].push(callback);
+        this._methodSubscriptions[method][callerId] = callback;
     }
 
     public sendActionEvent(event: WebviewTelemetryActionEvent) {

--- a/src/reactviews/common/vscodeWebviewProvider.tsx
+++ b/src/reactviews/common/vscodeWebviewProvider.tsx
@@ -121,22 +121,26 @@ export function VscodeWebviewProvider<State, Reducers>({
         void getLocalization();
     }, []);
 
-    extensionRpc.subscribe("onDidChangeTheme", (params) => {
-        const kind = params as ColorThemeKind;
-        switch (kind) {
-            case ColorThemeKind.Dark:
-                setTheme(webDarkTheme);
-                break;
-            case ColorThemeKind.HighContrast:
-                setTheme(teamsHighContrastTheme);
-                break;
-            default:
-                setTheme(webLightTheme);
-                break;
-        }
-    });
+    extensionRpc.subscribe(
+        "vscodeWebviewProvider",
+        "onDidChangeTheme",
+        (params) => {
+            const kind = params as ColorThemeKind;
+            switch (kind) {
+                case ColorThemeKind.Dark:
+                    setTheme(webDarkTheme);
+                    break;
+                case ColorThemeKind.HighContrast:
+                    setTheme(teamsHighContrastTheme);
+                    break;
+                default:
+                    setTheme(webLightTheme);
+                    break;
+            }
+        },
+    );
 
-    extensionRpc.subscribe("updateState", (params) => {
+    extensionRpc.subscribe("vscodeWebviewProvider", "updateState", (params) => {
         setState(params as State);
     });
 


### PR DESCRIPTION
Currently every time a page is re-rendered, the new page would subscribe to the events, but we are not cleaning up the stale subscribers.
This PR removes these stale subscribers by adding a `callerId` field and thus each caller can only have one subscription for one method.
 