### PR TITLE
Changes to client-side azure resource filtering

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -7,7 +7,6 @@ import * as vscode from "vscode";
 
 import {
     AuthenticationType,
-    AzureSqlServerInfo,
     AzureSubscriptionInfo,
     ConnectionDialogFormItemSpec,
     ConnectionDialogReducers,
@@ -26,19 +25,16 @@ import {
     FormItemType,
 } from "../reactviews/common/forms/form";
 import {
-    GenericResourceExpanded,
-    ResourceManagementClient,
-} from "@azure/arm-resources";
-import {
     ConnectionDialog as Loc,
     refreshTokenLabel,
 } from "../constants/locConstants";
 import {
     azureSubscriptionFilterConfigKey,
     confirmVscodeAzureSignin,
+    fetchServersFromAzure,
     promptForAzureSubscriptionFilter,
 } from "./azureHelper";
-import { getErrorMessage, listAllIterator } from "../utils/utils";
+import { getErrorMessage } from "../utils/utils";
 
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { AzureController } from "../azure/azureController";
@@ -1255,7 +1251,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
         );
 
         try {
-            const servers = await this.fetchServersFromAzure(azSub);
+            const servers = await fetchServersFromAzure(azSub);
             state.azureServers.push(...servers);
             stateSub.loaded = true;
             this.updateState();
@@ -1291,75 +1287,5 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             rv.get(keyValue)!.push(x);
             return rv;
         }, new Map<K, V[]>());
-    }
-
-    private async fetchServersFromAzure(
-        sub: AzureSubscription,
-    ): Promise<AzureSqlServerInfo[]> {
-        const result: AzureSqlServerInfo[] = [];
-        const client = new ResourceManagementClient(
-            sub.credential,
-            sub.subscriptionId,
-        );
-        const servers = await listAllIterator<GenericResourceExpanded>(
-            client.resources.list({
-                filter: "resourceType eq 'Microsoft.Sql/servers'",
-            }),
-        );
-        const databasesPromise = listAllIterator<GenericResourceExpanded>(
-            client.resources.list({
-                filter: "resourceType eq 'Microsoft.Sql/servers/databases'",
-            }),
-        );
-
-        for (const server of servers) {
-            result.push({
-                server: server.name,
-                databases: [],
-                location: server.location,
-                resourceGroup: this.extractFromResourceId(
-                    server.id,
-                    "resourceGroups",
-                ),
-                subscription: `${sub.name} (${sub.subscriptionId})`,
-            });
-        }
-
-        for (const database of await databasesPromise) {
-            const serverName = this.extractFromResourceId(
-                database.id,
-                "servers",
-            );
-            const server = result.find((s) => s.server === serverName);
-            if (server) {
-                server.databases.push(
-                    database.name.substring(serverName.length + 1),
-                ); // database.name is in the form 'serverName/databaseName', so we need to remove the server name and slash
-            }
-        }
-
-        return result;
-    }
-
-    private extractFromResourceId(
-        resourceId: string,
-        property: string,
-    ): string | undefined {
-        if (!property.endsWith("/")) {
-            property += "/";
-        }
-
-        let startIndex = resourceId.indexOf(property);
-
-        if (startIndex === -1) {
-            return undefined;
-        } else {
-            startIndex += property.length;
-        }
-
-        return resourceId.substring(
-            startIndex,
-            resourceId.indexOf("/", startIndex),
-        );
     }
 }

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -79,6 +79,7 @@ export const AzureBrowsePage = () => {
         setSubscriptions(subs.sort());
 
         if (!selectedSubscription && subs.length === 1) {
+            setSubscriptionValue(subs[0]);
             setSelectedSubscription(subs[0]);
         }
     }, [context.state.azureSubscriptions]);


### PR DESCRIPTION
Addresses #18240

I found that I was getting an error message saying that the resource filter argument I was passing for server-side processing was invalid... for some subscriptions, but not all (or even most). Curiously, it was consistently the same subscriptions that would return the error, and I didn't notice any pattern to it. My mind went to permissions, but the query for all resources under that sub is consistently working fine for all subs so that doesn't make sense.

In any case, I switched to doing the filtering client-side in order to solve the issue.