### PR TITLE
Improving the azure browse filter dropdown logic

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1211,6 +1211,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                 );
             } else {
                 state.loadingAzureServersStatus = ApiStatus.Loading;
+                state.azureServers = [];
                 this.updateState();
 
                 const startTime = Date.now();

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1138,6 +1138,8 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                         string[] | undefined
                     >(azureSubscriptionFilterConfigKey) !== undefined;
 
+            const startTime = Date.now();
+
             this._azureSubscriptions = new Map(
                 (await auth.getSubscriptions(shouldUseFilter)).map((s) => [
                     s.subscriptionId,
@@ -1145,7 +1147,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                 ]),
             );
             const tenantSubMap = this.groupBy<string, AzureSubscription>(
-                await auth.getSubscriptions(shouldUseFilter),
+                Array.from(this._azureSubscriptions.values()),
                 "tenantId",
             ); // TODO: replace with Object.groupBy once ES2024 is supported
 
@@ -1164,6 +1166,16 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             state.azureSubscriptions = subs;
             state.loadingAzureSubscriptionsStatus = ApiStatus.Loaded;
 
+            sendActionEvent(
+                TelemetryViews.ConnectionDialog,
+                TelemetryActions.LoadAzureSubscriptions,
+                undefined, // additionalProperties
+                {
+                    subscriptionCount: subs.length,
+                    msToLoadSubscriptions: Date.now() - startTime,
+                },
+            );
+
             this.updateState();
 
             return tenantSubMap;
@@ -1171,6 +1183,14 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             state.formError = l10n.t("Error loading Azure subscriptions.");
             state.loadingAzureSubscriptionsStatus = ApiStatus.Error;
             console.error(state.formError + "\n" + getErrorMessage(error));
+
+            sendErrorEvent(
+                TelemetryViews.ConnectionDialog,
+                TelemetryActions.LoadAzureSubscriptions,
+                error,
+                false, // includeErrorMessage
+            );
+
             return undefined;
         }
     }
@@ -1179,7 +1199,6 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
         state: ConnectionDialogWebviewState,
     ): Promise<void> {
         try {
-            const startTime = Date.now();
             const tenantSubMap = await this.loadAzureSubscriptions(state);
 
             if (!tenantSubMap) {
@@ -1193,6 +1212,8 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             } else {
                 state.loadingAzureServersStatus = ApiStatus.Loading;
                 this.updateState();
+
+                const startTime = Date.now();
 
                 const promiseArray: Promise<void>[] = [];
                 for (const t of tenantSubMap.keys()) {
@@ -1229,12 +1250,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                 TelemetryViews.ConnectionDialog,
                 TelemetryActions.LoadAzureServers,
                 error,
-                true, // includeErrorMessage
-                undefined, // errorCode
-                undefined, // errorType
-                {
-                    connectionInputType: this.state.selectedInputMode,
-                },
+                false, // includeErrorMessage
             );
 
             return;

--- a/src/reactviews/common/comboboxHelper.ts
+++ b/src/reactviews/common/comboboxHelper.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Behavior for how the default selection is determined */
+export enum DefaultSelectionMode {
+    /** If there are any options, the first is always selected.  Otherwise, selects nothing. */
+    SelectFirstIfAny,
+    /** Always selects nothing, regardless of if there are available options */
+    AlwaysSelectNone,
+    /** Selects the only option if there's only one.  Otherwise (many or no options) selects nothing. */
+    SelectOnlyOrNone,
+}
+
+export function updateComboboxSelection(
+    /** current selected (valid) option */
+    selected: string | undefined,
+    /** callback to set the selected (valid) option */
+    setSelected: (s: string | undefined) => void,
+    /** callback to set the displayed value (not guaranteed to be valid if the user has manually typed something) */
+    setValue: (v: string) => void,
+    /** list of valid options */
+    optionList: string[],
+    /** behavior for choosing the default selected value */
+    defaultSelectionMode: DefaultSelectionMode = DefaultSelectionMode.AlwaysSelectNone,
+) {
+    // if there is no current selection or if the current selection is no longer in the list of options (due to filter changes),
+    // then select the only option if there is only one option,
+    // or either the first option or none if there are multiple options, depending on how shouldSelectIfAny is set
+
+    if (
+        selected === undefined ||
+        (selected && !optionList.includes(selected))
+    ) {
+        let optionToSelect: string | undefined = undefined;
+
+        if (optionList.length > 0) {
+            switch (defaultSelectionMode) {
+                case DefaultSelectionMode.SelectFirstIfAny:
+                    optionToSelect =
+                        optionList.length > 0 ? optionList[0] : undefined;
+                    break;
+                case DefaultSelectionMode.SelectOnlyOrNone:
+                    optionToSelect =
+                        optionList.length === 1 ? optionList[0] : undefined;
+                    break;
+                case DefaultSelectionMode.AlwaysSelectNone:
+                default:
+                    optionToSelect = undefined;
+            }
+        }
+
+        setSelected(optionToSelect); // selected value's unselected state should be undefined
+        setValue(optionToSelect ?? ""); // displayed value's unselected state should be an empty string
+    }
+}

--- a/src/reactviews/common/comboboxHelper.ts
+++ b/src/reactviews/common/comboboxHelper.ts
@@ -26,8 +26,7 @@ export function updateComboboxSelection(
     defaultSelectionMode: DefaultSelectionMode = DefaultSelectionMode.AlwaysSelectNone,
 ) {
     // if there is no current selection or if the current selection is no longer in the list of options (due to filter changes),
-    // then select the only option if there is only one option,
-    // or either the first option or none if there are multiple options, depending on how shouldSelectIfAny is set
+    // then select the only option if there is only one option, then make a default selection according to specified `defaultSelectionMode`
 
     if (
         selected === undefined ||

--- a/src/reactviews/common/utils.ts
+++ b/src/reactviews/common/utils.ts
@@ -49,3 +49,8 @@ export function themeType(theme: Theme): string {
     }
     return themeType;
 }
+
+/** Removes duplicate values from an array */
+export function removeDuplicates<T>(array: T[]): T[] {
+    return Array.from(new Set(array));
+}

--- a/src/reactviews/pages/ConnectionDialog/AzureFilterCombobox.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/AzureFilterCombobox.component.tsx
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    Combobox,
+    ComboboxProps,
+    Field,
+    makeStyles,
+    OptionOnSelectData,
+    SelectionEvents,
+    Option,
+} from "@fluentui/react-components";
+import { useFormStyles } from "../../common/forms/form.component";
+import { useEffect, useState } from "react";
+
+const useFieldDecorationStyles = makeStyles({
+    decoration: {
+        display: "flex",
+        alignItems: "center",
+        columnGap: "4px",
+    },
+});
+
+export const AzureFilterCombobox = ({
+    label,
+    required,
+    clearable,
+    content,
+    decoration,
+    props,
+}: {
+    label: string;
+    required?: boolean;
+    clearable?: boolean;
+    content: {
+        /** list of valid values for the combo box */
+        valueList: string[];
+        /** currently-selected value from `valueList` */
+        selection?: string;
+        /** callback when the user has selected a value from `valueList` */
+        setSelection: (value: string | undefined) => void;
+        /** currently-entered text in the combox, may not be a valid selection value if the user is typing */
+        value: string;
+        /** callback when the user types in the combobox */
+        setValue: (value: string) => void;
+        /** placeholder text for the combobox */
+        placeholder?: string;
+        /** message displayed if focus leaves this combobox and `value` is not a valid value from `valueList` */
+        invalidOptionErrorMessage: string;
+    };
+    decoration?: JSX.Element;
+    props?: Partial<ComboboxProps>;
+}) => {
+    const formStyles = useFormStyles();
+    const decorationStyles = useFieldDecorationStyles();
+    const [validationMessage, setValidationMessage] = useState<string>("");
+
+    // clear validation message as soon as value is valid
+    useEffect(() => {
+        if (content.valueList.includes(content.value)) {
+            setValidationMessage("");
+        }
+    }, [content.value]);
+
+    // only display validation error if focus leaves the field and the value is not valid
+    const onBlur = () => {
+        if (content.value) {
+            setValidationMessage(
+                content.valueList.includes(content.value)
+                    ? ""
+                    : content.invalidOptionErrorMessage,
+            );
+        }
+    };
+
+    const onOptionSelect: (
+        _: SelectionEvents,
+        data: OptionOnSelectData,
+    ) => void = (_, data: OptionOnSelectData) => {
+        content.setSelection(
+            data.selectedOptions.length > 0 ? data.selectedOptions[0] : "",
+        );
+        content.setValue(data.optionText ?? "");
+    };
+
+    function onInput(ev: React.ChangeEvent<HTMLInputElement>) {
+        content.setValue(ev.target.value);
+    }
+
+    return (
+        <div className={formStyles.formComponentDiv}>
+            <Field
+                label={
+                    decoration ? (
+                        <div className={decorationStyles.decoration}>
+                            {label}
+                            {decoration}
+                        </div>
+                    ) : (
+                        label
+                    )
+                }
+                orientation="horizontal"
+                required={required}
+                validationMessage={validationMessage}
+                onBlur={onBlur}
+            >
+                <Combobox
+                    {...props}
+                    value={content.value}
+                    selectedOptions={
+                        content.selection ? [content.selection] : []
+                    }
+                    onInput={onInput}
+                    onOptionSelect={onOptionSelect}
+                    placeholder={content.placeholder}
+                    clearable={clearable}
+                >
+                    {content.valueList.map((val, idx) => {
+                        return (
+                            <Option key={idx} value={val}>
+                                {val}
+                            </Option>
+                        );
+                    })}
+                </Combobox>
+            </Field>
+        </div>
+    );
+};

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -31,19 +31,38 @@ function removeDuplicates<T>(array: T[]): T[] {
 
 function updateFilterSelection(
     /** current selected (valid) option */
-    selected: string,
+    selected: string | undefined,
     /** callback to set the selected (valid) option */
-    setSelected: (s: string) => void,
+    setSelected: (s: string | undefined) => void,
     /** callback to set the displayed value (not guaranteed to be valid if the user has manually typed something) */
     setValue: (v: string) => void,
     /** list of valid options */
     optionList: string[],
+    /** if true, will set to the first value in the list of values; if false, will set to undefined */
+    shouldSelectIfAny?: boolean,
 ) {
     // if current selection is no longer in the list of options,
     // set selection to undefined (if multiple options) or the only option (if only one)
-    if (selected && !optionList.includes(selected)) {
-        setSelected(optionList.length === 1 ? optionList[0] : undefined);
-        setValue(optionList.length === 1 ? optionList[0] : "");
+
+    // if there is no current selection or if the current selection is no longer in the list of options (due to filter changes),
+    // then select the only option if there is only one option,
+    // or either the first option or none if there are multiple options, depending on how shouldSelectIfAny is set
+
+    if (
+        selected === undefined ||
+        (selected && !optionList.includes(selected))
+    ) {
+        let optionToSelect: string | undefined = undefined;
+
+        if (optionList.length > 0) {
+            optionToSelect =
+                optionList.length === 1 || shouldSelectIfAny // list only has one item or it should always pick something
+                    ? optionList[0]
+                    : undefined;
+        }
+
+        setSelected(optionToSelect); // selected value's unselected state should be undefined
+        setValue(optionToSelect ?? ""); // displayed value's unselected state should be an empty string
     }
 }
 
@@ -190,6 +209,7 @@ export const AzureBrowsePage = () => {
                 setSelectedServer,
                 setServerValue,
                 srvs,
+                true, // shouldSelectIfAny
             );
         }
     }, [locations, selectedLocation, context.state.azureServers]);

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -29,6 +29,24 @@ function removeDuplicates<T>(array: T[]): T[] {
     return Array.from(new Set(array));
 }
 
+function updateFilterSelection(
+    /** current selected (valid) option */
+    selected: string,
+    /** callback to set the selected (valid) option */
+    setSelected: (s: string) => void,
+    /** callback to set the displayed value (not guaranteed to be valid if the user has manually typed something) */
+    setValue: (v: string) => void,
+    /** list of valid options */
+    optionList: string[],
+) {
+    // if current selection is no longer in the list of options,
+    // set selection to undefined (if multiple options) or the only option (if only one)
+    if (selected && !optionList.includes(selected)) {
+        setSelected(optionList.length === 1 ? optionList[0] : undefined);
+        setValue(optionList.length === 1 ? optionList[0] : "");
+    }
+}
+
 export const AzureBrowsePage = () => {
     const context = useContext(ConnectionDialogContext);
     const formStyles = useFormStyles();
@@ -78,9 +96,12 @@ export const AzureBrowsePage = () => {
         );
         setSubscriptions(subs.sort());
 
-        if (!selectedSubscription && subs.length === 1) {
-            setSelectedSubscription(subs[0]);
-        }
+        updateFilterSelection(
+            selectedSubscription,
+            setSelectedSubscription,
+            setSubscriptionValue,
+            subs,
+        );
     }, [context.state.azureSubscriptions]);
 
     useEffect(() => {
@@ -97,11 +118,12 @@ export const AzureBrowsePage = () => {
         );
         setResourceGroups(rgs.sort());
 
-        // if current selection is no longer in the list of options,
-        // set selection to undefined (if multiple options) or the only option (if only one)
-        if (selectedResourceGroup && !rgs.includes(selectedResourceGroup)) {
-            setSelectedResourceGroup(rgs.length === 1 ? rgs[0] : undefined);
-        }
+        updateFilterSelection(
+            selectedResourceGroup,
+            setSelectedResourceGroup,
+            setResourceGroupValue,
+            rgs,
+        );
     }, [subscriptions, selectedSubscription, context.state.azureServers]);
 
     useEffect(() => {
@@ -125,11 +147,12 @@ export const AzureBrowsePage = () => {
 
         setLocations(locs.sort());
 
-        // if current selection is no longer in the list of options,
-        // set selection to undefined (if multiple options) or the only option (if only one)
-        if (selectedLocation && !locs.includes(selectedLocation)) {
-            setSelectedLocation(locs.length === 1 ? locs[0] : undefined);
-        }
+        updateFilterSelection(
+            selectedLocation,
+            setSelectedLocation,
+            setLocationValue,
+            locs,
+        );
     }, [resourceGroups, selectedResourceGroup, context.state.azureServers]);
 
     useEffect(() => {
@@ -162,15 +185,12 @@ export const AzureBrowsePage = () => {
         if (selectedServer === "") {
             setServerValue("");
         } else {
-            // if there is no current selection or if the selection is no longer in the list of options (due to changed filters),
-            // set selection to the first option (if any)
-            if (
-                selectedServer === undefined ||
-                !srvs.includes(selectedServer)
-            ) {
-                setSelectedServer(srvs.length > 0 ? srvs[0] : undefined);
-                setServerValue(srvs.length > 0 ? srvs[0] : "");
-            }
+            updateFilterSelection(
+                selectedServer,
+                setSelectedServer,
+                setServerValue,
+                srvs,
+            );
         }
     }, [locations, selectedLocation, context.state.azureServers]);
 

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -24,47 +24,7 @@ import { IConnectionDialogProfile } from "../../../sharedInterfaces/connectionDi
 import { AdvancedOptionsDrawer } from "./components/advancedOptionsDrawer.component";
 import { locConstants as Loc } from "../../common/locConstants";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
-
-function removeDuplicates<T>(array: T[]): T[] {
-    return Array.from(new Set(array));
-}
-
-function updateFilterSelection(
-    /** current selected (valid) option */
-    selected: string | undefined,
-    /** callback to set the selected (valid) option */
-    setSelected: (s: string | undefined) => void,
-    /** callback to set the displayed value (not guaranteed to be valid if the user has manually typed something) */
-    setValue: (v: string) => void,
-    /** list of valid options */
-    optionList: string[],
-    /** if true, will set to the first value in the list of values; if false, will set to undefined */
-    shouldSelectIfAny?: boolean,
-) {
-    // if current selection is no longer in the list of options,
-    // set selection to undefined (if multiple options) or the only option (if only one)
-
-    // if there is no current selection or if the current selection is no longer in the list of options (due to filter changes),
-    // then select the only option if there is only one option,
-    // or either the first option or none if there are multiple options, depending on how shouldSelectIfAny is set
-
-    if (
-        selected === undefined ||
-        (selected && !optionList.includes(selected))
-    ) {
-        let optionToSelect: string | undefined = undefined;
-
-        if (optionList.length > 0) {
-            optionToSelect =
-                optionList.length === 1 || shouldSelectIfAny // list only has one item or it should always pick something
-                    ? optionList[0]
-                    : undefined;
-        }
-
-        setSelected(optionToSelect); // selected value's unselected state should be undefined
-        setValue(optionToSelect ?? ""); // displayed value's unselected state should be an empty string
-    }
-}
+import { removeDuplicates } from "../../common/utils";
 
 export const AzureBrowsePage = () => {
     const context = useContext(ConnectionDialogContext);
@@ -570,3 +530,37 @@ const AzureBrowseDropdown = ({
         </div>
     );
 };
+
+function updateFilterSelection(
+    /** current selected (valid) option */
+    selected: string | undefined,
+    /** callback to set the selected (valid) option */
+    setSelected: (s: string | undefined) => void,
+    /** callback to set the displayed value (not guaranteed to be valid if the user has manually typed something) */
+    setValue: (v: string) => void,
+    /** list of valid options */
+    optionList: string[],
+    /** if true, will set to the first value in the list of values; if false, will set to undefined */
+    shouldSelectIfAny: boolean = false,
+) {
+    // if there is no current selection or if the current selection is no longer in the list of options (due to filter changes),
+    // then select the only option if there is only one option,
+    // or either the first option or none if there are multiple options, depending on how shouldSelectIfAny is set
+
+    if (
+        selected === undefined ||
+        (selected && !optionList.includes(selected))
+    ) {
+        let optionToSelect: string | undefined = undefined;
+
+        if (optionList.length > 0) {
+            optionToSelect =
+                optionList.length === 1 || shouldSelectIfAny // list only has one item or it should always pick something
+                    ? optionList[0]
+                    : undefined;
+        }
+
+        setSelected(optionToSelect); // selected value's unselected state should be undefined
+        setValue(optionToSelect ?? ""); // displayed value's unselected state should be an empty string
+    }
+}

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -54,4 +54,5 @@ export enum TelemetryActions {
     LoadAzureServers = "LoadAzureServers",
     LoadConnectionProperties = "LoadConnectionProperties",
     LoadRecentConnections = "LoadRecentConnections",
+    LoadAzureSubscriptions = "LoadAzureSubscriptions",
 }


### PR DESCRIPTION
Refining and consolidating the logic to have more intuitive default logic.  The overall logic is now:
* `server` always selects the first one in the list to make sure it's always populated, unless the user has explicitly cleared it
* all others default to no filter
* dropdowns are automatically scoped by any upstream filters that are set (subscriptions/resource groups/locations/servers)
* if a value is already selected and the upstream filters change, the selection stays if it's still in-filter or is cleared if not

Also adding several telemetry more points around Azure load times and errors

Note: because contents of subscriptions are loaded asynchronously, different servers may end up being selected each time depending on which subscriptions finish first.  I thought it would be more confusing to swap the selection around to (e.g.) the first alphabetically as new entries loaded, so /shrug.  The other dropdowns don't have that issue because they aren't set to always make a selection when available.