### PR TITLE
Move onDidChangeActiveTextEditor event registration behind feature flag

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -531,6 +531,7 @@ export default class MainController implements vscode.Disposable {
             this._context,
             this.executionPlanService,
             this.untitledSqlDocumentService,
+            this._vscodeWrapper,
         );
 
         // Init content provider for results pane


### PR DESCRIPTION
This PR fixes #18285
In https://github.com/microsoft/vscode-mssql/pull/18192, the `onDidChangeActiveTextEditor` event handler was setup without checking the rich UI feature flag. This causes an error log in the dev console every time the user switches the editor tab if they don't have the rich UI flag turned on.
Note this does not break other features, just output error message to the dev console.
<img width="1428" alt="Screenshot 2024-10-18 at 16 21 49" src="https://github.com/user-attachments/assets/224604a9-4389-4c28-bcc4-d2f1f3444b6a">

 