### PR TITLE
Remove watch prelaunch command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,6 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "watch",
 			"rendererDebugOptions": {
 				"pauseForSourceMap": true,
 				"sourceMapRenames": true,
@@ -65,7 +64,6 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js",
 			],
-			"preLaunchTask": "watch",
 			"env": {
 				// Uncomment this to use a specified version of STS, see
 				// https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable


### PR DESCRIPTION
This seems to run watch every time the extension is debugged.  Which I don't think is ideal here.  For example, I usually have watch already running in a cmd window, so this just slows debug down and triggers unneeded watch.  It would be better to have something more like an "incremental build" that only triggers if there are unbuilt changes.  For now, I think it's better to just remove these prelaunch commands until we get something that works better.