### PR TITLE
Adjust the grid width calculation for scrollbars

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -29,7 +29,11 @@ import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import ResultGrid, { ResultGridHandle } from "./resultGrid";
 import CommandBar from "./commandBar";
 import { locConstants } from "../../common/locConstants";
-import { ACTIONBAR_WIDTH_PX, SCROLL_BAR_PX, TABLE_ALIGN_PX } from "./table/table";
+import {
+    ACTIONBAR_WIDTH_PX,
+    SCROLLBAR_PX,
+    TABLE_ALIGN_PX,
+} from "./table/table";
 import { ExecutionPlanPage } from "../ExecutionPlan/executionPlanPage";
 import { ExecutionPlanStateProvider } from "../ExecutionPlan/executionPlanStateProvider";
 import { hasResultsOrMessages } from "./queryResultUtils";
@@ -156,7 +160,10 @@ export const QueryResultPane = () => {
 
             if (gridParent.clientWidth && availableHeight) {
                 if (gridCount > 1) {
-                    let scrollbarAdjustment = gridCount * MIN_GRID_HEIGHT >= availableHeight ? SCROLL_BAR_PX : 0;
+                    let scrollbarAdjustment =
+                        gridCount * MIN_GRID_HEIGHT >= availableHeight
+                            ? SCROLLBAR_PX
+                            : 0;
 
                     // Calculate the grid height, ensuring it's not smaller than the minimum height
                     const gridHeight = Math.max(
@@ -167,14 +174,16 @@ export const QueryResultPane = () => {
 
                     gridRefs.current.forEach((gridRef) => {
                         gridRef?.resizeGrid(
-                            gridParent.clientWidth - ACTIONBAR_WIDTH_PX - scrollbarAdjustment,
+                            gridParent.clientWidth -
+                                ACTIONBAR_WIDTH_PX -
+                                scrollbarAdjustment,
                             gridHeight,
                         );
                     });
                 } else if (gridCount === 1) {
                     gridRefs.current[0]?.resizeGrid(
                         gridParent.clientWidth - ACTIONBAR_WIDTH_PX,
-                        availableHeight - TABLE_ALIGN_PX
+                        availableHeight - TABLE_ALIGN_PX,
                     );
                 }
             }

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -29,7 +29,7 @@ import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import ResultGrid, { ResultGridHandle } from "./resultGrid";
 import CommandBar from "./commandBar";
 import { locConstants } from "../../common/locConstants";
-import { ACTIONBAR_WIDTH_PX, TABLE_ALIGN_PX } from "./table/table";
+import { ACTIONBAR_WIDTH_PX, SCROLL_BAR_PX, TABLE_ALIGN_PX } from "./table/table";
 import { ExecutionPlanPage } from "../ExecutionPlan/executionPlanPage";
 import { ExecutionPlanStateProvider } from "../ExecutionPlan/executionPlanStateProvider";
 import { hasResultsOrMessages } from "./queryResultUtils";
@@ -156,6 +156,8 @@ export const QueryResultPane = () => {
 
             if (gridParent.clientWidth && availableHeight) {
                 if (gridCount > 1) {
+                    let scrollbarAdjustment = gridCount * MIN_GRID_HEIGHT >= availableHeight ? SCROLL_BAR_PX : 0;
+
                     // Calculate the grid height, ensuring it's not smaller than the minimum height
                     const gridHeight = Math.max(
                         (availableHeight - gridCount * TABLE_ALIGN_PX) /
@@ -165,19 +167,14 @@ export const QueryResultPane = () => {
 
                     gridRefs.current.forEach((gridRef) => {
                         gridRef?.resizeGrid(
-                            gridParent.clientWidth - ACTIONBAR_WIDTH_PX,
+                            gridParent.clientWidth - ACTIONBAR_WIDTH_PX - scrollbarAdjustment,
                             gridHeight,
                         );
                     });
                 } else if (gridCount === 1) {
-                    const singleGridHeight = Math.max(
-                        availableHeight - TABLE_ALIGN_PX,
-                        MIN_GRID_HEIGHT,
-                    );
-
                     gridRefs.current[0]?.resizeGrid(
                         gridParent.clientWidth - ACTIONBAR_WIDTH_PX,
-                        singleGridHeight,
+                        availableHeight - TABLE_ALIGN_PX
                     );
                 }
             }

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -34,7 +34,8 @@ function getDefaultOptions<T extends Slick.SlickData>(): Slick.GridOptions<T> {
 }
 
 export const ACTIONBAR_WIDTH_PX = 36;
-export const TABLE_ALIGN_PX = 5;
+export const TABLE_ALIGN_PX = 7;
+export const SCROLL_BAR_PX = 15;
 
 export class Table<T extends Slick.SlickData> implements IThemable {
     protected styleElement: HTMLStyleElement;

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -35,7 +35,7 @@ function getDefaultOptions<T extends Slick.SlickData>(): Slick.GridOptions<T> {
 
 export const ACTIONBAR_WIDTH_PX = 36;
 export const TABLE_ALIGN_PX = 7;
-export const SCROLL_BAR_PX = 15;
+export const SCROLLBAR_PX = 15;
 
 export class Table<T extends Slick.SlickData> implements IThemable {
     protected styleElement: HTMLStyleElement;


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-mssql/issues/18289.  Basically for one grid let's just fill the whole area, and with multiple grids adjust for the scrollbar if it's going to be visible.

Here's an example with multiple scrollbars on macos.  I could probably be tightened up a little, but the fine tuning can be done later.  On Windows it's a bit tighter since the scrollbars are little larger, IIRC.

![image](https://github.com/user-attachments/assets/f42c6263-763d-4500-b7e4-9fb7ae54f1dc)
