### PR TITLE
Fixing survey logic

### DIFF
--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -25,6 +25,7 @@ const SESSION_COUNT_KEY = "nps/sessionCount";
 const LAST_SESSION_DATE_KEY = "nps/lastSessionDate";
 const SKIP_VERSION_KEY = "nps/skipVersion";
 const IS_CANDIDATE_KEY = "nps/isCandidate";
+const NEVER_KEY = "nps/never";
 
 export class UserSurvey {
     private static _instance: UserSurvey;
@@ -39,8 +40,19 @@ export class UserSurvey {
 
     public async promptUserForNPSFeedback(): Promise<void> {
         const globalState = this._context.globalState;
+
+        // If the user has opted out of the survey, don't prompt for feedback
+        const isNeverUser = globalState.get(NEVER_KEY, false);
+        if (isNeverUser) {
+            return;
+        }
+
+        // If the user has already been prompted for feedback in this version, don't prompt again
+        const extensionVersion =
+            vscode.extensions.getExtension(constants.extensionId).packageJSON
+                .version || "unknown";
         const skipVersion = globalState.get(SKIP_VERSION_KEY, "");
-        if (skipVersion) {
+        if (skipVersion === extensionVersion) {
             return;
         }
 
@@ -69,9 +81,6 @@ export class UserSurvey {
 
         await globalState.update(IS_CANDIDATE_KEY, isCandidate);
 
-        const extensionVersion =
-            vscode.extensions.getExtension(constants.extensionId).packageJSON
-                .version || "unknown";
         if (!isCandidate) {
             await globalState.update(SKIP_VERSION_KEY, extensionVersion);
             return;
@@ -118,8 +127,7 @@ export class UserSurvey {
             title: locConstants.UserSurvey.dontShowAgain,
             isSecondary: true,
             run: async () => {
-                await globalState.update(IS_CANDIDATE_KEY, false);
-                await globalState.update(SKIP_VERSION_KEY, extensionVersion);
+                await globalState.update(NEVER_KEY, true);
             },
         };
 


### PR DESCRIPTION
Now, the survey is shown with the following conditions.

1. **Opt-Out Check**:  
   - If the user has opted out of the survey (`NEVER_KEY`), no further steps are taken.

2. **Version Check**:  
   - If the user has already been prompted for feedback in the current extension version (`SKIP_VERSION_KEY` matches the current version), no survey is shown.

3. **Session Date Check**:  
   - Each session is counted when the user performs some completion action on a new day.

4. **Session Count Check**:  
   - If the user hasn't used the extension at least 5 times (performed some completion on 5 different days) (`SESSION_COUNT_KEY < 5`), the survey is not prompted.

5. **Random Selection**:  
   - The user is randomly selected for the survey based on a probability (`Math.random() < PROBABILITY`), or if they are already marked as a candidate (`IS_CANDIDATE_KEY`).

6. **Candidate Confirmation**:  
   - If the user is selected as a candidate, they will see the survey prompt; otherwise, the current extension version is marked as skipped for future prompts (`SKIP_VERSION_KEY`).
