### PR TITLE
Fix colors / styling for new query results pane

### DIFF
--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -59,6 +59,7 @@ const CommandBar = (props: CommandBarProps) => {
     return (
         <div className={classes.commandBar}>
             <Button
+                appearance="subtle"
                 onClick={(_event) => {
                     saveResults("csv");
                 }}
@@ -72,6 +73,7 @@ const CommandBar = (props: CommandBarProps) => {
                 title={locConstants.queryResult.saveAsCsv}
             />
             <Button
+                appearance="subtle"
                 onClick={(_event) => {
                     saveResults("json");
                 }}
@@ -85,6 +87,7 @@ const CommandBar = (props: CommandBarProps) => {
                 title={locConstants.queryResult.saveAsJson}
             />
             <Button
+                appearance="subtle"
                 onClick={(_event) => {
                     saveResults("excel");
                 }}

--- a/src/reactviews/pages/QueryResult/table/plugins/contextMenu.css
+++ b/src/reactviews/pages/QueryResult/table/plugins/contextMenu.css
@@ -5,8 +5,8 @@
     display: inline-block;
     min-width: 100px;
     z-index: 99999;
-    color: var(--vscode-activityBar-background);
-    background-color: var(--vscode-activityBar-background);
+    color: var(--vscode-dropdown-foreground);
+    background-color: var(--vscode-dropdown-background);
     border-color: var(--vscode-menu-border);
     font-family: var(--vscode-font-family);
 }
@@ -15,13 +15,18 @@
     padding: 4px 4px 4px 14px;
     list-style: none;
     cursor: pointer;
-    color: var(--vscode-foreground);
+    color: var(--vscode-dropdown-foreground);
+    background-color: var(--vscode-dropdown-background);
+    border-color: var(--vscode-dropdown-border);
+    font-family: var(--vscode-font-family);
 }
 
 .contextMenu:hover {
-    background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
+    background-color: var(--vscode-list-hoverBackground);
 }
 
 .sort-btn:focus {
-    background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
+    background-color: var(--vscode-list-hoverBackground);
 }

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.css
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.css
@@ -1,35 +1,39 @@
 #popup-menu {
-  position: absolute;
-  padding: 0px;
-  display: inline-block;
-  min-width: 100px;
-  z-index: 99999;
-  border: 1px solid;
-  outline: 0;
-  color: var(--vscode-activityBar-background);
-  background-color: var(--vscode-activityBar-background);
-  border-color: var(--vscode-menu-border);
-  font-family: var(--vscode-font-family);
+    position: absolute;
+    padding: 0px;
+    display: inline-block;
+    min-width: 100px;
+    z-index: 99999;
+    border: 1px solid;
+    outline: 0;
+    color: var(--vscode-dropdown-foreground);
+    background-color: var(--vscode-dropdown-background);
+    border-color: var(--vscode-menu-border);
+    font-family: var(--vscode-font-family);
 }
 
 /* Button styling to match the design */
 .sort-btn {
-  width: 100%;
-  padding: 8px 10px;
-  text-align: left;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 13px;
-  color: var(--vscode-foreground);
-  background-color: var(--vscode-activityBar-background);
+    width: 100%;
+    padding: 8px 10px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--vscode-dropdown-foreground);
+    background-color: var(--vscode-dropdown-background);
+    border-color: var(--vscode-dropdown-border);
+    font-family: var(--vscode-font-family);
 }
 
 .sort-btn:hover {
-  background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
+    background-color: var(--vscode-list-hoverBackground);
 }
 
 /* Additional styling for active/focused states */
 .sort-btn:focus {
-  background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-list-hoverForeground);
+    background-color: var(--vscode-list-hoverBackground);
 }

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -121,15 +121,11 @@ export class HeaderFilter<T extends Slick.SlickData> {
         if (this.activePopup) {
             const isSameButton =
                 this.activePopup.data("button") === filterButton;
+            // close the popup and reset activePopup
+            this.activePopup.fadeOut();
+            this.activePopup = null;
             if (isSameButton) {
-                // If clicking the same button, close the popup and reset activePopup
-                this.activePopup.fadeOut();
-                this.activePopup = null;
-                return; // Exit since we're just closing the popup
-            } else {
-                // If it's a different button, close the current popup before opening the new one
-                this.activePopup.fadeOut();
-                this.activePopup = null;
+                return; // Exit since we're just closing the popup for the same button
             }
         }
 


### PR DESCRIPTION
Fixed context menu styling:
![Screenshot 2024-10-24 090108](https://github.com/user-attachments/assets/e653a961-c205-4fad-98df-e513ed26773c)

Fixed sort menu styling:
![Screenshot 2024-10-24 090115](https://github.com/user-attachments/assets/b2a97ec4-e2f5-4105-b4ff-1b8e90f1bf3a)

Changed button appearance:
![Screenshot 2024-10-24 090144](https://github.com/user-attachments/assets/4aae9c1a-aae6-437f-9318-eca71a2b2bbc)

Tested in both dark mode & light mode.

Also fix context menu behavior - 

![contextMenu](https://github.com/user-attachments/assets/1e17bcf8-e159-419a-b086-da6585a55648)

Before: 
Clicking dropdown arrow again wouldn't close context menu

After:
Clicking dropdown arrow again closes context menu, clicking other dropdown arrows closes current context menu and opens a new one

Fixes #18293
Fixes #18249