### PR TITLE
Support copying all messages in the Message pane

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1496,6 +1496,9 @@
     <trans-unit id="extension.connections">
       <source xml:lang="en">Connections</source>
     </trans-unit>
+    <trans-unit id="mssql.copyAll">
+      <source xml:lang="en">Copy All</source>
+    </trans-unit>
     <trans-unit id="mssql.copyObjectName">
       <source xml:lang="en">Copy Object Name</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -562,6 +562,12 @@
           "command": "mssql.editTable",
           "when": "view == objectExplorer && viewItem =~ /\\btype=(Table)\\b/ && config.mssql.enableRichExperiences"
         }
+      ],
+      "webview/context": [
+        {
+          "command": "mssql.copyAll",
+          "when": "webviewId == 'queryResult' && webviewSection == 'queryResultMessagesPane'"
+        }
       ]
     },
     "commands": [
@@ -581,6 +587,11 @@
         "title": "%mssql.cancelQuery%",
         "category": "MS SQL",
         "icon": "$(debug-stop)"
+      },
+      {
+        "command": "mssql.copyAll",
+        "title": "%mssql.copyAll%",
+        "category": "MS SQL"
       },
       {
         "command": "mssql.revealQueryResultPanel",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
 "mssql.runCurrentStatement":"Execute Current Statement",
 "mssql.cancelQuery":"Cancel Query",
 "mssql.revealQueryResultPanel":"Reveal Query Result Panel",
+"mssql.copyAll":"Copy All",
 "mssql.changeDatabase":"Change Database",
 "mssql.addObjectExplorer":"Add Connection",
 "mssql.scriptSelect":"Select Top 1000",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -24,6 +24,7 @@ export const cmdRunQuery = "mssql.runQuery";
 export const cmdRunCurrentStatement = "mssql.runCurrentStatement";
 export const cmdCancelQuery = "mssql.cancelQuery";
 export const cmdrevealQueryResultPanel = "mssql.revealQueryResultPanel";
+export const cmdCopyAll = "mssql.copyAll";
 export const cmdConnect = "mssql.connect";
 export const cmdDisconnect = "mssql.disconnect";
 export const cmdChangeDatabase = "mssql.changeDatabase";

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1091,6 +1091,19 @@ export default class MainController implements vscode.Disposable {
                 },
             ),
         );
+
+        // Query Results copy messages command
+        this._context.subscriptions.push(
+            vscode.commands.registerCommand(
+                Constants.cmdCopyAll,
+                async (context) => {
+                    const uri = context.uri;
+                    await this._queryResultWebviewController.copyAllMessagesToClipboard(
+                        uri,
+                    );
+                },
+            ),
+        );
     }
 
     /**

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -301,6 +301,21 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         this.untitledSqlDocumentService = service;
     }
 
+    public async copyAllMessagesToClipboard(uri: string): Promise<void> {
+        const messages = uri
+            ? this.getQueryResultState(uri)?.messages?.map(
+                  (message) => message.message,
+              )
+            : this.state?.messages?.map((message) => message.message);
+
+        if (!messages) {
+            return;
+        }
+
+        const messageText = messages.join("\n");
+        await this._vscodeWrapper.clipboardWriteText(messageText);
+    }
+
     private async createExecutionPlanGraphs(
         state: qr.QueryResultWebviewState,
         xmlPlans: string[],

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -438,7 +438,13 @@ export const QueryResultPane = () => {
                     renderGridPanel()}
                 {metadata.tabStates!.resultPaneTab ===
                     qr.QueryResultPaneTabs.Messages && (
-                    <div className={classes.messagesContainer}>
+                    <div
+                        className={classes.messagesContainer}
+                        data-vscode-context={JSON.stringify({
+                            webviewSection: "queryResultMessagesPane",
+                            uri: metadata?.uri,
+                        })}
+                    >
                         <Table
                             size="small"
                             as="table"


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-mssql/issues/18245
This PR adds the `Copy All` context menu to the messages pane. This context menu uses the VSCode `webview/context` contrib point so it's included in the native context menu.
https://code.visualstudio.com/api/extension-guides/webview#context-menus
I've also tested the 10k message copy and the perf is good.
![Oct-29-2024 13-36-49](https://github.com/user-attachments/assets/85c888e8-0d10-4994-85e7-b4274e6575d2)
