### PR TITLE
Adding more theme mappings to fix some issues

### DIFF
--- a/src/reactviews/common/theme.ts
+++ b/src/reactviews/common/theme.ts
@@ -53,4 +53,11 @@ export const webviewTheme: fluentui.Theme = {
     colorNeutralStroke2: "var(--vscode-editorWidget-border)",
     colorNeutralBackground2: "var(--vscode-keybindingTable-headerBackground)",
     colorNeutralStroke1: "var(--vscode-foreground)",
+    colorNeutralStrokeAccessible: "var(--vscode-foreground)",
+    colorNeutralForegroundDisabled: "var(--vscode-disabledForeground)",
+    colorNeutralStrokeDisabled: "var(--vscode-disabledForeground)",
+    colorStatusDangerForeground1: "var(--vscode-errorForeground)",
+    colorStatusDangerBorder1: "var(--vscode-errorForeground)",
+    colorStatusDangerBackground1:
+        "var(--vscode-diffEditor-removedTextBackground)",
 };

--- a/src/reactviews/common/theme.ts
+++ b/src/reactviews/common/theme.ts
@@ -53,11 +53,27 @@ export const webviewTheme: fluentui.Theme = {
     colorNeutralStroke2: "var(--vscode-editorWidget-border)",
     colorNeutralBackground2: "var(--vscode-keybindingTable-headerBackground)",
     colorNeutralStroke1: "var(--vscode-foreground)",
+    /**
+     * This specifies the border color for input elements.
+     */
     colorNeutralStrokeAccessible: "var(--vscode-foreground)",
+    /**
+     * This specifies the color of the text in disabled input elements.
+     */
     colorNeutralForegroundDisabled: "var(--vscode-disabledForeground)",
+    /**
+     * This specifies the border color for the disabled input elements
+     */
     colorNeutralStrokeDisabled: "var(--vscode-disabledForeground)",
+    /**
+     * This specifies the color of the error icon in the message box and other error indicators
+     */
     colorStatusDangerForeground1: "var(--vscode-errorForeground)",
+    /**
+     * The specifies the border color for an error message box
+     */
     colorStatusDangerBorder1: "var(--vscode-errorForeground)",
+    // This specifies the background color for an error message box
     colorStatusDangerBackground1:
         "var(--vscode-diffEditor-removedTextBackground)",
 };


### PR DESCRIPTION
This fixes the error message box styling in connection Dialog
Before:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/66d21551-b54e-4225-8dd7-6db3e6f78bfa">

Now:
<img width="629" alt="image" src="https://github.com/user-attachments/assets/5838a72d-5439-4bcc-8666-546c840b6807">
<img width="635" alt="image" src="https://github.com/user-attachments/assets/9d3bfc9d-db80-48d6-baf4-25d89c77df78">
<img width="667" alt="image" src="https://github.com/user-attachments/assets/1a867b36-9eda-40cb-b989-c27c2e79894a">

Also fixes, how disabled elements are highlighted in table designer.
Allow null in the first row is disabled and primary key and is identity in the second row is enabled.
Before:
<img width="954" alt="image" src="https://github.com/user-attachments/assets/4c23f3d5-d2c1-4a69-a26d-1669d4a5907b">
Now:
<img width="868" alt="image" src="https://github.com/user-attachments/assets/1c38684d-361d-4bc9-9dba-cc8b363c398a">
