### PR TITLE
Table Designer Styling Fixes.

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -773,6 +773,7 @@
       "{0} is the webview name"
     ]
   },
+  "General": "General",
   "Azure sign in failed.": "Azure sign in failed.",
   "Select subscriptions": "Select subscriptions",
   "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -593,6 +593,9 @@
       <source xml:lang="en">Found pending reconnect promise for uri {0}, waiting.</source>
       <note>{0} is the uri</note>
     </trans-unit>
+    <trans-unit id="++CODE++c910d474dcd724bff83ddedeb06bf1eceaf9fb3af7c76bb282be057f36e6dffa">
+      <source xml:lang="en">General</source>
+    </trans-unit>
     <trans-unit id="++CODE++e7789e4d6916633a7461743194a10f2bc4d20b06c2e329b35c7a2da87aa8cbae">
       <source xml:lang="en">Generate Script</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -741,3 +741,9 @@ export class Webview {
         });
     public static Restore = l10n.t("Restore");
 }
+
+export class TableDesigner {
+    public static General = l10n.t("General");
+    public static Columns = l10n.t("Columns");
+    public static AdvancedOptions = l10n.t("Advanced Options");
+}

--- a/src/reactviews/pages/TableDesigner/designerResultPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerResultPane.tsx
@@ -71,7 +71,7 @@ const useStyles = makeStyles({
     },
     issuesContainer: {
         width: "100%",
-        height: "100%",
+        height: "calc( 100% - 10px )", // Subtracting 10px to account for padding and hiding double scrollbars
         flexDirection: "column",
         "> *": {
             marginBottom: "10px",

--- a/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -6,11 +6,11 @@
 import * as fluentui from "@fluentui/react-components";
 import * as designer from "../../../sharedInterfaces/tableDesigner";
 import {
-    AddRegular,
     DeleteRegular,
-    ArrowCircleUpFilled,
-    ArrowCircleDownFilled,
     ReorderRegular,
+    AddFilled,
+    ArrowSortUpFilled,
+    ArrowSortDownFilled,
 } from "@fluentui/react-icons";
 import { useContext, useState } from "react";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
@@ -36,6 +36,10 @@ const useStyles = fluentui.makeStyles({
     tableCell: {
         display: "flex",
         flexDirection: "row",
+    },
+    tableActionIcon: {
+        height: "14px",
+        width: "14px",
     },
 });
 
@@ -302,7 +306,7 @@ export const DesignerTable = ({
                 {tableProps.canAddRows && (
                     <fluentui.Button
                         appearance="transparent"
-                        icon={<AddRegular />}
+                        icon={<AddFilled className={classes.tableActionIcon} />}
                         onClick={() => {
                             state?.provider.processTableEdit({
                                 path: [...componentPath, rows.length],
@@ -318,7 +322,11 @@ export const DesignerTable = ({
                 )}
                 {tableProps.canMoveRows && (
                     <fluentui.Button
-                        icon={<ArrowCircleUpFilled />}
+                        icon={
+                            <ArrowSortUpFilled
+                                className={classes.tableActionIcon}
+                            />
+                        }
                         onClick={(event) => {
                             (event.target as HTMLElement).focus();
                             moveRows(focusedRowId!, focusedRowId! - 1);
@@ -334,7 +342,11 @@ export const DesignerTable = ({
                 )}
                 {tableProps.canMoveRows && (
                     <fluentui.Button
-                        icon={<ArrowCircleDownFilled />}
+                        icon={
+                            <ArrowSortDownFilled
+                                className={classes.tableActionIcon}
+                            />
+                        }
                         onClick={(event) => {
                             (event.target as HTMLElement).focus();
                             moveRows(focusedRowId!, focusedRowId! + 1);
@@ -354,7 +366,6 @@ export const DesignerTable = ({
                 style={{
                     maxWidth: "calc(100% - 20px)",
                     width: "fit-content",
-                    border: "1px solid var(--vscode-editorWidget-border)",
                     overflowX: "auto",
                     paddingBottom: "5px",
                     paddingRight: "5px",
@@ -429,7 +440,11 @@ export const DesignerTable = ({
                                     }}
                                     draggable={tableProps.canMoveRows}
                                     onFocus={(event) => {
-                                        if (!loadPropertiesTabData) {
+                                        if (
+                                            !loadPropertiesTabData ||
+                                            tableProps.showItemDetailInPropertiesView ===
+                                                false
+                                        ) {
                                             return;
                                         }
                                         state?.provider.setPropertiesComponents(

--- a/src/reactviews/pages/TableDesigner/tableDesignerStateProvider.tsx
+++ b/src/reactviews/pages/TableDesigner/tableDesignerStateProvider.tsx
@@ -62,10 +62,10 @@ const TableDesignerStateProvider: React.FC<TableDesignerContextProps> = ({
     const [originalHeight, setOriginalHeight] = useState<number>(300);
 
     // Properties pane width state
-    const [propertiesPaneWidth, setPropertiesPaneWidth] = useState<number>(500);
+    const [propertiesPaneWidth, setPropertiesPaneWidth] = useState<number>(450);
     const [isPropertiesPaneFullScreen, setIsPropertiesPaneFullScreen] =
         useState<boolean>(false);
-    const [originalWidth, setOriginalWidth] = useState<number>(500);
+    const [originalWidth, setOriginalWidth] = useState<number>(450);
 
     const elementRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
     const tableState = webviewState?.state;

--- a/src/sharedInterfaces/tableDesigner.ts
+++ b/src/sharedInterfaces/tableDesigner.ts
@@ -192,6 +192,8 @@ export enum TableIndexProperty {
     Name = "name",
     Description = "description",
     Columns = "columns",
+    IncludedColumns = "includedColumns",
+    ColumnStoreIndex = "columnStoreIndexes",
 }
 
 /**
@@ -404,6 +406,10 @@ export interface DesignerTablePropertiesBase {
      * The label of the add new button. The default value is 'Add New'.
      */
     labelForAddNewButton?: string;
+    /**
+     * Groups that are expanded in properties view. The default value is empty.
+     */
+    expandedGroups?: string[];
 }
 
 /**

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -64,7 +64,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                         "tableDesignerEditor_light.svg",
                     ),
                 },
-                showRestorePromptAfterClose: true,
+                showRestorePromptAfterClose: false,
             },
         );
         void this.initialize();
@@ -83,6 +83,8 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
             this._targetNode.nodeType === "View"
                 ? true
                 : false;
+
+        this.showRestorePromptAfterClose = !this._isEdit; // Show restore prompt only for new table creation.
 
         const targetDatabase = this.getDatabaseNameForNode(this._targetNode);
         // get database name from connection string
@@ -217,6 +219,8 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                 state.tabStates.resultPaneTab =
                     designer.DesignerResultPaneTabs.Issues;
             }
+
+            this.showRestorePromptAfterClose = true;
 
             const afterEditState = {
                 ...state,
@@ -418,7 +422,6 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
 
         this.registerReducer("continueEditing", async (state) => {
             this.state.apiState.publishState = designer.LoadState.NotStarted;
-            this.showRestorePromptAfterClose = true;
             sendActionEvent(
                 TelemetryViews.TableDesigner,
                 TelemetryActions.ContinueEditing,


### PR DESCRIPTION
This PR brings in a lot of small styling fixes to table designer.

1. Fixing table designer table component action icons
     a. Before: ![image](https://github.com/user-attachments/assets/7e128c46-99b0-483c-843c-8ac7d1ee05a6)
     b.After: ![image](https://github.com/user-attachments/assets/7e4ae503-be79-4b51-b3ad-afedd7019627)

2. Removing Table borders to match fluent styling
     a. Before: 
![image](https://github.com/user-attachments/assets/f217fc92-67a9-4943-bf27-ed584445089c)
     b. After: 
![image](https://github.com/user-attachments/assets/f68e20f2-7767-4183-9ba3-897d704a83bc)

3. Cleaning Up Properties Window
   Cleaning up colors, recategorizing properties, making sure properties windows is not shown for primary key columns (as it is not needed), collapsing advanced properties. 
     a. Before:
![image](https://github.com/user-attachments/assets/1ef46536-48f2-43cd-a67e-eddefc69d282)
     b. After:
![image](https://github.com/user-attachments/assets/26e494d7-9dde-40bb-92fa-79874507814d)

4. Changing when 'restore' modal is shown when table designer is closed.
      1. In case of table edits the restore dialog will be shown only when an edit is made on the table
      2. After a publish is performed, the designer waits for the first publish before showing the restore modal again. 

