### PR TITLE
Add parameter to not include headers

### DIFF
--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -149,6 +149,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 message.batchId,
                 message.resultId,
                 message.selection,
+                false,
             );
         });
         this.registerRequestHandler("copyWithHeaders", async (message) => {


### PR DESCRIPTION
Before:

Copy was picking up the user setting: ![Image](https://github.com/user-attachments/assets/04b26cc5-d040-4858-ba55-3963f8f85056)

After:

Since we have both copy & copy with headers options in the context menu, pass includeHeaders = false in order to copy without headers

Fixes #18318