### PR TITLE
Remove min grid height for 1 grid

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -185,7 +185,7 @@ export const QueryResultPane = () => {
             );
         }
         // gridCount is 1
-        return Math.max(availableHeight - TABLE_ALIGN_PX, MIN_GRID_HEIGHT);
+        return availableHeight - TABLE_ALIGN_PX;
     };
 
     const calculateGridWidth = (


### PR DESCRIPTION
Removes the min grid height for scenarios with just 1 grid, this is consistent with the ADS behavior.
Before:
![minSizeBefore](https://github.com/user-attachments/assets/eb52afd2-81e6-4eaf-b9b3-06a496dcb052)


After:
![minSize](https://github.com/user-attachments/assets/96d305d5-ed60-4430-9319-f0c0dd22fa6e)
