### PR TITLE
[Port] Add ctrl + c to copy from grid (#18380)

### DIFF
--- a/src/controllers/reactWebviewBaseController.ts
+++ b/src/controllers/reactWebviewBaseController.ts
@@ -282,6 +282,9 @@ export abstract class ReactWebviewBaseController<State, Reducers>
                 ...args,
             );
         };
+        this._webviewRequestHandlers["getPlatform"] = async () => {
+            return process.platform;
+        };
     }
 
     /**

--- a/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyboardEvent } from "react";
+import {
+    QueryResultWebviewState,
+    QueryResultReducers,
+    ResultSetSummary,
+} from "../../../../../sharedInterfaces/queryResult";
+import { VscodeWebviewContext } from "../../../../common/vscodeWebviewProvider";
+import { tryCombineSelectionsForResults } from "../utils";
+
+/**
+ * Implements the various additional navigation keybindings we want out of slickgrid
+ */
+export class CopyKeybind<T extends Slick.SlickData> implements Slick.Plugin<T> {
+    private grid!: Slick.Grid<T>;
+    private handler = new Slick.EventHandler();
+    private uri: string;
+    private resultSetSummary: ResultSetSummary;
+    private webViewState: VscodeWebviewContext<
+        QueryResultWebviewState,
+        QueryResultReducers
+    >;
+
+    constructor(
+        uri: string,
+        resultSetSummary: ResultSetSummary,
+        webViewState: VscodeWebviewContext<
+            QueryResultWebviewState,
+            QueryResultReducers
+        >,
+    ) {
+        this.uri = uri;
+        this.resultSetSummary = resultSetSummary;
+        this.webViewState = webViewState;
+    }
+
+    public init(grid: Slick.Grid<T>) {
+        this.grid = grid;
+        this.handler.subscribe(this.grid.onKeyDown, (e: Slick.DOMEvent) =>
+            this.handleKeyDown(e as unknown as KeyboardEvent),
+        );
+    }
+
+    public destroy() {
+        this.grid.onKeyDown.unsubscribe();
+    }
+
+    private async handleKeyDown(e: KeyboardEvent): Promise<void> {
+        let handled = false;
+        let platform = await this.webViewState.extensionRpc.call("getPlatform");
+        if (platform === "darwin") {
+            // Cmd + C
+            if (e.metaKey && e.keyCode === 67) {
+                handled = true;
+                await this.handleCopySelection(
+                    this.grid,
+                    this.webViewState,
+                    this.uri,
+                    this.resultSetSummary,
+                );
+            }
+        } else {
+            if (e.ctrlKey && e.keyCode === 67) {
+                handled = true;
+                await this.handleCopySelection(
+                    this.grid,
+                    this.webViewState,
+                    this.uri,
+                    this.resultSetSummary,
+                );
+            }
+        }
+
+        if (handled) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }
+    public async handleCopySelection(
+        grid: Slick.Grid<T>,
+        webViewState: VscodeWebviewContext<
+            QueryResultWebviewState,
+            QueryResultReducers
+        >,
+        uri: string,
+        resultSetSummary: ResultSetSummary,
+    ) {
+        let selectedRanges = grid.getSelectionModel().getSelectedRanges();
+        let selection = tryCombineSelectionsForResults(selectedRanges);
+
+        await webViewState.extensionRpc.call("copySelection", {
+            uri: uri,
+            batchId: resultSetSummary.batchId,
+            resultId: resultSetSummary.id,
+            selection: selection,
+        });
+    }
+}

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -23,6 +23,7 @@ import {
     ResultSetSummary,
 } from "../../../../sharedInterfaces/queryResult";
 import { VscodeWebviewContext } from "../../../common/vscodeWebviewProvider";
+import { CopyKeybind } from "./plugins/copyKeybind.plugin";
 // import { MouseWheelSupport } from './plugins/mousewheelTableScroll.plugin';
 
 function getDefaultOptions<T extends Slick.SlickData>(): Slick.GridOptions<T> {
@@ -142,6 +143,9 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         this.registerPlugin(new HeaderFilter());
         this.registerPlugin(
             new ContextMenu(this.uri, this.resultSetSummary, this.webViewState),
+        );
+        this.registerPlugin(
+            new CopyKeybind(this.uri, this.resultSetSummary, this.webViewState),
         );
 
         if (configuration && configuration.columns) {


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode-mssql/issues/18315
Port request adding Ctrl/Cmd + C functionality to query result grid: https://github.com/microsoft/vscode-mssql/pull/18380

* add ctrl + c to copy from grid

* add platform rpc call

* remove console.log

* remove commented line