### PR TITLE
Fixing table header styling in table designer. (#18399)

### DIFF
--- a/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -3,21 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fluentui from "@fluentui/react-components";
 import * as designer from "../../../sharedInterfaces/tableDesigner";
+import * as fluentui from "@fluentui/react-components";
+import * as l10n from "@vscode/l10n";
+
 import {
+    AddFilled,
+    ArrowSortDownFilled,
+    ArrowSortUpFilled,
     DeleteRegular,
     ReorderRegular,
-    AddFilled,
-    ArrowSortUpFilled,
-    ArrowSortDownFilled,
 } from "@fluentui/react-icons";
 import { useContext, useState } from "react";
-import { TableDesignerContext } from "./tableDesignerStateProvider";
+
 import { DesignerCheckbox } from "./designerCheckbox";
 import { DesignerDropdown } from "./designerDropdown";
 import { DesignerInputBox } from "./designerInputBox";
-import * as l10n from "@vscode/l10n";
+import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { locConstants } from "../../common/locConstants";
 
 export type DesignerTableProps = {
@@ -395,6 +397,8 @@ export const DesignerTable = ({
                     <fluentui.TableHeader
                         style={{
                             marginBottom: "5px",
+                            backgroundColor:
+                                "var(--vscode-keybindingTable-headerBackground)",
                         }}
                     >
                         <fluentui.TableRow>


### PR DESCRIPTION
PR to main branch: #18399
Fixes: #18400  

Before:
<img width="884" alt="image" src="https://github.com/user-attachments/assets/dbf60e3c-8c3d-4273-8e14-80326e5449c2">

After:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/f9165e02-aca7-405b-a7bd-af55b7859529">
