### PR TITLE
Add a separate flag for new query result feature

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1656,6 +1656,9 @@
     <trans-unit id="mssql.enableExperimentalFeatures.description">
       <source xml:lang="en">Enables experimental features in the MSSQL extension. The features are not production-ready and may have bugs or issues. Restart Visual Studio Code after changing this setting.</source>
     </trans-unit>
+    <trans-unit id="mssql.enableNewQueryResultFeature.description">
+      <source xml:lang="en">Enables the new Query Results feature. The default value is true. This option takes effect only if `mssql.enableRichExperiences` is enabled.</source>
+    </trans-unit>
     <trans-unit id="mssql.enableSqlAuthenticationProvider">
       <source xml:lang="en">Enables use of the Sql Authentication Provider for &apos;Microsoft Entra Id Interactive&apos; authentication mode when user selects &apos;AzureMFA&apos; authentication. This enables Server-side resource endpoint integration when fetching access tokens. This option is only supported for &apos;MSAL&apos; Authentication Library. Please restart Visual Studio Code after changing this option.</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
           "type": "webview",
           "id": "queryResult",
           "name": "%extension.queryResult%",
-          "when": "config.mssql.enableRichExperiences"
+          "when": "config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature"
         }
       ],
       "objectExplorer": [
@@ -317,7 +317,7 @@
         },
         {
           "command": "mssql.revealQueryResultPanel",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && view.queryResult.visible == false",
+          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && view.queryResult.visible == false",
           "group": "navigation@2"
         },
         {
@@ -337,17 +337,17 @@
         },
         {
           "command": "mssql.showExecutionPlanInResults",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences",
+          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature",
           "group": "navigation@4"
         },
         {
           "command": "mssql.enableActualPlan",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && !(resource in mssql.executionPlan.urisWithActualPlanEnabled)",
+          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && !(resource in mssql.executionPlan.urisWithActualPlanEnabled)",
           "group": "navigation@5"
         },
         {
           "command": "mssql.disableActualPlan",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && resource in mssql.executionPlan.urisWithActualPlanEnabled",
+          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && resource in mssql.executionPlan.urisWithActualPlanEnabled",
           "group": "navigation@5"
         }
       ],
@@ -963,6 +963,12 @@
           "type": "boolean",
           "default": false,
           "description": "%mssql.openQueryResultsInTabByDefaultDoNotShowPrompt.description%",
+          "scope": "application"
+        },
+        "mssql.enableNewQueryResultFeature": {
+          "type": "boolean",
+          "default": true,
+          "description": "%mssql.enableNewQueryResultFeature.description%",
           "scope": "application"
         },
         "azureResourceGroups.selectedSubscriptions": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -159,6 +159,7 @@
 "mssql.enableRichExperiencesDoNotShowPrompt.description":"Do not show prompts to enable UI-based features",
 "mssql.openQueryResultsInTabByDefault.description":"Automatically display query results in a new tab instead of the query pane. This option takes effect only if `mssql.enableRichExperiences` is enabled.",
 "mssql.openQueryResultsInTabByDefaultDoNotShowPrompt.description":"Do not show prompts to display query results in a new tab.",
+"mssql.enableNewQueryResultFeature.description":"Enables the new Query Results feature. The default value is true. This option takes effect only if `mssql.enableRichExperiences` is enabled.",
 "mssql.userFeedback":"Give Feedback",
 "mssql.selectedSubscriptions":"Selected Subscriptions"
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -194,6 +194,8 @@ export const configEnableRichExperiencesDoNotShowPrompt =
 export const richFeaturesLearnMoreLink = "https://aka.ms/mssql-rich-features";
 export const configOpenQueryResultsInTabByDefault =
     "mssql.openQueryResultsInTabByDefault";
+export const configEnableNewQueryResultFeature =
+    "mssql.enableNewQueryResultFeature";
 export const configOpenQueryResultsInTabByDefaultDoNotShowPrompt =
     "mssql.openQueryResultsInTabByDefaultDoNotShowPrompt";
 

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -191,7 +191,7 @@ export class SqlOutputContentProvider {
             title,
             async (queryRunner: QueryRunner) => {
                 if (queryRunner) {
-                    if (!this.isRichExperiencesEnabled) {
+                    if (this.shouldUseOldResultPane) {
                         // if the panel isn't active and exists
                         if (this._panels.get(uri).isActive === false) {
                             this._panels.get(uri).revealToForeground(uri);
@@ -242,6 +242,19 @@ export class SqlOutputContentProvider {
             .get(Constants.configEnableRichExperiences);
     }
 
+    private get isNewQueryResultFeatureEnabled(): boolean {
+        return this._vscodeWrapper
+            .getConfiguration()
+            .get(Constants.configEnableNewQueryResultFeature);
+    }
+
+    private get shouldUseOldResultPane(): boolean {
+        return (
+            !this.isRichExperiencesEnabled ||
+            !this.isNewQueryResultFeatureEnabled
+        );
+    }
+
     private async runQueryCallback(
         statusView: StatusView,
         uri: string,
@@ -254,7 +267,7 @@ export class SqlOutputContentProvider {
             uri,
             title,
         );
-        if (!this.isRichExperiencesEnabled) {
+        if (this.shouldUseOldResultPane) {
             if (this._panels.has(uri)) {
                 let panelController = this._panels.get(uri);
                 if (panelController.isDisposed) {
@@ -413,7 +426,7 @@ export class SqlOutputContentProvider {
                 statusView ? statusView : this._statusView,
             );
             queryRunner.eventEmitter.on("start", async (panelUri) => {
-                if (!this.isRichExperiencesEnabled) {
+                if (this.shouldUseOldResultPane) {
                     this._panels.get(uri).proxy.sendEvent("start", panelUri);
                     sendActionEvent(
                         TelemetryViews.ResultsGrid,
@@ -457,7 +470,7 @@ export class SqlOutputContentProvider {
             queryRunner.eventEmitter.on(
                 "resultSet",
                 async (resultSet: ResultSetSummary) => {
-                    if (!this.isRichExperiencesEnabled) {
+                    if (this.shouldUseOldResultPane) {
                         this._panels
                             .get(uri)
                             .proxy.sendEvent("resultSet", resultSet);
@@ -491,7 +504,7 @@ export class SqlOutputContentProvider {
                         ),
                     },
                 };
-                if (!this.isRichExperiencesEnabled) {
+                if (this.shouldUseOldResultPane) {
                     this._panels.get(uri).proxy.sendEvent("message", message);
                 } else {
                     this._queryResultWebviewController
@@ -511,7 +524,7 @@ export class SqlOutputContentProvider {
                 }
             });
             queryRunner.eventEmitter.on("message", (message) => {
-                if (!this.isRichExperiencesEnabled) {
+                if (this.shouldUseOldResultPane) {
                     this._panels.get(uri).proxy.sendEvent("message", message);
                 } else {
                     this._queryResultWebviewController
@@ -552,7 +565,7 @@ export class SqlOutputContentProvider {
                             hasError,
                         );
                     }
-                    if (!this.isRichExperiencesEnabled) {
+                    if (this.shouldUseOldResultPane) {
                         this._panels
                             .get(uri)
                             .proxy.sendEvent("complete", totalMilliseconds);


### PR DESCRIPTION
This PR fixes #18377 
This PR adds a separate config flag `enableNewQueryResultFeature` for new query result feature, th default value is `true`. It allows users to turn off new query result feature while keeping the rich UI features enabled.

Setting | Behavior
-- | --
Nothing set | Old UX
enableRichExperiences: true | New UX, including query results pane
enableRichExperiences: true enableNewQueryResultFeature: false | New UX but old query results pane UX


