### PR TITLE
Fixing font style and size in webviews to match vscode font size 

### DIFF
--- a/src/reactviews/common/theme.ts
+++ b/src/reactviews/common/theme.ts
@@ -76,4 +76,9 @@ export const webviewTheme: fluentui.Theme = {
     // This specifies the background color for an error message box
     colorStatusDangerBackground1:
         "var(--vscode-diffEditor-removedTextBackground)",
+    fontSizeBase300: "13px",
+    fontFamilyBase: "var(--vscode-font-family)",
+    fontFamilyNumeric: "var(--vscode-font-family)",
+    fontFamilyMonospace: "var(--vscode-editor-font-family)",
+    lineHeightBase300: "1.4em",
 };

--- a/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
@@ -4,6 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
+    ArrowClockwise16Filled,
+    Delete16Regular,
+    ServerRegular,
+} from "@fluentui/react-icons";
+import {
     Button,
     Card,
     CardHeader,
@@ -13,15 +18,11 @@ import {
     makeStyles,
     tokens,
 } from "@fluentui/react-components";
-import {
-    ServerRegular,
-    ArrowClockwise16Filled,
-    Delete16Regular,
-} from "@fluentui/react-icons";
 import { MouseEventHandler, useContext } from "react";
+
 import { ConnectionDialogContext } from "./connectionDialogStateProvider";
-import { locConstants } from "../../common/locConstants";
 import { IConnectionDialogProfile } from "../../../sharedInterfaces/connectionDialog";
+import { locConstants } from "../../common/locConstants";
 
 const buttonContainer = "buttonContainer";
 
@@ -170,7 +171,7 @@ export const ConnectionCard = ({
             }}
         >
             <CardHeader
-                image={<ServerRegular />}
+                image={<ServerRegular fontSize={20} />}
                 header={connection.displayName}
                 action={
                     actionButton && (


### PR DESCRIPTION
Before:
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/2a566757-6c40-42e1-9b1d-4eba29a9ef09">

After:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/fe30360a-f9e1-4ca0-8220-8f57f04de3db">
