### PR TITLE
Fix result set rendering when batches don't have results

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -311,14 +311,12 @@ export const QueryResultPane = () => {
         const grids = [];
         gridRefs.current.forEach((r) => r?.refreshGrid());
         let count = 0;
-        for (
-            let i = 0;
-            i < Object.keys(metadata?.resultSetSummaries ?? []).length;
-            i++
-        ) {
-            var batch = metadata?.resultSetSummaries[i];
-            for (let j = 0; j < Object.keys(batch ?? []).length; j++) {
-                grids.push(renderGrid(i, j, count));
+        for (const batchIdStr in metadata?.resultSetSummaries ?? {}) {
+            const batchId = parseInt(batchIdStr);
+            for (const resultIdStr in metadata?.resultSetSummaries[batchId] ??
+                {}) {
+                const resultId = parseInt(resultIdStr);
+                grids.push(renderGrid(batchId, resultId, count));
                 count++;
             }
         }


### PR DESCRIPTION
Addresses #18329 
Previously we were iterating through resultSetSummaries using numeric indexes, which resulted in wrong rendering when batches don't have results. This PR fixes the issue by properly iterating through the resultSetSummaries object via keys.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/96d7ad74-47f7-4fad-a9cc-418c2383c4c0">
