### PR TITLE
Fix load stat for query result

### DIFF
--- a/src/controllers/reactWebviewBaseController.ts
+++ b/src/controllers/reactWebviewBaseController.ts
@@ -51,7 +51,7 @@ export abstract class ReactWebviewBaseController<State, Reducers>
         ) => ReducerResponse<State>
     >;
     private _isFirstLoad: boolean = true;
-    private _loadStartTime: number = Date.now();
+    protected _loadStartTime: number = Date.now();
     private _endLoadActivity = startActivity(
         TelemetryViews.WebviewController,
         TelemetryActions.Load,

--- a/src/controllers/reactWebviewViewController.ts
+++ b/src/controllers/reactWebviewViewController.ts
@@ -55,6 +55,7 @@ export class ReactWebviewViewController<State, Reducers>
         context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken,
     ) {
+        this._loadStartTime = Date.now();
         this._webviewView = webviewView;
 
         webviewView.webview.options = {


### PR DESCRIPTION
For `WebviewView`, the load time should start with the `resolveWebviewView ` call instead of with the controller initialization. The time from the latter approach can be artificially inflated as `reactWebviewViewController` instances are created during extension activation. 
Before:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/8c6fc105-b335-4882-80d4-8b6c59aa262a">

After:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/a52f7a87-f57b-4f50-8178-e5778c4f468d">
