### PR TITLE
Improve Vertical Resize Performance

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -101,7 +101,6 @@ const useStyles = makeStyles({
 });
 
 const MIN_GRID_HEIGHT = 273; // Minimum height for a grid
-let messageGridHeight = 0; // Global variable to track message grid height
 
 function getAvailableHeight(
     resultPaneParent: HTMLDivElement,
@@ -124,6 +123,7 @@ export const QueryResultPane = () => {
     const resultPaneParentRef = useRef<HTMLDivElement>(null);
     const ribbonRef = useRef<HTMLDivElement>(null);
     const gridParentRef = useRef<HTMLDivElement>(null);
+    const [messageGridHeight, setMessageGridHeight] = useState(0);
 
     // Resize grid when parent element resizes
     useEffect(() => {
@@ -152,7 +152,7 @@ export const QueryResultPane = () => {
                 metadata.tabStates?.resultPaneTab ===
                 qr.QueryResultPaneTabs.Messages
             ) {
-                messageGridHeight = availableHeight;
+                setMessageGridHeight(availableHeight);
             }
             if (resultPaneParent.clientWidth && availableHeight) {
                 const gridHeight = calculateGridHeight(

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -148,8 +148,12 @@ export const QueryResultPane = () => {
                 resultPaneParent,
                 ribbonRef.current,
             );
-            messageGridHeight = availableHeight; // Update the global variable
-
+            if (
+                metadata.tabStates?.resultPaneTab ===
+                qr.QueryResultPaneTabs.Messages
+            ) {
+                messageGridHeight = availableHeight;
+            }
             if (resultPaneParent.clientWidth && availableHeight) {
                 const gridHeight = calculateGridHeight(
                     gridCount,

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -101,6 +101,7 @@ const useStyles = makeStyles({
 });
 
 const MIN_GRID_HEIGHT = 273; // Minimum height for a grid
+let messageGridHeight = 0; // Global variable to track message grid height
 
 function getAvailableHeight(
     resultPaneParent: HTMLDivElement,
@@ -119,12 +120,11 @@ export const QueryResultPane = () => {
         qr.QueryResultWebviewState,
         qr.QueryResultReducers
     >();
-    webViewState;
     var metadata = state?.state;
     const resultPaneParentRef = useRef<HTMLDivElement>(null);
     const ribbonRef = useRef<HTMLDivElement>(null);
     const gridParentRef = useRef<HTMLDivElement>(null);
-    const [messageGridHeight, setMessageGridHeight] = useState(0);
+
     // Resize grid when parent element resizes
     useEffect(() => {
         let gridCount = 0;
@@ -148,7 +148,8 @@ export const QueryResultPane = () => {
                 resultPaneParent,
                 ribbonRef.current,
             );
-            setMessageGridHeight(availableHeight);
+            messageGridHeight = availableHeight; // Update the global variable
+
             if (resultPaneParent.clientWidth && availableHeight) {
                 const gridHeight = calculateGridHeight(
                     gridCount,

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -101,8 +101,8 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
         };
         useEffect(() => {
             const filter = async () => {
-                let newFilters = await table.setupState();
-                if (newFilters) {
+                let hasNewFilters = await table.setupFilterState();
+                if (hasNewFilters) {
                     table.rerenderGrid();
                 }
             };

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -86,23 +86,25 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
             setRefreshKey((prev) => prev + 1);
         };
         const resizeGrid = (width: number, height: number) => {
-            let gridParent;
-            if (props.resultSetSummary) {
-                gridParent = document.getElementById(
-                    `grid-parent-${props.resultSetSummary.batchId}-${props.resultSetSummary.id}`,
-                );
+            let gridParent: HTMLElement | null;
+            if (!props.resultSetSummary) {
+                return;
             }
+            gridParent = document.getElementById(
+                `grid-parent-${props.resultSetSummary.batchId}-${props.resultSetSummary.id}`,
+            );
             if (gridParent) {
-                gridParent.setAttribute("style", `width: ${width}px`);
-                gridParent.setAttribute("style", `height: ${height}px`);
+                gridParent.style.height = `${height}px`;
             }
             const dimension = new DOM.Dimension(width, height);
             table?.layout(dimension);
         };
         useEffect(() => {
             const filter = async () => {
-                await table.setupState();
-                table.rerenderGrid();
+                let newFilters = await table.setupState();
+                if (newFilters) {
+                    table.rerenderGrid();
+                }
             };
 
             const ROW_HEIGHT = 25;

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -193,7 +193,11 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         // this.registerPlugin(new MouseWheelSupport());
     }
 
-    public async setupState(): Promise<boolean> {
+    /**
+     * Load filters from the query result state and apply them to the table
+     * @returns true if filters were successfully loaded and applied, false if no filters were found
+     */
+    public async setupFilterState(): Promise<boolean> {
         this.columns.forEach((column) => {
             if (column.field) {
                 const filters =

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -201,6 +201,8 @@ export class Table<T extends Slick.SlickData> implements IThemable {
                 if (filters) {
                     (<FilterableColumn<T>>column).filterValues =
                         filters.filterValues;
+                } else {
+                    return false;
                 }
             }
         });

--- a/src/reactviews/pages/QueryResult/table/tableDataView.ts
+++ b/src/reactviews/pages/QueryResult/table/tableDataView.ts
@@ -174,7 +174,6 @@ export class TableDataView<T extends Slick.SlickData>
             this._data = this._allData;
             this._allData = [];
             this._filterEnabled = false;
-            console.log("filterstatechange");
             // this._onFilterStateChange.fire();
         }
     }


### PR DESCRIPTION
Updated the setMessageGridHeight call to only execute when we are on the Messages tab.
Also only rerender the grid if new filters have been applied.
Also set gridParent height correctly using style.height directly

Before:

https://github.com/user-attachments/assets/297b7c7f-4c7e-4571-9cf7-c14330cae28f

After:

https://github.com/user-attachments/assets/7769680e-2c69-4a9e-9c4d-bd5893ffe9ca

Fixes #18438

