### PR TITLE
Apply mssql font settings to result grid

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -170,12 +170,12 @@ export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";
 export const configSplitPaneSelection = "splitPaneSelection";
 export const configShowBatchTime = "showBatchTime";
-export const extConfigResultKeys = [
-    "shortcuts",
-    "messagesDefaultOpen",
-    "resultsFontSize",
-    "resultsFontFamily",
-];
+export enum extConfigResultKeys {
+    ShortCuts = "shortcuts",
+    MessagesDefaultOpen = "messagesDefaultOpen",
+    ResultsFontSize = "resultsFontSize",
+    ResultsFontFamily = "resultsFontFamily",
+}
 export const sqlToolsServiceInstallDirConfigKey = "installDir";
 export const sqlToolsServiceExecutableFilesConfigKey = "executableFiles";
 export const sqlToolsServiceVersionConfigKey = "version";

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -98,7 +98,7 @@ export class SqlOutputContentProvider {
             queryUri,
         );
         let config = new ResultsConfig();
-        for (let key of Constants.extConfigResultKeys) {
+        for (let key in Constants.extConfigResultKeys) {
             config[key] = extConfig[key];
         }
         return Promise.resolve(config);

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -55,6 +55,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             },
             executionPlanState: {},
             filterState: {},
+            fontSettings: {},
         });
 
         void this.initialize();
@@ -74,6 +75,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                         isExecutionPlan: false,
                         executionPlanState: {},
                         filterState: {},
+                        fontSettings: {},
                     };
                 }
             });
@@ -83,6 +85,29 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 const uri = document.uri.toString(true);
                 if (this._queryResultStateMap.has(uri)) {
                     this._queryResultStateMap.delete(uri);
+                }
+            });
+
+            this._vscodeWrapper.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration("mssql.resultsFontFamily")) {
+                    this.state.fontSettings.fontFamily = this._vscodeWrapper
+                        .getConfiguration(Constants.extensionName)
+                        .get(Constants.extConfigResultKeys.ResultsFontFamily);
+                    this.updateState();
+                    console.log("fontFamily changed");
+                }
+                if (e.affectsConfiguration("mssql.resultsFontSize")) {
+                    console.log(
+                        "new fontSize ",
+                        this._vscodeWrapper
+                            .getConfiguration(Constants.extensionName)
+                            .get(Constants.extConfigResultKeys.ResultsFontSize),
+                    );
+                    this.state.fontSettings.fontSize = this._vscodeWrapper
+                        .getConfiguration(Constants.extensionName)
+                        .get(Constants.extConfigResultKeys.ResultsFontSize);
+                    this.updateState();
+                    console.log("fontSize changed");
                 }
             });
         }
@@ -170,18 +195,6 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         this.registerRequestHandler("getWebviewLocation", async () => {
             return qr.QueryResultWebviewLocation.Panel;
         });
-        this.registerRequestHandler("getFontFamily", async () => {
-            console.log("getFontFamily");
-            return this._vscodeWrapper
-                .getConfiguration(Constants.extensionName)
-                .get(Constants.extConfigResultKeys[3]);
-        });
-        this.registerRequestHandler("getFontSize", async () => {
-            console.log("getFontSize");
-            return this._vscodeWrapper
-                .getConfiguration(Constants.extensionName)
-                .get(Constants.extConfigResultKeys[2]);
-        });
         registerCommonRequestHandlers(this, this._correlationId);
     }
 
@@ -237,6 +250,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 },
             }),
             filterState: {},
+            fontSettings: {},
         };
         this._queryResultStateMap.set(uri, currentState);
     }

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -170,6 +170,18 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         this.registerRequestHandler("getWebviewLocation", async () => {
             return qr.QueryResultWebviewLocation.Panel;
         });
+        this.registerRequestHandler("getFontFamily", async () => {
+            console.log("getFontFamily");
+            return this._vscodeWrapper
+                .getConfiguration(Constants.extensionName)
+                .get(Constants.extConfigResultKeys[3]);
+        });
+        this.registerRequestHandler("getFontSize", async () => {
+            console.log("getFontSize");
+            return this._vscodeWrapper
+                .getConfiguration(Constants.extensionName)
+                .get(Constants.extConfigResultKeys[2]);
+        });
         registerCommonRequestHandlers(this, this._correlationId);
     }
 

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -75,7 +75,20 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                         isExecutionPlan: false,
                         executionPlanState: {},
                         filterState: {},
-                        fontSettings: {},
+                        fontSettings: {
+                            fontSize: this._vscodeWrapper
+                                .getConfiguration(Constants.extensionName)
+                                .get(
+                                    Constants.extConfigResultKeys
+                                        .ResultsFontSize,
+                                ),
+                            fontFamily: this._vscodeWrapper
+                                .getConfiguration(Constants.extensionName)
+                                .get(
+                                    Constants.extConfigResultKeys
+                                        .ResultsFontFamily,
+                                ),
+                        },
                     };
                 }
             });
@@ -87,27 +100,24 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                     this._queryResultStateMap.delete(uri);
                 }
             });
-
             this._vscodeWrapper.onDidChangeConfiguration((e) => {
                 if (e.affectsConfiguration("mssql.resultsFontFamily")) {
-                    this.state.fontSettings.fontFamily = this._vscodeWrapper
-                        .getConfiguration(Constants.extensionName)
-                        .get(Constants.extConfigResultKeys.ResultsFontFamily);
-                    this.updateState();
-                    console.log("fontFamily changed");
+                    for (const [uri, state] of this._queryResultStateMap) {
+                        state.fontSettings.fontFamily = this._vscodeWrapper
+                            .getConfiguration(Constants.extensionName)
+                            .get(
+                                Constants.extConfigResultKeys.ResultsFontFamily,
+                            );
+                        this._queryResultStateMap.set(uri, state);
+                    }
                 }
                 if (e.affectsConfiguration("mssql.resultsFontSize")) {
-                    console.log(
-                        "new fontSize ",
-                        this._vscodeWrapper
+                    for (const [uri, state] of this._queryResultStateMap) {
+                        state.fontSettings.fontSize = this._vscodeWrapper
                             .getConfiguration(Constants.extensionName)
-                            .get(Constants.extConfigResultKeys.ResultsFontSize),
-                    );
-                    this.state.fontSettings.fontSize = this._vscodeWrapper
-                        .getConfiguration(Constants.extensionName)
-                        .get(Constants.extConfigResultKeys.ResultsFontSize);
-                    this.updateState();
-                    console.log("fontSize changed");
+                            .get(Constants.extConfigResultKeys.ResultsFontSize);
+                        this._queryResultStateMap.set(uri, state);
+                    }
                 }
             });
         }
@@ -250,7 +260,18 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 },
             }),
             filterState: {},
-            fontSettings: {},
+            fontSettings: {
+                fontSize: this._vscodeWrapper
+                    .getConfiguration(Constants.extensionName)
+                    .get(
+                        Constants.extConfigResultKeys.ResultsFontSize,
+                    ) as number,
+                fontFamily: this._vscodeWrapper
+                    .getConfiguration(Constants.extensionName)
+                    .get(
+                        Constants.extConfigResultKeys.ResultsFontFamily,
+                    ) as string,
+            },
         };
         this._queryResultStateMap.set(uri, currentState);
     }

--- a/src/queryResult/queryResultWebviewPanelController.ts
+++ b/src/queryResult/queryResultWebviewPanelController.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from "vscode";
 import * as qr from "../sharedInterfaces/queryResult";
-import * as Constants from "../constants/constants";
 import { randomUUID } from "crypto";
 import VscodeWrapper from "../controllers/vscodeWrapper";
 import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
@@ -37,6 +36,7 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
                 },
                 executionPlanState: {},
                 filterState: {},
+                fontSettings: {},
             },
             {
                 title: vscode.l10n.t({
@@ -73,18 +73,6 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
     private registerRpcHandlers() {
         this.registerRequestHandler("getWebviewLocation", async () => {
             return qr.QueryResultWebviewLocation.Document;
-        });
-        this.registerRequestHandler("getFontFamily", async () => {
-            console.log("getFontFamily");
-            return this._vscodeWrapper
-                .getConfiguration(Constants.extensionName)
-                .get(Constants.extConfigResultKeys[3]);
-        });
-        this.registerRequestHandler("getFontSize", async () => {
-            console.log("getFontFamily");
-            return this._vscodeWrapper
-                .getConfiguration(Constants.extensionName)
-                .get(Constants.extConfigResultKeys[2]);
         });
         registerCommonRequestHandlers(this, this._correlationId);
     }

--- a/src/queryResult/queryResultWebviewPanelController.ts
+++ b/src/queryResult/queryResultWebviewPanelController.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from "vscode";
 import * as qr from "../sharedInterfaces/queryResult";
-// import * as Constants from "../constants/constants";
+import * as Constants from "../constants/constants";
 import { randomUUID } from "crypto";
 import VscodeWrapper from "../controllers/vscodeWrapper";
 import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
@@ -73,6 +73,18 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
     private registerRpcHandlers() {
         this.registerRequestHandler("getWebviewLocation", async () => {
             return qr.QueryResultWebviewLocation.Document;
+        });
+        this.registerRequestHandler("getFontFamily", async () => {
+            console.log("getFontFamily");
+            return this._vscodeWrapper
+                .getConfiguration(Constants.extensionName)
+                .get(Constants.extConfigResultKeys[3]);
+        });
+        this.registerRequestHandler("getFontSize", async () => {
+            console.log("getFontFamily");
+            return this._vscodeWrapper
+                .getConfiguration(Constants.extensionName)
+                .get(Constants.extConfigResultKeys[2]);
         });
         registerCommonRequestHandlers(this, this._correlationId);
     }

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -234,8 +234,6 @@ export const QueryResultPane = () => {
         gridCount: number,
     ) => {
         const divId = `grid-parent-${batchId}-${resultId}`;
-        console.log("fontSize: ", metadata.fontSettings.fontSize);
-        console.log("fontFamily: ", metadata.fontSettings.fontFamily);
         return (
             <div
                 id={divId}

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -113,6 +113,7 @@ function getAvailableHeight(
 }
 
 export const QueryResultPane = () => {
+    const classes = useStyles();
     const state = useContext(QueryResultContext);
     if (!state) {
         return;
@@ -121,7 +122,6 @@ export const QueryResultPane = () => {
         qr.QueryResultWebviewState,
         qr.QueryResultReducers
     >();
-    const classes = useStyles();
     var metadata = state?.state;
     const resultPaneParentRef = useRef<HTMLDivElement>(null);
     const ribbonRef = useRef<HTMLDivElement>(null);

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -114,30 +114,6 @@ function getAvailableHeight(
 
 export const QueryResultPane = () => {
     const state = useContext(QueryResultContext);
-    const [fontFamily, setFontFamily] = useState("");
-    const [fontSize, setFontSize] = useState("");
-
-    useEffect(() => {
-        const getFontFamily = async () => {
-            let fontFamily = (await webViewState.extensionRpc.call(
-                "getFontFamily",
-            )) as string;
-            setFontFamily(fontFamily);
-        };
-
-        const getFontSize = async () => {
-            let fontSize = (await webViewState.extensionRpc.call(
-                "getFontSize",
-            )) as string;
-            setFontSize(fontSize);
-        };
-        if (!fontFamily) {
-            void getFontFamily();
-        }
-        if (!fontSize) {
-            void getFontSize();
-        }
-    });
     if (!state) {
         return;
     }
@@ -258,6 +234,8 @@ export const QueryResultPane = () => {
         gridCount: number,
     ) => {
         const divId = `grid-parent-${batchId}-${resultId}`;
+        console.log("fontSize: ", metadata.fontSettings.fontSize);
+        console.log("fontFamily: ", metadata.fontSettings.fontFamily);
         return (
             <div
                 id={divId}
@@ -274,8 +252,12 @@ export const QueryResultPane = () => {
                                   gridCount,
                               )}px`
                             : "",
-                    fontFamily: fontFamily,
-                    fontSize: fontSize,
+                    fontFamily: metadata.fontSettings.fontFamily
+                        ? metadata.fontSettings.fontFamily
+                        : "var(--vscode-editor-font-family)",
+                    fontSize: metadata.fontSettings.fontSize
+                        ? `${metadata.fontSettings.fontSize}px`
+                        : "var(--vscode-editor-font-size)",
                 }}
             >
                 <ResultGrid

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -66,9 +66,7 @@ const useStyles = makeStyles({
         width: "100%",
         position: "relative",
         display: "flex",
-        fontFamily: "Menlo, Monaco, 'Courier New', monospace",
         fontWeight: "normal",
-        fontSize: "12px",
     },
     queryResultPaneOpenButton: {
         position: "absolute",
@@ -110,8 +108,31 @@ function getAvailableHeight(
 }
 
 export const QueryResultPane = () => {
-    const classes = useStyles();
     const state = useContext(QueryResultContext);
+    const [fontFamily, setFontFamily] = useState("");
+    const [fontSize, setFontSize] = useState("");
+
+    useEffect(() => {
+        const getFontFamily = async () => {
+            let fontFamily = (await webViewState.extensionRpc.call(
+                "getFontFamily",
+            )) as string;
+            setFontFamily(fontFamily);
+        };
+
+        const getFontSize = async () => {
+            let fontSize = (await webViewState.extensionRpc.call(
+                "getFontSize",
+            )) as string;
+            setFontSize(fontSize);
+        };
+        if (!fontFamily) {
+            void getFontFamily();
+        }
+        if (!fontSize) {
+            void getFontSize();
+        }
+    });
     if (!state) {
         return;
     }
@@ -119,6 +140,7 @@ export const QueryResultPane = () => {
         qr.QueryResultWebviewState,
         qr.QueryResultReducers
     >();
+    const classes = useStyles();
     var metadata = state?.state;
     const resultPaneParentRef = useRef<HTMLDivElement>(null);
     const ribbonRef = useRef<HTMLDivElement>(null);
@@ -247,6 +269,8 @@ export const QueryResultPane = () => {
                                   gridCount,
                               )}px`
                             : "",
+                    fontFamily: fontFamily,
+                    fontSize: fontSize,
                 }}
             >
                 <ResultGrid

--- a/src/sharedInterfaces/queryResult.ts
+++ b/src/sharedInterfaces/queryResult.ts
@@ -61,6 +61,11 @@ export interface QueryResultTabStates {
     resultPaneTab: QueryResultPaneTabs;
 }
 
+export interface FontSettings {
+    fontSize?: number;
+    fontFamily?: string;
+}
+
 export interface QueryResultWebviewState extends ExecutionPlanWebviewState {
     uri?: string;
     title?: string;
@@ -72,6 +77,7 @@ export interface QueryResultWebviewState extends ExecutionPlanWebviewState {
     selection?: ISlickRange[];
     executionPlanState: ExecutionPlanState;
     filterState: Record<string, ColumnFilterState>;
+    fontSettings: FontSettings;
 }
 
 export interface QueryResultReducers


### PR DESCRIPTION
Fixes the query result grid to use the `mssql.resultsFontFamily` and `mssql.resultsFontSize` settings.
Example with font size: 20 & mac default font family
![Screenshot 2024-12-11 at 3 09 08 PM](https://github.com/user-attachments/assets/74920cb3-1558-4547-b246-0cab362a33c2)

Fixes #18351

