### PR TITLE
Preserve focus during query execution

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1111,7 +1111,9 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdrevealQueryResultPanel,
                 () => {
-                    vscode.commands.executeCommand("queryResult.focus");
+                    vscode.commands.executeCommand("queryResult.focus", {
+                        preserveFocus: true,
+                    });
                 },
             ),
         );

--- a/src/controllers/reactWebviewPanelController.ts
+++ b/src/controllers/reactWebviewPanelController.ts
@@ -53,7 +53,10 @@ export class ReactWebviewPanelController<
         this._panel = vscode.window.createWebviewPanel(
             "mssql-react-webview",
             this._options.title,
-            this._options.viewColumn,
+            {
+                viewColumn: this._options.viewColumn,
+                preserveFocus: this._options.preserveFocus,
+            },
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,

--- a/src/controllers/reactWebviewViewController.ts
+++ b/src/controllers/reactWebviewViewController.ts
@@ -28,6 +28,7 @@ export class ReactWebviewViewController<State, Reducers>
     constructor(
         _context: vscode.ExtensionContext,
         _sourceFile: string,
+        private _viewId: string,
         initialData: State,
     ) {
         super(_context, _sourceFile, initialData);
@@ -47,6 +48,13 @@ export class ReactWebviewViewController<State, Reducers>
      * Displays the webview in the foreground
      */
     public revealToForeground(): void {
+        if (!this._webviewView?.visible) {
+            // the preserveFocus arg is not documented
+            // https://github.com/microsoft/vscode/issues/205766#issuecomment-1994961088
+            void vscode.commands.executeCommand(`${this._viewId}.focus`, {
+                preserveFocus: true,
+            });
+        }
         this._webviewView.show(true);
     }
 

--- a/src/controllers/reactWebviewViewController.ts
+++ b/src/controllers/reactWebviewViewController.ts
@@ -23,6 +23,7 @@ export class ReactWebviewViewController<State, Reducers>
      * Creates a new ReactWebviewViewController
      * @param _context Extension context
      * @param _sourceFile Source file that the webview will use
+     * @param _viewId The id of the view, this should be the same id defined in the package.json
      * @param initialData Initial state object that the webview will use
      */
     constructor(

--- a/src/controllers/reactWebviewViewController.ts
+++ b/src/controllers/reactWebviewViewController.ts
@@ -48,8 +48,9 @@ export class ReactWebviewViewController<State, Reducers>
      * Displays the webview in the foreground
      */
     public revealToForeground(): void {
-        if (!this._webviewView?.visible) {
-            // the preserveFocus arg is not documented
+        if (!this._webviewView?.webview) {
+            // If the webview is not yet created, focus will force it to be created and shown.
+            // The preserveFocus arg is not documented
             // https://github.com/microsoft/vscode/issues/205766#issuecomment-1994961088
             void vscode.commands.executeCommand(`${this._viewId}.focus`, {
                 preserveFocus: true,

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -451,9 +451,7 @@ export class SqlOutputContentProvider {
                     }
                     this._queryResultWebviewController.updatePanelState(uri);
                     if (!this._queryResultWebviewController.hasPanel(uri)) {
-                        await vscode.commands.executeCommand(
-                            "queryResult.focus",
-                        );
+                        this._queryResultWebviewController.revealToForeground();
                     }
                     sendActionEvent(
                         TelemetryViews.QueryResult,
@@ -519,7 +517,7 @@ export class SqlOutputContentProvider {
                         );
                     this._queryResultWebviewController.updatePanelState(uri);
                     if (!this._queryResultWebviewController.hasPanel(uri)) {
-                        vscode.commands.executeCommand("queryResult.focus");
+                        this._queryResultWebviewController.revealToForeground();
                     }
                 }
             });
@@ -548,7 +546,7 @@ export class SqlOutputContentProvider {
                             uri,
                         );
                         if (!this._queryResultWebviewController.hasPanel(uri)) {
-                            vscode.commands.executeCommand("queryResult.focus");
+                            this._queryResultWebviewController.revealToForeground();
                         }
                         this._lastSendMessageTime = Date.now();
                     }
@@ -598,7 +596,7 @@ export class SqlOutputContentProvider {
                             uri,
                         );
                         if (!this._queryResultWebviewController.hasPanel(uri)) {
-                            vscode.commands.executeCommand("queryResult.focus");
+                            this._queryResultWebviewController.revealToForeground();
                         }
                     }
                 },

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -47,7 +47,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         private untitledSqlDocumentService: UntitledSqlDocumentService,
         private _vscodeWrapper: VscodeWrapper,
     ) {
-        super(context, "queryResult", {
+        super(context, "queryResult", "queryResult", {
             resultSetSummaries: {},
             messages: [],
             tabStates: {

--- a/src/queryResult/queryResultWebviewPanelController.ts
+++ b/src/queryResult/queryResultWebviewPanelController.ts
@@ -45,6 +45,7 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
                     comment: "{0} is the editor title",
                 }),
                 viewColumn: _viewColumn,
+                preserveFocus: true,
                 iconPath: {
                     dark: vscode.Uri.joinPath(
                         context.extensionUri,
@@ -83,7 +84,7 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
     }
 
     public revealToForeground() {
-        this.panel.reveal(this._viewColumn);
+        this.panel.reveal(this._viewColumn, true);
     }
 
     public getQueryResultWebviewViewController(): QueryResultWebviewController {

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -545,7 +545,7 @@ export const QueryResultPane = () => {
                     className={classes.hidePanelLink}
                     onClick={async () => {
                         await webViewState.extensionRpc.call("executeCommand", {
-                            command: "workbench.action.togglePanel",
+                            command: "workbench.action.closePanel",
                         });
                     }}
                 >

--- a/src/sharedInterfaces/webview.ts
+++ b/src/sharedInterfaces/webview.ts
@@ -82,6 +82,10 @@ export interface MssqlWebviewPanelOptions {
      */
     viewColumn: vscode.ViewColumn;
     /**
+     * Whether the focus should be preserved when the webview is revealed.
+     */
+    preserveFocus?: boolean;
+    /**
      * The icon path for the webview panel tab icon.
      */
     iconPath?:

--- a/test/unit/reactWebviewPanelController.test.ts
+++ b/test/unit/reactWebviewPanelController.test.ts
@@ -80,6 +80,7 @@ suite("ReactWebviewPanelController", () => {
         const defaultOptions: MssqlWebviewPanelOptions = {
             title: "Test Panel",
             viewColumn: vscode.ViewColumn.One,
+            preserveFocus: true,
             iconPath: vscode.Uri.file("path"),
             showRestorePromptAfterClose: true,
         };
@@ -95,6 +96,7 @@ suite("ReactWebviewPanelController", () => {
         const options = {
             title: "My Test Panel",
             viewColumn: vscode.ViewColumn.Two,
+            preserveFocus: true,
             iconPath: vscode.Uri.file("/path/to/test-icon.png"),
             showRestorePromptAfterClose: true,
         };
@@ -104,7 +106,10 @@ suite("ReactWebviewPanelController", () => {
             createWebviewPanelStub.calledWith(
                 "mssql-react-webview",
                 options.title,
-                options.viewColumn,
+                {
+                    viewColumn: options.viewColumn,
+                    preserveFocus: options.preserveFocus,
+                },
                 {
                     enableScripts: true,
                     retainContextWhenHidden: true,


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-mssql/issues/18489
This PR fixes the focus changes during query execution with the new query result feature.
With this change, the focus is preserved during:
1. Query Execution with "Run Query" button for both the bottom panel and the new tab.
2. Clicking "Hide this panel link" when there's no result in the bottom result area.
3. Clicking "Reveal Query Result" button
4. Clicking "Open in New Tab" button