### PR TITLE
bump STS

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "5.0.20241206.1",
+    "version": "5.0.20241218.1",
     "downloadFileNames": {
       "Windows_86": "win-x86-net8.0.zip",
       "Windows_64": "win-x64-net8.0.zip",


### PR DESCRIPTION
This PR bumps STS to a new version with updated signing cert.

https://github.com/microsoft/sqltoolsservice/compare/5.0.20241206.1...5.0.20241218.1
![image](https://github.com/user-attachments/assets/9a301742-85e9-42d2-a9e7-2f29fe1a435b)
