### PR TITLE
Handle zero results 

### DIFF
--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -239,7 +239,15 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
             let dataProvider = new HybridDataProvider(
                 collection,
                 (_startIndex, _count) => {
-                    return props.loadFunc(_startIndex, _count);
+                    //TODO: check if this is needed, load function shouldn't be called if we have an empty result set summary
+                    if (
+                        props.resultSetSummary?.rowCount &&
+                        props.resultSetSummary?.rowCount > 0
+                    ) {
+                        return props.loadFunc(_startIndex, _count);
+                    } else {
+                        return Promise.resolve([]);
+                    }
                 },
                 (data: DbCellValue) => {
                     if (!data || data.isNull) {

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -239,7 +239,6 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
             let dataProvider = new HybridDataProvider(
                 collection,
                 (_startIndex, _count) => {
-                    //TODO: check if this is needed, load function shouldn't be called if we have an empty result set summary
                     if (
                         props.resultSetSummary?.rowCount &&
                         props.resultSetSummary?.rowCount > 0


### PR DESCRIPTION
Before:
Running this query:
```
select top 10 *
from sys.objects
where 1 = 0
```
Gives an error message: `mssql: Something went wrong getting more rows: Start row cannot be less than 0 or greater than the number of rows in the result set (Parameter 'startRow')" is returned`

After:
No error message shown and correct results returned

Fixes #18531