### PR TITLE
Adding a prompt to file a bug on Github if the user rates MSSQL poorly

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -796,6 +796,8 @@
       "{0} is the feature name"
     ]
   },
+  "Are you encountering a bug that you would like to submit more details about?": "Are you encountering a bug that you would like to submit more details about?",
+  "Submit a bug": "Submit a bug",
   "{0} has been closed. Would you like to restore it?/{0} is the webview name": {
     "message": "{0} has been closed. Would you like to restore it?",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -796,8 +796,8 @@
       "{0} is the feature name"
     ]
   },
-  "Are you encountering a bug that you would like to submit more details about?": "Are you encountering a bug that you would like to submit more details about?",
-  "Submit a bug": "Submit a bug",
+  "Encountering a problem?  Share the details with us by opening a GitHub issue so we can improve!": "Encountering a problem?  Share the details with us by opening a GitHub issue so we can improve!",
+  "Submit an issue": "Submit an issue",
   "{0} has been closed. Would you like to restore it?/{0} is the webview name": {
     "message": "{0} has been closed. Would you like to restore it?",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -82,9 +82,6 @@
     <trans-unit id="++CODE++31e392d1c0378beca611de66c0f4c71cba29159905cc54242d9bddee5b23d851">
       <source xml:lang="en">Apply</source>
     </trans-unit>
-    <trans-unit id="++CODE++a61052279572d9f7869dede2d4bb60dc9fb5c8280996262599f925ab6b59f63c">
-      <source xml:lang="en">Are you encountering a bug that you would like to submit more details about?</source>
-    </trans-unit>
     <trans-unit id="++CODE++3d283f80f43f1833dcab882ad9efc24a86c0b17b0febb10fc37336590a7016e1">
       <source xml:lang="en">Are you sure you want to disconnect?</source>
     </trans-unit>
@@ -438,6 +435,9 @@
     </trans-unit>
     <trans-unit id="++CODE++45e33ceba31737f1cb793c231fafc9dd99074ca1f26476a70b0c830ef155c9d3">
       <source xml:lang="en">Enable Trust Server Certificate</source>
+    </trans-unit>
+    <trans-unit id="++CODE++76ad7b53af548367c78d7216972ce81ee53ecf7ee1d6fe5f3d16a73633bd4e49">
+      <source xml:lang="en">Encountering a problem?  Share the details with us by opening a GitHub issue so we can improve!</source>
     </trans-unit>
     <trans-unit id="++CODE++4f03bf1cdf8e7d1882e5198384139c078fa527857e7371ac6cb2d030dede15a3">
       <source xml:lang="en">Encrypt</source>
@@ -1205,8 +1205,8 @@
     <trans-unit id="++CODE++155f816c0407310c0dab222493370773e045ee7fe04e6c9a951b07f495531264">
       <source xml:lang="en">Submit</source>
     </trans-unit>
-    <trans-unit id="++CODE++c58f4903df0dee7d95fbb89a5a9c8406d84d1ad258a0fd47106f630af5ed8d3b">
-      <source xml:lang="en">Submit a bug</source>
+    <trans-unit id="++CODE++c4ed896e6258b54727811f7a2d17bf4e0a998497b6946da3718a0f5ca0c78ebd">
+      <source xml:lang="en">Submit an issue</source>
     </trans-unit>
     <trans-unit id="++CODE++4999c6c6c7badf456f5b0053b09a2076bdb2391a09ab10c9064a680f8f9a0b30">
       <source xml:lang="en">Subscription</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -82,6 +82,9 @@
     <trans-unit id="++CODE++31e392d1c0378beca611de66c0f4c71cba29159905cc54242d9bddee5b23d851">
       <source xml:lang="en">Apply</source>
     </trans-unit>
+    <trans-unit id="++CODE++a61052279572d9f7869dede2d4bb60dc9fb5c8280996262599f925ab6b59f63c">
+      <source xml:lang="en">Are you encountering a bug that you would like to submit more details about?</source>
+    </trans-unit>
     <trans-unit id="++CODE++3d283f80f43f1833dcab882ad9efc24a86c0b17b0febb10fc37336590a7016e1">
       <source xml:lang="en">Are you sure you want to disconnect?</source>
     </trans-unit>
@@ -1201,6 +1204,9 @@
     </trans-unit>
     <trans-unit id="++CODE++155f816c0407310c0dab222493370773e045ee7fe04e6c9a951b07f495531264">
       <source xml:lang="en">Submit</source>
+    </trans-unit>
+    <trans-unit id="++CODE++c58f4903df0dee7d95fbb89a5a9c8406d84d1ad258a0fd47106f630af5ed8d3b">
+      <source xml:lang="en">Submit a bug</source>
     </trans-unit>
     <trans-unit id="++CODE++4999c6c6c7badf456f5b0053b09a2076bdb2391a09ab10c9064a680f8f9a0b30">
       <source xml:lang="en">Subscription</source>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -775,6 +775,10 @@ export class UserSurvey {
             args: [featureName],
             comment: ["{0} is the feature name"],
         });
+    public static fileABugPrompt = l10n.t(
+        "Are you encountering a bug that you would like to submit more details about?",
+    );
+    public static submitBug = l10n.t("Submit a bug");
 }
 
 export class Webview {

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -775,10 +775,10 @@ export class UserSurvey {
             args: [featureName],
             comment: ["{0} is the feature name"],
         });
-    public static fileABugPrompt = l10n.t(
-        "Are you encountering a bug that you would like to submit more details about?",
+    public static fileAnIssuePrompt = l10n.t(
+        "Encountering a problem?  Share the details with us by opening a GitHub issue so we can improve!",
     );
-    public static submitBug = l10n.t("Submit a bug");
+    public static submitIssue = l10n.t("Submit an issue");
 }
 
 export class Webview {

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -43,8 +43,11 @@ export class UserSurvey {
     public async promptUserForNPSFeedback(): Promise<void> {
         const globalState = this._context.globalState;
         const sessionCount = globalState.get(SESSION_COUNT_KEY, 0) + 1;
+        const extensionVersion =
+            vscode.extensions.getExtension(constants.extensionId).packageJSON
+                .version || "unknown";
 
-        if (true && !this.shouldPromptForFeedback()) {
+        if (!this.shouldPromptForFeedback()) {
             return;
         }
 
@@ -54,9 +57,8 @@ export class UserSurvey {
                 const state: UserSurveyState = getStandardNPSQuestions();
                 await this.launchSurvey("nps", state);
 
-                // TODO: revert before PR
-                //await globalState.update(IS_CANDIDATE_KEY, false);
-                //await globalState.update(SKIP_VERSION_KEY, extensionVersion);
+                await globalState.update(IS_CANDIDATE_KEY, false);
+                await globalState.update(SKIP_VERSION_KEY, extensionVersion);
             },
         };
         const remind = {
@@ -108,11 +110,7 @@ export class UserSurvey {
             });
         });
 
-        // TODO: revert before PR
-        console.log(surveyId);
-        console.log(answers);
-
-        //sendSurveyTelemetry(surveyId, answers);
+        sendSurveyTelemetry(surveyId, answers);
         return answers;
     }
 
@@ -246,7 +244,7 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
                             typeof payload.answers.comments === "string"
                                 ? payload.answers.comments
                                 : "",
-                            context.extension.packageJSON.version,
+                            context.extension.packageJSON.version || "unknown",
                         ),
                     );
                     const issueUrl = `https://github.com/microsoft/vscode-mssql/issues/new?template=issue_template.md&body=${encodedIssueBody}`;
@@ -279,18 +277,18 @@ export function getGithubIssueText(
     comments: string,
     extensionVersion: string,
 ): string {
-    return `Describe issue:
+    return `**Describe issue:**
 ${comments}
 
-Steps to Reproduce:
+**Steps to Reproduce:**
 1.
 2.
 3.
 
-Expected Behavior:
+**Expected Behavior:**
 
 
-Actual Behavior:
+**Actual Behavior:**
 
 
 ----

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -241,26 +241,16 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
                 );
 
                 if (response === locConstants.UserSurvey.submitBug) {
-                    const issueText = `- MSSQL Extension Version: ${context.extension.packageJSON.version}
-- VSCode Version: ${vscode.version}
-- OS Version: ${os.type()} ${os.release()}
-
-${payload.answers.comments}
-
-Steps to Reproduce:
-
-1.
-2.`;
-                    const issueBody = encodeURIComponent(
-                        payload.answers.comments || "",
+                    const encodedIssueBody = encodeURIComponent(
+                        getGithubIssueText(
+                            typeof payload.answers.comments === "string"
+                                ? payload.answers.comments
+                                : "",
+                            context.extension.packageJSON.version,
+                        ),
                     );
-                    const issueUrl = `https://github.com/microsoft/vscode-mssql/issues/new?template=issue_template.md&body=${issueBody}`;
+                    const issueUrl = `https://github.com/microsoft/vscode-mssql/issues/new?template=issue_template.md&body=${encodedIssueBody}`;
                     vscode.env.openExternal(vscode.Uri.parse(issueUrl));
-
-                    vscode.commands.executeCommand("vscode.openIssueReporter", {
-                        extensionId: context.extension.id,
-                        issueBody: issueText,
-                    });
                 }
             }
 
@@ -283,6 +273,32 @@ Steps to Reproduce:
             this._onCancel.fire();
         });
     }
+}
+
+export function getGithubIssueText(
+    comments: string,
+    extensionVersion: string,
+): string {
+    return `Describe issue:
+${comments}
+
+Steps to Reproduce:
+1.
+2.
+3.
+
+Expected Behavior:
+
+
+Actual Behavior:
+
+
+----
+|Software|Version|
+|--|--|
+|MSSQL Extension|${extensionVersion}|
+|VS Code|${vscode.version}|
+|OS|${os.type()} ${os.release()}|`;
 }
 
 export function getStandardNPSQuestions(featureName?: string): UserSurveyState {

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -47,7 +47,7 @@ export class UserSurvey {
             vscode.extensions.getExtension(constants.extensionId).packageJSON
                 .version || "unknown";
 
-        if (!this.shouldPromptForFeedback()) {
+        if (!(await this.shouldPromptForFeedback())) {
             return;
         }
 

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -233,12 +233,23 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
                 (payload.answers.nsat as number) < 2 /* NSAT dissatisfied */
             ) {
                 const response = await vscode.window.showInformationMessage(
-                    locConstants.UserSurvey.fileABugPrompt,
-                    locConstants.UserSurvey.submitBug,
+                    locConstants.UserSurvey.fileAnIssuePrompt,
+                    locConstants.UserSurvey.submitIssue,
                     locConstants.Common.cancel,
                 );
 
-                if (response === locConstants.UserSurvey.submitBug) {
+                sendActionEvent(
+                    TelemetryViews.UserSurvey,
+                    TelemetryActions.SubmitGithubIssue,
+                    {
+                        response:
+                            response === locConstants.UserSurvey.submitIssue
+                                ? "submitted"
+                                : "not submitted",
+                    },
+                );
+
+                if (response === locConstants.UserSurvey.submitIssue) {
                     const encodedIssueBody = encodeURIComponent(
                         getGithubIssueText(
                             typeof payload.answers.comments === "string"
@@ -247,7 +258,7 @@ class UserSurveyWebviewController extends ReactWebviewPanelController<
                             context.extension.packageJSON.version || "unknown",
                         ),
                     );
-                    const issueUrl = `https://github.com/microsoft/vscode-mssql/issues/new?template=issue_template.md&body=${encodedIssueBody}`;
+                    const issueUrl = `https://github.com/microsoft/vscode-mssql/issues/new?labels=User-filed,Triage:%20Needed&body=${encodedIssueBody}`;
                     vscode.env.openExternal(vscode.Uri.parse(issueUrl));
                 }
             }

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -63,6 +63,7 @@ export enum TelemetryActions {
     LoadAzureTenantsForEntraAuth = "LoadAzureTenantsForEntraAuth",
     LoadConnections = "LoadConnections",
     AddFirewallRule = "AddFirewallRule",
+    SubmitGithubIssue = "SubmitGithubIssue",
 }
 
 /**

--- a/src/sharedInterfaces/userSurvey.ts
+++ b/src/sharedInterfaces/userSurvey.ts
@@ -44,14 +44,15 @@ export interface BaseQuestion {
 }
 
 /**
- * A question with a radio button with 0 to 10 options.
+ * A question with radio buttons with ratings of 0 through 10.
  */
 export interface NpsQuestion extends BaseQuestion {
     type: "nps";
 }
 
 /**
- * A question with a radio button with 'Very Satisfied', 'Satisfied', 'Dissatisfied', 'Very Dissatisfied' options.
+ * A question with radio buttons with 'Very Satisfied', 'Satisfied', 'Dissatisfied', 'Very Dissatisfied' options.
+ * Submitted as a number 0 through 3.
  */
 export interface NsatQuestion extends BaseQuestion {
     type: "nsat";

--- a/test/unit/userSurvey.test.ts
+++ b/test/unit/userSurvey.test.ts
@@ -17,7 +17,7 @@ import { UserSurvey } from "../../src/nps/userSurvey";
 import { stubTelemetry } from "./utils";
 
 suite("UserSurvey Tests", () => {
-    let sandbox;
+    let sandbox: sinon.SinonSandbox;
     let globalState;
     let context;
     let showInformationMessageStub: sinon.SinonStub;
@@ -59,10 +59,14 @@ suite("UserSurvey Tests", () => {
             true,
             "globalState.get should be called with 'nps/never' and false",
         );
+
         assert.strictEqual(
             showInformationMessageStub.called,
             false,
-            "showInformationMessage should not be called",
+            `showInformationMessage should not be called, but was called ${showInformationMessageStub.getCalls().length} times: ${showInformationMessageStub
+                .getCalls()
+                .map((call) => `"${call.args[0]}"`)
+                .join(", ")}`,
         );
     });
 
@@ -113,7 +117,6 @@ suite("UserSurvey Tests", () => {
         );
 
         const userSurvey = UserSurvey.getInstance();
-        sandbox.stub(userSurvey, "launchSurvey").resolves();
         const onSubmitStub = sandbox.stub();
         const onCancelStub = sandbox.stub();
         // Mock the webview controller
@@ -141,7 +144,7 @@ suite("UserSurvey Tests", () => {
         assert.strictEqual(
             mockWebviewController.revealToForeground.calledOnce,
             true,
-            "launchSurvey should be called",
+            "revealToForeground should have been called",
         );
 
         assert.strictEqual(


### PR DESCRIPTION
After the feedback form is submitted, users who rate the extension poorly (NPS < 7 or NSAT dissatisfied) are asked if they'd like to file a github issue.  Any comments they included in the feedback prompt are prepopulated in the github issue.

Feedback prompt:
![image](https://github.com/user-attachments/assets/f5ce259d-847b-4e64-a2f2-135c1e35bf16)

Prepopulated Github issue:
![image](https://github.com/user-attachments/assets/23a2fdb7-9ce9-4715-809b-99e442364a3f)
