### PR TITLE
Fixed tooltip bug in new query results pane

### DIFF
--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, makeStyles } from "@fluentui/react-components";
+import { Button, makeStyles, Tooltip } from "@fluentui/react-components";
 import { useContext, useState } from "react";
 import { QueryResultContext } from "./queryResultStateProvider";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
@@ -98,48 +98,63 @@ const CommandBar = (props: CommandBarProps) => {
                 ></Button>
             )}
 
-            <Button
-                appearance="subtle"
-                onClick={(_event) => {
-                    saveResults("csv");
-                }}
-                icon={
-                    <img
-                        className={classes.buttonImg}
-                        src={saveAsCsvIcon(context.theme)}
-                    />
-                }
-                className="codicon saveCsv"
-                title={locConstants.queryResult.saveAsCsv}
-            />
-            <Button
-                appearance="subtle"
-                onClick={(_event) => {
-                    saveResults("json");
-                }}
-                icon={
-                    <img
-                        className={classes.buttonImg}
-                        src={saveAsJsonIcon(context.theme)}
-                    />
-                }
-                className="codicon saveJson"
-                title={locConstants.queryResult.saveAsJson}
-            />
-            <Button
-                appearance="subtle"
-                onClick={(_event) => {
-                    saveResults("excel");
-                }}
-                icon={
-                    <img
-                        className={classes.buttonImg}
-                        src={saveAsExcelIcon(context.theme)}
-                    />
-                }
-                className="codicon saveExcel"
-                title={locConstants.queryResult.saveAsExcel}
-            />
+            <Tooltip
+                content={locConstants.queryResult.saveAsCsv}
+                relationship="label"
+            >
+                <Button
+                    appearance="subtle"
+                    onClick={(_event) => {
+                        saveResults("csv");
+                    }}
+                    icon={
+                        <img
+                            className={classes.buttonImg}
+                            src={saveAsCsvIcon(context.theme)}
+                        />
+                    }
+                    className="codicon saveCsv"
+                    title={locConstants.queryResult.saveAsCsv}
+                />
+            </Tooltip>
+            <Tooltip
+                content={locConstants.queryResult.saveAsJson}
+                relationship="label"
+            >
+                <Button
+                    appearance="subtle"
+                    onClick={(_event) => {
+                        saveResults("json");
+                    }}
+                    icon={
+                        <img
+                            className={classes.buttonImg}
+                            src={saveAsJsonIcon(context.theme)}
+                        />
+                    }
+                    className="codicon saveJson"
+                    title={locConstants.queryResult.saveAsJson}
+                />
+            </Tooltip>
+            <Tooltip
+                content={locConstants.queryResult.saveAsExcel}
+                relationship="label"
+            >
+                <Button
+                    appearance="subtle"
+                    onClick={(_event) => {
+                        saveResults("excel");
+                    }}
+                    icon={
+                        <img
+                            className={classes.buttonImg}
+                            src={saveAsExcelIcon(context.theme)}
+                        />
+                    }
+                    className="codicon saveExcel"
+                    title={locConstants.queryResult.saveAsExcel}
+                />
+            </Tooltip>
         </div>
     );
 };


### PR DESCRIPTION
Fixed this issue in new query results pane: https://github.com/microsoft/vscode-mssql/issues/17875

When you tab focus on the command bar buttons in the new query result pane, it shows the tooltips
![tooltip](https://github.com/user-attachments/assets/73a03773-ea1f-4018-aad5-528a07163f08)
