### PR TITLE
Use grid id to track filters for each grid

### DIFF
--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -227,11 +227,8 @@ export function registerCommonRequestHandlers(
     webviewController.registerReducer(
         "setFilterState",
         async (state, payload) => {
-            state.filterState[payload.filterState.columnDef] = {
-                filterValues: payload.filterState.filterValues,
-                columnDef: payload.filterState.columnDef,
-                seachText: payload.filterState.seachText,
-                sorted: payload.filterState.sorted,
+            state.filterState[payload.filterState.gridId] = {
+                columnFilters: payload.filterState.columnFilters,
             };
             return state;
         },

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -275,6 +275,7 @@ export const QueryResultPane = () => {
         gridCount: number,
     ) => {
         const divId = `grid-parent-${batchId}-${resultId}`;
+        const gridId = `resultGrid-${batchId}-${resultId}`;
         return (
             <div
                 id={divId}
@@ -360,6 +361,7 @@ export const QueryResultPane = () => {
                     webViewState={webViewState}
                     state={state}
                     linkHandler={linkHandler}
+                    gridId={gridId}
                 />
                 <CommandBar
                     uri={metadata?.uri}

--- a/src/reactviews/pages/QueryResult/queryResultStateProvider.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultStateProvider.tsx
@@ -10,7 +10,7 @@ import {
     useVscodeWebview,
 } from "../../common/vscodeWebviewProvider";
 import { ReactNode, createContext } from "react";
-import { ColumnFilterState } from "./table/interfaces";
+import { GridFilters } from "./table/interfaces";
 
 export interface QueryResultState {
     provider: qr.QueryResultReactProvider;
@@ -45,9 +45,7 @@ const QueryResultStateProvider: React.FC<QueryResultContextProps> = ({
                             tabId: tabId,
                         });
                     },
-                    setFilterState: function (
-                        filterState: ColumnFilterState,
-                    ): void {
+                    setFilterState: function (filterState: GridFilters): void {
                         webViewState?.extensionRpc.action("setFilterState", {
                             filterState: filterState,
                         });

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -60,6 +60,7 @@ export interface ResultGridProps {
     gridParentRef?: React.RefObject<HTMLDivElement>;
     state: QueryResultState;
     linkHandler: (fileContent: string, fileType: string) => void;
+    gridId: string;
 }
 
 export interface ResultGridHandle {
@@ -281,6 +282,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
                 props.webViewState!,
                 props.state,
                 props.linkHandler!,
+                props.gridId,
                 { dataProvider: dataProvider, columns: columns },
                 tableOptions,
                 props.gridParentRef,

--- a/src/reactviews/pages/QueryResult/table/interfaces.ts
+++ b/src/reactviews/pages/QueryResult/table/interfaces.ts
@@ -54,6 +54,11 @@ export interface ColumnFilterState {
     columnDef: string;
 }
 
+export interface GridFilters {
+    gridId: string;
+    columnFilters: ColumnFilterState;
+}
+
 export interface GridSortState {
     field: string;
     sortAsc: boolean;

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -61,12 +61,11 @@ export class HeaderFilter<T extends Slick.SlickData> {
 
     private _eventManager = new EventManager();
     private queryResultState: QueryResultState;
-    private gridId: string;
 
     constructor(
         theme: ColorThemeKind,
         queryResultState: QueryResultState,
-        gridId: string,
+        private gridId: string,
     ) {
         this.queryResultState = queryResultState;
         this.theme = theme;
@@ -468,7 +467,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                 sorted: this.columnDef.sorted,
             };
         }
-        let record: GridFilters = {
+        const record: GridFilters = {
             gridId: this.gridId,
             columnFilters: columnFilterState,
         };

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -9,6 +9,7 @@
 import {
     ColumnFilterState,
     FilterableColumn,
+    GridFilters,
     SortProperties,
 } from "../interfaces";
 import { append, $ } from "../dom";
@@ -60,10 +61,16 @@ export class HeaderFilter<T extends Slick.SlickData> {
 
     private _eventManager = new EventManager();
     private queryResultState: QueryResultState;
+    private gridId: string;
 
-    constructor(theme: ColorThemeKind, queryResultState: QueryResultState) {
+    constructor(
+        theme: ColorThemeKind,
+        queryResultState: QueryResultState,
+        gridId: string,
+    ) {
         this.queryResultState = queryResultState;
         this.theme = theme;
+        this.gridId = gridId;
     }
 
     public init(grid: Slick.Grid<T>): void {
@@ -461,10 +468,15 @@ export class HeaderFilter<T extends Slick.SlickData> {
                 sorted: this.columnDef.sorted,
             };
         }
-        this.updateState(columnFilterState);
+        let record: GridFilters = {
+            gridId: this.gridId,
+            columnFilters: columnFilterState,
+        };
+        //TODO: update state using a record object instead of columnFilterState
+        this.updateState(record);
     }
 
-    private updateState(newState: ColumnFilterState) {
+    private updateState(newState: GridFilters) {
         this.queryResultState.provider.setFilterState(newState);
     }
 

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -472,7 +472,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
             gridId: this.gridId,
             columnFilters: columnFilterState,
         };
-        //TODO: update state using a record object instead of columnFilterState
         this.updateState(record);
     }
 

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -70,6 +70,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         QueryResultReducers
     >;
     private linkHandler: (fileContent: string, fileType: string) => void;
+    private gridId: string;
 
     constructor(
         parent: HTMLElement,
@@ -82,6 +83,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         >,
         state: QueryResultState,
         linkHandler: (value: string, type: string) => void,
+        gridId: string,
         configuration?: ITableConfiguration<T>,
         options?: Slick.GridOptions<T>,
         gridParentRef?: React.RefObject<HTMLDivElement>,
@@ -97,6 +99,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             },
             webViewState,
         );
+        this.gridId = gridId;
         if (
             !configuration ||
             !configuration.dataProvider ||
@@ -157,7 +160,11 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             newOptions,
         );
         this.registerPlugin(
-            new HeaderFilter(webViewState.themeKind, this.queryResultState),
+            new HeaderFilter(
+                webViewState.themeKind,
+                this.queryResultState,
+                gridId,
+            ),
         );
         this.registerPlugin(
             new ContextMenu(this.uri, this.resultSetSummary, this.webViewState),
@@ -210,13 +217,16 @@ export class Table<T extends Slick.SlickData> implements IThemable {
      * @returns true if filters were successfully loaded and applied, false if no filters were found
      */
     public async setupFilterState(): Promise<boolean> {
+        console.log("gridId: " + this.gridId);
         this.columns.forEach((column) => {
             if (column.field) {
+                console.log("column field: " + column.field);
                 const filters =
-                    this.queryResultState.state.filterState[column.field];
+                    this.queryResultState.state.filterState[this.gridId];
                 if (filters) {
                     (<FilterableColumn<T>>column).filterValues =
-                        filters.filterValues;
+                        //@ts-ignore
+                        filters.columnFilters.filterValues[column.field];
                 } else {
                     return false;
                 }

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -217,10 +217,8 @@ export class Table<T extends Slick.SlickData> implements IThemable {
      * @returns true if filters were successfully loaded and applied, false if no filters were found
      */
     public async setupFilterState(): Promise<boolean> {
-        console.log("gridId: " + this.gridId);
         this.columns.forEach((column) => {
             if (column.field) {
-                console.log("column field: " + column.field);
                 const filters =
                     this.queryResultState.state.filterState[this.gridId];
                 if (filters) {

--- a/src/sharedInterfaces/queryResult.ts
+++ b/src/sharedInterfaces/queryResult.ts
@@ -9,7 +9,10 @@ import {
     ExecutionPlanState,
     ExecutionPlanWebviewState,
 } from "../reactviews/pages/ExecutionPlan/executionPlanInterfaces";
-import { ColumnFilterState } from "../reactviews/pages/QueryResult/table/interfaces";
+import {
+    ColumnFilterState,
+    GridFilters,
+} from "../reactviews/pages/QueryResult/table/interfaces";
 import { ISlickRange } from "../reactviews/pages/QueryResult/table/utils";
 
 export enum QueryResultLoadState {
@@ -31,7 +34,7 @@ export interface QueryResultReactProvider
      * @param filterState
      * @returns
      */
-    setFilterState: (filterState: ColumnFilterState) => void;
+    setFilterState: (filterState: GridFilters) => void;
     /**
      * Gets the execution plan graph from the provider for a result set
      * @param uri the uri of the query result state this request is associated with
@@ -76,7 +79,7 @@ export interface QueryResultWebviewState extends ExecutionPlanWebviewState {
     actualPlanEnabled?: boolean;
     selection?: ISlickRange[];
     executionPlanState: ExecutionPlanState;
-    filterState: Record<string, ColumnFilterState>;
+    filterState: Record<string, Record<string, ColumnFilterState>>;
     fontSettings: FontSettings;
     autoSizeColumns?: boolean;
 }
@@ -87,7 +90,7 @@ export interface QueryResultReducers
         tabId: QueryResultPaneTabs;
     };
     setFilterState: {
-        filterState: ColumnFilterState;
+        filterState: GridFilters;
     };
     /**
      * Gets the execution plan graph from the provider for given uri


### PR DESCRIPTION
Use grid id to track filters for each grid so when we apply the filters from the state, they are applied to the correct grid.

Before:
![filterFixBefore](https://github.com/user-attachments/assets/7bf3d816-37ea-4388-8bb5-13bb0c92154f)


After:
![filterFixAfter](https://github.com/user-attachments/assets/12f0a008-bbf5-411c-a151-3cb7526ed3db)


Addresses #18514 
(will close after port request)