### PR TITLE
Fixing clear all filters in release (#18573)

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -942,7 +942,7 @@ export default class MainController implements vscode.Disposable {
                     this._context,
                     node,
                 );
-                if (filters && filters.length > 0) {
+                if (filters) {
                     node.filters = filters;
                     if (
                         node.collapsibleState ===

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -379,6 +379,17 @@ export class ObjectExplorerService {
                     ),
                 );
                 self._treeNodeToChildrenMap.set(parentNode, children);
+                sendActionEvent(
+                    TelemetryViews.ObjectExplorer,
+                    TelemetryActions.ExpandNode,
+                    {
+                        nodeType: parentNode?.context?.subType ?? "",
+                        isErrored: (!!result.errorMessage).toString(),
+                    },
+                    {
+                        nodeCount: result?.nodes.length ?? 0,
+                    },
+                );
                 for (let key of self._expandParamsToPromiseMap.keys()) {
                     if (
                         key.sessionId === expandParams.sessionId &&
@@ -391,17 +402,6 @@ export class ObjectExplorerService {
                         return;
                     }
                 }
-                sendActionEvent(
-                    TelemetryViews.ObjectExplorer,
-                    TelemetryActions.ExpandNode,
-                    {
-                        nodeType: parentNode.nodeType,
-                        isErrored: (!!result.errorMessage).toString(),
-                    },
-                    {
-                        nodeCount: result?.nodes.length ?? 0,
-                    },
-                );
             }
         };
         return handler;
@@ -956,6 +956,7 @@ export class ObjectExplorerService {
             RefreshRequest.type,
             refreshParams,
         );
+        this._expandParamsToTreeNodeInfoMap.set(refreshParams, node);
         if (response) {
             this._treeNodeToChildrenMap.delete(node);
         }


### PR DESCRIPTION
Fixes #18573

PR to main branch https://github.com/microsoft/vscode-mssql/pull/18573


Description copied from main branch PR.
This PR fixes https://github.com/microsoft/vscode-mssql/issues/18572

This PR fixes the clear all button in filter dialog.
It makes sure that we are setting up the parent node to expand result map even when we are refreshing the node. Previously this wasn't set so when we tried to access parent node in expand results due to a refresh, we were getting undefined error causing https://github.com/microsoft/vscode-mssql/issues/18052
Additionally, this PR updates the telemetry event for expand operations to include the node's subtype instead of the type. Subtypes provide more detailed information—for example, the "Tables" and "Views" folders are both of type "Folder," but their subtypes are "Tables" and "Views," respectively.