### PR TITLE
Add tooltip for maximize to command bar

### DIFF
--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -71,31 +71,36 @@ const CommandBar = (props: CommandBarProps) => {
     return (
         <div className={classes.commandBar}>
             {hasMultipleResults && (
-                <Button
-                    appearance="subtle"
-                    onClick={() => {
-                        maxView
-                            ? props.restoreResults?.()
-                            : props.maximizeResults?.();
-                        setMaxView((prev) => !prev); // Toggle maxView state
-                    }}
-                    icon={
-                        maxView ? (
-                            <ArrowMinimize16Filled
-                                className={classes.buttonImg}
-                            />
-                        ) : (
-                            <ArrowMaximize16Filled
-                                className={classes.buttonImg}
-                            />
-                        )
-                    }
-                    title={
-                        maxView
-                            ? locConstants.queryResult.restore
-                            : locConstants.queryResult.maximize
-                    }
-                ></Button>
+                <Tooltip
+                    content={locConstants.queryResult.maximize}
+                    relationship="label"
+                >
+                    <Button
+                        appearance="subtle"
+                        onClick={() => {
+                            maxView
+                                ? props.restoreResults?.()
+                                : props.maximizeResults?.();
+                            setMaxView((prev) => !prev); // Toggle maxView state
+                        }}
+                        icon={
+                            maxView ? (
+                                <ArrowMinimize16Filled
+                                    className={classes.buttonImg}
+                                />
+                            ) : (
+                                <ArrowMaximize16Filled
+                                    className={classes.buttonImg}
+                                />
+                            )
+                        }
+                        title={
+                            maxView
+                                ? locConstants.queryResult.restore
+                                : locConstants.queryResult.maximize
+                        }
+                    ></Button>
+                </Tooltip>
             )}
 
             <Tooltip


### PR DESCRIPTION
Tooltips were added for all query result command bar items except for maximize, this adds it.

After:
![image](https://github.com/user-attachments/assets/6b6448c8-13f0-4929-bcc1-c50ce6e54fb9)


Addresses: #18578