### PR TITLE
Moving connection call from connectButton to form handler

### DIFF
--- a/src/reactviews/pages/ConnectionDialog/components/connectButton.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/connectButton.component.tsx
@@ -30,9 +30,6 @@ export const ConnectButton = ({
             type="submit"
             appearance="primary"
             disabled={context.state.connectionStatus === ApiStatus.Loading}
-            onClick={(_event) => {
-                context.connect();
-            }}
             className={className}
             style={style}
             iconPosition="after"

--- a/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
@@ -35,7 +35,6 @@ import { TrustServerCertificateDialog } from "./components/trustServerCertificat
 import { locConstants } from "../../common/locConstants";
 import { themeType } from "../../common/utils";
 import { AddFirewallRuleDialog } from "./components/addFirewallRule.component";
-import { ConnectButtonId } from "./components/connectButton.component";
 
 function renderContent(
     connectionDialogContext: ConnectionDialogContextProps,
@@ -63,13 +62,13 @@ export const ConnectionInfoFormContainer = () => {
         return saveIcon;
     }
 
-    function handleSubmit(event: React.FormEvent) {
+    function handleConnect(event: React.FormEvent) {
         event.preventDefault();
-        document.getElementById(ConnectButtonId)?.click();
+        context.connect();
     }
 
     return (
-        <form onSubmit={handleSubmit} className={formStyles.formRoot}>
+        <form onSubmit={handleConnect} className={formStyles.formRoot}>
             <ConnectionHeader />
 
             <div className={formStyles.formDiv} style={{ overflow: "auto" }}>


### PR DESCRIPTION
Addresses #18582 

Before, the click handler on the button control would execute before the form handler's submit event had a chance to call `event.preventDefault()` that would block the button control from executing.  This resulted in two calls to `connect()` in very quick succession, which then caused the first call to be cancelled by the second call in STS, but VSCode would react to the first call's cancellation before the second call's response was sent.

Now, the connection button is just a dumb button and the form wrapper handles everything. 