### PR TITLE
Dev/benjin/port18583

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -942,7 +942,7 @@ export default class MainController implements vscode.Disposable {
                     this._context,
                     node,
                 );
-                if (filters && filters.length > 0) {
+                if (filters) {
                     node.filters = filters;
                     if (
                         node.collapsibleState ===

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -379,6 +379,17 @@ export class ObjectExplorerService {
                     ),
                 );
                 self._treeNodeToChildrenMap.set(parentNode, children);
+                sendActionEvent(
+                    TelemetryViews.ObjectExplorer,
+                    TelemetryActions.ExpandNode,
+                    {
+                        nodeType: parentNode?.context?.subType ?? "",
+                        isErrored: (!!result.errorMessage).toString(),
+                    },
+                    {
+                        nodeCount: result?.nodes.length ?? 0,
+                    },
+                );
                 for (let key of self._expandParamsToPromiseMap.keys()) {
                     if (
                         key.sessionId === expandParams.sessionId &&
@@ -391,17 +402,6 @@ export class ObjectExplorerService {
                         return;
                     }
                 }
-                sendActionEvent(
-                    TelemetryViews.ObjectExplorer,
-                    TelemetryActions.ExpandNode,
-                    {
-                        nodeType: parentNode.nodeType,
-                        isErrored: (!!result.errorMessage).toString(),
-                    },
-                    {
-                        nodeCount: result?.nodes.length ?? 0,
-                    },
-                );
             }
         };
         return handler;
@@ -956,6 +956,7 @@ export class ObjectExplorerService {
             RefreshRequest.type,
             refreshParams,
         );
+        this._expandParamsToTreeNodeInfoMap.set(refreshParams, node);
         if (response) {
             this._treeNodeToChildrenMap.delete(node);
         }

--- a/src/reactviews/pages/ConnectionDialog/components/connectButton.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/connectButton.component.tsx
@@ -30,9 +30,6 @@ export const ConnectButton = ({
             type="submit"
             appearance="primary"
             disabled={context.state.connectionStatus === ApiStatus.Loading}
-            onClick={(_event) => {
-                context.connect();
-            }}
             className={className}
             style={style}
             iconPosition="after"

--- a/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
@@ -35,7 +35,6 @@ import { TrustServerCertificateDialog } from "./components/trustServerCertificat
 import { locConstants } from "../../common/locConstants";
 import { themeType } from "../../common/utils";
 import { AddFirewallRuleDialog } from "./components/addFirewallRule.component";
-import { ConnectButtonId } from "./components/connectButton.component";
 
 function renderContent(
     connectionDialogContext: ConnectionDialogContextProps,
@@ -63,13 +62,13 @@ export const ConnectionInfoFormContainer = () => {
         return saveIcon;
     }
 
-    function handleSubmit(event: React.FormEvent) {
+    function handleConnect(event: React.FormEvent) {
         event.preventDefault();
-        document.getElementById(ConnectButtonId)?.click();
+        context.connect();
     }
 
     return (
-        <form onSubmit={handleSubmit} className={formStyles.formRoot}>
+        <form onSubmit={handleConnect} className={formStyles.formRoot}>
             <ConnectionHeader />
 
             <div className={formStyles.formDiv} style={{ overflow: "auto" }}>


### PR DESCRIPTION
Fixes #18582

Original PR: #18583

Bug description:

Before, the click handler on the button control would execute before the form handler's submit event had a chance to call event.preventDefault() that would block the button control from executing. This resulted in two calls to connect() in very quick succession, which then caused the first call to be cancelled by the second call in STS, but VSCode would react to the first call's cancellation before the second call's response was sent.