### PR TITLE
[Port Request] Automatically disable language service when non T-SQL sql language is…

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -665,6 +665,7 @@
   "Choose SQL Language": "Choose SQL Language",
   "Use T-SQL intellisense and syntax error checking on current document": "Use T-SQL intellisense and syntax error checking on current document",
   "Disable intellisense and syntax error checking on current document": "Disable intellisense and syntax error checking on current document",
+  "Non-SQL Server SQL file detected. Disable IntelliSense for such files?": "Non-SQL Server SQL file detected. Disable IntelliSense for such files?",
   "Add Connection": "Add Connection",
   "Azure: Sign In": "Azure: Sign In",
   "Sign in to your Azure subscription": "Sign in to your Azure subscription",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -836,6 +836,9 @@
     <trans-unit id="++CODE++548271493601de8634bf0793fb0e09522c1bcce8e1e61c9e51186c9661137729">
       <source xml:lang="en">No subscriptions available.  Adjust your subscription filters to try again.</source>
     </trans-unit>
+    <trans-unit id="++CODE++522f7c01e016bd0f95cd3b404ebb0751a2b6db89a57ff1c7e5110b39e1f136e0">
+      <source xml:lang="en">Non-SQL Server SQL file detected. Disable IntelliSense for such files?</source>
+    </trans-unit>
     <trans-unit id="++CODE++dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91">
       <source xml:lang="en">None</source>
     </trans-unit>
@@ -1847,6 +1850,9 @@
     </trans-unit>
     <trans-unit id="mssql.format.keywordCasing">
       <source xml:lang="en">Should keywords be formatted as UPPERCASE, lowercase, or none (not formatted)</source>
+    </trans-unit>
+    <trans-unit id="mssql.autoDisableNonTSqlLanguageService">
+      <source xml:lang="en">Should language service be auto-disabled when extension detects Non-MSSQL files</source>
     </trans-unit>
     <trans-unit id="mssql.persistQueryResultTabs">
       <source xml:lang="en">Should query result selections and scroll positions be saved when switching tabs (may impact performance)</source>

--- a/package.json
+++ b/package.json
@@ -1450,6 +1450,11 @@
           "default": 2097152,
           "description": "%mssql.query.maxXmlCharsToStore%"
         },
+        "mssql.autoDisableNonTSqlLanguageService": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": "%mssql.autoDisableNonTSqlLanguageService%"
+        },
         "mssql.queryHistoryLimit": {
           "type": "number",
           "default": 20,

--- a/package.nls.json
+++ b/package.nls.json
@@ -110,6 +110,7 @@
 "mssql.intelliSense.lowerCaseSuggestions":"Should IntelliSense suggestions be lowercase",
 "mssql.persistQueryResultTabs":"Should query result selections and scroll positions be saved when switching tabs (may impact performance)",
 "mssql.queryHistoryLimit":"Number of query history entries to show in the Query History view",
+"mssql.autoDisableNonTSqlLanguageService":"Should language service be auto-disabled when extension detects Non-MSSQL files",
 "mssql.createAzureFunction":"Create Azure Function with SQL binding",
 "mssql.query.maxXmlCharsToStore":"Maximum number of characters to store for each value in XML columns after running a query. Default value: 2,097,152. Valid value range: 1 to 2,147,483,647.",
 "mssql.query.maxCharsToStore":"Maximum number of characters/bytes to store for each value in character/binary columns after running a query. Default value: 65,535. Valid value range: 1 to 2,147,483,647.",

--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "5.0.20250115.1",
+    "version": "5.0.20250123.1",
     "downloadFileNames": {
       "Windows_86": "win-x86-net8.0.zip",
       "Windows_64": "win-x64-net8.0.zip",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -199,6 +199,8 @@ export const configEnableNewQueryResultFeature =
 export const configOpenQueryResultsInTabByDefaultDoNotShowPrompt =
     "mssql.openQueryResultsInTabByDefaultDoNotShowPrompt";
 export const configAutoColumnSizing = "resultsGrid.autoSizeColumns";
+export const configAutoDisableNonTSqlLanguageService =
+    "mssql.autoDisableNonTSqlLanguageService";
 
 // ToolsService Constants
 export const serviceInstallingTo = "Installing SQL tools service to";

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -561,6 +561,9 @@ export let flavorDescriptionMssql = l10n.t(
 export let flavorDescriptionNone = l10n.t(
     "Disable intellisense and syntax error checking on current document",
 );
+export let autoDisableNonTSqlLanguageServicePrompt = l10n.t(
+    "Non-SQL Server SQL file detected. Disable IntelliSense for such files?",
+);
 export let msgAddConnection = l10n.t("Add Connection");
 export let msgConnect = l10n.t("Connect");
 export let azureSignIn = l10n.t("Azure: Sign In");

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -404,6 +404,7 @@ export default class MainController implements vscode.Disposable {
             this._vscodeWrapper.onDidChangeConfiguration((params) =>
                 this.onDidChangeConfiguration(params),
             );
+
             return true;
         }
     }

--- a/src/controllers/vscodeWrapper.ts
+++ b/src/controllers/vscodeWrapper.ts
@@ -161,6 +161,13 @@ export default class VscodeWrapper {
     }
 
     /**
+     * An event that is emitted when a [text document change](#TextDocumentChange) is detected.
+     */
+    public get onDidChangeTextDocument(): vscode.Event<vscode.TextDocumentChangeEvent> {
+        return vscode.workspace.onDidChangeTextDocument;
+    }
+
+    /**
      * Opens the denoted document from disk. Will return early if the
      * document is already open, otherwise the document is loaded and the
      * [open document](#workspace.onDidOpenTextDocument)-event fires.

--- a/src/languageservice/utils.ts
+++ b/src/languageservice/utils.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { languageId } from "../constants/constants";
+import {
+    DidChangeLanguageFlavorParams,
+    LanguageFlavorChangedNotification,
+} from "../models/contracts/languageService";
+import StatusView from "../views/statusView";
+import SqlToolsServiceClient from "./serviceclient";
+
+export function changeLanguageServiceForFile(
+    client: SqlToolsServiceClient,
+    uri: string,
+    flavor: string,
+    statusView: StatusView,
+): void {
+    client.sendNotification(LanguageFlavorChangedNotification.type, {
+        uri: uri,
+        language: languageId,
+        flavor: flavor,
+    } as DidChangeLanguageFlavorParams);
+    statusView.languageFlavorChanged(uri, flavor);
+}

--- a/src/models/contracts/languageService.ts
+++ b/src/models/contracts/languageService.ts
@@ -75,6 +75,31 @@ export class StatusChangeParams {
 
 // ------------------------------- </ Status Sent Event > ----------------------------------
 
+// ------------------------------- < Non T-Sql Event > ------------------------------------
+
+export class NonTSqlParams {
+    /**
+     * URI identifying the text document
+     */
+    public ownerUri: string;
+    /**
+     * Indicates whether the file was flagged due to containing
+     * non-TSQL keywords or hitting the error limit.
+     */
+    public containsNonTSqlKeywords: boolean;
+}
+
+/**
+ *
+ */
+export namespace NonTSqlNotification {
+    export const type = new NotificationType<NonTSqlParams, void>(
+        "textDocument/nonTSqlFileDetected",
+    );
+}
+
+// ------------------------------- </ Non T-Sql Event > ----------------------------------
+
 // ------------------------------- < Language Flavor Changed Event > ------------------------------------
 /**
  * Language flavor change event parameters

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -64,6 +64,7 @@ export enum TelemetryActions {
     LoadConnections = "LoadConnections",
     AddFirewallRule = "AddFirewallRule",
     AutoColumnSize = "AutoColumnSize",
+    DisableLanguageServiceForNonTSqlFiles = "DisableLanguageServiceForNonTSqlFiles",
 }
 
 /**


### PR DESCRIPTION
Port request for (#18557 )
Fixes (https://github.com/microsoft/vscode-mssql/issues/801)

… detected (#18557)

* language service auto disable

* narrowed down non tsql keyword list and ignored non sql code

* added telemetry

* changed prompt

* moved checking for non t sql syntax over to sts

* removed unused declaration

* updated prompt text

* addressed pr comments

* fixed launch file, and added comments

* fixed launch file

* fixed launch file

* bumped sts