### PR TITLE
Add check for nested resultSetSummaries

### DIFF
--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -64,9 +64,20 @@ const CommandBar = (props: CommandBarProps) => {
         });
     };
 
+    const checkMultipleResults = () => {
+        let multipleResultsFlag = false;
+        Object.keys(context.state.resultSetSummaries).forEach((resultSet) => {
+            if (resultSet.length > 1) {
+                multipleResultsFlag = true;
+            }
+        });
+        return multipleResultsFlag;
+    };
+
     const hasMultipleResults =
         context.state.resultSetSummaries &&
-        Object.keys(context.state.resultSetSummaries).length > 1;
+        (Object.keys(context.state.resultSetSummaries).length > 1 ||
+            checkMultipleResults);
 
     return (
         <div className={classes.commandBar}>

--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -65,17 +65,15 @@ const CommandBar = (props: CommandBarProps) => {
     };
 
     const checkMultipleResults = () => {
-        let multipleResultsFlag = false;
         if (Object.keys(context.state.resultSetSummaries).length > 1) {
             return true;
         }
-        Object.values(context.state.resultSetSummaries).forEach((resultSet) => {
+        for (let resultSet of Object.values(context.state.resultSetSummaries)) {
             if (Object.keys(resultSet).length > 1) {
-                console.log("True");
-                multipleResultsFlag = true;
+                return true;
             }
-        });
-        return multipleResultsFlag;
+        }
+        return false;
     };
 
     const hasMultipleResults = () => {

--- a/src/reactviews/pages/QueryResult/commandBar.tsx
+++ b/src/reactviews/pages/QueryResult/commandBar.tsx
@@ -66,22 +66,28 @@ const CommandBar = (props: CommandBarProps) => {
 
     const checkMultipleResults = () => {
         let multipleResultsFlag = false;
-        Object.keys(context.state.resultSetSummaries).forEach((resultSet) => {
-            if (resultSet.length > 1) {
+        if (Object.keys(context.state.resultSetSummaries).length > 1) {
+            return true;
+        }
+        Object.values(context.state.resultSetSummaries).forEach((resultSet) => {
+            if (Object.keys(resultSet).length > 1) {
+                console.log("True");
                 multipleResultsFlag = true;
             }
         });
         return multipleResultsFlag;
     };
 
-    const hasMultipleResults =
-        context.state.resultSetSummaries &&
-        (Object.keys(context.state.resultSetSummaries).length > 1 ||
-            checkMultipleResults);
+    const hasMultipleResults = () => {
+        return (
+            Object.keys(context.state.resultSetSummaries).length > 0 &&
+            checkMultipleResults()
+        );
+    };
 
     return (
         <div className={classes.commandBar}>
-            {hasMultipleResults && (
+            {hasMultipleResults() && (
                 <Tooltip
                     content={locConstants.queryResult.maximize}
                     relationship="label"


### PR DESCRIPTION
Before:
Maximize button for query results pane only appears if you add "GO" between queries.

After:
Maximize button for query results pane appears whenever there are multiple result grids.
![Screenshot 2025-01-27 at 5 15 54 PM](https://github.com/user-attachments/assets/59c2972e-c58b-4ea8-9b54-53f83c63d603)


The problem was that there were nested result sets like this if you didn't add "GO":
![Screenshot 2025-01-27 at 4 54 02 PM](https://github.com/user-attachments/assets/85d0942c-5f8e-445d-a884-59aeb6dd7db0)

Fixes #18581