### PR TITLE
Hide query editor action buttons when in diff editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,47 +307,47 @@
       "editor/title": [
         {
           "command": "mssql.runQuery",
-          "when": "editorLangId == sql",
+          "when": "editorLangId == sql && !isInDiffEditor",
           "group": "navigation@1"
         },
         {
           "command": "mssql.cancelQuery",
-          "when": "editorLangId == sql && resourcePath in mssql.runningQueries",
+          "when": "editorLangId == sql && !isInDiffEditor && resourcePath in mssql.runningQueries",
           "group": "navigation@2"
         },
         {
           "command": "mssql.revealQueryResultPanel",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && view.queryResult.visible == false",
+          "when": "editorLangId == sql && !isInDiffEditor && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && view.queryResult.visible == false",
           "group": "navigation@2"
         },
         {
           "command": "mssql.connect",
-          "when": "editorLangId == sql && resource not in mssql.connections",
+          "when": "editorLangId == sql && !isInDiffEditor && resource not in mssql.connections",
           "group": "navigation@3"
         },
         {
           "command": "mssql.disconnect",
-          "when": "editorLangId == sql && resource in mssql.connections",
+          "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections",
           "group": "navigation@3"
         },
         {
           "command": "mssql.changeDatabase",
-          "when": "editorLangId == sql",
+          "when": "editorLangId == sql && !isInDiffEditor",
           "group": "navigation@4"
         },
         {
           "command": "mssql.showExecutionPlanInResults",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature",
+          "when": "editorLangId == sql && !isInDiffEditor && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature",
           "group": "navigation@4"
         },
         {
           "command": "mssql.enableActualPlan",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && !(resource in mssql.executionPlan.urisWithActualPlanEnabled)",
+          "when": "editorLangId == sql && !isInDiffEditor && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && !(resource in mssql.executionPlan.urisWithActualPlanEnabled)",
           "group": "navigation@5"
         },
         {
           "command": "mssql.disableActualPlan",
-          "when": "editorLangId == sql && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && resource in mssql.executionPlan.urisWithActualPlanEnabled",
+          "when": "editorLangId == sql && !isInDiffEditor && config.mssql.enableRichExperiences && config.mssql.enableNewQueryResultFeature && resource in mssql.executionPlan.urisWithActualPlanEnabled",
           "group": "navigation@5"
         }
       ],


### PR DESCRIPTION
This PR fixes #18559 
Currently we show query editor action buttons in the diff editor which is not relevant. This bumps the diff-related actions into `...`. This PR adds an `isInDiffEditor` check during the action button contribution to hide them when the editor is in diff view. This change works for diff views originated from both git diff and the manual `Select for Compare` operation.

Before:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/c64a3e13-900a-42ac-a2d3-334a06e79c47" />


After:
<img width="1264" alt="Screenshot 2025-01-29 at 12 12 13" src="https://github.com/user-attachments/assets/23e6d801-3221-4d22-8368-904b6c976a1b" />

VSCode doc for `isInDiffEditor` flag:
https://code.visualstudio.com/api/references/when-clause-contexts#:~:text=editorLangId%20%3D%3D%20typescript%22.-,isInDiffEditor,-The%20active%20editor
