### PR TITLE
Add Clearer Privacy Statement to Feedback Page

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -275,6 +275,8 @@
   "Not likely at all": "Not likely at all",
   "Extremely likely": "Extremely likely",
   "Privacy Statement": "Privacy Statement",
+  "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions...": "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions...",
+  "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum.": "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum.",
   "Results": "Results",
   "Messages": "Messages",
   "Timestamp": "Timestamp",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -777,6 +777,12 @@
     <trans-unit id="++CODE++951f4af90cfde827d87f358b3d8d275ee60a3306d9ddb5c4615483cff067697a">
       <source xml:lang="en">Microsoft reviews your feedback to improve our products, so don&apos;t share any personal data or confidential/proprietary content.</source>
     </trans-unit>
+    <trans-unit id="++CODE++1f5c209a4ee7cb85322b1d1fbde63de014d0871930fa88895405ebaea926535d">
+      <source xml:lang="en">Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++87a43e5185b677199f2369f90cd8518b8b1d7702edff307ed9e79883f43aaaaa">
+      <source xml:lang="en">Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions...</source>
+    </trans-unit>
     <trans-unit id="++CODE++7d4b99d7fea1f8fb56040b0f388071d3f886f709000859485129c0ce1930fce9">
       <source xml:lang="en">Microsoft would like your feedback</source>
     </trans-unit>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -231,7 +231,7 @@ export const tenantDisplayName = "Microsoft";
 export const windowsResourceClientPath = "SqlToolsResourceProviderService.exe";
 export const unixResourceClientPath = "SqlToolsResourceProviderService";
 export const microsoftPrivacyStatementUrl =
-    "https://www.microsoft.com/en-us/privacy/privacystatement";
+    "https://go.microsoft.com/fwlink/?LinkId=521839";
 export const sqlPlanLanguageId = "sqlplan";
 export const showPlanXmlColumnName = "Microsoft SQL Server 2005 XML Showplan";
 export enum Platform {

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -285,6 +285,12 @@ export class LocConstants {
             notLikelyAtAll: l10n.t("Not likely at all"),
             extremelyLikely: l10n.t("Extremely likely"),
             privacyStatement: l10n.t("Privacy Statement"),
+            feedbackStatementShort: l10n.t(
+                "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions...",
+            ),
+            feedbackStatementLong: l10n.t(
+                "Microsoft will process the feedback you submit pursuant to your organization’s instructions in order to improve your and your organization’s experience with this product. If you have any questions about the use of feedback data, please contact your tenant administrator. Processing of feedback data is governed by the Microsoft Products and Services Data Protection Addendum between your organization and Microsoft, and the feedback you submit is considered Personal Data under that addendum.",
+            ),
         };
     }
 

--- a/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
+++ b/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
@@ -20,6 +20,9 @@ import {
     Text,
     Textarea,
     makeStyles,
+    Popover,
+    PopoverTrigger,
+    PopoverSurface,
 } from "@fluentui/react-components";
 import { useContext, useState } from "react";
 
@@ -51,6 +54,7 @@ const useStyles = makeStyles({
         },
     },
     privacyDisclaimer: {
+        marginTop: "30px",
         marginLeft: "auto",
     },
 });
@@ -150,6 +154,50 @@ export const UserSurveyPage = () => {
                             locConstants.common.cancel}
                     </Button>
                 </div>
+            </div>
+            <div className={classes.privacyDisclaimer}>
+                {/* <p>
+                    Microsoft will process the feedback you submit pursuant to
+                    your organization’s instructions in order to improve your
+                    and your organization’s experience with this product. If you
+                    have any questions about the use of feedback data, please
+                    contact your tenant administrator. Processing of feedback
+                    data is governed by the Microsoft Products and Services Data
+                    Protection Addendum between your organization and Microsoft,
+                    and the feedback you submit is considered Personal Data
+                    under that addendum.
+                </p> */}
+                <Popover
+                    inline
+                    withArrow
+                    openOnHover
+                    positioning={{ coverTarget: true }}
+                >
+                    <PopoverTrigger>
+                        <p>
+                            Microsoft will process the feedback you submit
+                            pursuant to your organization’s instructions in
+                            order to improve your and your organization’s
+                            experience with this product. If you have any
+                            questions about the use of feedback...
+                        </p>
+                    </PopoverTrigger>
+                    <PopoverSurface>
+                        <div style={{ width: "600px" }}>
+                            Microsoft will process the feedback you submit
+                            pursuant to your organization’s instructions in
+                            order to improve your and your organization’s
+                            experience with this product. If you have any
+                            questions about the use of feedback data, please
+                            contact your tenant administrator. Processing of
+                            feedback data is governed by the Microsoft Products
+                            and Services Data Protection Addendum between your
+                            organization and Microsoft, and the feedback you
+                            submit is considered Personal Data under that
+                            addendum.
+                        </div>
+                    </PopoverSurface>
+                </Popover>
                 <Link
                     onClick={() => {
                         userSurveryProvider.openPrivacyStatement();

--- a/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
+++ b/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
@@ -164,26 +164,12 @@ export const UserSurveyPage = () => {
                 >
                     <PopoverTrigger>
                         <p>
-                            Microsoft will process the feedback you submit
-                            pursuant to your organization’s instructions in
-                            order to improve your and your organization’s
-                            experience with this product. If you have any
-                            questions about the use of feedback...
+                            {locConstants.userFeedback.feedbackStatementShort}
                         </p>
                     </PopoverTrigger>
                     <PopoverSurface>
                         <div style={{ width: "600px" }}>
-                            Microsoft will process the feedback you submit
-                            pursuant to your organization’s instructions in
-                            order to improve your and your organization’s
-                            experience with this product. If you have any
-                            questions about the use of feedback data, please
-                            contact your tenant administrator. Processing of
-                            feedback data is governed by the Microsoft Products
-                            and Services Data Protection Addendum between your
-                            organization and Microsoft, and the feedback you
-                            submit is considered Personal Data under that
-                            addendum.
+                            {locConstants.userFeedback.feedbackStatementLong}
                         </div>
                     </PopoverSurface>
                 </Popover>

--- a/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
+++ b/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
@@ -156,12 +156,7 @@ export const UserSurveyPage = () => {
                 </div>
             </div>
             <div className={classes.privacyDisclaimer}>
-                <Popover
-                    inline
-                    withArrow
-                    openOnHover
-                    positioning={{ coverTarget: true }}
-                >
+                <Popover inline openOnHover positioning={{ coverTarget: true }}>
                     <PopoverTrigger>
                         <p>
                             {locConstants.userFeedback.feedbackStatementShort}

--- a/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
+++ b/src/reactviews/pages/UserSurvey/userSurveyPage.tsx
@@ -156,17 +156,6 @@ export const UserSurveyPage = () => {
                 </div>
             </div>
             <div className={classes.privacyDisclaimer}>
-                {/* <p>
-                    Microsoft will process the feedback you submit pursuant to
-                    your organization’s instructions in order to improve your
-                    and your organization’s experience with this product. If you
-                    have any questions about the use of feedback data, please
-                    contact your tenant administrator. Processing of feedback
-                    data is governed by the Microsoft Products and Services Data
-                    Protection Addendum between your organization and Microsoft,
-                    and the feedback you submit is considered Personal Data
-                    under that addendum.
-                </p> */}
                 <Popover
                     inline
                     withArrow


### PR DESCRIPTION
This PR adds a clearer privacy statement to the feedback page. The shortened version is initially displayed while the full statement is seen in a tooltip, as shown here:

![image](https://github.com/user-attachments/assets/b9d49198-7a3d-41a3-b6e5-3b11a3aeb51e)


![image](https://github.com/user-attachments/assets/a6a1b62a-e835-447b-9152-2bde0a4b35e6)
