### PR TITLE
Fix AAD connectivity issues with proxied networks

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -421,6 +421,7 @@
       "{0} is the provider"
     ]
   },
+  "Unable to read proxy agent options to get tenants.": "Unable to read proxy agent options to get tenants.",
   "Server could not start. This could be a permissions error or an incompatibility on your system. You can try enabling device code authentication from settings.": "Server could not start. This could be a permissions error or an incompatibility on your system. You can try enabling device code authentication from settings.",
   "Authentication failed due to a nonce mismatch, please close Azure Data Studio and try again.": "Authentication failed due to a nonce mismatch, please close Azure Data Studio and try again.",
   "Authentication failed due to a state mismatch, please close ADS and try again.": "Authentication failed due to a state mismatch, please close ADS and try again.",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1360,6 +1360,9 @@
     <trans-unit id="++CODE++30f9be31de0326b58d28b9578bd91145abf4047074018ac47bc845f960328167">
       <source xml:lang="en">Unable to expand. Please check logs for more information.</source>
     </trans-unit>
+    <trans-unit id="++CODE++582be79ed5a63b2569e2b21a28ab0fe1f7acc6307aaaa8e52510a647959d05fa">
+      <source xml:lang="en">Unable to read proxy agent options to get tenants.</source>
+    </trans-unit>
     <trans-unit id="++CODE++6f32c6efd3fd051f5df8f5a6926828722e2734a8b2138751abf9363a674550bd">
       <source xml:lang="en">Update Database</source>
     </trans-unit>

--- a/src/azure/msal/msalAzureAuth.ts
+++ b/src/azure/msal/msalAzureAuth.ts
@@ -31,11 +31,29 @@ import { AzureAuthError } from "../azureAuthError";
 import * as Constants from "../constants";
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
 import { ErrorResponseBody } from "@azure/arm-subscriptions";
+import * as tunnel from "tunnel";
+import * as http from "http";
+import * as https from "https";
+import { Url } from "url";
 
 export type GetTenantsResponseData = {
     value: ITenantResponse[];
 };
 export type ErrorResponseBodyWithError = Required<ErrorResponseBody>;
+
+interface ProxyAgent {
+    isHttps: boolean;
+    agent: http.Agent | https.Agent;
+}
+
+interface ProxyAgentOptions {
+    auth: string | null;
+    secureProxy?: boolean;
+    host?: string | null;
+    path?: string | null;
+    port?: string | number | null;
+    rejectUnauthorized: boolean;
+}
 
 export abstract class MsalAzureAuth {
     protected readonly loginEndpointUrl: string;
@@ -362,7 +380,7 @@ export abstract class MsalAzureAuth {
     }
 
     private async makeGetRequest<T>(
-        uri: string,
+        requestUrl: string,
         token: string,
     ): Promise<AxiosResponse<T>> {
         const config: AxiosRequestConfig = {
@@ -373,7 +391,67 @@ export abstract class MsalAzureAuth {
             validateStatus: () => true, // Never throw
         };
 
-        const response: AxiosResponse = await axios.get<T>(uri, config);
+        const httpConfig = vscode.workspace.getConfiguration("http");
+        let proxy: string | undefined = httpConfig["proxy"] as string;
+        if (!proxy) {
+            this.logger.verbose(
+                "Workspace HTTP config didn't contain a proxy endpoint. Checking environment variables.",
+            );
+
+            proxy = this.loadEnvironmentProxyValue();
+        }
+
+        if (proxy) {
+            this.logger.verbose(
+                "Proxy endpoint found in environment variables or workspace configuration.",
+            );
+
+            // Turning off automatic proxy detection to avoid issues with tunneling agent by setting proxy to false.
+            // https://github.com/axios/axios/blob/bad6d8b97b52c0c15311c92dd596fc0bff122651/lib/adapters/http.js#L85
+            config.proxy = false;
+
+            const agent = this.createProxyAgent(
+                requestUrl,
+                proxy,
+                httpConfig["proxyStrictSSL"],
+            );
+            if (agent.isHttps) {
+                config.httpsAgent = agent.agent;
+            } else {
+                config.httpAgent = agent.agent;
+            }
+
+            const HTTPS_PORT = 443;
+            const HTTP_PORT = 80;
+            const parsedRequestUrl = url.parse(requestUrl);
+            const port = parsedRequestUrl.protocol?.startsWith("https")
+                ? HTTPS_PORT
+                : HTTP_PORT;
+
+            // Request URL will include HTTPS port 443 ('https://management.azure.com:443/tenants?api-version=2019-11-01'), so
+            // that Axios doesn't try to reach this URL with HTTP port 80 on HTTP proxies, which result in an error. See https://github.com/axios/axios/issues/925
+            const requestUrlWithPort = `${parsedRequestUrl.protocol}//${parsedRequestUrl.hostname}:${port}${parsedRequestUrl.path}`;
+            const response: AxiosResponse = await axios.get<T>(
+                requestUrlWithPort,
+                config,
+            );
+            this.logger.piiSanitized(
+                "GET request ",
+                [
+                    {
+                        name: "response",
+                        objOrArray:
+                            (response.data?.value as ITenantResponse[]) ??
+                            (response.data as GetTenantsResponseData),
+                    },
+                ],
+                [],
+                requestUrl,
+            );
+            return response;
+        }
+
+        const response: AxiosResponse = await axios.get<T>(requestUrl, config);
         this.logger.piiSanitized(
             "GET request ",
             [
@@ -385,9 +463,180 @@ export abstract class MsalAzureAuth {
                 },
             ],
             [],
-            uri,
+            requestUrl,
         );
         return response;
+    }
+
+    private loadEnvironmentProxyValue(): string | undefined {
+        const HTTP_PROXY = "HTTP_PROXY";
+        const HTTPS_PROXY = "HTTPS_PROXY";
+
+        if (!process) {
+            this.logger.verbose(
+                "No process object found, unable to read environment variables for proxy.",
+            );
+            return undefined;
+        }
+
+        if (process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()]) {
+            this.logger.verbose(
+                "Loading proxy value from HTTP_PROXY environment variable.",
+            );
+
+            return (
+                process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()]
+            );
+        } else if (
+            process.env[HTTPS_PROXY] ||
+            process.env[HTTPS_PROXY.toLowerCase()]
+        ) {
+            this.logger.verbose(
+                "Loading proxy value from HTTPS_PROXY environment variable.",
+            );
+
+            return (
+                process.env[HTTPS_PROXY] ||
+                process.env[HTTPS_PROXY.toLowerCase()]
+            );
+        }
+
+        this.logger.verbose(
+            "No proxy value found in either HTTPS_PROXY or HTTP_PROXY environment variables.",
+        );
+
+        return undefined;
+    }
+
+    private createProxyAgent(
+        requestUrl: string,
+        proxy: string,
+        proxyStrictSSL: boolean,
+    ): ProxyAgent {
+        const agentOptions = this.getProxyAgentOptions(
+            url.parse(requestUrl),
+            proxy,
+            proxyStrictSSL,
+        );
+        if (!agentOptions || !agentOptions.host || !agentOptions.port) {
+            this.logger.verbose(
+                "Unable to read proxy agent options to create proxy agent.",
+            );
+            throw new Error(
+                "Unable to read proxy agent options to create proxy agent.",
+            );
+        }
+
+        let tunnelOptions: tunnel.HttpsOverHttpsOptions = {};
+        if (typeof agentOptions.auth === "string" && agentOptions.auth) {
+            tunnelOptions = {
+                proxy: {
+                    proxyAuth: agentOptions.auth,
+                    host: agentOptions.host,
+                    port: Number(agentOptions.port),
+                },
+            };
+        } else {
+            tunnelOptions = {
+                proxy: {
+                    host: agentOptions.host,
+                    port: Number(agentOptions.port),
+                },
+            };
+        }
+
+        const isHttpsRequest = requestUrl.startsWith("https");
+        const isHttpsProxy = proxy.startsWith("https");
+        const proxyAgent = {
+            isHttps: isHttpsProxy,
+            agent: this.createTunnelingAgent(
+                isHttpsRequest,
+                isHttpsProxy,
+                tunnelOptions,
+            ),
+        } as ProxyAgent;
+
+        return proxyAgent;
+    }
+
+    /*
+     * Returns the proxy agent using the proxy url in the parameters or the system proxy. Returns null if no proxy found
+     */
+    private getProxyAgentOptions(
+        requestURL: Url,
+        proxy?: string,
+        strictSSL?: boolean,
+    ): ProxyAgentOptions | undefined {
+        const proxyURL = proxy || this.getSystemProxyURL(requestURL);
+
+        if (!proxyURL) {
+            return undefined;
+        }
+
+        const proxyEndpoint = url.parse(proxyURL);
+
+        if (!/^https?:$/.test(proxyEndpoint.protocol!)) {
+            return undefined;
+        }
+
+        const opts: ProxyAgentOptions = {
+            host: proxyEndpoint.hostname,
+            port: Number(proxyEndpoint.port),
+            auth: proxyEndpoint.auth,
+            rejectUnauthorized: this.isBoolean(strictSSL) ? strictSSL : true,
+        };
+
+        return opts;
+    }
+
+    private getSystemProxyURL(requestURL: Url): string | undefined {
+        if (requestURL.protocol === "http:") {
+            return (
+                process.env.HTTP_PROXY || process.env.http_proxy || undefined
+            );
+        } else if (requestURL.protocol === "https:") {
+            return (
+                process.env.HTTPS_PROXY ||
+                process.env.https_proxy ||
+                process.env.HTTP_PROXY ||
+                process.env.http_proxy ||
+                undefined
+            );
+        }
+
+        return undefined;
+    }
+
+    private isBoolean(obj: any): obj is boolean {
+        return obj === true || obj === false;
+    }
+
+    private createTunnelingAgent(
+        isHttpsRequest: boolean,
+        isHttpsProxy: boolean,
+        tunnelOptions: tunnel.HttpsOverHttpsOptions,
+    ): http.Agent | https.Agent {
+        if (isHttpsRequest && isHttpsProxy) {
+            this.logger.verbose(
+                "Creating https request over https proxy tunneling agent",
+            );
+            return tunnel.httpsOverHttps(tunnelOptions);
+        } else if (isHttpsRequest && !isHttpsProxy) {
+            this.logger.verbose(
+                "Creating https request over http proxy tunneling agent",
+            );
+            return tunnel.httpsOverHttp(tunnelOptions);
+        } else if (!isHttpsRequest && isHttpsProxy) {
+            this.logger.verbose(
+                "Creating http request over https proxy tunneling agent",
+            );
+            return tunnel.httpOverHttps(tunnelOptions);
+        } else {
+            this.logger.verbose(
+                "Creating http request over http proxy tunneling agent",
+            );
+            return tunnel.httpOverHttp(tunnelOptions);
+        }
     }
 
     //#region interaction handling

--- a/src/azure/msal/msalAzureAuth.ts
+++ b/src/azure/msal/msalAzureAuth.ts
@@ -519,11 +519,11 @@ export abstract class MsalAzureAuth {
             proxyStrictSSL,
         );
         if (!agentOptions || !agentOptions.host || !agentOptions.port) {
-            this.logger.verbose(
+            this.logger.error(
                 "Unable to read proxy agent options to create proxy agent.",
             );
             throw new Error(
-                "Unable to read proxy agent options to create proxy agent.",
+                LocalizedConstants.unableToGetProxyAgentOptionsToGetTenants,
             );
         }
 

--- a/src/azure/msal/msalAzureController.ts
+++ b/src/azure/msal/msalAzureController.ts
@@ -107,7 +107,6 @@ export class MsalAzureController extends AzureController {
     }
 
     public async login(authType: AzureAuthType): Promise<IAccount | undefined> {
-        this.logger.verbose(`Logging in with with authType: ${authType}`);
         let azureAuth = await this.getAzureAuthInstance(authType);
         let response = await azureAuth!.startLogin();
         return response ? (response as IAccount) : undefined;

--- a/src/azure/msal/msalAzureController.ts
+++ b/src/azure/msal/msalAzureController.ts
@@ -107,6 +107,7 @@ export class MsalAzureController extends AzureController {
     }
 
     public async login(authType: AzureAuthType): Promise<IAccount | undefined> {
+        this.logger.verbose(`Logging in with with authType: ${authType}`);
         let azureAuth = await this.getAzureAuthInstance(authType);
         let response = await azureAuth!.startLogin();
         return response ? (response as IAccount) : undefined;

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -171,6 +171,9 @@ export function azureNoMicrosoftResource(provider: string) {
         comment: ["{0} is the provider"],
     });
 }
+export let unableToGetProxyAgentOptionsToGetTenants = l10n.t(
+    "Unable to read proxy agent options to get tenants.",
+);
 export let azureServerCouldNotStart = l10n.t(
     "Server could not start. This could be a permissions error or an incompatibility on your system. You can try enabling device code authentication from settings.",
 );


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-mssql/issues/17234

The PR works by using the user provided proxy endpoint and creating the necessary http(s) over http(s) tunnel to connect to the tenants endpoint to complete adding an AAD account.

As seen in the screenshot, the HTTP CONNECT method is being used to establish a network tunnel between the MSSQL extension and https://management.azure.com/tenants?api-version=2019-11-01 to allow the AAD request to complete successfully when the network environment is proxied.
![image](https://github.com/user-attachments/assets/a755502e-7232-4337-8427-60e75e0f5db3)
