### PR TITLE
Fix capitalization error with Schema Compare Controller that is causing console log error

### DIFF
--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -106,7 +106,7 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
         let source: mssql.SchemaCompareEndpointInfo;
 
         let connectionProfile: IConnectionProfile | undefined = sourceContext
-            ? (sourceContext.ConnectionInfo as IConnectionProfile)
+            ? (sourceContext.connectionInfo as IConnectionProfile)
             : undefined;
 
         if (connectionProfile) {

--- a/test/unit/schemaCompareWebViewController.test.ts
+++ b/test/unit/schemaCompareWebViewController.test.ts
@@ -246,6 +246,50 @@ suite("SchemaCompareWebViewController Tests", () => {
         );
     });
 
+    test("start - called with sqlproject path - completes successfully", async () => {
+        const mockSqlProjectNode = {
+            treeDataProvider: {
+                roots: [
+                    {
+                        projectFileUri: {
+                            fsPath: "c:\\TestSqlProject\\TestProject.sqlproj",
+                        },
+                    },
+                ],
+            },
+        };
+
+        const scController = new SchemaCompareWebViewController(
+            mockContext,
+            vscodeWrapper.object,
+            mockSqlProjectNode,
+            mockSchemaCompareService.object,
+            mockConnectionManager.object,
+            deploymentOptionsResultMock,
+            schemaCompareWebViewTitle,
+        );
+
+        const expected = {
+            endpointType: 2,
+            packageFilePath: "",
+            serverDisplayName: "",
+            serverName: "",
+            databaseName: "",
+            ownerUri: "",
+            connectionDetails: undefined,
+            projectFilePath: "c:\\TestSqlProject\\TestProject.sqlproj",
+            targetScripts: [],
+            dataSchemaProvider: undefined,
+            extractTarget: 5,
+        };
+
+        assert.deepEqual(
+            scController.state.sourceEndpointInfo,
+            expected,
+            "sourceEndpointInfo should match the expected path",
+        );
+    });
+
     test("compare reducer - when called - completes successfully", async () => {
         const expectedCompareResultMock: mssql.SchemaCompareResult = {
             operationId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",

--- a/test/unit/schemaCompareWebViewController.test.ts
+++ b/test/unit/schemaCompareWebViewController.test.ts
@@ -246,7 +246,7 @@ suite("SchemaCompareWebViewController Tests", () => {
         );
     });
 
-    test("start - called with sqlproject path - completes successfully", async () => {
+    test("start - called with sqlproject path - sets sourceEndpointInfo correctly", () => {
         const mockSqlProjectNode = {
             treeDataProvider: {
                 roots: [


### PR DESCRIPTION
This PR fixes the following console error that appears when the placeholder schema compare page is opened:
![image](https://github.com/user-attachments/assets/e80d4de6-03e3-4db2-9796-9416c471464b)