### PR TITLE
Fix copy behavior for sorted and/or filtered grid

### DIFF
--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -713,6 +713,13 @@ export default class QueryRunner {
         await this.writeStringToClipboard(copyString);
     }
 
+    /**
+     * Construct the row mappings, which contain the row data and selection data and are used to construct the copy string
+     * @param data
+     * @param range
+     * @param rowIdToSelectionMap
+     * @param rowIdToRowMap
+     */
     private getRowMappings(
         data: DbCellValue[][],
         range: ISlickRange,

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -660,7 +660,7 @@ export default class QueryRunner {
         }
         await p;
 
-        this.constructCopyString(
+        copyString = this.constructCopyString(
             copyString,
             rowIdToRowMap,
             rowIdToSelectionMap,
@@ -714,7 +714,7 @@ export default class QueryRunner {
         }
         await p;
 
-        this.constructCopyString(
+        copyString = this.constructCopyString(
             copyString,
             rowIdToRowMap,
             rowIdToSelectionMap,

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -634,8 +634,6 @@ export default class QueryRunner {
         // create a mapping of the ranges to get promises
         let tasks = selection.map((range) => {
             return async () => {
-                //TODO: instead of using get rows, we should use the data provider to fetch the data and get the sorted rows
-                //TODO: need to check if data is in memory or not from the data provider so we know if it's sorted
                 const result = await this.getRows(
                     range.fromRow,
                     range.toRow - range.fromRow + 1,
@@ -723,14 +721,12 @@ export default class QueryRunner {
     }
 
     public async sendToClipboard(
-        //TODO: what type is data?
         data: DbCellValue[][],
         batchId: number,
         resultId: number,
         selection: ISlickRange[],
         headersFlag,
     ) {
-        //TODO: filter array data based on the columns selected
         let copyString = "";
         if (headersFlag) {
             copyString = this.addHeaders(

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -159,7 +159,6 @@ export class SqlOutputContentProvider {
         selection: ISlickRange[],
         headersFlag: boolean,
     ): void {
-        console.log(data);
         void this._queryResultsMap
             .get(uri)
             .queryRunner.exportCellsToClipboard(

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -151,6 +151,26 @@ export class SqlOutputContentProvider {
             );
     }
 
+    public sendToClipboard(
+        uri: string,
+        data: Array<any>,
+        batchId: number,
+        resultId: number,
+        selection: ISlickRange[],
+        headersFlag: boolean,
+    ): void {
+        console.log(data);
+        void this._queryResultsMap
+            .get(uri)
+            .queryRunner.sendToClipboard(
+                data,
+                batchId,
+                resultId,
+                selection,
+                headersFlag,
+            );
+    }
+
     public editorSelectionRequestHandler(
         uri: string,
         selection: ISelectionData,

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -162,7 +162,7 @@ export class SqlOutputContentProvider {
         console.log(data);
         void this._queryResultsMap
             .get(uri)
-            .queryRunner.sendToClipboard(
+            .queryRunner.exportCellsToClipboard(
                 data,
                 batchId,
                 resultId,

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -156,6 +156,30 @@ export function registerCommonRequestHandlers(
                 message.selection,
             );
     });
+
+    webviewController.registerRequestHandler(
+        "sendToClipboard",
+        async (message) => {
+            sendActionEvent(
+                TelemetryViews.QueryResult,
+                TelemetryActions.CopyResults,
+                {
+                    correlationId: correlationId,
+                },
+            );
+            return webviewViewController
+                .getSqlOutputContentProvider()
+                .sendToClipboard(
+                    message.uri,
+                    message.data,
+                    message.batchId,
+                    message.resultId,
+                    message.selection,
+                    message.headersFlag,
+                );
+        },
+    );
+
     webviewController.registerRequestHandler(
         "copySelection",
         async (message) => {

--- a/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
@@ -10,8 +10,9 @@ import {
     ResultSetSummary,
 } from "../../../../../sharedInterfaces/queryResult";
 import { VscodeWebviewContext } from "../../../../common/vscodeWebviewProvider";
-import { tryCombineSelectionsForResults } from "../utils";
+import { selectionToRange, tryCombineSelectionsForResults } from "../utils";
 import { Keys } from "../../keys";
+import { IDisposableDataProvider } from "../dataProvider";
 
 /**
  * Implements the various additional navigation keybindings we want out of slickgrid
@@ -33,6 +34,7 @@ export class CopyKeybind<T extends Slick.SlickData> implements Slick.Plugin<T> {
             QueryResultWebviewState,
             QueryResultReducers
         >,
+        private dataProvider: IDisposableDataProvider<T>,
     ) {
         this.uri = uri;
         this.resultSetSummary = resultSetSummary;
@@ -90,14 +92,41 @@ export class CopyKeybind<T extends Slick.SlickData> implements Slick.Plugin<T> {
         uri: string,
         resultSetSummary: ResultSetSummary,
     ) {
+        //TODO: handle isdatainmemory just like context menu
         let selectedRanges = grid.getSelectionModel().getSelectedRanges();
         let selection = tryCombineSelectionsForResults(selectedRanges);
 
-        await webViewState.extensionRpc.call("copySelection", {
-            uri: uri,
-            batchId: resultSetSummary.batchId,
-            resultId: resultSetSummary.id,
-            selection: selection,
-        });
+        if (this.dataProvider.isDataInMemory) {
+            let range = selectionToRange(selection[0]);
+            let data = await this.dataProvider.getRangeAsync(
+                range.start,
+                range.length,
+            );
+            const dataArray = data.map((map) => {
+                const maxKey = Math.max(
+                    ...Array.from(Object.keys(map)).map(Number),
+                ); // Get the maximum key
+                return Array.from({ length: maxKey + 1 }, (_, index) => ({
+                    rowId: index,
+                    displayValue: map[index].displayValue || null,
+                }));
+            });
+
+            await this.webViewState.extensionRpc.call("sendToClipboard", {
+                uri: this.uri,
+                data: dataArray,
+                batchId: this.resultSetSummary.batchId,
+                resultId: this.resultSetSummary.id,
+                selection: selection,
+                headersFlag: false,
+            });
+        } else {
+            await webViewState.extensionRpc.call("copySelection", {
+                uri: uri,
+                batchId: resultSetSummary.batchId,
+                resultId: resultSetSummary.id,
+                selection: selection,
+            });
+        }
     }
 }

--- a/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
@@ -92,7 +92,6 @@ export class CopyKeybind<T extends Slick.SlickData> implements Slick.Plugin<T> {
         uri: string,
         resultSetSummary: ResultSetSummary,
     ) {
-        //TODO: handle isdatainmemory just like context menu
         let selectedRanges = grid.getSelectionModel().getSelectedRanges();
         let selection = tryCombineSelectionsForResults(selectedRanges);
 

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -85,7 +85,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         state: QueryResultState,
         linkHandler: (value: string, type: string) => void,
         private gridId: string,
-        configuration?: ITableConfiguration<T>,
+        private configuration: ITableConfiguration<T>,
         options?: Slick.GridOptions<T>,
         gridParentRef?: React.RefObject<HTMLDivElement>,
     ) {
@@ -168,10 +168,20 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             ),
         );
         this.registerPlugin(
-            new ContextMenu(this.uri, this.resultSetSummary, this.webViewState),
+            new ContextMenu(
+                this.uri,
+                this.resultSetSummary,
+                this.webViewState,
+                this.configuration.dataProvider as IDisposableDataProvider<T>,
+            ),
         );
         this.registerPlugin(
-            new CopyKeybind(this.uri, this.resultSetSummary, this.webViewState),
+            new CopyKeybind(
+                this.uri,
+                this.resultSetSummary,
+                this.webViewState,
+                this.configuration.dataProvider as IDisposableDataProvider<T>,
+            ),
         );
 
         this.registerPlugin(

--- a/src/reactviews/pages/QueryResult/table/utils.ts
+++ b/src/reactviews/pages/QueryResult/table/utils.ts
@@ -10,6 +10,11 @@ export interface ISlickRange {
     toRow: number;
 }
 
+export interface RowRange {
+    start: number;
+    length: number;
+}
+
 export function tryCombineSelectionsForResults(
     selections: ISlickRange[],
 ): ISlickRange[] {
@@ -22,6 +27,14 @@ export function tryCombineSelectionsForResults(
             toRow: range.toRow,
         };
     });
+}
+
+export function selectionToRange(selection: ISlickRange): RowRange {
+    let range: RowRange = {
+        start: selection.fromRow,
+        length: selection.toRow - selection.fromRow + 1,
+    };
+    return range;
 }
 
 export function tryCombineSelections(selections: ISlickRange[]): ISlickRange[] {


### PR DESCRIPTION
Correctly copies the grid values for a grid that has been sorted and/or filtered.

Before, we were using a getRows call to STS which fetches the data based on the initial query.  Once we sort or filter any data in the grid (which triggers isDataInMemory flag = true), we should use the dataProvider to tell us what data the user wants to copy, since it knows the context of the sort or filter states.  

Fixes https://github.com/microsoft/vscode-mssql/issues/18516
Fixes https://github.com/microsoft/vscode-mssql/issues/18620