### PR TITLE
Fix error handling in designer changes preview

### DIFF
--- a/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
+++ b/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
@@ -53,8 +53,9 @@ const useStyles = makeStyles({
     errorIcon: {
         fontSize: "100px",
         opacity: 0.5,
+        color: "var(--vscode-errorForeground)",
     },
-    retryButton: {
+    dialogFooterButtons: {
         marginTop: "10px",
     },
     markdownContainer: {
@@ -96,7 +97,6 @@ export const DesignerChangesPreviewButton = () => {
         return (
             <DialogTrigger disableButtonEnhancement>
                 <Button
-                    size="medium"
                     appearance="secondary"
                     onClick={() => setIsConfirmationChecked(false)}
                 >
@@ -211,11 +211,20 @@ export const DesignerChangesPreviewButton = () => {
         <>
             <DialogContent className={classes.dialogContent}>
                 <ErrorCircleRegular className={classes.errorIcon} />
-                <div>{locConstants.tableDesigner.errorLoadingPreview}</div>
+                <div>
+                    {designerContext.state.generatePreviewReportResult
+                        ?.schemaValidationError ??
+                        locConstants.tableDesigner.errorLoadingPreview}
+                </div>
             </DialogContent>
             <DialogActions>
+                <DialogTrigger action="close">
+                    <Button className={classes.dialogFooterButtons}>
+                        {locConstants.common.close}
+                    </Button>
+                </DialogTrigger>
                 <Button
-                    className={classes.retryButton}
+                    className={classes.dialogFooterButtons}
                     onClick={() => {
                         designerContext.generatePreviewReport();
                     }}

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -376,27 +376,17 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                     },
                 );
 
-                if (previewReport.schemaValidationError) {
-                    state = {
-                        ...state,
-                        apiState: {
-                            ...state.apiState,
-                            previewState: designer.LoadState.Error,
-                            publishState: designer.LoadState.NotStarted,
-                        },
-                        generatePreviewReportResult: previewReport,
-                    };
-                } else {
-                    state = {
-                        ...state,
-                        apiState: {
-                            ...state.apiState,
-                            previewState: designer.LoadState.Loaded,
-                            publishState: designer.LoadState.NotStarted,
-                        },
-                        generatePreviewReportResult: previewReport,
-                    };
-                }
+                state = {
+                    ...state,
+                    apiState: {
+                        ...state.apiState,
+                        previewState: previewReport.schemaValidationError
+                            ? designer.LoadState.Error
+                            : designer.LoadState.Loaded,
+                        publishState: designer.LoadState.NotStarted,
+                    },
+                    generatePreviewReportResult: previewReport,
+                };
                 return state;
             },
         );

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -375,15 +375,28 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                         correlationId: this._correlationId,
                     },
                 );
-                state = {
-                    ...state,
-                    apiState: {
-                        ...state.apiState,
-                        previewState: designer.LoadState.Loaded,
-                        publishState: designer.LoadState.NotStarted,
-                    },
-                    generatePreviewReportResult: previewReport,
-                };
+
+                if (previewReport.schemaValidationError) {
+                    state = {
+                        ...state,
+                        apiState: {
+                            ...state.apiState,
+                            previewState: designer.LoadState.Error,
+                            publishState: designer.LoadState.NotStarted,
+                        },
+                        generatePreviewReportResult: previewReport,
+                    };
+                } else {
+                    state = {
+                        ...state,
+                        apiState: {
+                            ...state.apiState,
+                            previewState: designer.LoadState.Loaded,
+                            publishState: designer.LoadState.NotStarted,
+                        },
+                        generatePreviewReportResult: previewReport,
+                    };
+                }
                 return state;
             },
         );


### PR DESCRIPTION
Previously designer preview error were not surfaced properly. This PR fixes that behavior. Happens in very rare edge cases where the validation happens once the user clicks the publish button. 

Previously:
![image](https://github.com/user-attachments/assets/e78ec482-b1cc-4e48-ae1a-00c2e818049e)


Now:
![image](https://github.com/user-attachments/assets/c6569d21-2722-4666-a3f2-153c19387bfa)
