### PR TITLE
Remove refreshkey

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -429,7 +429,6 @@ export const QueryResultPane = () => {
 
     const renderGridPanel = () => {
         const grids = [];
-        gridRefs.current.forEach((r) => r?.refreshGrid());
         let count = 0;
         for (const batchIdStr in state?.resultSetSummaries ?? {}) {
             const batchId = parseInt(batchIdStr);

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -10,7 +10,6 @@ import {
     useEffect,
     useImperativeHandle,
     useRef,
-    useState,
 } from "react";
 import "../../media/slickgrid.css";
 import { ACTIONBAR_WIDTH_PX, range, Table } from "./table/table";
@@ -81,7 +80,6 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
 
         const context = useContext(QueryResultContext);
         const gridContainerRef = useRef<HTMLDivElement>(null);
-        const [refreshkey, setRefreshKey] = useState(0);
         const refreshGrid = () => {
             if (gridContainerRef.current) {
                 while (gridContainerRef.current.firstChild) {
@@ -90,7 +88,6 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
                     );
                 }
             }
-            setRefreshKey((prev) => prev + 1);
         };
         const resizeGrid = (width: number, height: number) => {
             let gridParent: HTMLElement | null;
@@ -315,7 +312,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
                     ),
                 );
             }
-        }, [refreshkey]);
+        }, []);
 
         useImperativeHandle(ref, () => ({
             refreshGrid,


### PR DESCRIPTION
Removes the refreshkey, which @caohai had initially added to handle clearing the children of gridContainerRef, but this is no longer needed.

Fixes https://github.com/microsoft/vscode-mssql/issues/18577