### PR TITLE
[Port Request] Fix copy behavior for sorted and/or filtered grid (#18695)

### DIFF
--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -151,6 +151,25 @@ export class SqlOutputContentProvider {
             );
     }
 
+    public sendToClipboard(
+        uri: string,
+        data: Array<any>,
+        batchId: number,
+        resultId: number,
+        selection: ISlickRange[],
+        headersFlag: boolean,
+    ): void {
+        void this._queryResultsMap
+            .get(uri)
+            .queryRunner.exportCellsToClipboard(
+                data,
+                batchId,
+                resultId,
+                selection,
+                headersFlag,
+            );
+    }
+
     public editorSelectionRequestHandler(
         uri: string,
         selection: ISelectionData,

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -156,6 +156,30 @@ export function registerCommonRequestHandlers(
                 message.selection,
             );
     });
+
+    webviewController.registerRequestHandler(
+        "sendToClipboard",
+        async (message) => {
+            sendActionEvent(
+                TelemetryViews.QueryResult,
+                TelemetryActions.CopyResults,
+                {
+                    correlationId: correlationId,
+                },
+            );
+            return webviewViewController
+                .getSqlOutputContentProvider()
+                .sendToClipboard(
+                    message.uri,
+                    message.data,
+                    message.batchId,
+                    message.resultId,
+                    message.selection,
+                    message.headersFlag,
+                );
+        },
+    );
+
     webviewController.registerRequestHandler(
         "copySelection",
         async (message) => {

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -85,7 +85,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         state: QueryResultContextProps,
         linkHandler: (value: string, type: string) => void,
         private gridId: string,
-        configuration?: ITableConfiguration<T>,
+        private configuration: ITableConfiguration<T>,
         options?: Slick.GridOptions<T>,
         gridParentRef?: React.RefObject<HTMLDivElement>,
     ) {
@@ -168,10 +168,20 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             ),
         );
         this.registerPlugin(
-            new ContextMenu(this.uri, this.resultSetSummary, this.webViewState),
+            new ContextMenu(
+                this.uri,
+                this.resultSetSummary,
+                this.webViewState,
+                this.configuration.dataProvider as IDisposableDataProvider<T>,
+            ),
         );
         this.registerPlugin(
-            new CopyKeybind(this.uri, this.resultSetSummary, this.webViewState),
+            new CopyKeybind(
+                this.uri,
+                this.resultSetSummary,
+                this.webViewState,
+                this.configuration.dataProvider as IDisposableDataProvider<T>,
+            ),
         );
 
         this.registerPlugin(

--- a/src/reactviews/pages/QueryResult/table/utils.ts
+++ b/src/reactviews/pages/QueryResult/table/utils.ts
@@ -10,6 +10,11 @@ export interface ISlickRange {
     toRow: number;
 }
 
+export interface RowRange {
+    start: number;
+    length: number;
+}
+
 export function tryCombineSelectionsForResults(
     selections: ISlickRange[],
 ): ISlickRange[] {
@@ -22,6 +27,14 @@ export function tryCombineSelectionsForResults(
             toRow: range.toRow,
         };
     });
+}
+
+export function selectionToRange(selection: ISlickRange): RowRange {
+    let range: RowRange = {
+        start: selection.fromRow,
+        length: selection.toRow - selection.fromRow + 1,
+    };
+    return range;
 }
 
 export function tryCombineSelections(selections: ISlickRange[]): ISlickRange[] {


### PR DESCRIPTION
Fixes copy behavior by using the grid's built in Data provider if the grid is sorted or filtered (isDataInMemory = true), instead of making a getRows call to STS which would return the original grid data (before filtering/sorting is applied).


Ports https://github.com/microsoft/vscode-mssql/pull/18695

Fixes https://github.com/microsoft/vscode-mssql/issues/18516
Fixes https://github.com/microsoft/vscode-mssql/issues/18620

----

This is a re-issue of https://github.com/microsoft/vscode-mssql/pull/18719 which ported to the wrong release branch.