### PR TITLE
Add flag for distinguishing STS process launched from VS Code debug panel

### DIFF
--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -557,6 +557,17 @@ export default class SqlToolsServiceClient {
                 serverArgs.push("--locale");
                 serverArgs.push(locale);
             }
+
+            /**
+             * Adds a dummy argument to sts to indicate that the server is launched
+             * from the VS Code debug panel. This helps distinguish the sts process
+             * in the process list (for .NET Core attach), especially when multiple
+             * instances of the extension are running. This is particularly useful on
+             * macOS, where the process path is not visible in the process list.
+             */
+            if (process.env[STS_OVERRIDE_ENV_VAR]) {
+                serverArgs.push("--vscode-debug-launch");
+            }
         }
 
         // run the service host using dotnet.exe from the path

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -537,6 +537,17 @@ export default class SqlToolsServiceClient {
             serverArgs.push("--application-name", serviceName);
             serverArgs.push("--data-path", getAppDataPath());
 
+            /**
+             * Adds a dummy argument to sts to indicate that the server is launched
+             * from the VS Code debug panel. This helps distinguish the sts process
+             * in the process list (for .NET Core attach), especially when multiple
+             * instances of the extension are running. This is particularly useful on
+             * macOS, where the process path is not visible in the process list.
+             */
+            if (process.env[STS_OVERRIDE_ENV_VAR]) {
+                serverArgs.push("--vscode-debug-launch");
+            }
+
             // Enable SQL Auth Provider registration for Azure MFA Authentication
             const enableSqlAuthenticationProvider =
                 getEnableSqlAuthenticationProviderConfig();
@@ -556,17 +567,6 @@ export default class SqlToolsServiceClient {
                 let locale = vscode.env.language;
                 serverArgs.push("--locale");
                 serverArgs.push(locale);
-            }
-
-            /**
-             * Adds a dummy argument to sts to indicate that the server is launched
-             * from the VS Code debug panel. This helps distinguish the sts process
-             * in the process list (for .NET Core attach), especially when multiple
-             * instances of the extension are running. This is particularly useful on
-             * macOS, where the process path is not visible in the process list.
-             */
-            if (process.env[STS_OVERRIDE_ENV_VAR]) {
-                serverArgs.push("--vscode-debug-launch");
             }
         }
 


### PR DESCRIPTION
On macOS, identifying the correct sts instance for debugging can be challenging. This adds a dummy debug flag that appears in the process list, making it easier to identify the correct instance.
Before: 
<img width="605" alt="image" src="https://github.com/user-attachments/assets/e326939f-12ec-4e86-abbb-fb42cca87a68" />
After:
<img width="615" alt="image" src="https://github.com/user-attachments/assets/48f94bf9-5336-4673-8ded-765129e4f483" />
