### PR TITLE
Adding handling for expand node failures

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -747,6 +747,7 @@
     ]
   },
   "Enable Experiences & Reload": "Enable Experiences & Reload",
+  "Error loading; refresh to try again": "Error loading; refresh to try again",
   "Connection Dialog (Preview)": "Connection Dialog (Preview)",
   "Azure Account": "Azure Account",
   "Azure Account is required": "Azure Account is required",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -506,6 +506,9 @@
     <trans-unit id="++CODE++6d89c16c7cf3f832b29fe1d181d420d4a583f93bb02e63fdfa266c33b6b3fcaf">
       <source xml:lang="en">Error loading preview</source>
     </trans-unit>
+    <trans-unit id="++CODE++2b850d590d607436d4cbf751406a7626e01d0e5c775f26c880ab4fd21e70bb66">
+      <source xml:lang="en">Error loading; refresh to try again</source>
+    </trans-unit>
     <trans-unit id="++CODE++619d1a6dc49f043552f7b8d14e6483de4a2caf1c8270d6168a642c8eccc3a752">
       <source xml:lang="en">Error occurred opening content in editor.</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -680,6 +680,12 @@ export function enableRichExperiencesPrompt(learnMoreUrl: string) {
 }
 export let enableRichExperiences = l10n.t("Enable Experiences & Reload");
 
+export class ObjectExplorer {
+    public static ErrorLoadingRefreshToTryAgain = l10n.t(
+        "Error loading; refresh to try again",
+    );
+}
+
 export class ConnectionDialog {
     public static connectionDialog = l10n.t("Connection Dialog (Preview)");
     public static azureAccount = l10n.t("Azure Account");

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -357,7 +357,11 @@ export class ObjectExplorerService {
         return undefined;
     }
 
-    private handleExpandSessionNotification(): NotificationHandler<ExpandResponse> {
+    /**
+     * Handler for async response from SQL Tools Service.
+     * Public only for testing
+     */
+    public handleExpandSessionNotification(): NotificationHandler<ExpandResponse> {
         const self = this;
         const handler = (result: ExpandResponse) => {
             if (!result) {
@@ -426,6 +430,8 @@ export class ObjectExplorerService {
                     LocalizedConstants.ObjectExplorer.ErrorLoadingRefreshToTryAgain,
                     TreeItemCollapsibleState.None,
                 );
+
+                errorNode.tooltip = result.errorMessage;
 
                 self._treeNodeToChildrenMap.set(parentNode, [errorNode]);
 


### PR DESCRIPTION
Addresses #18014

When connecting to a serverless database's master db, it connects immediately.  If the underlying serverless db is paused, then expanding the database node can time out in STS, which sends a notification to MSSQL.  Unsuccessful expansions were not being handled at all; this PR adds basic handling there.