### PR TITLE
[Port Request] Revert "remove refreshKey, which was causing multiple grid rendering ..."

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -429,6 +429,7 @@ export const QueryResultPane = () => {
 
     const renderGridPanel = () => {
         const grids = [];
+        gridRefs.current.forEach((r) => r?.refreshGrid());
         let count = 0;
         for (const batchIdStr in state?.resultSetSummaries ?? {}) {
             const batchId = parseInt(batchIdStr);

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -10,6 +10,7 @@ import {
     useEffect,
     useImperativeHandle,
     useRef,
+    useState,
 } from "react";
 import "../../media/slickgrid.css";
 import { ACTIONBAR_WIDTH_PX, range, Table } from "./table/table";
@@ -80,6 +81,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
 
         const context = useContext(QueryResultContext);
         const gridContainerRef = useRef<HTMLDivElement>(null);
+        const [refreshkey, setRefreshKey] = useState(0);
         const refreshGrid = () => {
             if (gridContainerRef.current) {
                 while (gridContainerRef.current.firstChild) {
@@ -88,6 +90,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
                     );
                 }
             }
+            setRefreshKey((prev) => prev + 1);
         };
         const resizeGrid = (width: number, height: number) => {
             let gridParent: HTMLElement | null;
@@ -312,7 +315,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>(
                     ),
                 );
             }
-        }, []);
+        }, [refreshkey]);
 
         useImperativeHandle(ref, () => ({
             refreshGrid,


### PR DESCRIPTION
PR: https://github.com/microsoft/vscode-mssql/pull/18823

The commit caused an issue with result grid resizing not working when running a query and the terminal pane is closed.

This reverts commit 604cd252f30506c1beef6d8e0ba3851613b9ae2e.

<img width="1624" alt="Screenshot 2025-02-24 at 11 23 23 AM" src="https://github.com/user-attachments/assets/ed2b43f9-098e-4d0e-9927-82c9550746b5" />


Fixes https://github.com/microsoft/vscode-mssql/issues/18836