### PR TITLE
Refactoring form controller logic to base class for reuse

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -69,7 +69,6 @@ import {
 import { IAccount } from "../models/contracts/azure";
 import {
     generateConnectionComponents,
-    getActiveFormComponents,
     groupAdvancedOptions,
 } from "./formComponentHelpers";
 import { FormWebviewController } from "../forms/formWebviewController";
@@ -1279,7 +1278,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
     private clearFormError() {
         this.state.formError = "";
-        for (const component of getActiveFormComponents(this.state).map(
+        for (const component of this.getActiveFormComponents(this.state).map(
             (x) => this.state.formComponents[x],
         )) {
             component.validation = undefined;

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -20,6 +20,7 @@ import {
     AddFirewallRuleDialogProps,
     IConnectionDialogProfile,
     TrustServerCertDialogProps,
+    ConnectionComponentsInfo,
 } from "../sharedInterfaces/connectionDialog";
 import { ConnectionCompleteParams } from "../models/contracts/connection";
 import {
@@ -51,7 +52,6 @@ import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
 import { IConnectionInfo } from "vscode-mssql";
 import MainController from "../controllers/mainController";
 import { ObjectExplorerProvider } from "../objectExplorer/objectExplorerProvider";
-import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
 import { UserSurvey } from "../nps/userSurvey";
 import VscodeWrapper from "../controllers/vscodeWrapper";
 import {
@@ -70,11 +70,12 @@ import { IAccount } from "../models/contracts/azure";
 import {
     generateConnectionComponents,
     getActiveFormComponents,
-    getFormComponent,
     groupAdvancedOptions,
 } from "./formComponentHelpers";
+import { FormWebviewController } from "../forms/formWebviewController";
 
-export class ConnectionDialogWebviewController extends ReactWebviewPanelController<
+export class ConnectionDialogWebviewController extends FormWebviewController<
+    IConnectionDialogProfile,
     ConnectionDialogWebviewState,
     ConnectionDialogReducers
 > {
@@ -176,12 +177,13 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             );
         }
 
+        this.state.formComponents = await generateConnectionComponents(
+            this._mainController.connectionManager,
+            getAccounts(this._mainController.azureAccountService),
+            this.getAzureActionButtons(),
+        );
+
         this.state.connectionComponents = {
-            components: await generateConnectionComponents(
-                this._mainController.connectionManager,
-                getAccounts(this._mainController.azureAccountService),
-                this.getAzureActionButtons(),
-            ),
             mainOptions: [...ConnectionDialogWebviewController.mainOptions],
             topAdvancedOptions: [
                 "port",
@@ -195,7 +197,10 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
         };
 
         this.state.connectionComponents.groupedAdvancedOptions =
-            groupAdvancedOptions(this.state.connectionComponents);
+            groupAdvancedOptions(
+                this.state.formComponents,
+                this.state.connectionComponents,
+            );
 
         await this.updateItemVisibility();
         this.updateState();
@@ -219,36 +224,6 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
                 return state;
             },
         );
-
-        this.registerReducer("formAction", async (state, payload) => {
-            if (payload.event.isAction) {
-                const component = getFormComponent(
-                    this.state,
-                    payload.event.propertyName,
-                );
-                if (component && component.actionButtons) {
-                    const actionButton = component.actionButtons.find(
-                        (b) => b.id === payload.event.value,
-                    );
-                    if (actionButton?.callback) {
-                        await actionButton.callback();
-                    }
-                }
-            } else {
-                (this.state.connectionProfile[
-                    payload.event.propertyName
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                ] as any) = payload.event.value;
-                await this.validateConnectionProfile(
-                    this.state.connectionProfile,
-                    payload.event.propertyName,
-                );
-                await this.handleAzureMFAEdits(payload.event.propertyName);
-            }
-            await this.updateItemVisibility();
-
-            return state;
-        });
 
         this.registerReducer("loadConnection", async (state, payload) => {
             sendActionEvent(
@@ -432,7 +407,13 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
 
     //#region Connection helpers
 
-    private async updateItemVisibility() {
+    override async afterSetFormProperty(
+        propertyName: keyof IConnectionDialogProfile,
+    ): Promise<void> {
+        return await this.handleAzureMFAEdits(propertyName);
+    }
+
+    async updateItemVisibility() {
         let hiddenProperties: (keyof IConnectionDialogProfile)[] = [];
 
         if (
@@ -466,56 +447,23 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             }
         }
 
-        for (const component of Object.values(
-            this.state.connectionComponents.components,
-        )) {
+        for (const component of Object.values(this.state.formComponents)) {
             component.hidden = hiddenProperties.includes(
                 component.propertyName,
             );
         }
     }
 
-    private async validateConnectionProfile(
-        connectionProfile: IConnectionDialogProfile,
-        propertyName?: keyof IConnectionDialogProfile,
-    ): Promise<string[]> {
-        const erroredInputs = [];
-        if (propertyName) {
-            const component = getFormComponent(this.state, propertyName);
-            if (component && component.validate) {
-                component.validation = component.validate(
-                    this.state,
-                    connectionProfile[propertyName],
-                );
-                if (!component.validation.isValid) {
-                    erroredInputs.push(component.propertyName);
-                }
-            }
-        } else {
-            getActiveFormComponents(this.state)
-                .map((x) => this.state.connectionComponents.components[x])
-                .forEach((c) => {
-                    if (c.hidden) {
-                        c.validation = {
-                            isValid: true,
-                            validationMessage: "",
-                        };
-                        return;
-                    } else {
-                        if (c.validate) {
-                            c.validation = c.validate(
-                                this.state,
-                                connectionProfile[c.propertyName],
-                            );
-                            if (!c.validation.isValid) {
-                                erroredInputs.push(c.propertyName);
-                            }
-                        }
-                    }
-                });
+    protected getActiveFormComponents(
+        state: ConnectionDialogWebviewState,
+    ): (keyof IConnectionDialogProfile)[] {
+        if (
+            state.selectedInputMode === ConnectionInputMode.Parameters ||
+            state.selectedInputMode === ConnectionInputMode.AzureBrowse
+        ) {
+            return state.connectionComponents.mainOptions;
         }
-
-        return erroredInputs;
+        return ["connectionString", "profileName"];
     }
 
     /** Returns a copy of `connection` that's been cleaned up by clearing the properties that aren't being used
@@ -526,9 +474,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
         const cleanedConnection = structuredClone(connection);
 
         // Clear values for inputs that are hidden due to form selections
-        for (const option of Object.values(
-            this.state.connectionComponents.components,
-        )) {
+        for (const option of Object.values(this.state.formComponents)) {
             if (option.hidden) {
                 (cleanedConnection[
                     option.propertyName as keyof IConnectionDialogProfile
@@ -669,7 +615,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
         // clean the connection by clearing the options that aren't being used
         const cleanedConnection = this.cleanConnection(connectionProfile);
 
-        return await this.validateConnectionProfile(cleanedConnection);
+        return await this.validateForm(cleanedConnection);
     }
 
     private async connectHelper(
@@ -969,7 +915,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             callback: async () => {
                 const account =
                     await this._mainController.azureAccountService.addAccount();
-                const accountsComponent = getFormComponent(
+                const accountsComponent = this.getFormComponent(
                     this.state,
                     "accountId",
                 );
@@ -1052,8 +998,14 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
             ) {
                 return;
             }
-            const accountComponent = getFormComponent(this.state, "accountId");
-            const tenantComponent = getFormComponent(this.state, "tenantId");
+            const accountComponent = this.getFormComponent(
+                this.state,
+                "accountId",
+            );
+            const tenantComponent = this.getFormComponent(
+                this.state,
+                "tenantId",
+            );
             let tenants: FormItemOptions[] = [];
             switch (propertyName) {
                 case "accountId":
@@ -1327,7 +1279,7 @@ export class ConnectionDialogWebviewController extends ReactWebviewPanelControll
     private clearFormError() {
         this.state.formError = "";
         for (const component of getActiveFormComponents(this.state).map(
-            (x) => this.state.connectionComponents.components[x],
+            (x) => this.state.formComponents[x],
         )) {
             component.validation = undefined;
         }

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -20,7 +20,7 @@ import {
     AddFirewallRuleDialogProps,
     IConnectionDialogProfile,
     TrustServerCertDialogProps,
-    ConnectionComponentsInfo,
+    ConnectionDialogFormItemSpec,
 } from "../sharedInterfaces/connectionDialog";
 import { ConnectionCompleteParams } from "../models/contracts/connection";
 import {
@@ -77,6 +77,7 @@ import { FormWebviewController } from "../forms/formWebviewController";
 export class ConnectionDialogWebviewController extends FormWebviewController<
     IConnectionDialogProfile,
     ConnectionDialogWebviewState,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogReducers
 > {
     //#region Properties
@@ -198,7 +199,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
         this.state.connectionComponents.groupedAdvancedOptions =
             groupAdvancedOptions(
-                this.state.formComponents,
+                this.state.formComponents as any,
                 this.state.connectionComponents,
             );
 

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -145,7 +145,11 @@ export function groupAdvancedOptions(
 
 export function convertToFormComponent(
     connOption: ConnectionOption,
-): FormItemSpec<ConnectionDialogWebviewState, IConnectionDialogProfile> {
+): FormItemSpec<
+    IConnectionDialogProfile,
+    ConnectionDialogWebviewState,
+    ConnectionDialogFormItemSpec
+> {
     switch (connOption.valueType) {
         case "boolean":
             return {

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -352,15 +352,3 @@ export async function completeFormComponents(
         };
     };
 }
-
-export function getActiveFormComponents(
-    state: ConnectionDialogWebviewState,
-): (keyof IConnectionDialogProfile)[] {
-    if (
-        state.selectedInputMode === ConnectionInputMode.Parameters ||
-        state.selectedInputMode === ConnectionInputMode.AzureBrowse
-    ) {
-        return state.connectionComponents.mainOptions;
-    }
-    return ["connectionString", "profileName"];
-}

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -100,6 +100,10 @@ export async function generateConnectionComponents(
 }
 
 export function groupAdvancedOptions(
+    components: Record<
+        keyof IConnectionDialogProfile,
+        ConnectionDialogFormItemSpec
+    >,
     componentsInfo: ConnectionComponentsInfo,
 ): ConnectionComponentGroup[] {
     const groupMap: Map<string, ConnectionComponentGroup> = new Map([
@@ -112,7 +116,7 @@ export function groupAdvancedOptions(
         ["context", undefined],
     ]);
 
-    const optionsToGroup = Object.values(componentsInfo.components).filter(
+    const optionsToGroup = Object.values(components).filter(
         (c) =>
             c.isAdvancedOption &&
             !componentsInfo.mainOptions.includes(c.propertyName) &&
@@ -355,15 +359,4 @@ export function getActiveFormComponents(
         return state.connectionComponents.mainOptions;
     }
     return ["connectionString", "profileName"];
-}
-
-export function getFormComponent(
-    state: ConnectionDialogWebviewState,
-    propertyName: keyof IConnectionDialogProfile,
-):
-    | FormItemSpec<ConnectionDialogWebviewState, IConnectionDialogProfile>
-    | undefined {
-    return getActiveFormComponents(state).includes(propertyName)
-        ? state.connectionComponents.components[propertyName]
-        : undefined;
 }

--- a/src/forms/formWebviewController.ts
+++ b/src/forms/formWebviewController.ts
@@ -70,17 +70,6 @@ export abstract class FormWebviewController<
     }
 
     /**
-     * Method called after a form value has been set and validated.
-     * Override to perform additional actions after setting a form property.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async afterSetFormProperty(propertyName: keyof TForm): Promise<void> {
-        return;
-    }
-
-    abstract updateItemVisibility(): Promise<void>;
-
-    /**
      * Runs validation across the form fields
      * @param formTarget
      * @param propertyName
@@ -131,6 +120,18 @@ export abstract class FormWebviewController<
 
         return erroredInputs;
     }
+
+    /**
+     * Method called after a form value has been set and validated.
+     * Override to perform additional actions after setting a form property.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async afterSetFormProperty(propertyName: keyof TForm): Promise<void> {
+        return;
+    }
+
+    /** Updates the `hidden` property of each form component based on the current selections */
+    abstract updateItemVisibility(): Promise<void>;
 
     /** Gets the property names of the active form components */
     protected abstract getActiveFormComponents(state: TState): (keyof TForm)[];

--- a/src/forms/formWebviewController.ts
+++ b/src/forms/formWebviewController.ts
@@ -13,7 +13,8 @@ import { MssqlWebviewPanelOptions } from "../sharedInterfaces/webview";
 
 export abstract class FormWebviewController<
     TForm,
-    TState extends FormState<TForm>,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
     TReducers extends FormReducers<TForm>,
 > extends ReactWebviewPanelController<TState, TReducers> {
     constructor(
@@ -138,7 +139,7 @@ export abstract class FormWebviewController<
     protected getFormComponent(
         state: TState,
         propertyName: keyof TForm,
-    ): FormItemSpec<TState, TForm> {
+    ): FormItemSpec<TForm, TState, TFormItemSpec> {
         return this.getActiveFormComponents(state).includes(propertyName)
             ? state.formComponents[propertyName]
             : undefined;

--- a/src/forms/formWebviewController.ts
+++ b/src/forms/formWebviewController.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
+import {
+    FormItemSpec,
+    FormReducers,
+    FormState,
+} from "../reactviews/common/forms/form";
+import { MssqlWebviewPanelOptions } from "../sharedInterfaces/webview";
+
+abstract class FormWebviewController<
+    TForm,
+    TState extends FormState<TForm>,
+    TReducers extends FormReducers<TForm>,
+> extends ReactWebviewPanelController<TState, TReducers> {
+    constructor(
+        context,
+        vscodeWrapper,
+        sourceFile: string,
+        _viewId: string,
+        initialData: TState,
+        options: MssqlWebviewPanelOptions,
+    ) {
+        super(
+            context,
+            vscodeWrapper,
+            sourceFile,
+            _viewId,
+            initialData,
+            options,
+        );
+
+        this.registerRpcHandlers();
+    }
+
+    private registerRpcHandlers() {
+        this.registerReducer("formAction", (state, payload) => {
+            // TODO
+            return state;
+        });
+    }
+
+    /**
+     * Runs validation across the form fields
+     * @param formTarget
+     * @param propertyName
+     * @returns array of fields with errors
+     */
+    protected async validateForm(
+        formTarget: TForm,
+        propertyName: keyof TForm,
+    ): Promise<string[]> {
+        const erroredInputs = [];
+        if (propertyName) {
+            const component = this.getFormComponent(this.state, propertyName);
+            if (component && component.validate) {
+                component.validation = component.validate(
+                    this.state,
+                    formTarget[propertyName] as string | boolean | number,
+                );
+                if (!component.validation.isValid) {
+                    erroredInputs.push(component.propertyName);
+                }
+            }
+        } else {
+            this.getActiveFormComponents(this.state)
+                .map((x) => this.state.connectionComponents.components[x])
+                .forEach((c) => {
+                    if (c.hidden) {
+                        c.validation = {
+                            isValid: true,
+                            validationMessage: "",
+                        };
+                        return;
+                    } else {
+                        if (c.validate) {
+                            c.validation = c.validate(
+                                this.state,
+                                formTarget[c.propertyName],
+                            );
+                            if (!c.validation.isValid) {
+                                erroredInputs.push(c.propertyName);
+                            }
+                        }
+                    }
+                });
+        }
+
+        return erroredInputs;
+    }
+
+    protected abstract getActiveFormComponents(state: TState): (keyof TForm)[];
+
+    protected abstract getFormComponent(
+        state: TState,
+        propertyName: keyof TForm,
+    ): FormItemSpec<TState, TForm>;
+}

--- a/src/reactviews/common/forms/form.component.tsx
+++ b/src/reactviews/common/forms/form.component.tsx
@@ -27,9 +27,10 @@ import {
 import { useEffect, useState } from "react";
 
 export const FormInput = <
-    TContext extends FormContextProps<TState, TForm>,
-    TState extends FormState<TForm>,
     TForm,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+    TContext extends FormContextProps<TForm, TState, TFormItemSpec>,
 >({
     context,
     value,
@@ -111,9 +112,10 @@ export const FormInput = <
 };
 
 export const FormField = <
-    TContext extends FormContextProps<TState, TForm>,
-    TState extends FormState<TForm>,
     TForm,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+    TContext extends FormContextProps<TForm, TState, TFormItemSpec>,
 >({
     context,
     component,
@@ -122,7 +124,7 @@ export const FormField = <
     componentProps,
 }: {
     context: TContext;
-    component: FormItemSpec<TState, TForm>;
+    component: TFormItemSpec;
     idx: number;
     props?: FieldProps;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -172,7 +174,11 @@ export const FormField = <
                 {...props}
                 style={{ color: tokens.colorNeutralForeground1 }}
             >
-                {generateFormComponent(context, component, componentProps)}
+                {generateFormComponent<TForm, TState, TFormItemSpec, TContext>(
+                    context,
+                    component,
+                    componentProps,
+                )}
             </Field>
             {component?.actionButtons?.length! > 0 && (
                 <div className={formStyles.formComponentActionDiv}>
@@ -203,16 +209,17 @@ export const FormField = <
 };
 
 export function generateFormComponent<
-    TContext extends FormContextProps<TState, TForm>,
-    TState extends FormState<TForm>,
     TForm,
->(context: TContext, component: FormItemSpec<TState, TForm>, props?: any) {
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+    TContext extends FormContextProps<TForm, TState, TFormItemSpec>,
+>(context: TContext, component: TFormItemSpec, props?: any) {
     const formState = context.state.formState;
 
     switch (component.type) {
         case FormItemType.Input:
             return (
-                <FormInput<TContext, TState, TForm>
+                <FormInput<TForm, TState, TFormItemSpec, TContext>
                     context={context}
                     value={(formState[component.propertyName] as string) ?? ""}
                     target={component.propertyName}
@@ -222,7 +229,7 @@ export function generateFormComponent<
             );
         case FormItemType.TextArea:
             return (
-                <FormInput<TContext, TState, TForm>
+                <FormInput<TForm, TState, TFormItemSpec, TContext>
                     context={context}
                     value={(formState[component.propertyName] as string) ?? ""}
                     target={component.propertyName}
@@ -232,7 +239,7 @@ export function generateFormComponent<
             );
         case FormItemType.Password:
             return (
-                <FormInput<TContext, TState, TForm>
+                <FormInput<TForm, TState, TFormItemSpec, TContext>
                     context={context}
                     value={(formState[component.propertyName] as string) ?? ""}
                     target={component.propertyName}

--- a/src/reactviews/common/forms/form.ts
+++ b/src/reactviews/common/forms/form.ts
@@ -5,13 +5,19 @@
 
 import { WebviewContextProps } from "../vscodeWebviewProvider";
 
-export interface FormState<T> {
-    formState: T;
+export interface FormState<TForm> {
+    formState: TForm;
 }
 
 export interface FormContextProps<TState extends FormState<TForm>, TForm>
     extends WebviewContextProps<TState> {
     formAction: (event: FormEvent<TForm>) => void;
+}
+
+export interface FormReducers<TForm> {
+    formAction: {
+        event: FormEvent<TForm>;
+    };
 }
 
 /**

--- a/src/reactviews/common/forms/form.ts
+++ b/src/reactviews/common/forms/form.ts
@@ -7,6 +7,9 @@ import { WebviewContextProps } from "../vscodeWebviewProvider";
 
 export interface FormState<TForm> {
     formState: TForm;
+    formComponents: Partial<
+        Record<keyof TForm, FormItemSpec<FormState<TForm>, TForm>>
+    >;
 }
 
 export interface FormContextProps<TState extends FormState<TForm>, TForm>

--- a/src/reactviews/common/forms/form.ts
+++ b/src/reactviews/common/forms/form.ts
@@ -5,15 +5,20 @@
 
 import { WebviewContextProps } from "../vscodeWebviewProvider";
 
-export interface FormState<TForm> {
+export interface FormState<
+    TForm,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+> {
     formState: TForm;
-    formComponents: Partial<
-        Record<keyof TForm, FormItemSpec<FormState<TForm>, TForm>>
-    >;
+    formComponents: Partial<Record<keyof TForm, TFormItemSpec>>;
 }
 
-export interface FormContextProps<TState extends FormState<TForm>, TForm>
-    extends WebviewContextProps<TState> {
+export interface FormContextProps<
+    TForm,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+> extends WebviewContextProps<TState> {
     formAction: (event: FormEvent<TForm>) => void;
 }
 
@@ -26,7 +31,11 @@ export interface FormReducers<TForm> {
 /**
  * Describes a field in a connection dialog form.
  */
-export interface FormItemSpec<TState extends FormState<TForm>, TForm> {
+export interface FormItemSpec<
+    TForm,
+    TState extends FormState<TForm, TState, TFormItemSpec>,
+    TFormItemSpec extends FormItemSpec<TForm, TState, TFormItemSpec>,
+> {
     /**
      * The type of the form item
      */

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -342,7 +342,7 @@ export const AzureBrowsePage = () => {
                     <FormField
                         context={context}
                         component={
-                            context.state.connectionComponents.components[
+                            context.state.formComponents[
                                 "trustServerCertificate"
                             ] as FormItemSpec<
                                 ConnectionDialogWebviewState,
@@ -383,7 +383,7 @@ export const AzureBrowsePage = () => {
                         )
                         .map((inputName, idx) => {
                             const component =
-                                context.state.connectionComponents.components[
+                                context.state.formComponents[
                                     inputName as keyof IConnectionDialogProfile
                                 ];
                             if (component?.hidden !== false) {

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -9,8 +9,9 @@ import { ConnectButton } from "./components/connectButton.component";
 import { Button, Spinner } from "@fluentui/react-components";
 import { Filter16Filled } from "@fluentui/react-icons";
 import { FormField, useFormStyles } from "../../common/forms/form.component";
-import { FormItemSpec } from "../../common/forms/form";
 import {
+    ConnectionDialogContextProps,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
 } from "../../../sharedInterfaces/connectionDialog";
@@ -339,15 +340,17 @@ export const AzureBrowsePage = () => {
 
             {selectedServer && (
                 <>
-                    <FormField
+                    <FormField<
+                        IConnectionDialogProfile,
+                        ConnectionDialogWebviewState,
+                        ConnectionDialogFormItemSpec,
+                        ConnectionDialogContextProps
+                    >
                         context={context}
                         component={
                             context.state.formComponents[
                                 "trustServerCertificate"
-                            ] as FormItemSpec<
-                                ConnectionDialogWebviewState,
-                                IConnectionDialogProfile
-                            >
+                            ]!
                         }
                         idx={0}
                         props={{ orientation: "horizontal" }}
@@ -391,15 +394,15 @@ export const AzureBrowsePage = () => {
                             }
 
                             return (
-                                <FormField
+                                <FormField<
+                                    IConnectionDialogProfile,
+                                    ConnectionDialogWebviewState,
+                                    ConnectionDialogFormItemSpec,
+                                    ConnectionDialogContextProps
+                                >
                                     key={idx}
                                     context={context}
-                                    component={
-                                        component as FormItemSpec<
-                                            ConnectionDialogWebviewState,
-                                            IConnectionDialogProfile
-                                        >
-                                    }
+                                    component={component}
                                     idx={idx}
                                     props={{ orientation: "horizontal" }}
                                 />

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -70,8 +70,7 @@ export const AdvancedOptionsDrawer = ({
                                     key={idx}
                                     context={context}
                                     component={
-                                        context.state.connectionComponents
-                                            .components[
+                                        context.state.formComponents[
                                             optionName
                                         ] as FormItemSpec<
                                             ConnectionDialogWebviewState,
@@ -100,9 +99,9 @@ export const AdvancedOptionsDrawer = ({
                                             (optionName, idx) => {
                                                 if (
                                                     context.state
-                                                        .connectionComponents
-                                                        .components[optionName]
-                                                        ?.hidden === true
+                                                        .formComponents[
+                                                        optionName
+                                                    ]?.hidden === true
                                                 ) {
                                                     return undefined;
                                                 }
@@ -112,8 +111,7 @@ export const AdvancedOptionsDrawer = ({
                                                         context={context}
                                                         component={
                                                             context.state
-                                                                .connectionComponents
-                                                                .components[
+                                                                .formComponents[
                                                                 optionName
                                                             ] as FormItemSpec<
                                                                 ConnectionDialogWebviewState,

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -20,8 +20,9 @@ import { locConstants } from "../../../common/locConstants";
 import { useContext } from "react";
 import { FormField } from "../../../common/forms/form.component";
 import { ConnectionDialogContext } from "../connectionDialogStateProvider";
-import { FormItemSpec } from "../../../common/forms/form";
 import {
+    ConnectionDialogContextProps,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
 } from "../../../../sharedInterfaces/connectionDialog";
@@ -66,16 +67,18 @@ export const AdvancedOptionsDrawer = ({
                     {context.state.connectionComponents.topAdvancedOptions.map(
                         (optionName, idx) => {
                             return (
-                                <FormField
+                                <FormField<
+                                    IConnectionDialogProfile,
+                                    ConnectionDialogWebviewState,
+                                    ConnectionDialogFormItemSpec,
+                                    ConnectionDialogContextProps
+                                >
                                     key={idx}
                                     context={context}
                                     component={
                                         context.state.formComponents[
                                             optionName
-                                        ] as FormItemSpec<
-                                            ConnectionDialogWebviewState,
-                                            IConnectionDialogProfile
-                                        >
+                                        ]!
                                     }
                                     idx={idx}
                                 />
@@ -106,17 +109,19 @@ export const AdvancedOptionsDrawer = ({
                                                     return undefined;
                                                 }
                                                 return (
-                                                    <FormField
+                                                    <FormField<
+                                                        IConnectionDialogProfile,
+                                                        ConnectionDialogWebviewState,
+                                                        ConnectionDialogFormItemSpec,
+                                                        ConnectionDialogContextProps
+                                                    >
                                                         key={idx}
                                                         context={context}
                                                         component={
                                                             context.state
                                                                 .formComponents[
                                                                 optionName
-                                                            ] as FormItemSpec<
-                                                                ConnectionDialogWebviewState,
-                                                                IConnectionDialogProfile
-                                                            >
+                                                            ]!
                                                         }
                                                         idx={idx}
                                                     />

--- a/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
@@ -7,8 +7,9 @@ import { useContext, useState } from "react";
 import { Button } from "@fluentui/react-components";
 import { ConnectionDialogContext } from "./connectionDialogStateProvider";
 import { FormField, useFormStyles } from "../../common/forms/form.component";
-import { FormItemSpec } from "../../common/forms/form";
 import {
+    ConnectionDialogContextProps,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
 } from "../../../sharedInterfaces/connectionDialog";
@@ -38,15 +39,15 @@ export const ConnectionFormPage = () => {
                     }
 
                     return (
-                        <FormField
+                        <FormField<
+                            IConnectionDialogProfile,
+                            ConnectionDialogWebviewState,
+                            ConnectionDialogFormItemSpec,
+                            ConnectionDialogContextProps
+                        >
                             key={idx}
                             context={context}
-                            component={
-                                component as FormItemSpec<
-                                    ConnectionDialogWebviewState,
-                                    IConnectionDialogProfile
-                                >
-                            }
+                            component={component}
                             idx={idx}
                             props={{ orientation: "horizontal" }}
                         />

--- a/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionFormPage.tsx
@@ -30,7 +30,7 @@ export const ConnectionFormPage = () => {
             {context.state.connectionComponents.mainOptions.map(
                 (inputName, idx) => {
                     const component =
-                        context.state.connectionComponents.components[
+                        context.state.formComponents[
                             inputName as keyof IConnectionDialogProfile
                         ];
                     if (component?.hidden !== false) {

--- a/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
@@ -99,7 +99,7 @@ export const ConnectionInfoFormContainer = () => {
                 <FormField
                     context={context}
                     component={
-                        context.state.connectionComponents.components[
+                        context.state.formComponents[
                             "profileName"
                         ] as FormItemSpec<
                             ConnectionDialogWebviewState,

--- a/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
@@ -8,6 +8,7 @@ import "./sqlServerRotation.css";
 import {
     AddFirewallRuleDialogProps,
     ConnectionDialogContextProps,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
     ConnectionInputMode,
     IConnectionDialogProfile,
@@ -30,7 +31,6 @@ import { ConnectionDialogContext } from "./connectionDialogStateProvider";
 import { ConnectionFormPage } from "./connectionFormPage";
 import { ConnectionHeader } from "./components/connectionHeader.component";
 import { ConnectionStringPage } from "./connectionStringPage";
-import { FormItemSpec } from "../../common/forms/form";
 import { TrustServerCertificateDialog } from "./components/trustServerCertificateDialog.component";
 import { locConstants } from "../../common/locConstants";
 import { themeType } from "../../common/utils";
@@ -96,15 +96,17 @@ export const ConnectionInfoFormContainer = () => {
                     />
                 )}
 
-                <FormField
+                <FormField<
+                    IConnectionDialogProfile,
+                    ConnectionDialogWebviewState,
+                    ConnectionDialogFormItemSpec,
+                    ConnectionDialogContextProps
+                >
                     context={context}
                     component={
                         context.state.formComponents[
                             "profileName"
-                        ] as FormItemSpec<
-                            ConnectionDialogWebviewState,
-                            IConnectionDialogProfile
-                        >
+                        ] as ConnectionDialogFormItemSpec
                     }
                     idx={0}
                     props={{ orientation: "horizontal" }}

--- a/src/reactviews/pages/ConnectionDialog/connectionStringPage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionStringPage.tsx
@@ -29,8 +29,9 @@ export const ConnectionStringPage = () => {
                 key={index++}
                 context={connectionDialogContext}
                 component={
-                    connectionDialogContext.state.connectionComponents
-                        .components["connectionString"] as FormItemSpec<
+                    connectionDialogContext.state.formComponents[
+                        "connectionString"
+                    ] as FormItemSpec<
                         ConnectionDialogWebviewState,
                         IConnectionDialogProfile
                     >

--- a/src/reactviews/pages/ConnectionDialog/connectionStringPage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionStringPage.tsx
@@ -6,13 +6,14 @@
 import { useContext } from "react";
 import { ConnectionDialogContext } from "./connectionDialogStateProvider";
 import { FormField, useFormStyles } from "../../common/forms/form.component";
+import { ConnectButton } from "./components/connectButton.component";
+import { TextareaProps } from "@fluentui/react-components";
 import {
+    ConnectionDialogContextProps,
+    ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
 } from "../../../sharedInterfaces/connectionDialog";
-import { FormItemSpec } from "../../common/forms/form";
-import { ConnectButton } from "./components/connectButton.component";
-import { TextareaProps } from "@fluentui/react-components";
 
 export const ConnectionStringPage = () => {
     const connectionDialogContext = useContext(ConnectionDialogContext);
@@ -25,16 +26,18 @@ export const ConnectionStringPage = () => {
     let index = 0;
     return (
         <div>
-            <FormField
+            <FormField<
+                IConnectionDialogProfile,
+                ConnectionDialogWebviewState,
+                ConnectionDialogFormItemSpec,
+                ConnectionDialogContextProps
+            >
                 key={index++}
                 context={connectionDialogContext}
                 component={
                     connectionDialogContext.state.formComponents[
                         "connectionString"
-                    ] as FormItemSpec<
-                        ConnectionDialogWebviewState,
-                        IConnectionDialogProfile
-                    >
+                    ]!
                 }
                 idx={index}
                 props={{ orientation: "horizontal" }}

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -13,7 +13,12 @@ import {
 import { ApiStatus } from "./webview";
 
 export class ConnectionDialogWebviewState
-    implements FormState<IConnectionDialogProfile>
+    implements
+        FormState<
+            IConnectionDialogProfile,
+            ConnectionDialogWebviewState,
+            ConnectionDialogFormItemSpec
+        >
 {
     /** the underlying connection profile for the form target; same as `connectionProfile` */
     formState: IConnectionDialogProfile = {} as IConnectionDialogProfile;
@@ -25,18 +30,8 @@ export class ConnectionDialogWebviewState
         this.formState = value;
     }
 
-    // formComponents: Partial<
-    //     Record<keyof IConnectionDialogProfile, ConnectionDialogFormItemSpec>
-    // > = {};
-
     formComponents: Partial<
-        Record<
-            keyof IConnectionDialogProfile,
-            FormItemSpec<
-                FormState<IConnectionDialogProfile>,
-                IConnectionDialogProfile
-            >
-        >
+        Record<keyof IConnectionDialogProfile, ConnectionDialogFormItemSpec>
     > = {};
 
     public selectedInputMode: ConnectionInputMode =
@@ -110,8 +105,9 @@ export interface ConnectionComponentGroup {
 
 export interface ConnectionDialogFormItemSpec
     extends FormItemSpec<
+        IConnectionDialogProfile,
         ConnectionDialogWebviewState,
-        IConnectionDialogProfile
+        ConnectionDialogFormItemSpec
     > {
     isAdvancedOption: boolean;
     optionCategory?: string;
@@ -137,8 +133,9 @@ export interface IConnectionDialogProfile extends vscodeMssql.IConnectionInfo {
 
 export interface ConnectionDialogContextProps
     extends FormContextProps<
+        IConnectionDialogProfile,
         ConnectionDialogWebviewState,
-        IConnectionDialogProfile
+        ConnectionDialogFormItemSpec
     > {
     loadConnection: (connection: IConnectionDialogProfile) => void;
     setConnectionInputType: (inputType: ConnectionInputMode) => void;

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -7,7 +7,6 @@ import * as vscodeMssql from "vscode-mssql";
 import {
     FormItemSpec,
     FormContextProps,
-    FormEvent,
     FormState,
     FormReducers,
 } from "../reactviews/common/forms/form";
@@ -25,11 +24,24 @@ export class ConnectionDialogWebviewState
     set connectionProfile(value: IConnectionDialogProfile) {
         this.formState = value;
     }
+
+    // formComponents: Partial<
+    //     Record<keyof IConnectionDialogProfile, ConnectionDialogFormItemSpec>
+    // > = {};
+
+    formComponents: Partial<
+        Record<
+            keyof IConnectionDialogProfile,
+            FormItemSpec<
+                FormState<IConnectionDialogProfile>,
+                IConnectionDialogProfile
+            >
+        >
+    > = {};
+
     public selectedInputMode: ConnectionInputMode =
         ConnectionInputMode.Parameters;
     public connectionComponents: ConnectionComponentsInfo = {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        components: {} as any, // force empty record for intial blank state
         mainOptions: [],
         topAdvancedOptions: [],
         groupedAdvancedOptions: [],
@@ -86,9 +98,6 @@ export interface AzureSqlServerInfo {
 }
 
 export interface ConnectionComponentsInfo {
-    components: Partial<
-        Record<keyof IConnectionDialogProfile, ConnectionDialogFormItemSpec>
-    >;
     mainOptions: (keyof IConnectionDialogProfile)[];
     topAdvancedOptions: (keyof IConnectionDialogProfile)[];
     groupedAdvancedOptions: ConnectionComponentGroup[];

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -9,6 +9,7 @@ import {
     FormContextProps,
     FormEvent,
     FormState,
+    FormReducers,
 } from "../reactviews/common/forms/form";
 import { ApiStatus } from "./webview";
 
@@ -152,12 +153,10 @@ export enum AuthenticationType {
     AzureMFA = "AzureMFA",
 }
 
-export interface ConnectionDialogReducers {
+export interface ConnectionDialogReducers
+    extends FormReducers<IConnectionDialogProfile> {
     setConnectionInputType: {
         inputMode: ConnectionInputMode;
-    };
-    formAction: {
-        event: FormEvent<IConnectionDialogProfile>;
     };
     loadConnection: {
         connection: IConnectionDialogProfile;


### PR DESCRIPTION
Moving some of the sharable logic for forms to a base class.  Other form UIs (like container deployment) should be able to reuse the `formAction` reducer, validation, and error reporting now.