### PR TITLE
Preserve sort state when context switching

### DIFF
--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -150,7 +150,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
                 column.filterValues?.length > 0,
             );
         }
-        //TODO: need to set reset data too
         if (column.sorted) {
             this.setSortButtonImage($sortButton, column);
         }

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -63,7 +63,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
         string,
         HTMLElement
     >();
-    private columnSortButtonMapping: Map<string, SortProperties> = new Map<
+    private columnSortStateMapping: Map<string, SortProperties> = new Map<
         string,
         SortProperties
     >();
@@ -152,6 +152,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
         }
         if (column.sorted) {
             this.setSortButtonImage($sortButton, column);
+            this.columnSortStateMapping.set(column.id!, column.sorted);
         }
 
         const filterButton = $filterButton.get(0);
@@ -182,9 +183,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                         filterValues: this.columnDef.filterValues!,
                         sorted: this.columnDef.sorted ?? SortProperties.NONE,
                     };
-                    let sortState = this.columnSortButtonMapping.get(
-                        column.id!,
-                    );
+                    let sortState = this.columnSortStateMapping.get(column.id!);
 
                     switch (sortState) {
                         case SortProperties.NONE:
@@ -204,7 +203,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                                 $prevSortButton.addClass(
                                     "slick-header-sort-button",
                                 );
-                                this.columnSortButtonMapping.set(
+                                this.columnSortStateMapping.set(
                                     this.currentSortColumn,
                                     SortProperties.NONE,
                                 );
@@ -222,7 +221,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                             $sortButton.removeClass("slick-header-sort-button");
                             $sortButton.addClass("slick-header-sortasc-button");
                             await this.handleMenuItemClick("sort-asc", column);
-                            this.columnSortButtonMapping.set(
+                            this.columnSortStateMapping.set(
                                 column.id!,
                                 SortProperties.ASC,
                             );
@@ -238,7 +237,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                                 "slick-header-sortdesc-button",
                             );
                             await this.handleMenuItemClick("sort-desc", column);
-                            this.columnSortButtonMapping.set(
+                            this.columnSortStateMapping.set(
                                 column.id!,
                                 SortProperties.DESC,
                             );
@@ -249,7 +248,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                                 "slick-header-sortdesc-button",
                             );
                             $sortButton.addClass("slick-header-sort-button");
-                            this.columnSortButtonMapping.set(
+                            this.columnSortStateMapping.set(
                                 column.id!,
                                 SortProperties.NONE,
                             );
@@ -275,8 +274,8 @@ export class HeaderFilter<T extends Slick.SlickData> {
         $filterButton.appendTo(args.node);
 
         this.columnFilterButtonMapping.set(column.id!, filterButton);
-        if (this.columnSortButtonMapping.get(column.id!) === undefined) {
-            this.columnSortButtonMapping.set(column.id!, SortProperties.NONE);
+        if (this.columnSortStateMapping.get(column.id!) === undefined) {
+            this.columnSortStateMapping.set(column.id!, SortProperties.NONE);
         }
     }
 
@@ -907,7 +906,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
                     $sortButton.addClass("slick-header-sortdesc-button");
                     break;
             }
-            this.columnSortButtonMapping.set(column.id!, column.sorted);
         }
     }
 }

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -145,7 +145,14 @@ export class HeaderFilter<T extends Slick.SlickData> {
             .addClass("slick-header-sort-button")
             .data("column", column);
         if (column.filterValues?.length) {
-            this.setButtonImage($filterButton, column.filterValues?.length > 0);
+            this.setFilterButtonImage(
+                $filterButton,
+                column.filterValues?.length > 0,
+            );
+        }
+        //TODO: need to set reset data too
+        if (column.sorted) {
+            this.setSortButtonImage($sortButton, column);
         }
 
         const filterButton = $filterButton.get(0);
@@ -256,12 +263,11 @@ export class HeaderFilter<T extends Slick.SlickData> {
                             this.currentSortColumn = "";
                             break;
                     }
-                    this.grid.onHeaderClick.notify();
-
                     await this.updateState(
                         columnFilterState,
                         this.columnDef.id!,
                     );
+                    this.grid.onHeaderClick.notify();
                 },
             );
         }
@@ -270,7 +276,9 @@ export class HeaderFilter<T extends Slick.SlickData> {
         $filterButton.appendTo(args.node);
 
         this.columnFilterButtonMapping.set(column.id!, filterButton);
-        this.columnSortButtonMapping.set(column.id!, SortProperties.NONE);
+        if (this.columnSortButtonMapping.get(column.id!) === undefined) {
+            this.columnSortButtonMapping.set(column.id!, SortProperties.NONE);
+        }
     }
 
     private async showFilter(filterButton: HTMLElement) {
@@ -441,7 +449,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                     return;
                 }
                 if (this.columnDef.filterValues) {
-                    this.setButtonImage(
+                    this.setFilterButtonImage(
                         $menuButton,
                         this.columnDef.filterValues.length > 0,
                     );
@@ -461,7 +469,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
                 if (!$menuButton) {
                     return;
                 }
-                this.setButtonImage($menuButton, false);
+                this.setFilterButtonImage($menuButton, false);
                 await this.handleApply(this.columnDef, true);
             },
         );
@@ -867,7 +875,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
         }
     }
 
-    private setButtonImage($el: JQuery<HTMLElement>, filtered: boolean) {
+    private setFilterButtonImage($el: JQuery<HTMLElement>, filtered: boolean) {
         const element: HTMLElement | undefined = $el.get(0);
         if (element) {
             if (filtered) {
@@ -878,6 +886,29 @@ export class HeaderFilter<T extends Slick.SlickData> {
                     classList.remove("filtered");
                 }
             }
+        }
+    }
+
+    private setSortButtonImage(
+        $sortButton: JQuery<HTMLElement>,
+        column: FilterableColumn<T>,
+    ) {
+        if (
+            $sortButton &&
+            column.sorted &&
+            column.sorted !== SortProperties.NONE
+        ) {
+            switch (column.sorted) {
+                case SortProperties.ASC:
+                    $sortButton.removeClass("slick-header-sort-button");
+                    $sortButton.addClass("slick-header-sortasc-button");
+                    break;
+                case SortProperties.DESC:
+                    $sortButton.removeClass("slick-header-sort-button");
+                    $sortButton.addClass("slick-header-sortdesc-button");
+                    break;
+            }
+            this.columnSortButtonMapping.set(column.id!, column.sorted);
         }
     }
 }

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -273,8 +273,6 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             };
             await this._data.sort(sortArgs);
         }
-        //TODO: need to set sort button image to indicate sort is applied
-
         return true;
     }
 


### PR DESCRIPTION
Before: 
Switching to another context (e.g. to the Messages tab) and coming back will reset the sort state for the results grid.

After:
Sort state is preserved even when switching between contexts.

![sortStateFinal](https://github.com/user-attachments/assets/762ac826-bf53-4ab2-9c29-5575fa127e48)


Fixes https://github.com/microsoft/vscode-mssql/issues/18725