### PR TITLE
Rename getDefaultOptions to schemaCompareGetDefaultOptions

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2005,7 +2005,8 @@ export default class MainController implements vscode.Disposable {
     }
 
     public async onSchemaCompare(node: any): Promise<void> {
-        const result = await this.schemaCompareService.getDefaultOptions();
+        const result =
+            await this.schemaCompareService.schemaCompareGetDefaultOptions();
         const schemaCompareWebView = new SchemaCompareWebViewController(
             this._context,
             this._vscodeWrapper,

--- a/src/schemaCompare/schemaCompareUtils.ts
+++ b/src/schemaCompare/schemaCompareUtils.ts
@@ -118,7 +118,7 @@ export async function publishProjectChanges(
 export async function getDefaultOptions(
     schemaCompareService: mssql.ISchemaCompareService,
 ): Promise<mssql.SchemaCompareOptionsResult> {
-    const result = await schemaCompareService.getDefaultOptions();
+    const result = await schemaCompareService.schemaCompareGetDefaultOptions();
 
     return result;
 }

--- a/src/services/schemaCompareService.ts
+++ b/src/services/schemaCompareService.ts
@@ -90,7 +90,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
         );
     }
 
-    public getDefaultOptions(): Thenable<mssql.SchemaCompareOptionsResult> {
+    public schemaCompareGetDefaultOptions(): Thenable<mssql.SchemaCompareOptionsResult> {
         const params: mssql.SchemaCompareGetOptionsParams = {};
 
         return this._client.sendRequest(

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -449,7 +449,7 @@ declare module 'vscode-mssql' {
 		generateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: TaskExecutionMode): Thenable<ResultStatus>;
 		publishDatabaseChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: TaskExecutionMode): Thenable<ResultStatus>;
 		publishProjectChanges(operationId: string, targetProjectPath: string, targetFolderStructure: ExtractTarget, taskExecutionMode: TaskExecutionMode): Thenable<SchemaComparePublishProjectResult>;
-		getDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
+		schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
 		includeExcludeNode(operationId: string, diffEntry: DiffEntry, includeRequest: boolean, taskExecutionMode: TaskExecutionMode): Thenable<SchemaCompareIncludeExcludeResult>;
 		openScmp(filePath: string): Thenable<SchemaCompareOpenScmpResult>;
 		saveScmp(sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: TaskExecutionMode, deploymentOptions: DeploymentOptions, scmpFilePath: string, excludedSourceObjects: SchemaCompareObjectId[], excludedTargetObjects: SchemaCompareObjectId[]): Thenable<ResultStatus>;

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -444,6 +444,12 @@ declare module 'vscode-mssql' {
 		schemaObjectType = 5
 	}
 
+	/**
+     * WARNING: The methods in this interface may be used by the SQL Projects extension.
+     * 1. Be sure to check the current usage of these methods in the SQL Projects extension.
+     * 2. Test against the current version of the SQL Projects extension by creating a vsix of
+     * 	this extension and installing it alongside he SQL Projects extension.
+     */
 	export interface ISchemaCompareService {
 		compare(operationId: string, sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: TaskExecutionMode, deploymentOptions: DeploymentOptions): Thenable<SchemaCompareResult>;
 		generateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: TaskExecutionMode): Thenable<ResultStatus>;

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -445,11 +445,11 @@ declare module 'vscode-mssql' {
 	}
 
 	/**
-     * WARNING: The methods in this interface may be used by the SQL Projects extension.
-     * 1. Be sure to check the current usage of these methods in the SQL Projects extension.
-     * 2. Test against the current version of the SQL Projects extension by creating a vsix of
-     * 	this extension and installing it alongside he SQL Projects extension.
-     */
+	 * WARNING: The methods in this interface may be used by the SQL Projects extension.
+	 * 1. Be sure to check the current usage of these methods in the SQL Projects extension.
+	 * 2. Test against the current version of the SQL Projects extension by creating a vsix of
+	 * 	this extension and installing it alongside he SQL Projects extension.
+	 */
 	export interface ISchemaCompareService {
 		compare(operationId: string, sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: TaskExecutionMode, deploymentOptions: DeploymentOptions): Thenable<SchemaCompareResult>;
 		generateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: TaskExecutionMode): Thenable<ResultStatus>;


### PR DESCRIPTION
This PR is to address this issue: https://github.com/microsoft/azuredatastudio/issues/26217

The SQL Projects extension is expecting to find a method named schemaCompareGetDefaultOptions, but because the method was renamed it is not able to find it.