### PR TITLE
Enable select all keyboard shortcut in query result grid

### DIFF
--- a/src/reactviews/pages/QueryResult/keys.ts
+++ b/src/reactviews/pages/QueryResult/keys.ts
@@ -9,4 +9,5 @@ export enum Keys {
     Enter = "Enter",
     Space = " ",
     c = "c",
+    a = "a",
 }

--- a/src/reactviews/pages/QueryResult/queryResultPage.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPage.tsx
@@ -94,6 +94,8 @@ export const QueryResult = () => {
     const classes = useStyles();
     const context = useContext(QueryResultContext);
     const state = context?.state;
+
+    // This is needed to stop the browser from selecting all the raw text in the webview when ctrl+a is pressed
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent): void => {
             if (e.ctrlKey && e.key === Keys.a) {

--- a/src/reactviews/pages/QueryResult/queryResultPage.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPage.tsx
@@ -8,8 +8,6 @@ import { useContext, useEffect } from "react";
 import { QueryResultContext } from "./queryResultStateProvider";
 import { QueryResultPane } from "./queryResultPane";
 import { Keys } from "./keys";
-import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
-import * as qr from "../../../sharedInterfaces/queryResult";
 
 const useStyles = makeStyles({
     root: {
@@ -94,17 +92,13 @@ const useStyles = makeStyles({
 export const QueryResult = () => {
     const classes = useStyles();
     const context = useContext(QueryResultContext);
-    const webViewState = useVscodeWebview<
-        qr.QueryResultWebviewState,
-        qr.QueryResultReducers
-    >();
     const state = context?.state;
 
     // This is needed to stop the browser from selecting all the raw text in the webview when ctrl+a is pressed
     useEffect(() => {
         const handleKeyDown = async (e: KeyboardEvent): Promise<void> => {
-            let platform = await webViewState.extensionRpc.call("getPlatform");
-            if (platform === "darwin") {
+            const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+            if (isMac) {
                 // Cmd + A
                 if (e.metaKey && e.key === Keys.a) {
                     e.preventDefault();
@@ -117,7 +111,9 @@ export const QueryResult = () => {
                 }
             }
         };
-        document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("keydown", async (e) => {
+            await handleKeyDown(e);
+        });
         return function cleanup() {
             document.removeEventListener("keydown", handleKeyDown);
         };

--- a/src/reactviews/pages/QueryResult/queryResultPage.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPage.tsx
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { makeStyles, shorthands } from "@fluentui/react-components";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { QueryResultContext } from "./queryResultStateProvider";
 // import { ResizableBox } from "react-resizable";
 import { QueryResultPane } from "./queryResultPane";
+import { Keys } from "./keys";
 
 const useStyles = makeStyles({
     root: {
@@ -93,6 +94,18 @@ export const QueryResult = () => {
     const classes = useStyles();
     const context = useContext(QueryResultContext);
     const state = context?.state;
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.ctrlKey && e.key === Keys.a) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return function cleanup() {
+            document.removeEventListener("keydown", handleKeyDown);
+        };
+    }, []);
     if (!state) {
         return null;
     }

--- a/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
@@ -18,6 +18,7 @@ import { VscodeWebviewContext } from "../../../../common/vscodeWebviewProvider";
 import { isUndefinedOrNull } from "../tableDataView";
 import { mixin } from "../objects";
 import { tokens } from "@fluentui/react-components";
+import { Keys } from "../../keys";
 
 export interface ICellSelectionModelOptions {
     cellRangeSelector?: any;
@@ -72,7 +73,9 @@ export class CellSelectionModel<T extends Slick.SlickData>
 
     public init(grid: Slick.Grid<T>) {
         this.grid = grid;
-        // this._handler.subscribe(this.grid.onKeyDown, (e: Slick.DOMEvent) => this.handleKeyDown(convertJQueryKeyDownEvent(e)));
+        this._handler.subscribe(this.grid.onKeyDown, (e: Slick.DOMEvent) =>
+            this.handleKeyDown(e as unknown as KeyboardEvent),
+        );
         this._handler.subscribe(
             this.grid.onAfterKeyboardNavigation,
             (_e: Event) => this.handleAfterKeyboardNavigationEvent(),
@@ -459,6 +462,49 @@ export class CellSelectionModel<T extends Slick.SlickData>
             ? { cell: 1, row: args.row }
             : { cell: args.cell, row: args.row };
         this.grid.setActiveCell(newActiveCell.row, newActiveCell.cell);
+    }
+
+    public async handleSelectAll() {
+        let ranges: Slick.Range[];
+        let startColumn = 0;
+        // check for number column
+        if (
+            !isUndefinedOrNull(this.grid.getColumns()[0].selectable) &&
+            !this.grid.getColumns()[0].selectable
+        ) {
+            startColumn = 1;
+        }
+        ranges = [
+            new Slick.Range(
+                0,
+                startColumn,
+                this.grid.getDataLength() - 1,
+                this.grid.getColumns().length - 1,
+            ),
+        ];
+        this.setSelectedRanges(ranges);
+    }
+
+    private async handleKeyDown(e: KeyboardEvent): Promise<void> {
+        let handled = false;
+        let platform = await this.webViewState.extensionRpc.call("getPlatform");
+        if (platform === "darwin") {
+            // Cmd + C
+            if (e.metaKey && e.key === Keys.a) {
+                handled = true;
+                await this.handleSelectAll();
+            }
+        } else {
+            if (e.ctrlKey && e.key === Keys.a) {
+                handled = true;
+                await this.handleSelectAll();
+            }
+        }
+
+        if (handled) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
     }
 
     // private handleKeyDown(e: StandardKeyboardEvent) {

--- a/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
@@ -489,7 +489,7 @@ export class CellSelectionModel<T extends Slick.SlickData>
         let handled = false;
         let platform = await this.webViewState.extensionRpc.call("getPlatform");
         if (platform === "darwin") {
-            // Cmd + C
+            // Cmd + A
             if (e.metaKey && e.key === Keys.a) {
                 handled = true;
                 await this.handleSelectAll();


### PR DESCRIPTION
Adds Ctrl + A functionality in the query results grid to select all cells.

Fixes https://github.com/microsoft/vscode-mssql/issues/18860