### PR TITLE
Making NPS feedback non-blocking

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -712,7 +712,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 expand: true,
             });
             await this.panel.dispose();
-            await UserSurvey.getInstance().promptUserForNPSFeedback();
+            UserSurvey.getInstance().promptUserForNPSFeedback();
         } catch (error) {
             this.state.connectionStatus = ApiStatus.Error;
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1093,7 +1093,7 @@ export default class MainController implements vscode.Disposable {
                 Constants.cmdScriptSelect,
                 async (node: TreeNodeInfo) => {
                     await this.scriptNode(node, ScriptOperation.Select, true);
-                    await UserSurvey.getInstance().promptUserForNPSFeedback();
+                    UserSurvey.getInstance().promptUserForNPSFeedback();
                 },
             ),
         );

--- a/src/nps/userSurvey.ts
+++ b/src/nps/userSurvey.ts
@@ -47,7 +47,11 @@ export class UserSurvey {
     }
 
     /** checks user eligibility for NPS survey and, if eligible, displays the survey and submits feedback */
-    public async promptUserForNPSFeedback(): Promise<void> {
+    public promptUserForNPSFeedback(): void {
+        void (async () => this.promptUserForNPSFeedbackAsync)();
+    }
+
+    private async promptUserForNPSFeedbackAsync(): Promise<void> {
         const globalState = this._context.globalState;
         const sessionCount = globalState.get(SESSION_COUNT_KEY, 0) + 1;
         const extensionVersion =

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -293,7 +293,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                 };
                 this.panel.title = state.tableInfo.title;
                 this.showRestorePromptAfterClose = false;
-                await UserSurvey.getInstance().promptUserForNPSFeedback();
+                UserSurvey.getInstance().promptUserForNPSFeedback();
             } catch (e) {
                 state = {
                     ...state,
@@ -348,7 +348,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                 },
             };
             await this._untitledSqlDocumentService.newQuery(script);
-            await UserSurvey.getInstance().promptUserForNPSFeedback();
+            UserSurvey.getInstance().promptUserForNPSFeedback();
             return state;
         });
 

--- a/test/unit/userSurvey.test.ts
+++ b/test/unit/userSurvey.test.ts
@@ -59,8 +59,8 @@ suite("UserSurvey Tests", () => {
 
     test("should not prompt the user if they opted out of the survey", async () => {
         globalState.get.withArgs("nps/never", false).returns(true);
-        const instance = UserSurvey.getInstance();
-        await instance.promptUserForNPSFeedback();
+        const userSurvey = UserSurvey.getInstance();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
         assert.strictEqual(
             (globalState.get as sinon.SinonStub).calledWith("nps/never", false),
             true,
@@ -84,8 +84,8 @@ suite("UserSurvey Tests", () => {
             },
         } as any);
         globalState.get.withArgs("nps/skipVersion", "").returns("someVersion");
-        const instance = UserSurvey.getInstance();
-        await instance.promptUserForNPSFeedback();
+        const userSurvey = UserSurvey.getInstance();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
         assert.strictEqual(
             showInformationMessageStub.called,
             false,
@@ -105,7 +105,7 @@ suite("UserSurvey Tests", () => {
             run: sandbox.stub(),
         });
         const userSurvey = UserSurvey.getInstance();
-        await userSurvey.promptUserForNPSFeedback();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
         assert.strictEqual(
             showInformationMessageStub.calledOnce,
             true,
@@ -146,7 +146,7 @@ suite("UserSurvey Tests", () => {
 
         (userSurvey as any)._webviewController = mockWebviewController;
 
-        await userSurvey.promptUserForNPSFeedback();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
 
         assert.strictEqual(
             mockWebviewController.revealToForeground.calledOnce,
@@ -191,7 +191,7 @@ suite("UserSurvey Tests", () => {
         const userSurvey = UserSurvey.getInstance();
         sandbox.stub(userSurvey, "launchSurvey").resolves();
 
-        await userSurvey.promptUserForNPSFeedback();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
 
         assert.strictEqual(
             globalState.update.calledWith("nps/sessionCount", 3),
@@ -211,7 +211,7 @@ suite("UserSurvey Tests", () => {
         const userSurvey = UserSurvey.getInstance();
         sandbox.stub(userSurvey, "launchSurvey").resolves();
 
-        await userSurvey.promptUserForNPSFeedback();
+        await (userSurvey as any).promptUserForNPSFeedbackAsync();
 
         assert.strictEqual(
             globalState.update.calledWith("nps/never", true),


### PR DESCRIPTION
PR to main branch: #18954
Fixes #18955 

This PR fixes an issue where NPS prompt calls were unintentionally blocking execution. Previously, if the NPS prompt appeared during the table designer's publish action, the publish process would be stalled until the user responded to the prompt. This fix ensures that the NPS prompt is now non-blocking, preventing similar issues in the future.

