### PR TITLE
Removing connection ID and group ID assignments

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "rangy": "^1.3.0",
     "reflect-metadata": "0.1.12",
     "semver": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+    "shallowequal": "^1.1.0",
     "signal-exit": "^4.1.0",
     "tar": "^7.4.3",
     "tmp": "^0.0.28",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -106,3 +106,29 @@ export async function listAllIterator<T>(
 
     return resources;
 }
+
+/**
+ * Helper function to concatenate two arrays, but exclude duplicates.  E.g. concatUnique([1, 2], [2, 3]) => [1, 2, 3]
+ * @param areEqual optional equality function to determine if two items are duplicates.  Uses `===` if not provided
+ * @returns Concatenatation of the two arrays, excluding duplicates
+ */
+export function concatUnique<T>(
+    a: T[],
+    b: T[],
+    areEqual?: (a: T, b: T) => boolean,
+): T[] {
+    const result = [...a];
+    for (const item of b) {
+        if (
+            !result.some((i) =>
+                areEqual
+                    ? areEqual(i, item) // use custom function if provided
+                    : i === item,
+            )
+        ) {
+            result.push(item);
+        }
+    }
+
+    return result;
+}

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -6,6 +6,7 @@
 import { expect, assert } from "chai";
 import * as Utils from "../../src/models/utils";
 import * as Constants from "../../src/constants/constants";
+import * as SrcUtils from "../../src/utils/utils";
 import { ConnectionCredentials } from "../../src/models/connectionCredentials";
 
 suite("Utility Tests - parseTimeString", () => {
@@ -157,5 +158,35 @@ suite.skip("Utility tests - Timer Class", () => {
             }, 100);
         });
         void p.then(() => done());
+    });
+});
+
+suite("src/utils/utils.ts tests", () => {
+    suite("Utility tests - concatUnique()", () => {
+        test("should return the correct concatenated array with default equality", () => {
+            let a = [1, 2, 3];
+            let b = [2, 3, 4];
+            let result = SrcUtils.concatUnique(a, b);
+            assert.deepEqual(
+                result,
+                [1, 2, 3, 4],
+                "Arrays should have been concatenated with duplicate values removed",
+            );
+        });
+
+        test("should return the correct concatenated array with custom equality function", () => {
+            let a = ["ONE", "TWO", "THREE"];
+            let b = ["two", "three", "four"];
+            let result = SrcUtils.concatUnique(
+                a,
+                b,
+                (a, b) => a.toLowerCase() === b.toLowerCase(), // custom equality function
+            );
+            assert.deepEqual(
+                result,
+                ["ONE", "TWO", "THREE", "four"], // "two" and "three" from the second array are duplicates by the .toLowerCase() equality function
+                "Arrays should have been concatenated with duplicate values removed",
+            );
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10968,6 +10968,11 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
Begins to address https://github.com/microsoft/vscode-mssql/issues/18854 by removing the connection ID and group ID assignments, and also deduping between workspace and workspace folder connections.

This area needs additional improvement, but this patch is intended to fix behavior for this release while the larger issue gets addressed.  I've created #18965 for the larger issue, and put some investigation notes in there.