### PR TITLE
Fixing issue where OE nodes would appear the first time time connections were upgraded with IDs and groups

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -7,7 +7,7 @@ export default testCli.defineConfig([
 		version: 'insiders',
 		mocha: {
 			ui: 'tdd',
-			timeout: 5000
+			timeout: 6000
 		}
 	}
 ])

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -508,7 +508,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         recentConnections: IConnectionDialogProfile[];
     }> {
         const unsortedConnections: IConnectionProfileWithSource[] =
-            this._mainController.connectionManager.connectionStore.readAllConnections(
+            await this._mainController.connectionManager.connectionStore.readAllConnections(
                 true /* includeRecentConnections */,
             );
 

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -153,9 +153,11 @@ export class ConnectionConfig implements IConnectionConfig {
      * are sorted first by whether they were found in the user/workspace settings,
      * and next alphabetically by profile/server name.
      */
-    public getConnections(
+    public async getConnections(
         getWorkspaceConnections: boolean,
-    ): IConnectionProfile[] {
+    ): Promise<IConnectionProfile[]> {
+        await this.initialized;
+
         let profiles: IConnectionProfile[] = [];
 
         // Read from user settings

--- a/src/connectionconfig/iconnectionconfig.ts
+++ b/src/connectionconfig/iconnectionconfig.ts
@@ -13,6 +13,8 @@ import { IConnectionProfile } from "../models/interfaces";
  */
 export interface IConnectionConfig {
     addConnection(profile: IConnectionProfile): Promise<void>;
-    getConnections(getWorkspaceConnections: boolean): IConnectionProfile[];
+    getConnections(
+        getWorkspaceConnections: boolean,
+    ): Promise<IConnectionProfile[]>;
     removeConnection(profile: IConnectionProfile): Promise<boolean>;
 }

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -212,6 +212,10 @@ export default class ConnectionManager {
         }
     }
 
+    public get initialized(): Deferred<void> {
+        return this.connectionStore.initialized;
+    }
+
     /**
      * Exposed for testing purposes
      */

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1103,7 +1103,11 @@ export default class ConnectionManager {
         fileUri: string,
     ): Promise<IConnectionInfo> {
         // show connection picklist
-        const connectionCreds = await this.connectionUI.promptForConnection();
+        const connectionProfileList =
+            await this._connectionStore.getPickListItems();
+        const connectionCreds = await this.connectionUI.promptForConnection(
+            connectionProfileList,
+        );
         if (connectionCreds) {
             // close active connection
             await this.disconnect(fileUri);

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2211,7 +2211,7 @@ export default class MainController implements vscode.Disposable {
             // user connections is a super set of object explorer connections
             // read the connections from glocal settings and workspace settings.
             let userConnections: any[] =
-                this.connectionManager.connectionStore.connectionConfig.getConnections(
+                await this.connectionManager.connectionStore.connectionConfig.getConnections(
                     true,
                 );
             let objectExplorerConnections =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,8 +40,11 @@ export async function activate(
     await controller.activate();
     return {
         sqlToolsServicePath: SqlToolsServerClient.instance.sqlToolsServicePath,
-        promptForConnection: (ignoreFocusOut?: boolean) => {
+        promptForConnection: async (ignoreFocusOut?: boolean) => {
+            const connectionProfileList =
+                await this._connectionStore.getPickListItems();
             return controller.connectionManager.connectionUI.promptForConnection(
+                connectionProfileList,
                 ignoreFocusOut,
             );
         },

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -23,6 +23,7 @@ import { ConnectionConfig } from "../connectionconfig/connectionconfig";
 import VscodeWrapper from "../controllers/vscodeWrapper";
 import { IConnectionInfo } from "vscode-mssql";
 import { Logger } from "./logger";
+import { Deferred } from "../protocol";
 
 /**
  * Manages the connections list including saved profiles and the most recently used connections
@@ -44,6 +45,10 @@ export class ConnectionStore {
         if (!this._connectionConfig) {
             this._connectionConfig = new ConnectionConfig();
         }
+    }
+
+    public get initialized(): Deferred<void> {
+        return (this._connectionConfig as ConnectionConfig).initialized;
     }
 
     public static get CRED_PREFIX(): string {
@@ -183,9 +188,11 @@ export class ConnectionStore {
      *
      * @returns
      */
-    public getPickListItems(): IConnectionCredentialsQuickPickItem[] {
+    public async getPickListItems(): Promise<
+        IConnectionCredentialsQuickPickItem[]
+    > {
         let pickListItems: IConnectionCredentialsQuickPickItem[] =
-            this.getConnectionQuickpickItems(false);
+            await this.getConnectionQuickpickItems(false);
         pickListItems.push(<IConnectionCredentialsQuickPickItem>{
             label: `$(add) ${LocalizedConstants.CreateProfileFromConnectionsListLabel}`,
             connectionCreds: undefined,
@@ -202,7 +209,7 @@ export class ConnectionStore {
      */
     public getProfilePickListItems(
         getWorkspaceProfiles: boolean,
-    ): IConnectionCredentialsQuickPickItem[] {
+    ): Promise<IConnectionCredentialsQuickPickItem[]> {
         return this.loadProfiles(getWorkspaceProfiles);
     }
 
@@ -614,18 +621,18 @@ export class ConnectionStore {
         await this.saveProfile(profile);
     }
 
-    public readAllConnections(
+    public async readAllConnections(
         includeRecentConnections: boolean = false,
-    ): IConnectionProfileWithSource[] {
+    ): Promise<IConnectionProfileWithSource[]> {
         let connResults: IConnectionProfileWithSource[] = [];
 
-        const configConnections = this._connectionConfig
-            .getConnections(true)
-            .map((c) => {
-                const conn = c as IConnectionProfileWithSource;
-                conn.profileSource = CredentialsQuickPickItemType.Profile;
-                return conn;
-            });
+        const connections = await this._connectionConfig.getConnections(true);
+
+        const configConnections = connections.map((c) => {
+            const conn = c as IConnectionProfileWithSource;
+            conn.profileSource = CredentialsQuickPickItemType.Profile;
+            return conn;
+        });
 
         connResults = connResults.concat(configConnections);
 
@@ -650,11 +657,13 @@ export class ConnectionStore {
         return connResults;
     }
 
-    public getConnectionQuickpickItems(
+    public async getConnectionQuickpickItems(
         includeRecentConnections: boolean = false,
-    ): IConnectionCredentialsQuickPickItem[] {
+    ): Promise<IConnectionCredentialsQuickPickItem[]> {
         let output: IConnectionCredentialsQuickPickItem[] = [];
-        const connections = this.readAllConnections(includeRecentConnections);
+        const connections = await this.readAllConnections(
+            includeRecentConnections,
+        );
 
         output = connections.map((c) => {
             return this.createQuickPickItem(c, c.profileSource);
@@ -663,11 +672,11 @@ export class ConnectionStore {
         return output;
     }
 
-    private loadProfiles(
+    private async loadProfiles(
         loadWorkspaceProfiles: boolean,
-    ): IConnectionCredentialsQuickPickItem[] {
+    ): Promise<IConnectionCredentialsQuickPickItem[]> {
         let connections: IConnectionProfile[] =
-            this._connectionConfig.getConnections(loadWorkspaceProfiles);
+            await this._connectionConfig.getConnections(loadWorkspaceProfiles);
         let quickPickItems = connections.map((c) =>
             this.createQuickPickItem(c, CredentialsQuickPickItemType.Profile),
         );

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -207,10 +207,10 @@ export class ConnectionStore {
      *
      * @returns
      */
-    public getProfilePickListItems(
+    public async getProfilePickListItems(
         getWorkspaceProfiles: boolean,
     ): Promise<IConnectionCredentialsQuickPickItem[]> {
-        return this.loadProfiles(getWorkspaceProfiles);
+        return await this.loadProfiles(getWorkspaceProfiles);
     }
 
     public async addSavedPassword(

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -536,7 +536,7 @@ export class ObjectExplorerService {
      */
     private async addSavedNodesConnectionsToRoot(): Promise<void> {
         let savedConnections =
-            this._connectionManager.connectionStore.readAllConnections();
+            await this._connectionManager.connectionStore.readAllConnections();
         for (const conn of savedConnections) {
             let nodeLabel =
                 ConnInfo.getSimpleConnectionDisplayName(conn) === conn.server
@@ -690,7 +690,7 @@ export class ObjectExplorerService {
 
             // retrieve saved connections first when opening object explorer for the first time
             let savedConnections =
-                this._connectionManager.connectionStore.readAllConnections();
+                await this._connectionManager.connectionStore.readAllConnections();
 
             // if there are no saved connections, show the add connection node
             if (savedConnections.length === 0) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -534,7 +534,9 @@ export class ObjectExplorerService {
     /**
      * Get nodes from saved connections
      */
-    private async addSavedNodesConnectionsToRoot(): Promise<void> {
+    private async getSavedConnectionNodes(): Promise<TreeNodeInfo[]> {
+        const result: TreeNodeInfo[] = [];
+
         let savedConnections =
             await this._connectionManager.connectionStore.readAllConnections();
         for (const conn of savedConnections) {
@@ -565,8 +567,10 @@ export class ObjectExplorerService {
                 undefined,
                 undefined,
             );
-            this._rootTreeNodeArray.push(node);
+            result.push(node);
         }
+
+        return result;
     }
 
     private static get disconnectedNodeContextValue(): TreeNodeContextValue {
@@ -703,10 +707,9 @@ export class ObjectExplorerService {
             // if OE doesn't exist the first time, then build the nodes off of saved connections
             if (!this._objectExplorerProvider.objectExplorerExists) {
                 // if there are actually saved connections
-                this._rootTreeNodeArray = [];
-                await this.addSavedNodesConnectionsToRoot();
+                this._rootTreeNodeArray = await this.getSavedConnectionNodes();
                 this._logger.logDebug(
-                    `No current OE; added ${this._rootTreeNodeArray.length} nodes to OE root`,
+                    `No current OE; created OE root with ${this._rootTreeNodeArray.length}`,
                 );
                 this._objectExplorerProvider.objectExplorerExists = true;
                 return this.sortByServerName(this._rootTreeNodeArray);

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -100,9 +100,9 @@ export class ConnectionUI {
     ): Promise<IConnectionInfo | undefined> {
         // Let this design use Promise and resolve/reject pattern instead of async/await
         // because resolve/reject is done in in callback events.
-        return await new Promise<IConnectionInfo | undefined>((resolve, _) => {
+        return await new Promise<IConnectionInfo | undefined>(async (resolve, _) => {
             let connectionProfileList =
-                this._connectionStore.getPickListItems();
+                await this._connectionStore.getPickListItems();
             // We have recent connections - show them in a prompt for connection profiles
             const connectionProfileQuickPick =
                 this.vscodeWrapper.createQuickPick<IConnectionCredentialsQuickPickItem>();
@@ -1002,7 +1002,7 @@ export class ConnectionUI {
         let self = this;
 
         // Flow: Select profile to remove, confirm removal, remove, notify
-        let profiles = self._connectionStore.getProfilePickListItems(false);
+        let profiles = await self._connectionStore.getProfilePickListItems(false);
         let profile = await self.selectProfileForRemoval(profiles);
         let profileRemoved = profile
             ? await self._connectionStore.removeProfile(profile)

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -96,13 +96,12 @@ export class ConnectionUI {
      * @returns The connectionInfo choosen or created from the user, or undefined if the user cancels the prompt.
      */
     public async promptForConnection(
+        connectionProfileList: IConnectionCredentialsQuickPickItem[],
         ignoreFocusOut: boolean = false,
     ): Promise<IConnectionInfo | undefined> {
         // Let this design use Promise and resolve/reject pattern instead of async/await
         // because resolve/reject is done in in callback events.
-        return await new Promise<IConnectionInfo | undefined>(async (resolve, _) => {
-            let connectionProfileList =
-                await this._connectionStore.getPickListItems();
+        return await new Promise<IConnectionInfo | undefined>((resolve, _) => {
             // We have recent connections - show them in a prompt for connection profiles
             const connectionProfileQuickPick =
                 this.vscodeWrapper.createQuickPick<IConnectionCredentialsQuickPickItem>();
@@ -610,23 +609,18 @@ export class ConnectionUI {
             return await this.saveProfile(profile);
         } else {
             // Check whether the error was for firewall rule or not
-            if (
-                this.connectionManager.failedUriToFirewallIpMap.has(uri)
-            ) {
+            if (this.connectionManager.failedUriToFirewallIpMap.has(uri)) {
                 let success = await this.addFirewallRule(uri, profile);
                 if (success) {
                     return await this.validateAndSaveProfile(profile);
                 }
                 return undefined;
-            } else if (
-                this.connectionManager.failedUriToSSLMap.has(uri)
-            ) {
+            } else if (this.connectionManager.failedUriToSSLMap.has(uri)) {
                 // SSL error
-                let updatedConn =
-                    await this.connectionManager.handleSSLError(
-                        uri,
-                        profile,
-                    );
+                let updatedConn = await this.connectionManager.handleSSLError(
+                    uri,
+                    profile,
+                );
                 if (updatedConn) {
                     return await this.validateAndSaveProfile(
                         updatedConn as IConnectionProfile,
@@ -1002,7 +996,8 @@ export class ConnectionUI {
         let self = this;
 
         // Flow: Select profile to remove, confirm removal, remove, notify
-        let profiles = await self._connectionStore.getProfilePickListItems(false);
+        let profiles =
+            await self._connectionStore.getProfilePickListItems(false);
         let profile = await self.selectProfileForRemoval(profiles);
         let profileRemoved = profile
             ? await self._connectionStore.removeProfile(profile)

--- a/test/unit/connectionUI.test.ts
+++ b/test/unit/connectionUI.test.ts
@@ -127,15 +127,11 @@ suite("Connection UI tests", () => {
             .setup((p) => p.prompt(TypeMoq.It.isAny(), true))
             .returns(() => Promise.resolve(mockConnection));
 
-        const promptPromise = connectionUI.promptForConnection();
+        const promptPromise = connectionUI.promptForConnection(undefined);
         // Trigger onDidChangeSelection event to simulate user selecting new connection option
         onDidChangeSelectionEventEmitter.fire([item]);
         await promptPromise;
 
-        connectionStore.verify(
-            (c) => c.getPickListItems(),
-            TypeMoq.Times.once(),
-        );
         quickPickMock.verify((q) => q.show(), TypeMoq.Times.once());
     });
 
@@ -155,15 +151,11 @@ suite("Connection UI tests", () => {
             .setup((q) => q.onDidChangeSelection)
             .returns(() => onDidChangeSelectionEventEmitter.event);
 
-        const promptPromise = connectionUI.promptForConnection();
+        const promptPromise = connectionUI.promptForConnection(undefined);
         // Trigger onDidChangeSelection event to simulate user selecting edit connection option
         onDidChangeSelectionEventEmitter.fire([item]);
         await promptPromise;
 
-        connectionStore.verify(
-            (c) => c.getPickListItems(),
-            TypeMoq.Times.once(),
-        );
         quickPickMock.verify((q) => q.show(), TypeMoq.Times.once());
     });
 
@@ -173,15 +165,12 @@ suite("Connection UI tests", () => {
         quickPickMock
             .setup((q) => q.onDidHide)
             .returns(() => onDidHideEventEmitter.event);
-        const promptForConnectionPromise = connectionUI.promptForConnection();
+        const promptForConnectionPromise =
+            connectionUI.promptForConnection(undefined);
         // Trigger onDidHide event to simulate user exiting the dialog without choosing anything
         onDidHideEventEmitter.fire();
         await promptForConnectionPromise;
 
-        connectionStore.verify(
-            (c) => c.getPickListItems(),
-            TypeMoq.Times.once(),
-        );
         quickPickMock.verify((q) => q.show(), TypeMoq.Times.once());
     });
 
@@ -259,13 +248,15 @@ suite("Connection UI tests", () => {
     test("removeProfile should prompt for a profile and remove it", () => {
         connectionStore
             .setup((c) => c.getProfilePickListItems(TypeMoq.It.isAny()))
-            .returns(() => [
-                {
-                    connectionCreds: undefined,
-                    quickPickItemType: undefined,
-                    label: "test",
-                },
-            ]);
+            .returns(() =>
+                Promise.resolve([
+                    {
+                        connectionCreds: undefined,
+                        quickPickItemType: undefined,
+                        label: "test",
+                    },
+                ]),
+            );
         connectionStore.setup(
             async (c) => await c.removeProfile(TypeMoq.It.isAny()),
         );

--- a/test/unit/perFileConnection.test.ts
+++ b/test/unit/perFileConnection.test.ts
@@ -25,7 +25,6 @@ import * as Utils from "../../src/models/utils";
 import { ConnectionUI } from "../../src/views/connectionUI";
 import StatusView from "../../src/views/statusView";
 import { TestExtensionContext, TestPrompter } from "./stubs";
-import { Type } from "@angular/core";
 
 function createTestConnectionResult(
     ownerUri?: string,

--- a/test/unit/perFileConnection.test.ts
+++ b/test/unit/perFileConnection.test.ts
@@ -25,6 +25,7 @@ import * as Utils from "../../src/models/utils";
 import { ConnectionUI } from "../../src/views/connectionUI";
 import StatusView from "../../src/views/statusView";
 import { TestExtensionContext, TestPrompter } from "./stubs";
+import { Type } from "@angular/core";
 
 function createTestConnectionResult(
     ownerUri?: string,
@@ -163,7 +164,7 @@ suite("Per File Connection Tests", () => {
             .setup((x) => x.promptToChangeLanguageMode())
             .returns((x) => Promise.resolve(true));
         connectionUIMock
-            .setup((x) => x.promptForConnection())
+            .setup((x) => x.promptForConnection(TypeMoq.It.isAny()))
             .returns((x) => Promise.resolve(connectionCreds));
 
         // Return undefined to simulate the scenario that user doesn't want to enter new credentials
@@ -241,7 +242,7 @@ suite("Per File Connection Tests", () => {
             .setup((x) => x.promptToChangeLanguageMode())
             .returns((x) => Promise.resolve(true));
         connectionUIMock
-            .setup((x) => x.promptForConnection())
+            .setup((x) => x.promptForConnection(TypeMoq.It.isAny()))
             .returns((x) => Promise.resolve(connectionCreds));
 
         connectionUIMock


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode-mssql/issues/18854

Investigation found two bugs occuring with two interweaving flows:

1) Duplciate connections in OE immediately after upgrading:

The core bug was that when ConnectionConfig would detect connections that needed upgrading (with new `id` and `groupId` properties) in the User `settings.json` and save those, it would trigger the `onDidChangeConfiguration` event which refreshes the OE with the updated connections.  Because this would occur before the OE had actually loaded, it adds new root nodes intead.  When OE eventually loads, it reads the connections from config, and adds the connection nodes to the root node list (because it assumed it was the first to get there).

Fix: replace the list of root nodes when OE loads instead of appending to it.

2) When OE would do its later loading, it would read the connections from config before the ConnectionStore had finished initializing, so those connections wouldn't have the new IDs populated.  Because the duplicate OE nodes were triggered as a result of the onDidChangeConfiguration event, those _did_ have the IDs, so the result was that one of the dupes had the new ID and the other didn't.

Fix: await the deferred initialization flag before reading the connections from config.