### PR TITLE
Fixing table designer overwriting OE connections

### DIFF
--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -95,7 +95,9 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
         // get database name from connection string
         const databaseName = targetDatabase ? targetDatabase : "master";
 
-        const connectionInfo = this._targetNode.connectionInfo;
+        const connectionInfo = {
+            ...this._targetNode.connectionInfo,
+        };
         connectionInfo.database = databaseName;
 
         let connectionString;


### PR DESCRIPTION
Creating a copy of the connection in table designer before making any changes to it. This makes sure that the original connection info for the node is not modified. 