### PR TITLE
[PORT] Update sqltoolsservice to 5.0.20250321.1

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
   "service": {
     "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-    "version": "5.0.20250220.4",
+    "version": "5.0.20250321.1",
     "downloadFileNames": {
       "Windows_86": "win-x86-net8.0.zip",
       "Windows_64": "win-x64-net8.0.zip",


### PR DESCRIPTION
Porting #18982 to release/1.30 branch

Update STS to [5.0.20250321.1](https://github.com/microsoft/sqltoolsservice/releases/tag/5.0.20250321.1) to bring in https://github.com/microsoft/sqltoolsservice/pull/2457 which addresses https://github.com/microsoft/vscode-mssql/issues/18968