### PR TITLE
Making sure tree node connection info is not accidentally modified by consumers. 

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -448,7 +448,7 @@ export default class MainController implements vscode.Disposable {
         executeScript: boolean = false,
     ): Promise<void> {
         const nodeUri = ObjectExplorerUtils.getNodeUri(node);
-        let connectionCreds = node.connectionInfoClone;
+        let connectionCreds = node.connectionInfo;
         const databaseName = ObjectExplorerUtils.getDatabaseName(node);
         // if not connected or different database
         if (
@@ -809,8 +809,7 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdObjectExplorerNewQuery,
                 async (treeNodeInfo: TreeNodeInfo) => {
-                    const connectionCredentials =
-                        treeNodeInfo.connectionInfoClone;
+                    const connectionCredentials = treeNodeInfo.connectionInfo;
                     const databaseName =
                         ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
 
@@ -1940,7 +1939,7 @@ export default class MainController implements vscode.Disposable {
             const uri = editor.document.uri.toString(true);
             if (node) {
                 // connect to the node if the command came from the context
-                const connectionCreds = node.connectionInfoClone;
+                const connectionCreds = node.connectionInfo;
                 // if the node isn't connected
                 if (!node.sessionId) {
                     // connect it first

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -814,20 +814,17 @@ export default class MainController implements vscode.Disposable {
                     const databaseName =
                         ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
 
-                    let updatedDatabaseName = "";
                     if (
                         databaseName !== connectionCredentials.database &&
                         databaseName !== LocalizedConstants.defaultDatabaseLabel
                     ) {
-                        updatedDatabaseName = databaseName;
+                        connectionCredentials.database = databaseName;
                     } else if (
                         databaseName === LocalizedConstants.defaultDatabaseLabel
                     ) {
-                        updatedDatabaseName = "";
+                        connectionCredentials.database = "";
                     }
-                    treeNodeInfo.updateConnectionInfo((conn) => {
-                        conn.database = updatedDatabaseName;
-                    });
+                    treeNodeInfo.updateConnectionInfo(connectionCredentials);
                     await self.onNewQuery(treeNodeInfo);
                 },
             ),
@@ -878,7 +875,7 @@ export default class MainController implements vscode.Disposable {
                             profile,
                         );
                     if (profile) {
-                        node.parentNode.updateConnectionInfo(() => profile);
+                        node.parentNode.updateConnectionInfo(profile);
                         self._objectExplorerProvider.updateNode(
                             node.parentNode,
                         );

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -202,9 +202,9 @@ export class ObjectExplorerService {
             } else {
                 // create session failure
                 if (self._currentNode?.connectionInfo?.password) {
-                    this._currentNode.updateConnectionInfo((conn) => {
-                        conn.password = "";
-                    });
+                    const profile = this._currentNode.connectionInfoClone;
+                    profile.password = "";
+                    this._currentNode.updateConnectionInfo(profile);
                 }
                 let error = LocalizedConstants.connectErrorLabel;
                 let errorNumber: number;
@@ -292,7 +292,7 @@ export class ObjectExplorerService {
         node: TreeNodeInfo,
         profile: IConnectionInfo,
     ): Promise<void> {
-        node.updateConnectionInfo(() => profile);
+        node.updateConnectionInfo(profile);
         this.updateNode(node);
         let fileUri = this.getNodeIdentifier(node);
         if (
@@ -957,9 +957,9 @@ export class ObjectExplorerService {
             node.context = ObjectExplorerService.disconnectedNodeContextValue;
             node.sessionId = undefined;
             if (!(node.connectionInfo as IConnectionProfile).savePassword) {
-                node.updateConnectionInfo((conn) => {
-                    conn.password = "";
-                });
+                const profile = node.connectionInfoClone;
+                profile.password = "";
+                node.updateConnectionInfo(profile);
             }
             const label =
                 typeof node.label === "string" ? node.label : node.label.label;

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -202,7 +202,9 @@ export class ObjectExplorerService {
             } else {
                 // create session failure
                 if (self._currentNode?.connectionInfo?.password) {
-                    self._currentNode.connectionInfo.password = "";
+                    this._currentNode.updateConnectionInfo((conn) => {
+                        conn.password = "";
+                    });
                 }
                 let error = LocalizedConstants.connectErrorLabel;
                 let errorNumber: number;
@@ -290,7 +292,7 @@ export class ObjectExplorerService {
         node: TreeNodeInfo,
         profile: IConnectionInfo,
     ): Promise<void> {
-        node.connectionInfo = profile;
+        node.updateConnectionInfo(() => profile);
         this.updateNode(node);
         let fileUri = this.getNodeIdentifier(node);
         if (
@@ -955,7 +957,9 @@ export class ObjectExplorerService {
             node.context = ObjectExplorerService.disconnectedNodeContextValue;
             node.sessionId = undefined;
             if (!(node.connectionInfo as IConnectionProfile).savePassword) {
-                node.connectionInfo.password = "";
+                node.updateConnectionInfo((conn) => {
+                    conn.password = "";
+                });
             }
             const label =
                 typeof node.label === "string" ? node.label : node.label.label;

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -202,7 +202,7 @@ export class ObjectExplorerService {
             } else {
                 // create session failure
                 if (self._currentNode?.connectionInfo?.password) {
-                    const profile = this._currentNode.connectionInfoClone;
+                    const profile = this._currentNode.connectionInfo;
                     profile.password = "";
                     this._currentNode.updateConnectionInfo(profile);
                 }
@@ -957,7 +957,7 @@ export class ObjectExplorerService {
             node.context = ObjectExplorerService.disconnectedNodeContextValue;
             node.sessionId = undefined;
             if (!(node.connectionInfo as IConnectionProfile).savePassword) {
-                const profile = node.connectionInfoClone;
+                const profile = node.connectionInfo;
                 profile.password = "";
                 node.updateConnectionInfo(profile);
             }

--- a/src/objectExplorer/treeNodeInfo.ts
+++ b/src/objectExplorer/treeNodeInfo.ts
@@ -129,7 +129,12 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
      * If you want to update the actual connection info stored in the node, use the `updateConnectionInfo` method instead.
      */
     public get connectionInfo(): IConnectionInfo {
-        return Object.assign({}, this._connectionInfo);
+        if (!this._connectionInfo) {
+            return undefined;
+        }
+        return {
+            ...this._connectionInfo,
+        };
     }
 
     public get metadata(): ObjectMetadata {

--- a/src/objectExplorer/treeNodeInfo.ts
+++ b/src/objectExplorer/treeNodeInfo.ts
@@ -123,17 +123,12 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
     }
 
     /**
-     * Gets a read-only copy of the connection info object.
-     * If you need to modify the connectionInfoClone, use the updateConnectionInfo method.
+     * Returns a **copy** of the node's connection information.
+     *
+     * ⚠️ Note: This is a **shallow copy**—modifying the returned object will NOT affect the original connection info.
+     * If you want to update the actual connection info stored in the node, use the `updateConnectionInfo` method instead.
      */
-    public get connectionInfo(): Readonly<IConnectionInfo> {
-        return this._connectionInfo;
-    }
-
-    /**
-     * Gets a clone of the connection info object.
-     */
-    public get connectionInfoClone(): IConnectionInfo {
+    public get connectionInfo(): IConnectionInfo {
         return Object.assign({}, this._connectionInfo);
     }
 
@@ -187,10 +182,6 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
         this._parentNode = value;
     }
 
-    public updateConnectionInfo(value: IConnectionInfo): void {
-        this._connectionInfo = value;
-    }
-
     public set filterableProperties(value: vscodeMssql.NodeFilterProperty[]) {
         this._filterableProperties = value;
         this._updateContextValue();
@@ -207,6 +198,10 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
 
     public set context(value: vscodeMssql.TreeNodeContextValue) {
         this.contextValue = this._convertToContextValue(value);
+    }
+
+    public updateConnectionInfo(value: IConnectionInfo): void {
+        this._connectionInfo = value;
     }
 
     private _updateContextValue() {

--- a/src/objectExplorer/treeNodeInfo.ts
+++ b/src/objectExplorer/treeNodeInfo.ts
@@ -187,10 +187,8 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
         this._parentNode = value;
     }
 
-    public updateConnectionInfo(
-        mutator: (conn: IConnectionInfo) => void,
-    ): void {
-        mutator(this._connectionInfo);
+    public updateConnectionInfo(value: IConnectionInfo): void {
+        this._connectionInfo = value;
     }
 
     public set filterableProperties(value: vscodeMssql.NodeFilterProperty[]) {

--- a/src/objectExplorer/treeNodeInfo.ts
+++ b/src/objectExplorer/treeNodeInfo.ts
@@ -122,8 +122,19 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
         return this._parentNode;
     }
 
-    public get connectionInfo(): IConnectionInfo {
+    /**
+     * Gets a read-only copy of the connection info object.
+     * If you need to modify the connectionInfoClone, use the updateConnectionInfo method.
+     */
+    public get connectionInfo(): Readonly<IConnectionInfo> {
         return this._connectionInfo;
+    }
+
+    /**
+     * Gets a clone of the connection info object.
+     */
+    public get connectionInfoClone(): IConnectionInfo {
+        return Object.assign({}, this._connectionInfo);
     }
 
     public get metadata(): ObjectMetadata {
@@ -176,8 +187,10 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
         this._parentNode = value;
     }
 
-    public set connectionInfo(value: IConnectionInfo) {
-        this._connectionInfo = value;
+    public updateConnectionInfo(
+        mutator: (conn: IConnectionInfo) => void,
+    ): void {
+        mutator(this._connectionInfo);
     }
 
     public set filterableProperties(value: vscodeMssql.NodeFilterProperty[]) {

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -95,9 +95,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
         // get database name from connection string
         const databaseName = targetDatabase ? targetDatabase : "master";
 
-        const connectionInfo = {
-            ...this._targetNode.connectionInfo,
-        };
+        const connectionInfo = this._targetNode.connectionInfoClone;
         connectionInfo.database = databaseName;
 
         let connectionString;

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -95,7 +95,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
         // get database name from connection string
         const databaseName = targetDatabase ? targetDatabase : "master";
 
-        const connectionInfo = this._targetNode.connectionInfoClone;
+        const connectionInfo = this._targetNode.connectionInfo;
         connectionInfo.database = databaseName;
 
         let connectionString;

--- a/test/unit/objectExplorerProvider.test.ts
+++ b/test/unit/objectExplorerProvider.test.ts
@@ -709,7 +709,7 @@ suite("Object Explorer Node Types Test", () => {
             treeNode.parentNode,
             "Parent node should be equal to expected value",
         ).is.equal(undefined);
-        treeNode.connectionInfo = treeNode.connectionInfo;
+        treeNode.updateConnectionInfo(() => treeNode.connectionInfo);
         expect(
             treeNode.connectionInfo,
             "Connection credentials should be equal to expected value",

--- a/test/unit/objectExplorerProvider.test.ts
+++ b/test/unit/objectExplorerProvider.test.ts
@@ -23,6 +23,7 @@ import {
     ExpandResponse,
 } from "../../src/models/contracts/objectExplorer/expandNodeRequest";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
+import { IConnectionInfo } from "vscode-mssql";
 
 suite("Object Explorer Provider Tests", function () {
     let objectExplorerService: TypeMoq.IMock<ObjectExplorerService>;
@@ -775,5 +776,51 @@ suite("Object Explorer Node Types Test", () => {
             treeNodeInfo.metadata,
             "Node metadata should be the same as nodeInfo metadata",
         ).is.equal(nodeInfo.metadata);
+    });
+
+    test("Connection Info is not accidentally modified", () => {
+        const testConnnectionInfo = {
+            server: "test_server",
+            database: "test_db",
+        } as IConnectionInfo;
+
+        const nodeInfo: NodeInfo = {
+            nodePath: "test_path",
+            nodeStatus: undefined,
+            nodeSubType: undefined,
+            nodeType: undefined,
+            label: "test_node",
+            isLeaf: false,
+            errorMessage: undefined,
+            metadata: undefined,
+        };
+
+        const treeNodeInfo = TreeNodeInfo.fromNodeInfo(
+            nodeInfo,
+            "test_session",
+            undefined,
+            testConnnectionInfo,
+            undefined,
+        );
+
+        const connectionInfo = treeNodeInfo.connectionInfo;
+        expect(
+            connectionInfo,
+            "Connection credentials should be equal to expected value",
+        ).to.deep.equal(testConnnectionInfo);
+
+        connectionInfo.server = "modified_server";
+
+        expect(
+            treeNodeInfo.connectionInfo.server,
+            "Connection credentials should not be modified",
+        ).is.equal("test_server");
+
+        treeNodeInfo.updateConnectionInfo(connectionInfo);
+
+        expect(
+            treeNodeInfo.connectionInfo.server,
+            "connectionInfo should be updated",
+        ).is.equal("modified_server");
     });
 });

--- a/test/unit/objectExplorerProvider.test.ts
+++ b/test/unit/objectExplorerProvider.test.ts
@@ -709,7 +709,7 @@ suite("Object Explorer Node Types Test", () => {
             treeNode.parentNode,
             "Parent node should be equal to expected value",
         ).is.equal(undefined);
-        treeNode.updateConnectionInfo(() => treeNode.connectionInfo);
+        treeNode.updateConnectionInfo(treeNode.connectionInfo);
         expect(
             treeNode.connectionInfo,
             "Connection credentials should be equal to expected value",


### PR DESCRIPTION
Several features rely on `treeNode.connectionInfo` to create or reuse existing connections. However, when this object is modified directly, it can lead to unintended side effects — such as breaking future connection reuse or connection lookup logic which breaks apis like `getUriForConnection()`

This PR introduces the following improvements to make connection management safer and more intentional:

1. **Makes `connectionInfo` return a shallow copy**  
   Exposes a shallow copy of the connectionInfo to prevent accidental modifications by callers.

2. **Adds `updateConnectionInfo` method**  
   Provides a deliberate, controlled way to update the internal connection info.
   
3. **Removes `connectionInfo` setter**
   Removes connectionInfo setter so that callers cannot accidentally update the connectionInfo. 
