### PR TITLE
Enable rich UI features by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -973,7 +973,7 @@
         },
         "mssql.enableRichExperiences": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%mssql.enableRichExperiences.description%",
           "scope": "application"
         },


### PR DESCRIPTION
This turns on UI features by default.  I left the whole notification stuff there in case we change this back later, and it reminds the user to reenable if the setting is false already (they can click don't show again if desired).  We can remove the notification stuff when we delete this flag later.