### PR TITLE
Fixing smattering of connection management bugs

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -640,6 +640,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                     this.state.selectedInputMode ===
                     ConnectionInputMode.ConnectionString
                 ) {
+                    // convert connection string to an IConnectionProfile object
                     const connDetails =
                         await this._mainController.connectionManager.buildConnectionDetails(
                             this.state.connectionProfile.connectionString,
@@ -652,7 +653,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                     cleanedConnection.profileName =
                         this.state.connectionProfile.profileName;
                     cleanedConnection.savePassword =
-                        !!cleanedConnection.password;
+                        !!cleanedConnection.password; // if the password is included in the connection string, saving it is implied
 
                     // overwrite SQL Tools Service's default application name with the one the user provided (or MSSQL's default)
                     cleanedConnection.applicationName =
@@ -703,7 +704,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             );
 
             if (this._connectionToEditCopy) {
-                await this._mainController.connectionManager.getUriForConnection(
+                this._mainController.connectionManager.getUriForConnection(
                     this._connectionToEditCopy,
                 );
                 await this._objectExplorerProvider.removeConnectionNodes([
@@ -719,8 +720,8 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
             // all properties are set when converting from a ConnectionDetails object,
             // so we want to clean the default undefined properties before saving.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cleanedConnection = this.removeDefaultProperties(
+            cleanedConnection = this.removeUndefinedProperties(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 cleanedConnection as any,
             );
 
@@ -766,7 +767,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         return state;
     }
 
-    private removeDefaultProperties(
+    private removeUndefinedProperties(
         connProfile: IConnectionProfile,
     ): IConnectionProfile {
         // TODO: ideally this compares against the default values acquired from a source of truth (e.g. STS),

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -72,6 +72,7 @@ import {
     groupAdvancedOptions,
 } from "./formComponentHelpers";
 import { FormWebviewController } from "../forms/formWebviewController";
+import { ConnectionCredentials } from "../models/connectionCredentials";
 
 export class ConnectionDialogWebviewController extends FormWebviewController<
     IConnectionDialogProfile,
@@ -619,8 +620,9 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         this.state.connectionStatus = ApiStatus.Loading;
         this.updateState();
 
-        const cleanedConnection: IConnectionDialogProfile =
-            this.cleanConnection(this.state.connectionProfile);
+        let cleanedConnection: IConnectionDialogProfile = this.cleanConnection(
+            this.state.connectionProfile,
+        );
 
         const erroredInputs = await this.validateProfile(cleanedConnection);
 
@@ -634,8 +636,21 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
         try {
             try {
+                if (
+                    this.state.selectedInputMode ===
+                    ConnectionInputMode.ConnectionString
+                ) {
+                    const connDetails =
+                        await this._mainController.connectionManager.buildConnectionDetails(
+                            this.state.connectionProfile.connectionString,
+                        );
+
+                    cleanedConnection =
+                        ConnectionCredentials.createConnectionInfo(connDetails);
+                }
+
                 const result =
-                    await this._mainController.connectionManager.connectionUI.validateAndSaveProfileFromDialog(
+                    await this._mainController.connectionManager.connectDialog(
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         cleanedConnection as any,
                     );
@@ -692,13 +707,20 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 this._objectExplorerProvider.refresh(undefined);
             }
 
-            await this._mainController.connectionManager.connectionUI.saveProfile(
+            // all properties are set when converting from a ConnectionDetails object,
+            // so we want to clean the default undefined properties before saving.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cleanedConnection = this.removeDefaultProperties(
+                cleanedConnection as any,
+            );
+
+            await this._mainController.connectionManager.connectionStore.saveProfile(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                this.state.connectionProfile as any,
+                cleanedConnection as any,
             );
             const node =
                 await this._mainController.createObjectExplorerSessionFromDialog(
-                    this.state.connectionProfile,
+                    cleanedConnection,
                 );
 
             this._objectExplorerProvider.refresh(undefined);
@@ -732,6 +754,26 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             return state;
         }
         return state;
+    }
+
+    private removeDefaultProperties(
+        connProfile: IConnectionProfile,
+    ): IConnectionProfile {
+        // TODO: ideally this compares against the default values acquired from a source of truth (e.g. STS),
+        // so that it can clean up more than just undefined properties.
+
+        const output = Object.assign({}, connProfile);
+        for (const key of Object.keys(output)) {
+            if (
+                output[key] === undefined ||
+                // eslint-disable-next-line no-restricted-syntax
+                output[key] === null
+            ) {
+                delete output[key];
+            }
+        }
+
+        return output;
     }
 
     private async handleConnectionErrorCodes(

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -647,6 +647,16 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
                     cleanedConnection =
                         ConnectionCredentials.createConnectionInfo(connDetails);
+
+                    // re-add profileName and savePassword because they aren't part of the connection string
+                    cleanedConnection.profileName =
+                        this.state.connectionProfile.profileName;
+                    cleanedConnection.savePassword =
+                        !!cleanedConnection.password;
+
+                    // overwrite SQL Tools Service's default application name with the one the user provided (or MSSQL's default)
+                    cleanedConnection.applicationName =
+                        this.state.connectionProfile.applicationName;
                 }
 
                 const result =

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -137,6 +137,10 @@ export class ConnectionConfig implements IConnectionConfig {
             }
         }
 
+        if (profile.id === undefined) {
+            ConnectionProfile.addIdIfMissing(profile);
+        }
+
         let profiles = this.getProfilesFromSettings();
 
         // Remove the profile if already set

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -383,6 +383,15 @@ export default class ConnectionManager {
         );
     }
 
+    public async buildConnectionDetails(
+        connectionString: string,
+    ): Promise<ConnectionDetails> {
+        return await this.client.sendRequest(
+            ConnectionContracts.BuildConnectionDetailsRequest.type,
+            connectionString,
+        );
+    }
+
     /**
      * Set connection details for the provided connection info
      * Able to use this for getConnectionString requests to STS that require ConnectionDetails type

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -79,7 +79,11 @@ export class ConnectionCredentials implements IConnectionInfo {
         details.options["user"] = credentials.user || credentials.email;
         details.options["password"] = credentials.password;
         details.options["authenticationType"] = credentials.authenticationType;
+        details.options["email"] = credentials.email;
+        details.options["accountId"] = credentials.accountId;
+        details.options["tenantId"] = credentials.tenantId;
         details.options["azureAccountToken"] = credentials.azureAccountToken;
+        details.options["expiresOn"] = credentials.expiresOn;
         details.options["encrypt"] = credentials.encrypt;
         details.options["trustServerCertificate"] =
             credentials.trustServerCertificate;
@@ -132,7 +136,7 @@ export class ConnectionCredentials implements IConnectionInfo {
             connectionString: options["connectionString"],
             server: options["server"],
             port: options["server"]?.includes(",")
-                ? parseInt(options["server"].split(",")[1], 10)
+                ? parseInt(options["server"].split(",")[1])
                 : undefined,
             database: options["database"],
             user: options["user"],

--- a/src/models/connectionCredentials.ts
+++ b/src/models/connectionCredentials.ts
@@ -16,7 +16,7 @@ import {
 import SqlToolsServerClient from "../languageservice/serviceclient";
 import { ConnectionDetails, IConnectionInfo } from "vscode-mssql";
 
-// Concrete implementation of the IConnectionCredentials interface
+// Concrete implementation of the IConnectionInfo interface
 export class ConnectionCredentials implements IConnectionInfo {
     public server: string;
     public database: string;
@@ -118,6 +118,61 @@ export class ConnectionCredentials implements IConnectionInfo {
         details.options["typeSystemVersion"] = credentials.typeSystemVersion;
 
         return details;
+    }
+
+    /**
+     * Create an IConnectionInfo object from a ConnectionDetails contract.
+     */
+    public static createConnectionInfo(
+        connDetails: ConnectionDetails,
+    ): IConnectionInfo {
+        const options = connDetails.options || {};
+
+        const connInfo: IConnectionInfo = {
+            connectionString: options["connectionString"],
+            server: options["server"],
+            port: options["server"]?.includes(",")
+                ? parseInt(options["server"].split(",")[1], 10)
+                : undefined,
+            database: options["database"],
+            user: options["user"],
+            password: options["password"],
+            authenticationType: options["authenticationType"],
+            azureAccountToken: options["azureAccountToken"],
+            encrypt: options["encrypt"],
+            trustServerCertificate: options["trustServerCertificate"],
+            hostNameInCertificate: options["hostNameInCertificate"],
+            persistSecurityInfo: options["persistSecurityInfo"],
+            secureEnclaves: options["secureEnclaves"],
+            columnEncryptionSetting: options["columnEncryptionSetting"],
+            attestationProtocol: options["attestationProtocol"],
+            enclaveAttestationUrl: options["enclaveAttestationUrl"],
+            connectTimeout: options["connectTimeout"],
+            commandTimeout: options["commandTimeout"],
+            connectRetryCount: options["connectRetryCount"],
+            connectRetryInterval: options["connectRetryInterval"],
+            applicationName: options["applicationName"],
+            workstationId: options["workstationId"],
+            applicationIntent: options["applicationIntent"],
+            currentLanguage: options["currentLanguage"],
+            pooling: options["pooling"],
+            maxPoolSize: options["maxPoolSize"],
+            minPoolSize: options["minPoolSize"],
+            loadBalanceTimeout: options["loadBalanceTimeout"],
+            replication: options["replication"],
+            attachDbFilename: options["attachDbFilename"],
+            failoverPartner: options["failoverPartner"],
+            multiSubnetFailover: options["multiSubnetFailover"],
+            multipleActiveResultSets: options["multipleActiveResultSets"],
+            packetSize: options["packetSize"],
+            typeSystemVersion: options["typeSystemVersion"],
+            email: options["email"],
+            accountId: options["accountId"],
+            tenantId: options["tenantId"],
+            expiresOn: options["expiresOn"],
+        };
+
+        return connInfo;
     }
 
     public static async ensureRequiredPropertiesSet(

--- a/src/models/contracts/connection.ts
+++ b/src/models/contracts/connection.ts
@@ -216,7 +216,7 @@ export class ListDatabasesResult {
 
 // ------------------------------- </ List Databases Request > --------------------------------------
 
-// ------------------------------- < Connection String Request > ---------------------------------------
+// ------------------------------- < Get Connection String Request > ---------------------------------------
 /**
  * Get Connection String request callback declaration
  */
@@ -257,7 +257,19 @@ export class GetConnectionStringParams {
     public includeApplicationName?: boolean;
 }
 
-// ------------------------------- </ Connection String Request > --------------------------------------
+// ------------------------------- </ Get Connection String Request > --------------------------------------
+
+// ------------------------------- < Build Connection Details Request > ---------------------------------------
+/**
+ * Get Connection String request callback declaration
+ */
+export namespace BuildConnectionDetailsRequest {
+    export const type = new RequestType<string, ConnectionDetails, void, void>(
+        "connection/buildconnectioninfo",
+    );
+}
+
+// ------------------------------- </ Build Connection Details > --------------------------------------
 
 // ------------------------------- < Encryption IV/KEY updation Event > ------------------------------------
 /**

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -851,12 +851,14 @@ export class ObjectExplorerService {
                     connectionDetails,
                 );
 
-            if ((connectionProfile as IConnectionProfile).profileName) {
-                this._sessionIdToNodeLabelMap.set(
-                    sessionIdResponse.sessionId,
-                    (connectionProfile as IConnectionProfile).profileName,
-                );
-            }
+            const nodeLabel =
+                (connectionProfile as IConnectionProfile).profileName ??
+                ConnInfo.getConnectionDisplayName(connectionProfile);
+
+            this._sessionIdToNodeLabelMap.set(
+                sessionIdResponse.sessionId,
+                nodeLabel,
+            );
 
             const response: CreateSessionResponse =
                 await this._connectionManager.client.sendRequest(

--- a/test/unit/connectionCredentials.test.ts
+++ b/test/unit/connectionCredentials.test.ts
@@ -15,11 +15,14 @@ import { ConnectionStore } from "../../src/models/connectionStore";
 import { ConnectionCredentials } from "../../src/models/connectionCredentials";
 import { IPrompter, IQuestion } from "../../src/prompts/question";
 import { TestPrompter } from "./stubs";
-import { IConnectionProfile } from "../../src/models/interfaces";
+import {
+    AuthenticationTypes,
+    IConnectionProfile,
+} from "../../src/models/interfaces";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 
 import * as assert from "assert";
-import { IConnectionInfo } from "vscode-mssql";
+import { ConnectionDetails, IConnectionInfo } from "vscode-mssql";
 
 suite("ConnectionCredentials Tests", () => {
     let defaultProfile: interfaces.IConnectionProfile;
@@ -176,133 +179,232 @@ suite("ConnectionCredentials Tests", () => {
         };
     }
 
-    // Connect with savePassword true and filled password and ensure password is saved and removed from plain text
-    test("ensureRequiredPropertiesSet should remove password from plain text and save password to Credential Store", (done) => {
-        // Setup Profile Information to have savePassword on and filled in password
-        let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
-            savePassword: true,
-            password: "oldPassword",
-        });
-        let emptyPassword = false;
+    suite("ensureRequiredPropertiesSet Tests", () => {
+        // Connect with savePassword true and filled password and ensure password is saved and removed from plain text
+        test("ensureRequiredPropertiesSet should remove password from plain text and save password to Credential Store", (done) => {
+            // Setup Profile Information to have savePassword on and filled in password
+            let profile = Object.assign(
+                new ConnectionProfile(),
+                defaultProfile,
+                {
+                    savePassword: true,
+                    password: "oldPassword",
+                },
+            );
+            let emptyPassword = false;
 
-        connectProfile(profile, emptyPassword)
-            .then((success) => {
-                assert.ok(success);
-                connectionStore.verify(
-                    async (x) => await x.removeProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.once(),
-                );
-                connectionStore.verify(
-                    async (x) => await x.saveProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.once(),
-                );
-                done();
-            })
-            .catch((err) => done(new Error(err)));
-    });
-
-    // Connect with savePassword true and empty password does not reset password
-    test("ensureRequiredPropertiesSet should keep Credential Store password", (done) => {
-        // Setup Profile Information to have savePassword on and blank
-        let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
-            savePassword: true,
-            password: "",
+            connectProfile(profile, emptyPassword)
+                .then((success) => {
+                    assert.ok(success);
+                    connectionStore.verify(
+                        async (x) => await x.removeProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.once(),
+                    );
+                    connectionStore.verify(
+                        async (x) => await x.saveProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.once(),
+                    );
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
         });
 
-        let emptyPassword = true;
-        connectProfile(profile, emptyPassword)
-            .then((success) => {
-                assert.ok(success);
-                connectionStore.verify(
-                    async (x) => await x.removeProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                connectionStore.verify(
-                    async (x) => await x.saveProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                done();
-            })
-            .catch((err) => done(new Error(err)));
-    });
+        // Connect with savePassword true and empty password does not reset password
+        test("ensureRequiredPropertiesSet should keep Credential Store password", (done) => {
+            // Setup Profile Information to have savePassword on and blank
+            let profile = Object.assign(
+                new ConnectionProfile(),
+                defaultProfile,
+                {
+                    savePassword: true,
+                    password: "",
+                },
+            );
 
-    // Connect with savePassword false and ensure password is never saved
-    test("ensureRequiredPropertiesSet should not save password", (done) => {
-        // Setup Profile Information to have savePassword off and blank
-        let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
-            savePassword: false,
-            password: "oldPassword",
+            let emptyPassword = true;
+            connectProfile(profile, emptyPassword)
+                .then((success) => {
+                    assert.ok(success);
+                    connectionStore.verify(
+                        async (x) => await x.removeProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    connectionStore.verify(
+                        async (x) => await x.saveProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
         });
 
-        let emptyPassword = false;
-        connectProfile(profile, emptyPassword)
-            .then((success) => {
-                assert.ok(success);
-                connectionStore.verify(
-                    async (x) => await x.removeProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                connectionStore.verify(
-                    async (x) => await x.saveProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                done();
-            })
-            .catch((err) => done(new Error(err)));
-    });
+        // Connect with savePassword false and ensure password is never saved
+        test("ensureRequiredPropertiesSet should not save password", (done) => {
+            // Setup Profile Information to have savePassword off and blank
+            let profile = Object.assign(
+                new ConnectionProfile(),
+                defaultProfile,
+                {
+                    savePassword: false,
+                    password: "oldPassword",
+                },
+            );
 
-    // Connect with savePassword false and ensure empty password is never saved
-    test("ensureRequiredPropertiesSet should not save password, empty password case", (done) => {
-        // Setup Profile Information to have savePassword off and blank
-        let profile = Object.assign(new ConnectionProfile(), defaultProfile, {
-            savePassword: false,
-            password: "",
+            let emptyPassword = false;
+            connectProfile(profile, emptyPassword)
+                .then((success) => {
+                    assert.ok(success);
+                    connectionStore.verify(
+                        async (x) => await x.removeProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    connectionStore.verify(
+                        async (x) => await x.saveProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
         });
 
-        let emptyPassword = true;
-        connectProfile(profile, emptyPassword)
-            .then((success) => {
-                assert.ok(success);
-                connectionStore.verify(
-                    async (x) => await x.removeProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                connectionStore.verify(
-                    async (x) => await x.saveProfile(TypeMoq.It.isAny()),
-                    TypeMoq.Times.never(),
-                );
-                done();
-            })
-            .catch((err) => done(new Error(err)));
-    });
+        // Connect with savePassword false and ensure empty password is never saved
+        test("ensureRequiredPropertiesSet should not save password, empty password case", (done) => {
+            // Setup Profile Information to have savePassword off and blank
+            let profile = Object.assign(
+                new ConnectionProfile(),
+                defaultProfile,
+                {
+                    savePassword: false,
+                    password: "",
+                },
+            );
 
-    // Connect with savePassword true and blank password and
-    // confirm password is prompted for and saved for non-empty password
-    test(
-        "ensureRequiredPropertiesSet should request password and save it for non-empty passwords",
-        ensureRequestAndSavePassword(false),
-    );
+            let emptyPassword = true;
+            connectProfile(profile, emptyPassword)
+                .then((success) => {
+                    assert.ok(success);
+                    connectionStore.verify(
+                        async (x) => await x.removeProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    connectionStore.verify(
+                        async (x) => await x.saveProfile(TypeMoq.It.isAny()),
+                        TypeMoq.Times.never(),
+                    );
+                    done();
+                })
+                .catch((err) => done(new Error(err)));
+        });
 
-    // Connect with savePassword true and blank password and
-    // confirm password is prompted for and saved correctly for an empty password
-    test(
-        "ensureRequiredPropertiesSet should request password and save it correctly for empty passswords",
-        ensureRequestAndSavePassword(true),
-    );
-
-    // A connection string can be set alongside other properties for createConnectionDetails
-    test("createConnectionDetails sets properties in addition to the connection string", () => {
-        let credentials = new ConnectionCredentials();
-        credentials.connectionString = "server=some-server";
-        credentials.database = "some-db";
-
-        let connectionDetails =
-            ConnectionCredentials.createConnectionDetails(credentials);
-        assert.equal(
-            connectionDetails.options.connectionString,
-            credentials.connectionString,
+        // Connect with savePassword true and blank password and
+        // confirm password is prompted for and saved for non-empty password
+        test(
+            "ensureRequiredPropertiesSet should request password and save it for non-empty passwords",
+            ensureRequestAndSavePassword(false),
         );
-        assert.equal(connectionDetails.options.database, credentials.database);
+
+        // Connect with savePassword true and blank password and
+        // confirm password is prompted for and saved correctly for an empty password
+        test(
+            "ensureRequiredPropertiesSet should request password and save it correctly for empty passswords",
+            ensureRequestAndSavePassword(true),
+        );
+    });
+
+    suite("ConnectionDetails conversion tests", () => {
+        // A connection string can be set alongside other properties for createConnectionDetails
+        test("createConnectionDetails sets properties in addition to the connection string", () => {
+            let credentials = new ConnectionCredentials();
+            credentials.connectionString = "server=some-server";
+            credentials.database = "some-db";
+
+            let connectionDetails =
+                ConnectionCredentials.createConnectionDetails(credentials);
+            assert.equal(
+                connectionDetails.options.connectionString,
+                credentials.connectionString,
+            );
+            assert.equal(
+                connectionDetails.options.database,
+                credentials.database,
+            );
+        });
+
+        test("createConnectionDetails sets properties from the connection string", () => {
+            const connDetails: ConnectionDetails = {
+                options: {
+                    server: "someServer,1234",
+                    user: "testUser",
+                    password: "testPassword",
+                },
+            };
+
+            const connInfo =
+                ConnectionCredentials.createConnectionInfo(connDetails);
+
+            assert.equal(connInfo.server, connDetails.options.server);
+            assert.equal(connInfo.user, connDetails.options.user);
+            assert.equal(connInfo.password, connDetails.options.password);
+            assert.equal(connInfo.port, 1234);
+        });
+
+        test("IConnectionInfo-ConnectionDetails conversion roundtrip", () => {
+            const originalConnInfo: IConnectionInfo = {
+                server: "testServer,1234",
+                database: "testDatabase",
+                user: "testUser",
+                password: "testPassword",
+                email: "testEmail@contoso.com",
+                accountId: "testAccountid",
+                tenantId: "testTenantId",
+                port: 1234,
+                authenticationType:
+                    AuthenticationTypes[AuthenticationTypes.SqlLogin],
+                azureAccountToken: "testToken",
+                expiresOn: 5678,
+                encrypt: "Strict",
+                trustServerCertificate: true,
+                hostNameInCertificate: "testHostName",
+                persistSecurityInfo: true,
+                secureEnclaves: "testSecureEnclaves",
+                columnEncryptionSetting: "Enabled",
+                attestationProtocol: "HGS",
+                enclaveAttestationUrl: "testEnclaveAttestationUrl",
+                connectTimeout: 7,
+                commandTimeout: 11,
+                connectRetryCount: 17,
+                connectRetryInterval: 19,
+                applicationName: "testApplicationName",
+                workstationId: "testWorkstationId",
+                applicationIntent: "ReadOnly",
+                currentLanguage: "",
+                pooling: true,
+                maxPoolSize: 23,
+                minPoolSize: 29,
+                loadBalanceTimeout: 31,
+                replication: true,
+                attachDbFilename: "testAttachDbFilename",
+                failoverPartner: "testFailoverPartner",
+                multiSubnetFailover: true,
+                multipleActiveResultSets: true,
+                packetSize: 37,
+                typeSystemVersion: "testTypeSystemVersion",
+                connectionString: "testConnectionString",
+            };
+
+            const connDetails =
+                ConnectionCredentials.createConnectionDetails(originalConnInfo);
+            const convertedConnInfo =
+                ConnectionCredentials.createConnectionInfo(connDetails);
+
+            for (const key in originalConnInfo) {
+                assert.equal(
+                    originalConnInfo[key as keyof IConnectionInfo],
+                    convertedConnInfo[key as keyof IConnectionInfo],
+                    `Mismatch on ${key}`,
+                );
+            }
+        });
     });
 
     test("Subsequent connection credential questions are skipped if a connection string is given", async () => {


### PR DESCRIPTION
Addresses bugs:
* Adding a connection string creates an "undefined <undefined> (undefined)" Object Explorer entry (https://github.com/microsoft/vscode-mssql/issues/18616)
* Adding a connection via connection string in Connection Dialog results in a password in the config file, and the OE label (for a connection without a profileName) includes that (https://github.com/microsoft/vscode-mssql/issues/19005)

With this change, all new connections are serialized the same way, regardless of input method (same as Azure Data Studio), which also allows connectionString connections to be more readily parsed for sanitized default OE connection labels.