### PR TITLE
Fixed pipeline tasks for non-Pull request runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -310,7 +310,7 @@ jobs:
             # Updates to localized strings required
 
       - name: Create or update comment
-        if: ${{ env.loc_update_required == 'true' }} && github.event_name != 'push'
+        if: github.event_name != 'push' && ${{ env.loc_update_required == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}
@@ -326,7 +326,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete comment
-        if: ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != '' && github.event_name != 'push'
+        if: github.event_name != 'push' && ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != ''
         run: |
           curl -X DELETE \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,7 +247,6 @@ jobs:
 
       - name: Write PR results to markdown
         run: |
-          echo "$GITHUB_EVENT_NAME"
           echo "### PR Changes" >> results.md
           echo "| Category                      | Main Branch        | PR Branch         | Difference           |" >> results.md
           echo "|------------------------------|--------------------|-------------------|----------------------|" >> results.md

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - 'laurennat/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Write PR results to markdown
         run: |
-          echo github.event_name
+          echo "$GITHUB_EVENT_NAME"
           echo "### PR Changes" >> results.md
           echo "| Category                      | Main Branch        | PR Branch         | Difference           |" >> results.md
           echo "|------------------------------|--------------------|-------------------|----------------------|" >> results.md
@@ -311,7 +311,7 @@ jobs:
             # Updates to localized strings required
 
       - name: Create or update comment
-        if: github.event_name == 'pull_request' && ${{ env.loc_update_required == 'true' }}
+        if: github.event_name == 'pull_request' && env.loc_update_required == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - 'laurennat/**'
   pull_request:
     branches:
       - main
@@ -255,6 +256,7 @@ jobs:
 
       - name: Find comment
         uses: peter-evans/find-comment@v3
+        if: github.event_name != 'push'
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -264,6 +266,7 @@ jobs:
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
+        if: github.event_name != 'push'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -298,6 +301,7 @@ jobs:
 
       - name: Find comment
         uses: peter-evans/find-comment@v3
+        if: github.event_name != 'push'
         id: loc-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -306,7 +310,7 @@ jobs:
             # Updates to localized strings required
 
       - name: Create or update comment
-        if: ${{ env.loc_update_required == 'true' }}
+        if: ${{ env.loc_update_required == 'true' }} && github.event_name != 'push'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}
@@ -322,7 +326,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete comment
-        if: ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != ''
+        if: ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != '' && github.event_name != 'push'
         run: |
           curl -X DELETE \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,6 +247,7 @@ jobs:
 
       - name: Write PR results to markdown
         run: |
+          echo github.event_name
           echo "### PR Changes" >> results.md
           echo "| Category                      | Main Branch        | PR Branch         | Difference           |" >> results.md
           echo "|------------------------------|--------------------|-------------------|----------------------|" >> results.md
@@ -256,7 +257,7 @@ jobs:
 
       - name: Find comment
         uses: peter-evans/find-comment@v3
-        if: github.event_name != 'push'
+        if: github.event_name == 'pull_request'
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -266,7 +267,7 @@ jobs:
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name != 'push'
+        if: github.event_name == 'pull_request'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -301,7 +302,7 @@ jobs:
 
       - name: Find comment
         uses: peter-evans/find-comment@v3
-        if: github.event_name != 'push'
+        if: github.event_name == 'pull_request'
         id: loc-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -310,7 +311,7 @@ jobs:
             # Updates to localized strings required
 
       - name: Create or update comment
-        if: github.event_name != 'push' && ${{ env.loc_update_required == 'true' }}
+        if: github.event_name == 'pull_request' && ${{ env.loc_update_required == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}
@@ -326,7 +327,7 @@ jobs:
           edit-mode: replace
 
       - name: Delete comment
-        if: github.event_name != 'push' && ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != ''
+        if: github.event_name == 'pull_request' && ${{ env.loc_update_required == 'false' }} && steps.loc-comment.outputs.comment-id != ''
         run: |
           curl -X DELETE \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build and Test (Unit + E2E)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml)
+[![Build and Test (Unit + E2E)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml/badge.svg?branch=main&event=push)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml)
 ![GitHub Discussions](https://img.shields.io/github/discussions/microsoft/vscode-mssql)
 
 # MSSQL extension for Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build and Test](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml/badge.svg?branch=main&event=schedule)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml)
+[![Build and Test (Unit + E2E)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml)
 ![GitHub Discussions](https://img.shields.io/github/discussions/microsoft/vscode-mssql)
 
 # MSSQL extension for Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Daily Build and Test](https://github.com/microsoft/vscode-mssql/actions/workflows/daily-build-and-test.yml/badge.svg?branch=main&event=schedule)](https://github.com/microsoft/vscode-mssql/actions/workflows/daily-build-and-test.yml)
+[![Build and Test](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml/badge.svg?branch=main&event=schedule)](https://github.com/microsoft/vscode-mssql/actions/workflows/build-and-test.yml)
 ![GitHub Discussions](https://img.shields.io/github/discussions/microsoft/vscode-mssql)
 
 # MSSQL extension for Visual Studio Code


### PR DESCRIPTION
Updated the PR comment tasks to run only when the pipeline is triggered by a pull request.

Here is a successful pipeline run for a non-PR event: https://github.com/microsoft/vscode-mssql/actions/runs/14140475114