### PR TITLE
Fixing node centering after a new table is added. 

### DIFF
--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -35,7 +35,7 @@ export interface SchemaDesignerContextProps
     deleteTable: (table: SchemaDesigner.Table) => Promise<boolean>;
     deleteSelectedNodes: () => void;
     getTableWithForeignKeys: (tableId: string) => SchemaDesigner.Table | undefined;
-    setCenter: (nodeId: string) => void;
+    setCenter: (nodeId: string, zoomIn?: boolean) => void;
 }
 
 const SchemaDesignerContext = createContext<SchemaDesignerContextProps>(
@@ -275,14 +275,14 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
         }
     };
 
-    const setCenter = (nodeId: string) => {
+    const setCenter = (nodeId: string, shouldZoomIn: boolean = false) => {
         const node = reactFlow.getNode(nodeId) as Node<SchemaDesigner.Table>;
         if (node) {
             void reactFlow.setCenter(
                 node.position.x + flowUtils.getTableWidth() / 2,
                 node.position.y + flowUtils.getTableHeight(node.data) / 2,
                 {
-                    zoom: reactFlow.getZoom(),
+                    zoom: shouldZoomIn ? 1 : reactFlow.getZoom(),
                     duration: 500,
                 },
             );

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -169,7 +169,7 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
             reactFlow.addNodes(nodeWithPosition);
             reactFlow.addEdges(edgesForNewTable);
             requestAnimationFrame(async () => {
-                setCenter(nodeWithPosition.id);
+                setCenter(nodeWithPosition.id, true);
             });
 
             eventBus.emit("getScript");

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -35,7 +35,7 @@ export interface SchemaDesignerContextProps
     deleteTable: (table: SchemaDesigner.Table) => Promise<boolean>;
     deleteSelectedNodes: () => void;
     getTableWithForeignKeys: (tableId: string) => SchemaDesigner.Table | undefined;
-    setCenter: (nodeId: string, zoomIn?: boolean) => void;
+    setCenter: (nodeId: string, shouldZoomIn?: boolean) => void;
 }
 
 const SchemaDesignerContext = createContext<SchemaDesignerContextProps>(

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -35,6 +35,7 @@ export interface SchemaDesignerContextProps
     deleteTable: (table: SchemaDesigner.Table) => Promise<boolean>;
     deleteSelectedNodes: () => void;
     getTableWithForeignKeys: (tableId: string) => SchemaDesigner.Table | undefined;
+    setCenter: (nodeId: string) => void;
 }
 
 const SchemaDesignerContext = createContext<SchemaDesignerContextProps>(
@@ -168,13 +169,7 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
             reactFlow.addNodes(nodeWithPosition);
             reactFlow.addEdges(edgesForNewTable);
             requestAnimationFrame(async () => {
-                await reactFlow.setCenter(
-                    nodeWithPosition.position.x,
-                    nodeWithPosition.position.y,
-                    {
-                        duration: 500,
-                    },
-                );
+                setCenter(nodeWithPosition.id);
             });
 
             eventBus.emit("getScript");
@@ -277,6 +272,20 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
                 nodes: [],
                 edges: selectedEdges,
             });
+        }
+    };
+
+    const setCenter = (nodeId: string) => {
+        const node = reactFlow.getNode(nodeId) as Node<SchemaDesigner.Table>;
+        if (node) {
+            void reactFlow.setCenter(
+                node.position.x + flowUtils.getTableWidth() / 2,
+                node.position.y + flowUtils.getTableHeight(node.data) / 2,
+                {
+                    zoom: reactFlow.getZoom(),
+                    duration: 500,
+                },
+            );
         }
     };
 


### PR DESCRIPTION
Changing the node centering api from top left of the node to actual center of the node. Also exposing this in the context so I can use it in other components

Before: 
![image](https://github.com/user-attachments/assets/03ba2caa-1d65-45d0-9c52-f16c9cb7ad38)

After:
![image](https://github.com/user-attachments/assets/e4ba3202-eee3-4fc3-be91-010d315e0972)
