### PR TITLE
Improve how option descriptions appear in Schema Compare

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
@@ -161,7 +161,11 @@ const SchemaOptionsDrawer = (props: Props) => {
                         {includeObjectTypesLookup &&
                             includeObjectTypesEntries.map(([key, value]) => {
                                 return (
-                                    <ListItem key={key} value={key} aria-label={value}>
+                                    <ListItem
+                                        className={classes.listItemContainer}
+                                        key={key}
+                                        value={key}
+                                        aria-label={value}>
                                         <Checkbox
                                             checked={handleSetObjectTypesCheckedState(key)}
                                             onChange={() => handleObjectTypesOptionChanged(key)}

--- a/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
@@ -32,6 +32,11 @@ const useStyles = makeStyles({
         height: "80vh",
         overflowY: "auto",
     },
+
+    listItemContainer: {
+        display: "flex",
+        alignItems: "center",
+    },
 });
 
 interface Props {
@@ -131,11 +136,16 @@ const SchemaOptionsDrawer = (props: Props) => {
                         {optionsToValueNameLookup &&
                             generalOptionEntries.map(([key, value]) => {
                                 return (
-                                    <ListItem key={key} value={key} aria-label={value.displayName}>
+                                    <ListItem
+                                        className={classes.listItemContainer}
+                                        key={key}
+                                        value={key}
+                                        aria-label={value.displayName}>
                                         <Checkbox
                                             checked={value.value}
                                             onChange={() => handleSettingChanged(key)}
                                         />
+
                                         <InfoLabel
                                             aria-label={value.displayName}
                                             info={<>{value.description}</>}>

--- a/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
@@ -5,10 +5,6 @@
 
 import { useContext, useEffect, useState } from "react";
 import {
-    Accordion,
-    AccordionHeader,
-    AccordionItem,
-    AccordionPanel,
     Button,
     Checkbox,
     Drawer,
@@ -16,6 +12,7 @@ import {
     DrawerFooter,
     DrawerHeader,
     DrawerHeaderTitle,
+    InfoLabel,
     Label,
     makeStyles,
     SelectTabData,
@@ -31,12 +28,7 @@ import { schemaCompareContext } from "../SchemaCompareStateProvider";
 import { DacDeployOptionPropertyBoolean } from "vscode-mssql";
 
 const useStyles = makeStyles({
-    generalOptionsContainer: {
-        height: "55vh",
-        overflowY: "auto",
-    },
-
-    objectTypesContainer: {
+    optionsContainer: {
         height: "80vh",
         overflowY: "auto",
     },
@@ -80,7 +72,6 @@ const SchemaOptionsDrawer = (props: Props) => {
 
     const [optionsChanged, setOptionsChanged] = useState(false);
     const [selectedValue, setSelectedValue] = useState<TabValue>("generalOptions");
-    const [description, setDescription] = useState<string>("");
 
     const onTabSelect = (_: SelectTabEvent, data: SelectTabData) => {
         setSelectedValue(data.value);
@@ -136,43 +127,27 @@ const SchemaOptionsDrawer = (props: Props) => {
                     </Tab>
                 </TabList>
                 {selectedValue === "generalOptions" && (
-                    <Accordion collapsible multiple defaultOpenItems={["0", "1"]}>
-                        <AccordionItem value="0">
-                            <AccordionHeader>{loc.schemaCompare.settings}</AccordionHeader>
-                            <AccordionPanel className={classes.generalOptionsContainer}>
-                                <List>
-                                    {optionsToValueNameLookup &&
-                                        generalOptionEntries.map(([key, value]) => {
-                                            return (
-                                                <ListItem
-                                                    key={key}
-                                                    value={key}
-                                                    aria-label={value.displayName}>
-                                                    <Checkbox
-                                                        checked={value.value}
-                                                        onChange={() => handleSettingChanged(key)}
-                                                    />
-                                                    <Label
-                                                        aria-label={value.displayName}
-                                                        onClick={() =>
-                                                            setDescription(value.description)
-                                                        }>
-                                                        {value.displayName}
-                                                    </Label>
-                                                </ListItem>
-                                            );
-                                        })}
-                                </List>
-                            </AccordionPanel>
-                        </AccordionItem>
-                        <AccordionItem value="1">
-                            <AccordionHeader>{loc.schemaCompare.description}</AccordionHeader>
-                            {!!description && <AccordionPanel>{description}</AccordionPanel>}
-                        </AccordionItem>
-                    </Accordion>
+                    <List className={classes.optionsContainer}>
+                        {optionsToValueNameLookup &&
+                            generalOptionEntries.map(([key, value]) => {
+                                return (
+                                    <ListItem key={key} value={key} aria-label={value.displayName}>
+                                        <Checkbox
+                                            checked={value.value}
+                                            onChange={() => handleSettingChanged(key)}
+                                        />
+                                        <InfoLabel
+                                            aria-label={value.displayName}
+                                            info={<>{value.description}</>}>
+                                            {value.displayName}
+                                        </InfoLabel>
+                                    </ListItem>
+                                );
+                            })}
+                    </List>
                 )}
                 {selectedValue === "includeObjectTypes" && (
-                    <List className={classes.objectTypesContainer}>
+                    <List className={classes.optionsContainer}>
                         {includeObjectTypesLookup &&
                             includeObjectTypesEntries.map(([key, value]) => {
                                 return (


### PR DESCRIPTION
This PR improves how the descriptions for schema compare options appears by having an informational icon appear to the right of the label, like this:
![image](https://github.com/user-attachments/assets/ba9e321c-d910-40f2-9722-097e6973a0d4)


When a user clicks on the informational icon, a tooltip will appear with a description of the option and that tooltip looks like this:
![image](https://github.com/user-attachments/assets/a363a80a-844d-4719-b017-6668dfaa3a95)

Checkbox alignment is also fixed: 
![image](https://github.com/user-attachments/assets/bc02c58a-b4a1-4cc2-abde-e772c3e443fc)
![image](https://github.com/user-attachments/assets/5d0812e6-05f0-4179-9df6-003898989948)



