### PR TITLE
Fixing input styling in webviews to make them look more native. 

### DIFF
--- a/src/reactviews/common/searchableDropdown.component.tsx
+++ b/src/reactviews/common/searchableDropdown.component.tsx
@@ -314,6 +314,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                     aria-expanded={isMenuOpen}
                     aria-label={props.ariaLabel}
                     disabled={props.disabled}
+                    className={isMenuOpen ? "dropdown-open" : ""}
                     style={{
                         ...props.style,
                         justifyContent: "space-between",
@@ -324,6 +325,12 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                             overflow: "hidden",
                             textOverflow: "ellipsis",
                         }}
+                        className={
+                            getOptionDisplayText(selectedOption, props.placeholder) ===
+                            props.placeholder
+                                ? "placeholder"
+                                : ""
+                        }
                         title={getOptionDisplayText(selectedOption, props.placeholder)}>
                         {getOptionDisplayText(selectedOption, props.placeholder)}
                     </Text>

--- a/src/reactviews/index.css
+++ b/src/reactviews/index.css
@@ -1,26 +1,59 @@
+/* Root container styles */
 #root {
     left: 0;
     right: 0;
     width: 100%;
     height: 100%;
     overflow: hidden;
-    color: "var(--vscode-foreground)";
+    color: var(--vscode-foreground);
 }
 
-/* Make fluent focus fields look more like vscode focus  */
-a:focus,
-input:not([type="search"]):focus,
-select:focus,
-textarea:focus,
-button[role="combobox"]:focus,
-.fui-Combobox:focus-within,
-.fui-Input:focus-within,
-.fui-Dropdown:focus-within {
-    outline: 1px solid var(--colorCompoundBrandStroke, --vscode-focusBorder) !important;
-    border-radius: var(--borderRadiusSmall, 2px) !important;
+/* fluent ui adds some hover styles to the input elements, which vscode doens't have. This is a workaround to remove those styles. */
+.fui-Input,
+.fui-Textarea,
+.fui-Input:hover,
+.fui-Textarea:hover {
+    background-color: var(--vscode-input-background) !important;
+    color: var(--vscode-input-foreground) !important;
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 2px;
+}
+
+/* Combobox styling */
+.fui-Dropdown {
     border: none !important;
 }
+button[role="combobox"] {
+    background-color: var(--vscode-dropdown-background) !important;
+    color: var(--vscode-dropdown-foreground) !important;
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 2px;
+    min-height: 26px !important;
+    line-height: 19px !important;
+}
+button[role="combobox"] .placeholder {
+    color: var(--vscode-input-placeholderForeground) !important;
+}
 
-input[type="search"]:focus {
+/* Adding focus styles to the input elements */
+a:focus,
+select:focus,
+.fui-Combobox:focus-within,
+.fui-Input:focus-within,
+.fui-Dropdown:focus-within,
+.fui-Textarea:focus-within,
+button[role="combobox"].dropdown-open {
+    border: 1px solid var(--vscode-focusBorder) !important;
+    border-radius: var(--borderRadiusSmall, 2px) !important;
+}
+
+/* Removing focus styling on actual elements as we have already added focus styles to the container */
+input[type="search"]:focus,
+input[type="text"]:focus,
+input[type="password"]:focus,
+input:not([type="search"]):focus,
+textarea:focus,
+button[role="combobox"]:focus {
     outline: none !important;
+    border: none !important;
 }


### PR DESCRIPTION
Inputbox style:
Before: 
![image](https://github.com/user-attachments/assets/14b88549-c2a2-4da3-a8aa-5f28361dfbf7)
After:
![image](https://github.com/user-attachments/assets/2c60e6c3-a20b-4439-b2a5-9b6921867d40)
Focus:
![image](https://github.com/user-attachments/assets/ba97c6ff-0b0d-441b-b906-375394af03f0)

Input with icon focused:
Before:
![image](https://github.com/user-attachments/assets/f30d5f80-b84a-427e-88ac-f3d55e091cc9)
After:
![image](https://github.com/user-attachments/assets/d7f61053-f97d-4f42-a5ce-0e071a4031c1)


Combox:
Before:
![image](https://github.com/user-attachments/assets/f2b841d6-35f9-469c-ae1f-79102cad0e1b)
After:
![image](https://github.com/user-attachments/assets/2003a643-1f04-4dee-94c8-8e0f171bba29)

Focused:
Before:
![image](https://github.com/user-attachments/assets/abfc5070-7f5b-4b22-a853-f83f3606fe7c)
After:
![image](https://github.com/user-attachments/assets/718080f9-8174-48b0-9bbd-2e78cb3fe776)


Pages:

Connection Dialog: 
Before:
![image](https://github.com/user-attachments/assets/f2c29378-9c22-44b6-afc6-ee14ac14c649)
After:
![image](https://github.com/user-attachments/assets/365afaee-7c1f-4500-b4e1-6af2d9a55a8e)

Table Designer:
Before:
![image](https://github.com/user-attachments/assets/c390103c-9183-4ffc-93f9-1321b83aa4fc)
After:
![image](https://github.com/user-attachments/assets/0ca91b53-2ff3-4070-9e0e-1d9ec1b6724e)



