### PR TITLE
Set combo box labels for Options drawer correctly

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
@@ -144,13 +144,14 @@ const SchemaOptionsDrawer = (props: Props) => {
                                         <Checkbox
                                             checked={value.value}
                                             onChange={() => handleSettingChanged(key)}
+                                            label={
+                                                <InfoLabel
+                                                    aria-label={value.displayName}
+                                                    info={<>{value.description}</>}>
+                                                    {value.displayName}
+                                                </InfoLabel>
+                                            }
                                         />
-
-                                        <InfoLabel
-                                            aria-label={value.displayName}
-                                            info={<>{value.description}</>}>
-                                            {value.displayName}
-                                        </InfoLabel>
                                     </ListItem>
                                 );
                             })}
@@ -169,8 +170,8 @@ const SchemaOptionsDrawer = (props: Props) => {
                                         <Checkbox
                                             checked={handleSetObjectTypesCheckedState(key)}
                                             onChange={() => handleObjectTypesOptionChanged(key)}
+                                            label={<Label aria-label={value}>{value}</Label>}
                                         />
-                                        <Label aria-label={value}>{value}</Label>
                                     </ListItem>
                                 );
                             })}


### PR DESCRIPTION
This PR attaches the label to the checkbox for screen readers by using the label option on the checkbox.
![image](https://github.com/user-attachments/assets/180345f9-8aaa-40d9-a8c3-f11fb75a11af)
![image](https://github.com/user-attachments/assets/45b049c0-619c-43ce-96a4-b3ed4df38f7d)

