### PR TITLE
Adding .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+2285966c88a83c3aa924f6c989b3d50e3f5ff701 # updating printWidth to 100 and enabling bracketSameLine rule, applying to all .ts, .tsx, and .json files
+1f83f62f411befea33642b72911e1a4f85d803cf # applying printWidth formatting rule to .d.ts files
+a24ef741db649b756d7c7eb5fd0ddacd81c49718 # applying formatting rules to .css files

--- a/CODE_FORMATTING.md
+++ b/CODE_FORMATTING.md
@@ -1,0 +1,21 @@
+## Code Formatting
+
+### Steps to Update Rules
+
+1. Update config files
+2. Mass-apply config changes using the CLI method (see table below for usage)
+3. Commit changes and send for PR
+4. After that PR is merged, add its commit hash to `.git-blame-ignore-revs` so that `git blame` ignores mass-formatting commits and instead focuses on "real" changes
+
+### Config Locations
+
+Code formatting is done via Prettier, but that can be triggered in several different ways and each has its own config location.
+
+> 👉 Update _all_ locations when changing formatting rules.
+
+|File|Function|How to Use|
+|-|-|-|
+| `prettier.config.mjs` | used by the command-line `prettier` command for bulk formatting|`npm install -g prettier`<br /> `prettier "**/*.ts" [--write \| --check]` |
+| `.vscode/settings.json` | used by VS Code's Prettier extension | Install Prettier extension (`esbenp.prettier-vscode`), then run the "Format Document" command |
+| `eslint.config.mjs` | used by Git's precommit ESLint checks | Automatically run when creating a commit |
+ß


### PR DESCRIPTION
.git-blame-ignore-revs files are supported by both Github and ADO
Additional info: https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt