### PR TITLE
Rename key prop to cardKey in ConnectionCard to remove console errors

### DIFF
--- a/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
@@ -87,7 +87,7 @@ export const ConnectionsListContainer = () => {
                     return (
                         <ConnectionCard
                             connection={connection}
-                            key={"saved" + index}
+                            cardKey={"saved" + index}
                             actionButton={{
                                 icon: <Delete16Regular />,
                                 onClick: (e) => {
@@ -116,7 +116,7 @@ export const ConnectionsListContainer = () => {
                     return (
                         <ConnectionCard
                             connection={connection}
-                            key={"mru" + index}
+                            cardKey={"mru" + index}
                             actionButton={{
                                 icon: <Delete16Regular />,
                                 onClick: (e) => {
@@ -135,11 +135,11 @@ export const ConnectionsListContainer = () => {
 
 export const ConnectionCard = ({
     connection,
-    key,
+    cardKey,
     actionButton,
 }: {
     connection: IConnectionDialogProfile;
-    key?: string;
+    cardKey?: string;
     actionButton?: {
         icon: Slot<"span">;
         onClick: MouseEventHandler;
@@ -155,7 +155,7 @@ export const ConnectionCard = ({
 
     return (
         <Card
-            key={key}
+            key={cardKey}
             className={styles.connectionContainer}
             appearance="subtle"
             onClick={() => {

--- a/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
@@ -135,11 +135,9 @@ export const ConnectionsListContainer = () => {
 
 export const ConnectionCard = ({
     connection,
-    key,
     actionButton,
 }: {
     connection: IConnectionDialogProfile;
-    key?: string;
     actionButton?: {
         icon: Slot<"span">;
         onClick: MouseEventHandler;
@@ -155,7 +153,6 @@ export const ConnectionCard = ({
 
     return (
         <Card
-            key={key}
             className={styles.connectionContainer}
             appearance="subtle"
             onClick={() => {

--- a/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionsListContainer.tsx
@@ -87,7 +87,7 @@ export const ConnectionsListContainer = () => {
                     return (
                         <ConnectionCard
                             connection={connection}
-                            cardKey={"saved" + index}
+                            key={"saved" + index}
                             actionButton={{
                                 icon: <Delete16Regular />,
                                 onClick: (e) => {
@@ -116,7 +116,7 @@ export const ConnectionsListContainer = () => {
                     return (
                         <ConnectionCard
                             connection={connection}
-                            cardKey={"mru" + index}
+                            key={"mru" + index}
                             actionButton={{
                                 icon: <Delete16Regular />,
                                 onClick: (e) => {
@@ -135,11 +135,11 @@ export const ConnectionsListContainer = () => {
 
 export const ConnectionCard = ({
     connection,
-    cardKey,
+    key,
     actionButton,
 }: {
     connection: IConnectionDialogProfile;
-    cardKey?: string;
+    key?: string;
     actionButton?: {
         icon: Slot<"span">;
         onClick: MouseEventHandler;
@@ -155,7 +155,7 @@ export const ConnectionCard = ({
 
     return (
         <Card
-            key={cardKey}
+            key={key}
             className={styles.connectionContainer}
             appearance="subtle"
             onClick={() => {


### PR DESCRIPTION
<img width="571" alt="image" src="https://github.com/user-attachments/assets/6c23ab1a-615f-4dd3-8eb4-ebf4764906d8" />

I was seeing this error in connection dialog. Googling the error, it seems that key prop is already present in all components and redeclaring it causes these warnings
