### PR TITLE
Add search functionality to schema compare options drawer

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -469,6 +469,7 @@
   "Settings": "Settings",
   "Compare": "Compare",
   "Schema Compare Options": "Schema Compare Options",
+  "Search options...": "Search options...",
   "General Options": "General Options",
   "Include Object Types": "Include Object Types",
   "Option Description": "Option Description",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1406,6 +1406,9 @@
     <trans-unit id="++CODE++f6a9305d2a22223e43e016e6ed4d342a8a4a249c1202322338ee3e0d5f26e596">
       <source xml:lang="en">Script copied to clipboard</source>
     </trans-unit>
+    <trans-unit id="++CODE++49ff54ad141b9f4b74b176a98807c6b9a1282dfe026c3f38015dd596c54c4a84">
+      <source xml:lang="en">Search options...</source>
+    </trans-unit>
     <trans-unit id="++CODE++7f55382219f0202c1b4f56deb099e2fedcec87ee73fe2edb2105df5447323bc6">
       <source xml:lang="en">Search...</source>
     </trans-unit>

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -514,6 +514,7 @@ export class LocConstants {
             settings: l10n.t("Settings"),
             compare: l10n.t("Compare"),
             schemaCompareOptions: l10n.t("Schema Compare Options"),
+            searchOptions: l10n.t("Search options..."),
             generalOptions: l10n.t("General Options"),
             includeObjectTypes: l10n.t("Include Object Types"),
             optionDescription: l10n.t("Option Description"),

--- a/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaOptionsDrawer.tsx
@@ -15,6 +15,7 @@ import {
     InfoLabel,
     Label,
     makeStyles,
+    SearchBox,
     SelectTabData,
     SelectTabEvent,
     Tab,
@@ -29,13 +30,18 @@ import { DacDeployOptionPropertyBoolean } from "vscode-mssql";
 
 const useStyles = makeStyles({
     optionsContainer: {
-        height: "80vh",
+        height: "75vh",
         overflowY: "auto",
     },
 
     listItemContainer: {
         display: "flex",
         alignItems: "center",
+    },
+
+    searchContainer: {
+        margin: "10px 0",
+        width: "100%",
     },
 });
 
@@ -46,8 +52,10 @@ interface Props {
 
 const SchemaOptionsDrawer = (props: Props) => {
     const classes = useStyles();
-
     const context = useContext(schemaCompareContext);
+    const [optionsChanged, setOptionsChanged] = useState(false);
+    const [selectedValue, setSelectedValue] = useState<TabValue>("generalOptions");
+    const [searchQuery, setSearchQuery] = useState("");
 
     useEffect(() => {
         context.setIntermediarySchemaOptions();
@@ -75,8 +83,16 @@ const SchemaOptionsDrawer = (props: Props) => {
         );
     }
 
-    const [optionsChanged, setOptionsChanged] = useState(false);
-    const [selectedValue, setSelectedValue] = useState<TabValue>("generalOptions");
+    const filteredGeneralOptions = generalOptionEntries.filter(
+        ([_, value]) =>
+            searchQuery === "" ||
+            value.displayName.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+
+    const filteredObjectTypes = includeObjectTypesEntries.filter(
+        ([_, value]) =>
+            searchQuery === "" || value.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
 
     const onTabSelect = (_: SelectTabEvent, data: SelectTabData) => {
         setSelectedValue(data.value);
@@ -123,6 +139,13 @@ const SchemaOptionsDrawer = (props: Props) => {
                 </DrawerHeaderTitle>
             </DrawerHeader>
             <DrawerBody>
+                <SearchBox
+                    className={classes.searchContainer}
+                    placeholder={loc.schemaCompare.searchOptions}
+                    value={searchQuery}
+                    onChange={(_, data) => setSearchQuery(data.value)}
+                />
+
                 <TabList selectedValue={selectedValue} onTabSelect={onTabSelect}>
                     <Tab id="GeneralOptions" value="generalOptions">
                         {loc.schemaCompare.generalOptions}
@@ -131,10 +154,11 @@ const SchemaOptionsDrawer = (props: Props) => {
                         {loc.schemaCompare.includeObjectTypes}
                     </Tab>
                 </TabList>
+
                 {selectedValue === "generalOptions" && (
                     <List className={classes.optionsContainer}>
                         {optionsToValueNameLookup &&
-                            generalOptionEntries.map(([key, value]) => {
+                            filteredGeneralOptions.map(([key, value]) => {
                                 return (
                                     <ListItem
                                         className={classes.listItemContainer}
@@ -157,10 +181,11 @@ const SchemaOptionsDrawer = (props: Props) => {
                             })}
                     </List>
                 )}
+
                 {selectedValue === "includeObjectTypes" && (
                     <List className={classes.optionsContainer}>
                         {includeObjectTypesLookup &&
-                            includeObjectTypesEntries.map(([key, value]) => {
+                            filteredObjectTypes.map(([key, value]) => {
                                 return (
                                     <ListItem
                                         className={classes.listItemContainer}


### PR DESCRIPTION
This PR adds a search box to the Schema Compare Options Drawer:

![image](https://github.com/user-attachments/assets/5a206725-9d98-4f63-8777-734c281e22e0)
![image](https://github.com/user-attachments/assets/e753b275-6fc1-44c7-a080-19b78aaeca25)
![image](https://github.com/user-attachments/assets/82f6edec-17d9-4f76-aa91-5eb3bf2fe112)


