### PR TITLE
Fix Vector data type and add Vector functions

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "5.0.20250402.1",
+        "version": "5.0.20250409.1",
         "downloadFileNames": {
             "Windows_86": "win-x86-net8.0.zip",
             "Windows_64": "win-x64-net8.0.zip",

--- a/syntaxes/SQL.plist
+++ b/syntaxes/SQL.plist
@@ -566,6 +566,18 @@
 			</dict>
 		</dict>
 		<dict>
+			<key>match</key>
+			<string>(?i)\b(vector_distance|vector_norm|vector_normalize)\b\s*\(</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.vector.sql</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This PR fixes #18850 
This PR fixes #19087 

This PR bumps STS to bring in Vector data type and Vector functions support from SMO and SqlParser.
STS PR to bump SMO and SqlParser: https://github.com/microsoft/sqltoolsservice/pull/2468
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/f14df245-5dab-4031-b6fc-2a6b1b1e2fb7" />

STS changes with this vbump:
https://github.com/microsoft/sqltoolsservice/compare/5.0.20250402.1...5.0.20250409.1
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/ba4d55c0-ffe8-4290-9d79-60315f3cd113" />

