### PR TITLE
Get the correct scmp connection to open scmp files for database endpoint types

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -329,6 +329,15 @@ export default class ConnectionManager {
         return undefined;
     }
 
+    public getUriForScmpConnection(connection: IConnectionInfo): string {
+        for (let uri of Object.keys(this._connections)) {
+            if (Utils.isSameScmpConnection(this._connections[uri].credentials, connection)) {
+                return uri;
+            }
+        }
+        return undefined;
+    }
+
     public isConnected(fileUri: string): boolean {
         return (
             fileUri in this._connections &&

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -328,6 +328,41 @@ export function isSameConnectionInfo(
 }
 
 /**
+ * Compares 2 connections to see if they match. Logic for matching:
+ * match on properties like the (connectionString or server, auth type, user) being identical.
+ * Other properties are ignored for this purpose
+ *
+ * @param conn the connection to check
+ * @param expectedConn the connection to try to match
+ * @returns boolean that is true if the connections match
+ */
+export function isSameScmpConnection(
+    conn: IConnectionInfo,
+    expectedConn: IConnectionInfo,
+): boolean {
+    if (conn.connectionString) {
+        return conn.connectionString === expectedConn.connectionString;
+    } else if (
+        expectedConn.authenticationType === Constants.azureMfa &&
+        conn.authenticationType === Constants.azureMfa
+    ) {
+        return (
+            expectedConn.server === conn.server &&
+            isSameAccountKey(expectedConn.accountId, conn.accountId)
+        );
+    } else if (
+        expectedConn.server === conn.server &&
+        isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType)
+    ) {
+        if (conn.authenticationType === Constants.sqlAuthentication) {
+            return conn.user === expectedConn.user;
+        } else {
+            return isEmpty(conn.user) === isEmpty(expectedConn.user);
+        }
+    }
+}
+
+/**
  * Check if a file exists on disk
  */
 export function isFileExisting(filePath: string): boolean {

--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -1052,9 +1052,9 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
         if (endpoint && endpoint.endpointType === mssql.SchemaCompareEndpointType.Database) {
             const connInfo = endpoint.connectionDetails.options as mssql.IConnectionInfo;
 
-            ownerUri = this.connectionMgr.getUriForConnection(connInfo);
+            ownerUri = this.connectionMgr.getUriForScmpConnection(connInfo);
 
-            let isConnected = false;
+            let isConnected = ownerUri ? true : false;
             if (!ownerUri) {
                 ownerUri = utils.generateQueryUri().toString();
 


### PR DESCRIPTION
Before:
Opening an scmp file is not able to load source and target correctly because it is not able to find the connection URI and leaves "source" and "target" empty;
![image](https://github.com/user-attachments/assets/1fa8ee0c-2993-42d1-bc80-638feaf44e01)
![image](https://github.com/user-attachments/assets/d9d28a3a-8a4a-448f-ae75-24c528cb71e6)



After:
Opening an scmp file loads source and target correctly because it is able to find the connection URI correctly:
![image](https://github.com/user-attachments/assets/a9d93af9-8299-4d9e-a288-d2ec00bb58d1)
![image](https://github.com/user-attachments/assets/ac50f418-9cac-4bc3-b547-ba00aa00c315)

