### PR TITLE
Update .git-blame-ignore-revs to include more eslint commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+8521e41b30f76be6835e2715b22a3df989bf8314 # Fixed tslin errors
+9b8f4644ad676d277613ffc2adc78a927d103617 # spaces -> tabs
+57f780a9e54745ac4c8eab67df8f5fb068d4c8c2 # Eslint fixes
 2285966c88a83c3aa924f6c989b3d50e3f5ff701 # updating printWidth to 100 and enabling bracketSameLine rule, applying to all .ts, .tsx, and .json files
 1f83f62f411befea33642b72911e1a4f85d803cf # applying printWidth formatting rule to .d.ts files
 a24ef741db649b756d7c7eb5fd0ddacd81c49718 # applying formatting rules to .css files


### PR DESCRIPTION
Adding additional historical eslint formatting commits to the ignore list