### PR TITLE
Using Ids to match is same connection profile.

### DIFF
--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -261,6 +261,10 @@ export function isSameProfile(
     currentProfile: IConnectionProfile,
     expectedProfile: IConnectionProfile,
 ): boolean {
+    if (currentProfile.id && expectedProfile.id) {
+        // If connection profile has an id, use that to compare connections
+        return currentProfile.id === expectedProfile.id;
+    }
     if (currentProfile === undefined) {
         return false;
     }
@@ -308,6 +312,13 @@ export function isSameConnectionInfo(
     conn: IConnectionInfo,
     expectedConn: IConnectionInfo,
 ): boolean {
+    // If connection info has an id, use that to compare connections
+    const connId = (<IConnectionProfile>conn).id;
+    const expectedConnId = (<IConnectionProfile>expectedConn).id;
+    if (connId && expectedConnId) {
+        return connId === expectedConnId;
+    }
+    // If no id, compare the connection string or other properties
     return conn.connectionString || expectedConn.connectionString
         ? conn.connectionString === expectedConn.connectionString
         : // Azure MFA connections

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -313,8 +313,8 @@ export function isSameConnectionInfo(
     expectedConn: IConnectionInfo,
 ): boolean {
     // If connection info has an id, use that to compare connections
-    const connId = (<IConnectionProfile>conn).id;
-    const expectedConnId = (<IConnectionProfile>expectedConn).id;
+    const connId = (conn as IConnectionProfile).id;
+    const expectedConnId = (expectedConn as IConnectionProfile).id;
     if (connId && expectedConnId) {
         return connId === expectedConnId;
     }


### PR DESCRIPTION
Fixes #19091

This PR resolves an issue where connections created using a connection string and the old connection prompt flow were not being correctly reconciled in the Object Explorer (OE).

Initially, we stored the disconnected node's profile like this:
```json
{
  "connectionString": "{lookup-key}"
}
```

But once the connection was established, the node's profile changed to:
```json
{
  "connectionString": "{actual-connection}"
}
```

This mismatch caused OE to treat them as different connections, so instead of replacing the disconnected node with the connected one, it just added a new connected node leading to duplicates.

This PR ensures the profiles match correctly so OE can update the existing node instead of duplicating it.