### PR TITLE
Enable 'Collapse All' option in Object Explorer tree view

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -658,6 +658,7 @@ export default class MainController implements vscode.Disposable {
         this.objectExplorerTree = vscode.window.createTreeView("objectExplorer", {
             treeDataProvider: this._objectExplorerProvider,
             canSelectMany: false,
+            showCollapseAll: true,
             dragAndDropController: new ObjectExplorerDragAndDropController(),
         });
         this._context.subscriptions.push(this.objectExplorerTree);


### PR DESCRIPTION
Before:
<img width="382" alt="image" src="https://github.com/user-attachments/assets/adc2c618-36ae-421d-ab43-c99a0b3ead14" />

Now:
<img width="468" alt="image" src="https://github.com/user-attachments/assets/6e40facc-690f-49b0-acbc-d5f39bb3a4ff" />
