### PR TITLE
Add "Compare Details" header above diff editor in compare panel

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -541,6 +541,7 @@
   "Database Project": "Database Project",
   "Source": "Source",
   "Target": "Target",
+  "Compare Details": "Compare Details",
   "Are you sure you want to update the target?": "Are you sure you want to update the target?",
   "There was an error updating the project": "There was an error updating the project",
   "Failed to apply changes: '{0}'/{0} is the error message returned from the publish changes operation": {

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -541,7 +541,7 @@
   "Database Project": "Database Project",
   "Source": "Source",
   "Target": "Target",
-  "Compare Details": "Compare Details",
+  "Comparison Details": "Comparison Details",
   "Are you sure you want to update the target?": "Are you sure you want to update the target?",
   "There was an error updating the project": "There was an error updating the project",
   "Failed to apply changes: '{0}'/{0} is the error message returned from the publish changes operation": {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -366,6 +366,9 @@
     <trans-unit id="++CODE++e888155d8c7d2e3c3f9eb1bf57e8d81ba1a3c182b5e94b01e09de2cb2cca81f9">
       <source xml:lang="en">Compare</source>
     </trans-unit>
+    <trans-unit id="++CODE++c4ae321845b8426b2c5b2dd0cc8ab747e08280d6b61c4d1bb778694c51bab904">
+      <source xml:lang="en">Compare Details</source>
+    </trans-unit>
     <trans-unit id="++CODE++eb83f1820ce359dc5c9aa6ca4d08fad60256a9808c58ad93f89db3c182908364">
       <source xml:lang="en">Confirm to clear recent connections list</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -366,8 +366,8 @@
     <trans-unit id="++CODE++e888155d8c7d2e3c3f9eb1bf57e8d81ba1a3c182b5e94b01e09de2cb2cca81f9">
       <source xml:lang="en">Compare</source>
     </trans-unit>
-    <trans-unit id="++CODE++c4ae321845b8426b2c5b2dd0cc8ab747e08280d6b61c4d1bb778694c51bab904">
-      <source xml:lang="en">Compare Details</source>
+    <trans-unit id="++CODE++5b79ce1b6eead3275d92572d5997ed876b99fe9d47141f8b785abf94a4ff52c0">
+      <source xml:lang="en">Comparison Details</source>
     </trans-unit>
     <trans-unit id="++CODE++eb83f1820ce359dc5c9aa6ca4d08fad60256a9808c58ad93f89db3c182908364">
       <source xml:lang="en">Confirm to clear recent connections list</source>

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -605,7 +605,7 @@ export class LocConstants {
             cancel: l10n.t("Cancel"),
             source: l10n.t("Source"),
             target: l10n.t("Target"),
-            compareDetails: l10n.t("Compare Details"),
+            compareDetails: l10n.t("Comparison Details"),
             areYouSureYouWantToUpdateTheTarget: l10n.t(
                 "Are you sure you want to update the target?",
             ),

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -605,6 +605,7 @@ export class LocConstants {
             cancel: l10n.t("Cancel"),
             source: l10n.t("Source"),
             target: l10n.t("Target"),
+            compareDetails: l10n.t("Compare Details"),
             areYouSureYouWantToUpdateTheTarget: l10n.t(
                 "Are you sure you want to update the target?",
             ),

--- a/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
@@ -7,6 +7,24 @@ import { useContext } from "react";
 import { DiffEditor } from "@monaco-editor/react";
 import { schemaCompareContext } from "../SchemaCompareStateProvider";
 import { resolveVscodeThemeType } from "../../../common/utils";
+import { Divider, makeStyles, tokens } from "@fluentui/react-components";
+import { locConstants as loc } from "../../../common/locConstants";
+
+const useStyles = makeStyles({
+    dividerContainer: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyItems: "center",
+        minHeight: "96px",
+        backgroundColor: tokens.colorNeutralBackground1,
+    },
+
+    dividerFont: {
+        fontSize: "16px",
+        fontWeight: "bold",
+    },
+});
 
 const formatScript = (script: string): string => {
     if (!script) {
@@ -22,6 +40,7 @@ interface Props {
 }
 
 const CompareDiffEditor = ({ selectedDiffId, renderSideBySide }: Props) => {
+    const classes = useStyles();
     const context = useContext(schemaCompareContext);
     const compareResult = context.state.schemaCompareResult;
     const diff = compareResult?.differences[selectedDiffId];
@@ -30,21 +49,28 @@ const CompareDiffEditor = ({ selectedDiffId, renderSideBySide }: Props) => {
     const modified = formatScript(diff?.targetScript);
 
     return (
-        <div style={{ height: "60vh" }}>
-            <DiffEditor
-                height="60vh"
-                language="sql"
-                original={modified}
-                modified={original}
-                theme={resolveVscodeThemeType(context.themeKind)}
-                options={{
-                    renderSideBySide: renderSideBySide ?? true,
-                    renderOverviewRuler: true,
-                    OverviewRulerLane: 0,
-                    readOnly: true,
-                }}
-            />
-        </div>
+        <>
+            <div className={classes.dividerContainer}>
+                <Divider className={classes.dividerFont} alignContent="start">
+                    {loc.schemaCompare.compareDetails}
+                </Divider>
+            </div>
+            <div style={{ height: "60vh" }}>
+                <DiffEditor
+                    height="60vh"
+                    language="sql"
+                    original={modified}
+                    modified={original}
+                    theme={resolveVscodeThemeType(context.themeKind)}
+                    options={{
+                        renderSideBySide: renderSideBySide ?? true,
+                        renderOverviewRuler: true,
+                        OverviewRulerLane: 0,
+                        readOnly: true,
+                    }}
+                />
+            </div>
+        </>
     );
 };
 


### PR DESCRIPTION
This PR fixes #19148

This PR adds a clear divider to separate the Compare Details diff editor from the list of schema differences.
![image](https://github.com/user-attachments/assets/86e850f1-9342-4cb0-ab78-f805fac79b45)
