### PR TITLE
Select first diff after comparison completes automatically

### DIFF
--- a/src/reactviews/pages/SchemaCompare/SchemaCompare.tsx
+++ b/src/reactviews/pages/SchemaCompare/SchemaCompare.tsx
@@ -64,7 +64,12 @@ export const SchemaComparePage = () => {
 
             {showMessage() && <Message />}
 
-            {!showMessage() && <SchemaDifferences onDiffSelected={handleDiffSelected} />}
+            {!showMessage() && (
+                <SchemaDifferences
+                    selectedDiffId={selectedDiffId}
+                    onDiffSelected={handleDiffSelected}
+                />
+            )}
 
             {!showMessage() && <CompareDiffEditor selectedDiffId={selectedDiffId} />}
 

--- a/src/reactviews/pages/SchemaCompare/SchemaCompare.tsx
+++ b/src/reactviews/pages/SchemaCompare/SchemaCompare.tsx
@@ -15,7 +15,7 @@ import Message from "./components/Message";
 
 export const SchemaComparePage = () => {
     const context = useContext(schemaCompareContext);
-    const [selectedDiffId, setSelectedDiffId] = useState(-1);
+    const [selectedDiffId, setSelectedDiffId] = useState(0);
     const [showDrawer, setShowDrawer] = useState(false);
     const [showOptionsDrawer, setShowOptionsDrawer] = useState(false);
     const [endpointType, setEndpointType] = useState<"source" | "target">("source");
@@ -66,9 +66,7 @@ export const SchemaComparePage = () => {
 
             {!showMessage() && <SchemaDifferences onDiffSelected={handleDiffSelected} />}
 
-            {!showMessage() && selectedDiffId !== -1 && (
-                <CompareDiffEditor selectedDiffId={selectedDiffId} />
-            )}
+            {!showMessage() && <CompareDiffEditor selectedDiffId={selectedDiffId} />}
 
             {showDrawer && (
                 <SchemaSelectorDrawer

--- a/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
@@ -26,8 +26,8 @@ const CompareDiffEditor = ({ selectedDiffId, renderSideBySide }: Props) => {
     const compareResult = context.state.schemaCompareResult;
     const diff = compareResult?.differences[selectedDiffId];
 
-    const original = formatScript(diff?.sourceScript);
-    const modified = formatScript(diff?.targetScript);
+    const original = diff?.sourceScript ? formatScript(diff?.sourceScript) : "";
+    const modified = diff?.targetScript ? formatScript(diff?.targetScript) : "";
 
     return (
         <div style={{ height: "60vh" }}>

--- a/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
@@ -32,6 +32,14 @@ const useStyles = makeStyles({
     HeaderCellPadding: {
         padding: "0 8px",
     },
+    selectedRow: {
+        backgroundColor: "var(--vscode-list-activeSelectionBackground)",
+        color: "var(--vscode-list-activeSelectionForeground)",
+        "& td": {
+            backgroundColor: "var(--vscode-list-activeSelectionBackground)",
+            color: "var(--vscode-list-activeSelectionForeground)",
+        },
+    },
 });
 
 interface TableRowData extends RowStateBase<DiffEntry> {
@@ -47,9 +55,10 @@ interface ReactWindowRenderFnProps extends ListChildComponentProps {
 
 interface Props {
     onDiffSelected: (id: number) => void;
+    selectedDiffId: number;
 }
 
-export const SchemaDifferences = ({ onDiffSelected }: Props) => {
+export const SchemaDifferences = ({ onDiffSelected, selectedDiffId }: Props) => {
     const classes = useStyles();
     const { targetDocument } = useFluent();
     const scrollbarWidth = useScrollbarWidth({ targetDocument });
@@ -240,7 +249,8 @@ export const SchemaDifferences = ({ onDiffSelected }: Props) => {
                 key={item.position}
                 onKeyDown={onKeyDown}
                 onClick={() => onDiffSelected(index)}
-                appearance={appearance}>
+                appearance={appearance}
+                className={index === selectedDiffId ? classes.selectedRow : undefined}>
                 <TableCell>{item.name}</TableCell>
                 <TableCell>{formatName(item.sourceValue)}</TableCell>
                 <TableCell>


### PR DESCRIPTION
This PR fixes #19146 
This PR fixes #19159
This PR fixes https://github.com/microsoft/vscode-mssql/issues/19160


This PR selects the first diff after a comparison to avoid showing an empty space below the list of schema differences after a comparison is made and highlights the first diff item in the diff list.
![image](https://github.com/user-attachments/assets/486bf8a8-e27b-46e8-9065-ac8a4c5310fe)

Selecting a different list item will change which diff item is highlighted:
![image](https://github.com/user-attachments/assets/f1a57384-0ad4-4d4a-8f7d-1cfa4227c799)

