### PR TITLE
Add spacing to "browse connection" button

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SelectSchemaInput.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SelectSchemaInput.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles({
     },
 
     buttonLeftSmallMargin: {
-        marginLeft: "2px",
+        marginLeft: "8px",
     },
 });
 


### PR DESCRIPTION
This PR fixes #19162

The PR adds extra spacing between the "Browse connection" button and the textbox showing the source and target endpoints
![image](https://github.com/user-attachments/assets/4ad58462-edd1-482b-888e-1119fbcc3fce)
