### PR TITLE
Correct logic to disable buttons in Schema Compare panel

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
@@ -87,6 +87,14 @@ const CompareActionBar = (props: Props) => {
         );
     };
 
+    const hasIncludedDiffs = (): boolean => {
+        const includedDiffs = context.state.schemaCompareResult.differences.filter(
+            (diff) => diff.included,
+        );
+
+        return includedDiffs.length > 0;
+    };
+
     const disableGenerateScriptButton = (): boolean => {
         if (
             !(
@@ -106,10 +114,8 @@ const CompareActionBar = (props: Props) => {
             return true;
         }
 
-        const includedDiffs = context.state.schemaCompareResult.differences.filter(
-            (diff) => diff.included,
-        );
-        if (includedDiffs.length === 0) {
+        const isIncludingDiffs = hasIncludedDiffs();
+        if (!isIncludingDiffs) {
             return true;
         }
 
@@ -123,6 +129,11 @@ const CompareActionBar = (props: Props) => {
             context.state.schemaCompareResult.differences.length > 0 &&
             Number(context.state.targetEndpointInfo.endpointType) !== 1 // Dacpac lewissanchez todo: Figure out how to move away from these magic numbers for enums
         ) {
+            const isIncludingDiffs = hasIncludedDiffs();
+            if (!isIncludingDiffs) {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
@@ -87,6 +87,35 @@ const CompareActionBar = (props: Props) => {
         );
     };
 
+    const disableGenerateScriptButton = (): boolean => {
+        if (
+            !(
+                (
+                    context.state.targetEndpointInfo &&
+                    Number(context.state.targetEndpointInfo.endpointType) === 0
+                ) /* Database */
+            )
+        ) {
+            return true;
+        } else if (context.state.isComparisonInProgress) {
+            return true;
+        } else if (
+            context.state.schemaCompareResult === undefined ||
+            context.state.schemaCompareResult.differences.length === 0
+        ) {
+            return true;
+        }
+
+        const includedDiffs = context.state.schemaCompareResult.differences.filter(
+            (diff) => diff.included,
+        );
+        if (includedDiffs.length === 0) {
+            return true;
+        }
+
+        return false;
+    };
+
     const disableApplyButton = (): boolean => {
         if (
             context.state.schemaCompareResult &&
@@ -127,12 +156,7 @@ const CompareActionBar = (props: Props) => {
                 title={loc.schemaCompare.generateScriptToDeployChangesToTarget}
                 icon={<DocumentChevronDoubleRegular />}
                 onClick={handleGenerateScript}
-                disabled={
-                    context.state.targetEndpointInfo &&
-                    Number(context.state.targetEndpointInfo.endpointType) === 0 // Database lewissanchez todo: Get rid of this magic number too by figuring out how to ref it from vscode-mssql
-                        ? false
-                        : true
-                }>
+                disabled={disableGenerateScriptButton()}>
                 {loc.schemaCompare.generateScript}
             </ToolbarButton>
             <ToolbarButton
@@ -140,7 +164,7 @@ const CompareActionBar = (props: Props) => {
                 title={loc.schemaCompare.applyChangesToTarget}
                 icon={<PlayFilled />}
                 onClick={handlePublishChanges}
-                disabled={disableApplyButton()}>
+                disabled={context.state.isComparisonInProgress || disableApplyButton()}>
                 {loc.schemaCompare.apply}
             </ToolbarButton>
             <ToolbarButton
@@ -149,6 +173,7 @@ const CompareActionBar = (props: Props) => {
                 icon={<SettingsRegular />}
                 onClick={handleOptionsClicked}
                 disabled={
+                    context.state.isComparisonInProgress ||
                     isEndpointEmpty(context.state.sourceEndpointInfo) ||
                     isEndpointEmpty(context.state.targetEndpointInfo)
                 }>
@@ -161,6 +186,7 @@ const CompareActionBar = (props: Props) => {
                 icon={<ArrowSwapFilled />}
                 onClick={handleSwitchEndpoints}
                 disabled={
+                    context.state.isComparisonInProgress ||
                     isEndpointEmpty(context.state.sourceEndpointInfo) ||
                     isEndpointEmpty(context.state.targetEndpointInfo)
                 }>
@@ -171,7 +197,8 @@ const CompareActionBar = (props: Props) => {
                 aria-label={loc.schemaCompare.openScmpFile}
                 title={loc.schemaCompare.loadSourceTargetAndOptionsSavedInAnScmpFile}
                 icon={<DocumentArrowUpRegular />}
-                onClick={handleOpenScmp}>
+                onClick={handleOpenScmp}
+                disabled={context.state.isComparisonInProgress}>
                 {loc.schemaCompare.openScmpFile}
             </ToolbarButton>
             <ToolbarButton

--- a/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
@@ -20,6 +20,7 @@ import {
 import { locConstants as loc } from "../../../common/locConstants";
 import { useContext, useEffect } from "react";
 import { schemaCompareContext } from "../SchemaCompareStateProvider";
+import { SchemaCompareEndpointType } from "../../../../sharedInterfaces/schemaCompare";
 
 interface Props {
     onOptionsClicked: () => void;
@@ -98,10 +99,9 @@ const CompareActionBar = (props: Props) => {
     const disableGenerateScriptButton = (): boolean => {
         if (
             !(
-                (
-                    context.state.targetEndpointInfo &&
-                    Number(context.state.targetEndpointInfo.endpointType) === 0
-                ) /* Database */
+                context.state.targetEndpointInfo &&
+                Number(context.state.targetEndpointInfo.endpointType) ===
+                    SchemaCompareEndpointType.Database
             )
         ) {
             return true;
@@ -127,7 +127,8 @@ const CompareActionBar = (props: Props) => {
             context.state.schemaCompareResult &&
             context.state.schemaCompareResult.differences &&
             context.state.schemaCompareResult.differences.length > 0 &&
-            Number(context.state.targetEndpointInfo.endpointType) !== 1 // Dacpac lewissanchez todo: Figure out how to move away from these magic numbers for enums
+            Number(context.state.targetEndpointInfo.endpointType) !==
+                SchemaCompareEndpointType.Dacpac
         ) {
             const isIncludingDiffs = hasIncludedDiffs();
             if (!isIncludingDiffs) {

--- a/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
@@ -207,6 +207,7 @@ const CompareActionBar = (props: Props) => {
                 icon={<SaveRegular />}
                 onClick={handleSaveScmp}
                 disabled={
+                    context.state.isComparisonInProgress ||
                     isEndpointEmpty(context.state.sourceEndpointInfo) ||
                     isEndpointEmpty(context.state.targetEndpointInfo)
                 }>

--- a/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareActionBar.tsx
@@ -89,11 +89,7 @@ const CompareActionBar = (props: Props) => {
     };
 
     const hasIncludedDiffs = (): boolean => {
-        const includedDiffs = context.state.schemaCompareResult.differences.filter(
-            (diff) => diff.included,
-        );
-
-        return includedDiffs.length > 0;
+        return context.state.schemaCompareResult.differences.some((diff) => diff.included);
     };
 
     const disableGenerateScriptButton = (): boolean => {
@@ -114,8 +110,7 @@ const CompareActionBar = (props: Props) => {
             return true;
         }
 
-        const isIncludingDiffs = hasIncludedDiffs();
-        if (!isIncludingDiffs) {
+        if (!hasIncludedDiffs()) {
             return true;
         }
 
@@ -130,8 +125,7 @@ const CompareActionBar = (props: Props) => {
             Number(context.state.targetEndpointInfo.endpointType) !==
                 SchemaCompareEndpointType.Dacpac
         ) {
-            const isIncludingDiffs = hasIncludedDiffs();
-            if (!isIncludingDiffs) {
+            if (!hasIncludedDiffs()) {
                 return true;
             }
 

--- a/src/reactviews/pages/SchemaCompare/components/SelectSchemaInput.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SelectSchemaInput.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles({
 
 interface Props extends InputProps {
     label: string;
+    disableBrowseButton: boolean;
     selectFile: () => void;
 }
 
@@ -53,6 +54,7 @@ const SelectSchemaInput = (props: Props) => {
                 <Button
                     size="small"
                     className={classes.buttonLeftSmallMargin}
+                    disabled={props.disableBrowseButton}
                     onClick={props.selectFile}>
                     ...
                 </Button>

--- a/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
@@ -92,6 +92,7 @@ const SelectSchemasPanel = ({ onSelectSchemaClicked }: Props) => {
                 id={sourceId}
                 label={loc.schemaCompare.source}
                 value={sourceEndpointDisplay}
+                disableBrowseButton={context.state.isComparisonInProgress}
                 selectFile={() => onSelectSchemaClicked("source")}
                 className={classes.marginRight}
             />
@@ -100,6 +101,7 @@ const SelectSchemasPanel = ({ onSelectSchemaClicked }: Props) => {
                 id={targetId}
                 label={loc.schemaCompare.target}
                 value={targetEndpointDisplay}
+                disableBrowseButton={context.state.isComparisonInProgress}
                 selectFile={() => onSelectSchemaClicked("target")}
             />
 

--- a/src/sharedInterfaces/schemaCompare.ts
+++ b/src/sharedInterfaces/schemaCompare.ts
@@ -25,6 +25,14 @@ export const enum SchemaUpdateAction {
     Add = 2,
 }
 
+export const enum SchemaCompareEndpointType {
+    Database = 0,
+    Dacpac = 1,
+    Project = 2,
+    // must be kept in-sync with SchemaCompareEndpointType in SQL Tools Service
+    // located at \src\Microsoft.SqlTools.ServiceLayer\SchemaCompare\Contracts\SchemaCompareRequest.cs
+}
+
 export interface SchemaCompareWebViewState {
     isSqlProjectExtensionInstalled: boolean;
     isComparisonInProgress: boolean;


### PR DESCRIPTION
This PR fixes #19170
This PR fixes #19177

When a schema comparison is in progress, all buttons except for "stop" are disabled
![disable_buttons_with_running_comparison](https://github.com/user-attachments/assets/a22d968c-fa52-4f8a-bda8-9a9023185480)

If all differences are excluded, the generate script button is disabled.
NEW: The apply button is also fixed to address @tauseefsiddique10's comment in the discussion.
![image](https://github.com/user-attachments/assets/d8cf0aee-0a58-4121-b026-e14e002f2784)

Including one or more diffs will re-enable the generate script button
![including_a_single_diff_entry_will_enable_generate_script_btn](https://github.com/user-attachments/assets/e93f1968-dc9a-410e-b521-2a526b21716a)

A comparison with no found differences will not have the generate script button enabled.
![no_differences_in_a_comparison_will_disable_generate_script_btn](https://github.com/user-attachments/assets/0c9f95c0-87b6-4b98-8962-02f37324ced8)

