### PR TITLE
Open schema compare from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -746,6 +746,11 @@
                 "category": "MS SQL"
             },
             {
+                "command": "mssql.schemaCompareOpenFromCommandPalette",
+                "title": "%mssql.schemaCompare%",
+                "category": "MS SQL"
+            },
+            {
                 "command": "mssql.rebuildIntelliSenseCache",
                 "title": "%mssql.rebuildIntelliSenseCache%",
                 "category": "MS SQL"

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -45,6 +45,7 @@ export const cmdPauseQueryHistory = "mssql.pauseQueryHistoryCapture";
 export const cmdCommandPaletteQueryHistory = "mssql.commandPaletteQueryHistory";
 export const cmdNewQuery = "mssql.newQuery";
 export const cmdSchemaCompare = "mssql.schemaCompare";
+export const cmdSchemaCompareOpenFromCommandPalette = "mssql.schemaCompareOpenFromCommandPalette";
 export const cmdManageConnectionProfiles = "mssql.manageProfiles";
 export const cmdClearPooledConnections = "mssql.clearPooledConnections";
 export const cmdRebuildIntelliSenseCache = "mssql.rebuildIntelliSenseCache";

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -824,6 +824,15 @@ export default class MainController implements vscode.Disposable {
 
             this._context.subscriptions.push(
                 vscode.commands.registerCommand(
+                    Constants.cmdSchemaCompareOpenFromCommandPalette,
+                    async () => {
+                        await this.onSchemaCompare();
+                    },
+                ),
+            );
+
+            this._context.subscriptions.push(
+                vscode.commands.registerCommand(
                     Constants.cmdEditConnection,
                     async (node: TreeNodeInfo) => {
                         const connDialog = new ConnectionDialogWebviewController(
@@ -1758,7 +1767,7 @@ export default class MainController implements vscode.Disposable {
         return false;
     }
 
-    public async onSchemaCompare(node: any): Promise<void> {
+    public async onSchemaCompare(node?: any): Promise<void> {
         const result = await this.schemaCompareService.schemaCompareGetDefaultOptions();
         const schemaCompareWebView = new SchemaCompareWebViewController(
             this._context,


### PR DESCRIPTION
This PR fixes #19171

The PR adds a command to the command palette to open the schema compare web view:
![image](https://github.com/user-attachments/assets/dca606d3-cda6-4f85-8323-6d42883a1d5b)

![image](https://github.com/user-attachments/assets/29285b78-5f2e-4d8a-86fc-d70626c3b3b3)
