### PR TITLE
Invert diff editor to match Azure Data Studio's schema compare diff editor

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
@@ -27,6 +27,7 @@ import { SchemaUpdateAction } from "../../../../sharedInterfaces/schemaCompare";
 import { locConstants as loc } from "../../../common/locConstants";
 import { DiffEntry } from "vscode-mssql";
 import { schemaCompareContext } from "../SchemaCompareStateProvider";
+import "./compareDiffEditor.css";
 
 const useStyles = makeStyles({
     HeaderCellPadding: {

--- a/src/reactviews/pages/SchemaCompare/components/compareDiffEditor.css
+++ b/src/reactviews/pages/SchemaCompare/components/compareDiffEditor.css
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+.monaco-diff-editor.side-by-side,
+.diffOverview {
+    display: flex;
+}
+
+.monaco-diff-editor.side-by-side > .editor.original,
+.diffOverview > .original.diffOverviewRuler {
+    position: unset !important;
+    order: 1; /* Move original to the right */
+}
+
+.monaco-diff-editor.side-by-side > .editor.modified,
+.diffOverview > .modified.diffOverviewRuler {
+    position: unset !important;
+    order: 0; /* Move modified to the left */
+}


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-mssql/issues/19154

This is what the diff editor looks like with the changes in this PR in the MSSQL extension:
![image](https://github.com/user-attachments/assets/2a7b3bb1-bebc-412a-b7f8-5cb14ffae728)

For comparison here is what it looks like in Azure Data Studio:
![image](https://github.com/user-attachments/assets/c2ff75da-8e21-408b-9f86-45c8d617e349)

