### PR TITLE
Include all scripts in the diff editor

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
@@ -10,6 +10,7 @@ import { resolveVscodeThemeType } from "../../../common/utils";
 import { Divider, makeStyles, tokens } from "@fluentui/react-components";
 import { locConstants as loc } from "../../../common/locConstants";
 import * as mssql from "vscode-mssql";
+import "./compareDiffEditor.css";
 
 const useStyles = makeStyles({
     dividerContainer: {


### PR DESCRIPTION
This PR fixes #19157

The PR fixes an issue where index scripts were previously not being included in the diff editor.
![image](https://github.com/user-attachments/assets/a443ba21-68cb-4ef9-b2a8-7747910653a1)

Here is a screenshot of what this same script looks like in Azure Data Studio.
![image](https://github.com/user-attachments/assets/d3fd5d53-8967-4982-948e-01d206166089)


