### PR TITLE
Add connection profile names and prefill select schema drawer

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
@@ -110,7 +110,7 @@ const SchemaSelectorDrawer = (props: Props) => {
             : context.state.targetEndpointInfo;
 
     const [schemaType, setSchemaType] = useState(
-        endpointTypeToString(currentEndpoint?.endpointType) || "database",
+        endpointTypeToString(currentEndpoint?.endpointType || SchemaCompareEndpointType.Database),
     );
     const [disableOkButton, setDisableOkButton] = useState(true);
     const [serverConnectionUri, setServerConnectionUri] = useState(currentEndpoint?.ownerUri || "");
@@ -119,7 +119,9 @@ const SchemaSelectorDrawer = (props: Props) => {
     );
     const [databaseName, setDatabaseName] = useState(currentEndpoint?.databaseName || "");
     const [folderStructure, setFolderStructure] = useState(
-        extractTargetTypeToString(currentEndpoint?.extractTarget) || "Schema/Object Type",
+        extractTargetTypeToString(
+            currentEndpoint?.extractTarget || SharedExtractTarget.schemaObjectType,
+        ),
     );
 
     const fileId = useId("file");

--- a/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles({
     },
 });
 
-const endpointTypeToString = (endpointType: number | undefined) => {
+function endpointTypeToString(endpointType: number | undefined): string {
     if (endpointType === undefined) {
         return "";
     }
@@ -71,9 +71,9 @@ const endpointTypeToString = (endpointType: number | undefined) => {
         default:
             return "";
     }
-};
+}
 
-const extractTargetTypeToString = (extractTarget: number | undefined) => {
+function extractTargetTypeToString(extractTarget: number | undefined): string {
     if (extractTarget === undefined) {
         return "";
     }
@@ -91,7 +91,7 @@ const extractTargetTypeToString = (extractTarget: number | undefined) => {
         default:
             return "Schema/Object Type";
     }
-};
+}
 
 interface Props extends InputProps {
     show: boolean;

--- a/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaSelectorDrawer.tsx
@@ -227,7 +227,8 @@ const SchemaSelectorDrawer = (props: Props) => {
                                 {Object.keys(context.state.activeServers).map((connUri) => {
                                     return (
                                         <Option key={connUri} value={connUri}>
-                                            {context.state.activeServers[connUri]}
+                                            {context.state.activeServers[connUri].profileName ||
+                                                context.state.activeServers[connUri].server}
                                         </Option>
                                     );
                                 })}

--- a/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
@@ -52,7 +52,7 @@ const SelectSchemasPanel = ({ onSelectSchemaClicked }: Props) => {
     const sourceEndpointInfo = context.state.sourceEndpointInfo;
     let sourceEndpointDisplay =
         (sourceEndpointInfo?.serverName && sourceEndpointInfo?.databaseName
-            ? `${sourceEndpointInfo?.serverName}.${sourceEndpointInfo?.databaseName}`
+            ? `${sourceEndpointInfo?.connectionName || sourceEndpointInfo?.serverName}.${sourceEndpointInfo?.databaseName}`
             : "") ||
         sourceEndpointInfo?.packageFilePath ||
         sourceEndpointInfo?.projectFilePath ||
@@ -61,7 +61,7 @@ const SelectSchemasPanel = ({ onSelectSchemaClicked }: Props) => {
     const targetEndpointInfo = context.state.targetEndpointInfo;
     let targetEndpointDisplay =
         (targetEndpointInfo?.serverName && targetEndpointInfo?.databaseName
-            ? `${targetEndpointInfo?.serverName}.${targetEndpointInfo?.databaseName}`
+            ? `${targetEndpointInfo?.connectionName || targetEndpointInfo?.serverName}.${targetEndpointInfo?.databaseName}`
             : "") ||
         targetEndpointInfo?.packageFilePath ||
         targetEndpointInfo?.projectFilePath ||

--- a/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SelectSchemasPanel.tsx
@@ -39,6 +39,18 @@ const useStyles = makeStyles({
     },
 });
 
+function getEndpointDisplayName(endpoint: mssql.SchemaCompareEndpointInfo): string {
+    let displayName =
+        (endpoint?.serverName && endpoint?.databaseName
+            ? `${endpoint?.connectionName || endpoint?.serverName}.${endpoint?.databaseName}`
+            : "") ||
+        endpoint?.packageFilePath ||
+        endpoint?.projectFilePath ||
+        "";
+
+    return displayName;
+}
+
 interface Props {
     onSelectSchemaClicked: (endpointType: "source" | "target") => void;
 }
@@ -50,22 +62,10 @@ const SelectSchemasPanel = ({ onSelectSchemaClicked }: Props) => {
     const context = useContext(schemaCompareContext);
 
     const sourceEndpointInfo = context.state.sourceEndpointInfo;
-    let sourceEndpointDisplay =
-        (sourceEndpointInfo?.serverName && sourceEndpointInfo?.databaseName
-            ? `${sourceEndpointInfo?.connectionName || sourceEndpointInfo?.serverName}.${sourceEndpointInfo?.databaseName}`
-            : "") ||
-        sourceEndpointInfo?.packageFilePath ||
-        sourceEndpointInfo?.projectFilePath ||
-        "";
+    let sourceEndpointDisplay = getEndpointDisplayName(sourceEndpointInfo);
 
     const targetEndpointInfo = context.state.targetEndpointInfo;
-    let targetEndpointDisplay =
-        (targetEndpointInfo?.serverName && targetEndpointInfo?.databaseName
-            ? `${targetEndpointInfo?.connectionName || targetEndpointInfo?.serverName}.${targetEndpointInfo?.databaseName}`
-            : "") ||
-        targetEndpointInfo?.packageFilePath ||
-        targetEndpointInfo?.projectFilePath ||
-        "";
+    let targetEndpointDisplay = getEndpointDisplayName(targetEndpointInfo);
 
     const handleCompare = () => {
         context.compare(

--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -982,20 +982,15 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
     } {
         const activeServers: { [connectionUri: string]: { profileName: string; server: string } } =
             {};
-        let seenServerNames = new Set<string>();
-
         const activeConnections = this.connectionMgr.activeConnections;
         Object.keys(activeConnections).forEach((connectionUri) => {
             let credentials = activeConnections[connectionUri]
                 .credentials as IConnectionDialogProfile;
 
-            if (!seenServerNames.has(credentials.server)) {
-                activeServers[connectionUri] = {
-                    profileName: credentials.profileName,
-                    server: credentials.server,
-                };
-                seenServerNames.add(credentials.server);
-            }
+            activeServers[connectionUri] = {
+                profileName: credentials.profileName ?? "",
+                server: credentials.server,
+            };
         });
 
         return activeServers;

--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -11,7 +11,6 @@ import { ObjectExplorerUtils } from "../objectExplorer/objectExplorerUtils";
 
 import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
 import {
-    ISchemaCompareConnectionProfile,
     SchemaCompareReducers,
     SchemaCompareWebViewState,
 } from "../sharedInterfaces/schemaCompare";
@@ -42,6 +41,7 @@ import { ActivityStatus, TelemetryActions, TelemetryViews } from "../sharedInter
 import { deepClone } from "../models/utils";
 import { isNullOrUndefined } from "util";
 import * as locConstants from "../constants/locConstants";
+import { IConnectionDialogProfile } from "../sharedInterfaces/connectionDialog";
 
 export class SchemaCompareWebViewController extends ReactWebviewPanelController<
     SchemaCompareWebViewState,
@@ -984,7 +984,7 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
         const activeConnections = this.connectionMgr.activeConnections;
         Object.keys(activeConnections).forEach((connectionUri) => {
             let credentials = activeConnections[connectionUri]
-                .credentials as ISchemaCompareConnectionProfile;
+                .credentials as IConnectionDialogProfile;
 
             if (!seenServerNames.has(credentials.server)) {
                 activeServers[connectionUri] = {

--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -11,6 +11,7 @@ import { ObjectExplorerUtils } from "../objectExplorer/objectExplorerUtils";
 
 import { ReactWebviewPanelController } from "../controllers/reactWebviewPanelController";
 import {
+    ISchemaCompareConnectionProfile,
     SchemaCompareReducers,
     SchemaCompareWebViewState,
 } from "../sharedInterfaces/schemaCompare";
@@ -973,17 +974,24 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
         }
     }
 
-    private getActiveServersList(): { [connectionUri: string]: string } {
-        const activeServers: { [connectionUri: string]: string } = {};
+    private getActiveServersList(): {
+        [connectionUri: string]: { profileName: string; server: string };
+    } {
+        const activeServers: { [connectionUri: string]: { profileName: string; server: string } } =
+            {};
         let seenServerNames = new Set<string>();
 
         const activeConnections = this.connectionMgr.activeConnections;
         Object.keys(activeConnections).forEach((connectionUri) => {
-            let serverName = activeConnections[connectionUri].credentials.server;
+            let credentials = activeConnections[connectionUri]
+                .credentials as ISchemaCompareConnectionProfile;
 
-            if (!seenServerNames.has(serverName)) {
-                activeServers[connectionUri] = serverName;
-                seenServerNames.add(serverName);
+            if (!seenServerNames.has(credentials.server)) {
+                activeServers[connectionUri] = {
+                    profileName: credentials.profileName,
+                    server: credentials.server,
+                };
+                seenServerNames.add(credentials.server);
             }
         });
 

--- a/src/sharedInterfaces/schemaCompare.ts
+++ b/src/sharedInterfaces/schemaCompare.ts
@@ -16,6 +16,7 @@ import {
     SchemaCompareIncludeExcludeResult,
     SchemaCompareObjectId,
     SchemaCompareOpenScmpResult,
+    IConnectionInfo,
 } from "vscode-mssql";
 import { ColorThemeKind } from "./webview";
 
@@ -33,11 +34,15 @@ export const enum SchemaCompareEndpointType {
     // located at \src\Microsoft.SqlTools.ServiceLayer\SchemaCompare\Contracts\SchemaCompareRequest.cs
 }
 
+export interface ISchemaCompareConnectionProfile extends IConnectionInfo {
+    profileName?: string;
+}
+
 export interface SchemaCompareWebViewState {
     isSqlProjectExtensionInstalled: boolean;
     isComparisonInProgress: boolean;
     isIncludeExcludeAllOperationInProgress: boolean;
-    activeServers: { [connectionUri: string]: string };
+    activeServers: { [connectionUri: string]: { profileName: string; server: string } };
     databases: string[];
     defaultDeploymentOptionsResult: SchemaCompareOptionsResult;
     auxiliaryEndpointInfo: SchemaCompareEndpointInfo;

--- a/src/sharedInterfaces/schemaCompare.ts
+++ b/src/sharedInterfaces/schemaCompare.ts
@@ -16,7 +16,6 @@ import {
     SchemaCompareIncludeExcludeResult,
     SchemaCompareObjectId,
     SchemaCompareOpenScmpResult,
-    IConnectionInfo,
 } from "vscode-mssql";
 import { ColorThemeKind } from "./webview";
 
@@ -32,10 +31,6 @@ export const enum SchemaCompareEndpointType {
     Project = 2,
     // must be kept in-sync with SchemaCompareEndpointType in SQL Tools Service
     // located at \src\Microsoft.SqlTools.ServiceLayer\SchemaCompare\Contracts\SchemaCompareRequest.cs
-}
-
-export interface ISchemaCompareConnectionProfile extends IConnectionInfo {
-    profileName?: string;
 }
 
 export interface SchemaCompareWebViewState {

--- a/src/sharedInterfaces/schemaCompare.ts
+++ b/src/sharedInterfaces/schemaCompare.ts
@@ -33,6 +33,7 @@ export const enum SchemaCompareEndpointType {
     // located at \src\Microsoft.SqlTools.ServiceLayer\SchemaCompare\Contracts\SchemaCompareRequest.cs
 }
 
+// If this enum changes, then please update the ExtractTarget enum in vscode-mssql.d.ts.
 export const enum SharedExtractTarget {
     dacpac = 0,
     file = 1,

--- a/test/unit/schemaCompareWebViewController.test.ts
+++ b/test/unit/schemaCompareWebViewController.test.ts
@@ -279,6 +279,7 @@ suite("SchemaCompareWebViewController Tests", () => {
 
         mockServerConnInfo = TypeMoq.Mock.ofType<mssql.IConnectionInfo>();
         mockServerConnInfo.setup((info) => info.server).returns(() => "server1");
+        mockServerConnInfo.setup((info: any) => info.profileName).returns(() => "profile1");
 
         mockConnectionInfo = TypeMoq.Mock.ofType<ConnectionInfo>();
         mockConnectionInfo
@@ -747,7 +748,7 @@ suite("SchemaCompareWebViewController Tests", () => {
         publishProjectChangesStub.restore();
     });
 
-    test("listActiveServers reducer - when called - returns: {conn_uri: 'server1'}", async () => {
+    test("listActiveServers reducer - when called - returns: {conn_uri: {profileName: 'profile1', server: 'server1'}}", async () => {
         const payload = {};
 
         const actualResult = await controller["_reducers"]["listActiveServers"](
@@ -755,12 +756,12 @@ suite("SchemaCompareWebViewController Tests", () => {
             payload,
         );
 
-        const expectedResult = { conn_uri: "server1" };
+        const expectedResult = { conn_uri: { profileName: "profile1", server: "server1" } };
 
         assert.deepEqual(
             actualResult.activeServers,
             expectedResult,
-            "listActiveServers should return: {conn_uri: 'server1'}",
+            "listActiveServers should return: {conn_uri: {profileName: 'profile1', server: 'server1'}}",
         );
     });
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -438,6 +438,7 @@ declare module "vscode-mssql" {
         connectionString: string | undefined;
     }
 
+    // If this enum changes, please update the SharedExtractTarget enum in schemaCompare.ts
     export const enum ExtractTarget {
         dacpac = 0,
         file = 1,


### PR DESCRIPTION
Issue #19153

Connection profile names are included in the drop down for database types in the schema compare dialog when selecting a source/target endpoint.
![image](https://github.com/user-attachments/assets/fcb540ae-4657-4d48-a248-04f96a931fc6)
![image](https://github.com/user-attachments/assets/d4d5172e-998c-4064-85ce-ac6811e18533)

 
This PR also includes #19163

The select schema drawer will now be prefilled with the values of the currently selected endpoint, if any.

![Open-prefilled-select-drawer](https://github.com/user-attachments/assets/e7b660e9-8596-4684-b84e-1ca4719b4f02)




