### PR TITLE
Add command + click to select multiple ranges on mac

### DIFF
--- a/src/reactviews/pages/QueryResult/table/plugins/cellRangeSelector.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/cellRangeSelector.ts
@@ -3,11 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-    QueryResultWebviewState,
-    QueryResultReducers,
-} from "../../../../../sharedInterfaces/queryResult";
-import { VscodeWebviewContext } from "../../../../common/vscodeWebviewProvider";
 import { mixin } from "../objects";
 
 const defaultOptions: ICellRangeSelectorOptions = {
@@ -48,25 +43,22 @@ export class CellRangeSelector<T extends Slick.SlickData> implements ICellRangeS
     private decorator!: ICellRangeDecorator;
     private canvas!: HTMLCanvasElement;
     private currentlySelectedRange?: { start: Slick.Cell; end?: Slick.Cell };
-    private platform: string | undefined;
+    private isMac: boolean | undefined;
 
     public onBeforeCellRangeSelected = new Slick.Event<Slick.Cell>();
     public onCellRangeSelected = new Slick.Event<Slick.Range>();
     public onAppendCellRangeSelected = new Slick.Event<Slick.Range>();
 
-    constructor(
-        private options: ICellRangeSelectorOptions,
-        private webViewState: VscodeWebviewContext<QueryResultWebviewState, QueryResultReducers>,
-    ) {
+    constructor(private options: ICellRangeSelectorOptions) {
         this.options = mixin(this.options, defaultOptions, false);
     }
 
-    public async init(grid: Slick.Grid<T>) {
+    public init(grid: Slick.Grid<T>) {
         this.decorator =
             this.options.cellDecorator || new (<any>Slick).CellRangeDecorator(grid, this.options);
         this.grid = grid;
         this.canvas = this.grid.getCanvasNode();
-        this.platform = (await this.webViewState.extensionRpc.call("getPlatform")) as string;
+        this.isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
         this.handler
             .subscribe(this.grid.onDragInit, (e) => this.handleDragInit(e))
             .subscribe(this.grid.onDragStart, (e: Slick.DOMEvent, dd) =>
@@ -166,7 +158,7 @@ export class CellRangeSelector<T extends Slick.SlickData> implements ICellRangeS
             dd.range.end.row,
             dd.range.end.cell,
         );
-        if (this.platform === "darwin") {
+        if (this.isMac) {
             // MacOS uses metaKey instead of ctrlKey
             if (e.metaKey) {
                 this.onAppendCellRangeSelected.notify(newRange);

--- a/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/cellSelectionModel.plugin.ts
@@ -45,7 +45,7 @@ export class CellSelectionModel<T extends Slick.SlickData>
     private ranges: Array<Slick.Range> = [];
     private _handler = new Slick.EventHandler();
     private webViewState: VscodeWebviewContext<QueryResultWebviewState, QueryResultReducers>;
-    private platform: string | undefined;
+    private isMac: boolean | undefined;
 
     public onSelectedRangesChanged = new Slick.Event<Array<Slick.Range>>();
 
@@ -59,20 +59,17 @@ export class CellSelectionModel<T extends Slick.SlickData>
             this.selector = this.options.cellRangeSelector;
         } else {
             // this is added by the node requires above
-            this.selector = new CellRangeSelector(
-                {
-                    selectionCss: {
-                        border: `3px dashed ${tokens.colorStrokeFocus1}`,
-                    },
+            this.selector = new CellRangeSelector({
+                selectionCss: {
+                    border: `3px dashed ${tokens.colorStrokeFocus1}`,
                 },
-                this.webViewState,
-            );
+            });
         }
     }
 
-    public async init(grid: Slick.Grid<T>) {
+    public init(grid: Slick.Grid<T>) {
         this.grid = grid;
-        this.platform = (await this.webViewState.extensionRpc.call("getPlatform")) as string;
+        this.isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
         this._handler.subscribe(this.grid.onKeyDown, (e: Slick.DOMEvent) =>
             this.handleKeyDown(e as unknown as KeyboardEvent),
         );
@@ -177,7 +174,7 @@ export class CellSelectionModel<T extends Slick.SlickData>
     }
 
     private isMultiSelection(_e: MouseEvent): boolean {
-        return this.platform === "darwin" ? _e.metaKey : _e.ctrlKey;
+        return this.isMac ? _e.metaKey : _e.ctrlKey;
     }
 
     private handleHeaderClick(e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>) {
@@ -412,7 +409,7 @@ export class CellSelectionModel<T extends Slick.SlickData>
 
     private async handleKeyDown(e: KeyboardEvent): Promise<void> {
         let handled = false;
-        if (this.platform === "darwin") {
+        if (this.isMac) {
             // Cmd + A
             if (e.metaKey && e.key === Keys.a) {
                 handled = true;


### PR DESCRIPTION
Adds command + click functionality to mac so users can select multiple ranges in the query results grid. (this works via Ctrl + click on windows)


Fixes https://github.com/microsoft/vscode-mssql/issues/18507