### PR TITLE
Adding <enter> and <esc> support for submitting and canceling Trust Server Certificate dialog

### DIFF
--- a/src/reactviews/pages/ConnectionDialog/components/trustServerCertificateDialog.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/trustServerCertificateDialog.component.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { useContext } from "react";
+import { useContext, useRef, useEffect } from "react";
 import { ConnectionDialogContext } from "../connectionDialogStateProvider";
 import {
     Button,
@@ -27,14 +27,32 @@ export const TrustServerCertificateDialog = ({
     dialogProps: TrustServerCertDialogProps;
 }) => {
     const context = useContext(ConnectionDialogContext)!;
+    // eslint-disable-next-line no-restricted-syntax -- Ref needs to be null, not undefined
+    const trustCertButtonRef = useRef<HTMLButtonElement | null>(null);
 
     if (context.state.dialog?.type !== "trustServerCert") {
         return undefined;
     }
 
+    useEffect(() => {
+        // Focus the "Trust Server Certificate" button when the dialog opens
+        if (trustCertButtonRef.current) {
+            trustCertButtonRef.current.focus();
+        }
+    }, []);
+
+    const handleCancel = () => {
+        context.closeDialog();
+    };
+
     return (
         <Dialog open={dialogProps.type === "trustServerCert"}>
-            <DialogSurface>
+            <DialogSurface
+                onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === "Escape") {
+                        handleCancel();
+                    }
+                }}>
                 <DialogBody>
                     <DialogTitle>{locConstants.connectionDialog.connectionErrorTitle}</DialogTitle>
                     <DialogContent>
@@ -53,25 +71,20 @@ export const TrustServerCertificateDialog = ({
                     </DialogContent>
                     <DialogActions>
                         <Button
+                            ref={trustCertButtonRef}
                             appearance="primary"
                             onClick={() => {
                                 context.closeDialog();
-
                                 context.formAction({
                                     propertyName: "trustServerCertificate",
                                     value: true,
                                     isAction: false,
                                 });
-
                                 context.connect();
                             }}>
                             {locConstants.connectionDialog.enableTrustServerCertificateButton}
                         </Button>
-                        <Button
-                            appearance="secondary"
-                            onClick={() => {
-                                context.closeDialog();
-                            }}>
+                        <Button appearance="secondary" onClick={handleCancel}>
                             {locConstants.common.cancel}
                         </Button>
                     </DialogActions>

--- a/src/reactviews/pages/ConnectionDialog/components/trustServerCertificateDialog.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/trustServerCertificateDialog.component.tsx
@@ -73,6 +73,7 @@ export const TrustServerCertificateDialog = ({
                         <Button
                             ref={trustCertButtonRef}
                             appearance="primary"
+                            style={{ width: "auto", whiteSpace: "nowrap" }}
                             onClick={() => {
                                 context.closeDialog();
                                 context.formAction({


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode-mssql/issues/18519

Also updates the button wrapping:

Before:
![image](https://github.com/user-attachments/assets/299aa769-a48b-4594-ab9c-1e4bea7a244e)

After:
![image](https://github.com/user-attachments/assets/fa06ef3d-b38d-486e-aabf-89eee1cb19b3)
