### PR TITLE
Fixing parallel node expansion.

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1062,6 +1062,7 @@
       "{0} is the node label"
     ]
   },
+  "Loading...": "Loading...",
   "Connection Dialog (Preview)": "Connection Dialog (Preview)",
   "Azure Account": "Azure Account",
   "Azure Account is required": "Azure Account is required",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1023,6 +1023,9 @@
     <trans-unit id="++CODE++10a371b8dc47cdf83c4cd7f926daf76305a6b52311a69b3087d744151dc53501">
       <source xml:lang="en">Loading Table Designer</source>
     </trans-unit>
+    <trans-unit id="++CODE++47d2a515ef2f05b87d688656286a61e4f743da4b878684c7654969db17711c40">
+      <source xml:lang="en">Loading...</source>
+    </trans-unit>
     <trans-unit id="++CODE++15b61974b2707a7b3d4201385e0f01f4ff5eb1f17c5639d98788ee5add2025cd">
       <source xml:lang="en">Location</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -594,6 +594,7 @@ export class ObjectExplorer {
     }
     public static NodeDeletionConfirmationYes = l10n.t("Yes");
     public static NodeDeletionConfirmationNo = l10n.t("No");
+    public static LoadingNodeLabel = l10n.t("Loading...");
 }
 
 export class ConnectionDialog {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -718,10 +718,8 @@ export default class MainController implements vscode.Disposable {
         );
 
         const connectParentNode = async (node: AccountSignInTreeNode | ConnectTreeNode) => {
-            node.label = LocalizedConstants.ObjectExplorer.Connecting;
-            await this._objectExplorerProvider.refresh(node as unknown as TreeNodeInfo);
             this._objectExplorerProvider.deleteChildrenCache(node.parentNode);
-            await this._objectExplorerProvider.refresh(node.parentNode);
+            void this._objectExplorerProvider.refresh(node.parentNode);
         };
 
         // Sign In into Object Explorer Node

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -396,7 +396,10 @@ export class ObjectExplorerService {
          * one blocked operation can delay the others.
          */
         void this.getOrCreateNodeChildrenWithSession(element);
-        const loadingNode = new vscode.TreeItem("Loading...", vscode.TreeItemCollapsibleState.None);
+        const loadingNode = new vscode.TreeItem(
+            LocalizedConstants.ObjectExplorer.LoadingNodeLabel,
+            vscode.TreeItemCollapsibleState.None,
+        );
         loadingNode.iconPath = new vscode.ThemeIcon("loading~spin");
         this._treeNodeToChildrenMap.set(element, [loadingNode]);
         return [loadingNode];

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -314,7 +314,7 @@ export class ObjectExplorerService {
                     uniqueConnections.set(conn.id, conn);
                 } else {
                     this._logger.verbose(
-                        `Duplicate connection ID found: ${conn.id}. Removing duplicate connection.`,
+                        `Duplicate connection ID found: ${conn.id}. Ignoring duplicate connection.`,
                     );
                 }
             }
@@ -392,8 +392,8 @@ export class ObjectExplorerService {
          * If no children are cached, return a temporary loading node to keep the UI responsive
          * and trigger the async call to fetch real children.
          * This node will be replaced once the data is retrieved and the tree is refreshed.
-         * Without this, tree expansion is queued—so if multiple connections are expanding,
-         * one blocked operation can delay the others.
+         * Tree expansion is queued, so without this if multiple connections are expanding,
+         * one blocked operation can delay the other.
          */
         void this.getOrCreateNodeChildrenWithSession(element);
         const loadingNode = new vscode.TreeItem(

--- a/test/unit/objectExplorerProvider.test.ts
+++ b/test/unit/objectExplorerProvider.test.ts
@@ -171,10 +171,17 @@ suite("Object Explorer Provider Tests", function () {
 
         parentTreeNode.setup((s) => s.sessionId).returns(() => "test_session");
 
-        const children = await testObjectExplorerService.getChildren(parentTreeNode.object);
+        let children = await testObjectExplorerService.getChildren(parentTreeNode.object);
+        expect(children.length, "loading node should be returned").is.equal(1);
+        expect(children[0].label, "Should return loading node").is.equal(
+            LocalizedConstants.ObjectExplorer.LoadingNodeLabel,
+        );
 
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        children = await testObjectExplorerService.getChildren(parentTreeNode.object);
         expect(children.length, "No items nodes should be returned").is.equal(1);
-        expect(children[0].label, "No items nodes should have the correct label").is.equal(
+        expect(children[0].label, "should return No items node").is.equal(
             LocalizedConstants.ObjectExplorer.NoItems,
         );
     });


### PR DESCRIPTION
Returning a temporary loading node to keep the UI responsive in the tree. It is necessary to do this in order to allow multiple refresh of the tree. 

How the UI looks for long running expansions.

https://github.com/user-attachments/assets/efa00ee2-6733-458b-9827-2acab20cf1d2

