### PR TITLE
Adding report error handling in table designer.

### DIFF
--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -365,7 +365,7 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                         publishState: designer.LoadState.NotStarted,
                     },
                     generatePreviewReportResult: {
-                        schemaValidationError: e.toString(),
+                        schemaValidationError: getErrorMessage(e),
                         report: "",
                         mimeType: "",
                     },

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -341,24 +341,40 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
                 },
                 publishingError: undefined,
             };
-            const previewReport = await this._tableDesignerService.generatePreviewReport(
-                payload.table,
-            );
+            try {
+                const previewReport = await this._tableDesignerService.generatePreviewReport(
+                    payload.table,
+                );
+                state = {
+                    ...state,
+                    apiState: {
+                        ...state.apiState,
+                        previewState: previewReport.schemaValidationError
+                            ? designer.LoadState.Error
+                            : designer.LoadState.Loaded,
+                        publishState: designer.LoadState.NotStarted,
+                    },
+                    generatePreviewReportResult: previewReport,
+                };
+            } catch (e) {
+                state = {
+                    ...state,
+                    apiState: {
+                        ...state.apiState,
+                        previewState: designer.LoadState.Error,
+                        publishState: designer.LoadState.NotStarted,
+                    },
+                    generatePreviewReportResult: {
+                        schemaValidationError: e.toString(),
+                        report: "",
+                        mimeType: "",
+                    },
+                };
+            }
             sendActionEvent(TelemetryViews.TableDesigner, TelemetryActions.GenerateScript, {
                 correlationId: this._correlationId,
             });
 
-            state = {
-                ...state,
-                apiState: {
-                    ...state.apiState,
-                    previewState: previewReport.schemaValidationError
-                        ? designer.LoadState.Error
-                        : designer.LoadState.Loaded,
-                    publishState: designer.LoadState.NotStarted,
-                },
-                generatePreviewReportResult: previewReport,
-            };
             return state;
         });
 


### PR DESCRIPTION
This PR fixes #19295 

Some times the schema validation results are returned in the report whereas sometimes they are thrown as an error. This logic consolidates that. 

Before:
<img width="596" alt="Image" src="https://github.com/user-attachments/assets/d695f09c-74de-4fde-8727-000c5962f8a9" />

Now:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/647f6e14-89a5-43cf-a729-d6861027d93d" />

