### PR TITLE
Adding categories in advanced connection

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -267,6 +267,7 @@
   "Copy connection string to clipboard": "Copy connection string to clipboard",
   "Paste connection string from clipboard": "Paste connection string from clipboard",
   "Paste": "Paste",
+  "Search settings...": "Search settings...",
   "Query {0}:  Query cost (relative to the script):  {1}%/{0} is the query number{1} is the query cost": {
     "message": "Query {0}:  Query cost (relative to the script):  {1}%",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1549,6 +1549,9 @@
     <trans-unit id="++CODE++49ff54ad141b9f4b74b176a98807c6b9a1282dfe026c3f38015dd596c54c4a84">
       <source xml:lang="en">Search options...</source>
     </trans-unit>
+    <trans-unit id="++CODE++6801207d5994165123a10ab767fd9439130fae500f8c407877ae5070843b906d">
+      <source xml:lang="en">Search settings...</source>
+    </trans-unit>
     <trans-unit id="++CODE++7f55382219f0202c1b4f56deb099e2fedcec87ee73fe2edb2105df5447323bc6">
       <source xml:lang="en">Search...</source>
     </trans-unit>

--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "5.0.20250416.6",
+        "version": "5.0.20250501.5",
         "downloadFileNames": {
             "Windows_86": "win-x86-net8.0.zip",
             "Windows_64": "win-x64-net8.0.zip",

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -871,6 +871,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             authenticationType: AuthenticationType.SqlLogin,
             connectTimeout: 30, // seconds
             applicationName: "vscode-mssql",
+            applicationIntent: "ReadWrite",
         } as IConnectionDialogProfile;
     }
 

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -155,12 +155,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
         this.state.connectionComponents = {
             mainOptions: [...ConnectionDialogWebviewController.mainOptions],
-            topAdvancedOptions: [
-                "port",
-                "applicationName",
-                "connectTimeout",
-                "multiSubnetFailover",
-            ],
+            topAdvancedOptions: [],
             groupedAdvancedOptions: [], // computed below
         };
 

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -155,7 +155,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
         this.state.connectionComponents = {
             mainOptions: [...ConnectionDialogWebviewController.mainOptions],
-            topAdvancedOptions: [],
             groupedAdvancedOptions: [], // computed below
         };
 

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -99,10 +99,7 @@ export function groupAdvancedOptions(
     ]);
 
     const optionsToGroup = Object.values(components).filter(
-        (c) =>
-            c.isAdvancedOption &&
-            !componentsInfo.mainOptions.includes(c.propertyName) &&
-            !componentsInfo.topAdvancedOptions.includes(c.propertyName),
+        (c) => c.isAdvancedOption && !componentsInfo.mainOptions.includes(c.propertyName),
     );
 
     for (const option of optionsToGroup) {

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -88,7 +88,7 @@ export function groupAdvancedOptions(
     componentsInfo: ConnectionComponentsInfo,
 ): ConnectionComponentGroup[] {
     const groupMap: Map<string, ConnectionComponentGroup> = new Map([
-        // intialize with display order; any that aren't pre-defined will be appended
+        // initialize with display order; any that aren't pre-defined will be appended
         // these values must match the GroupName defined in SQL Tools Service.
         ["general", undefined],
         ["security", undefined],

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -90,9 +90,10 @@ export function groupAdvancedOptions(
     const groupMap: Map<string, ConnectionComponentGroup> = new Map([
         // intialize with display order; any that aren't pre-defined will be appended
         // these values must match the GroupName defined in SQL Tools Service.
+        ["general", undefined],
         ["security", undefined],
-        ["initialization", undefined],
         ["resiliency", undefined],
+        ["failover", undefined],
         ["pooling", undefined],
         ["context", undefined],
     ]);

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -245,6 +245,7 @@ export class LocConstants {
             pasteConnectionString: l10n.t("Paste connection string from clipboard"),
             copy: l10n.t("Copy"),
             paste: l10n.t("Paste"),
+            searchSettings: l10n.t("Search settings..."),
         };
     }
 

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -13,14 +13,16 @@ import {
     DrawerHeader,
     DrawerHeaderTitle,
     OverlayDrawer,
+    SearchBox,
 } from "@fluentui/react-components";
 import { Dismiss24Regular } from "@fluentui/react-icons";
 
 import { locConstants } from "../../../common/locConstants";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { FormField } from "../../../common/forms/form.component";
 import { ConnectionDialogContext } from "../connectionDialogStateProvider";
 import {
+    ConnectionComponentGroup,
     ConnectionDialogContextProps,
     ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
@@ -35,10 +37,36 @@ export const AdvancedOptionsDrawer = ({
     setIsAdvancedDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     const context = useContext(ConnectionDialogContext);
+    const [searchSettingsText, setSearchSettingText] = useState<string>("");
+    const [userOpenedSections, setUserOpenedSections] = useState<string[]>(["General"]);
 
     if (context === undefined) {
         return undefined;
     }
+
+    const doesGroupHaveVisibleOptions = (group: ConnectionComponentGroup) => {
+        return group.options.some((optionName) => {
+            if (context.state.formComponents[optionName]?.hidden === true) {
+                return false;
+            }
+            if (searchSettingsText) {
+                return optionName.toLowerCase().includes(searchSettingsText.toLowerCase());
+            } else {
+                return true;
+            }
+        });
+    };
+
+    const isOptionVisible = (optionName: keyof IConnectionDialogProfile) => {
+        if (context.state.formComponents[optionName]?.hidden === true) {
+            return false;
+        }
+        if (searchSettingsText) {
+            return optionName.toLowerCase().includes(searchSettingsText.toLowerCase());
+        } else {
+            return true;
+        }
+    };
 
     return (
         <OverlayDrawer
@@ -61,9 +89,19 @@ export const AdvancedOptionsDrawer = ({
             </DrawerHeader>
 
             <DrawerBody>
+                <SearchBox
+                    size="medium"
+                    style={{ width: "100%", maxWidth: "100%" }}
+                    placeholder={locConstants.connectionDialog.searchSettings}
+                    onChange={(_e, data) => {
+                        setSearchSettingText(data.value ?? "");
+                    }}
+                    value={searchSettingsText}
+                />
                 <div style={{ margin: "20px 0px" }}>
-                    {context.state.connectionComponents.topAdvancedOptions.map(
-                        (optionName, idx) => {
+                    {context.state.connectionComponents.topAdvancedOptions
+                        .filter((optionName) => isOptionVisible(optionName))
+                        .map((optionName, idx) => {
                             return (
                                 <FormField<
                                     IConnectionDialogProfile,
@@ -77,44 +115,62 @@ export const AdvancedOptionsDrawer = ({
                                     idx={idx}
                                 />
                             );
-                        },
-                    )}
+                        })}
                 </div>
-                <Accordion multiple collapsible>
-                    {context.state.connectionComponents.groupedAdvancedOptions.map(
-                        (group, groupIndex) => {
+                <Accordion
+                    multiple
+                    collapsible
+                    onToggle={(_e, data) => {
+                        if (searchSettingsText) {
+                            // We don't support expanding/collapsing sections when searching
+                            return;
+                        } else {
+                            setUserOpenedSections(data.openItems as string[]);
+                        }
+                    }}
+                    openItems={
+                        /**
+                         * If the user is searching, we keep all sections open
+                         * If the user is not searching, we only open the sections that the user has opened
+                         */
+                        searchSettingsText
+                            ? context.state.connectionComponents.groupedAdvancedOptions.map(
+                                  (group) => group.groupName,
+                              )
+                            : userOpenedSections
+                    }>
+                    {context.state.connectionComponents.groupedAdvancedOptions
+                        .filter((group) => doesGroupHaveVisibleOptions(group))
+                        .map((group, groupIndex) => {
                             return (
                                 <AccordionItem value={group.groupName} key={groupIndex}>
                                     <AccordionHeader>{group.groupName}</AccordionHeader>
                                     <AccordionPanel>
-                                        {group.options.map((optionName, idx) => {
-                                            if (
-                                                context.state.formComponents[optionName]?.hidden ===
-                                                true
-                                            ) {
-                                                return undefined;
-                                            }
-                                            return (
-                                                <FormField<
-                                                    IConnectionDialogProfile,
-                                                    ConnectionDialogWebviewState,
-                                                    ConnectionDialogFormItemSpec,
-                                                    ConnectionDialogContextProps
-                                                >
-                                                    key={idx}
-                                                    context={context}
-                                                    component={
-                                                        context.state.formComponents[optionName]!
-                                                    }
-                                                    idx={idx}
-                                                />
-                                            );
-                                        })}
+                                        {group.options
+                                            .filter((optionName) => isOptionVisible(optionName))
+                                            .map((optionName, idx) => {
+                                                return (
+                                                    <FormField<
+                                                        IConnectionDialogProfile,
+                                                        ConnectionDialogWebviewState,
+                                                        ConnectionDialogFormItemSpec,
+                                                        ConnectionDialogContextProps
+                                                    >
+                                                        key={idx}
+                                                        context={context}
+                                                        component={
+                                                            context.state.formComponents[
+                                                                optionName
+                                                            ]!
+                                                        }
+                                                        idx={idx}
+                                                    />
+                                                );
+                                            })}
                                     </AccordionPanel>
                                 </AccordionItem>
                             );
-                        },
-                    )}
+                        })}
                 </Accordion>
             </DrawerBody>
         </OverlayDrawer>

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -44,29 +44,17 @@ export const AdvancedOptionsDrawer = ({
         return undefined;
     }
 
-    const doesGroupHaveVisibleOptions = (group: ConnectionComponentGroup) => {
-        return group.options.some((optionName) => {
-            if (context.state.formComponents[optionName]?.hidden === true) {
-                return false;
-            }
-            if (searchSettingsText) {
-                return optionName.toLowerCase().includes(searchSettingsText.toLowerCase());
-            } else {
-                return true;
-            }
-        });
-    };
+    function doesGroupHaveVisibleOptions(group: ConnectionComponentGroup) {
+        return group.options.some((optionName) => isOptionVisible(optionName));
+    }
 
-    const isOptionVisible = (optionName: keyof IConnectionDialogProfile) => {
-        if (context.state.formComponents[optionName]?.hidden === true) {
-            return false;
-        }
+    function isOptionVisible(optionName: keyof IConnectionDialogProfile) {
         if (searchSettingsText) {
             return optionName.toLowerCase().includes(searchSettingsText.toLowerCase());
         } else {
             return true;
         }
-    };
+    }
 
     return (
         <OverlayDrawer

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -98,25 +98,6 @@ export const AdvancedOptionsDrawer = ({
                     }}
                     value={searchSettingsText}
                 />
-                <div style={{ margin: "20px 0px" }}>
-                    {context.state.connectionComponents.topAdvancedOptions
-                        .filter((optionName) => isOptionVisible(optionName))
-                        .map((optionName, idx) => {
-                            return (
-                                <FormField<
-                                    IConnectionDialogProfile,
-                                    ConnectionDialogWebviewState,
-                                    ConnectionDialogFormItemSpec,
-                                    ConnectionDialogContextProps
-                                >
-                                    key={idx}
-                                    context={context}
-                                    component={context.state.formComponents[optionName]!}
-                                    idx={idx}
-                                />
-                            );
-                        })}
-                </div>
                 <Accordion
                     multiple
                     collapsible

--- a/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/advancedOptionsDrawer.component.tsx
@@ -45,12 +45,19 @@ export const AdvancedOptionsDrawer = ({
     }
 
     function doesGroupHaveVisibleOptions(group: ConnectionComponentGroup) {
-        return group.options.some((optionName) => isOptionVisible(optionName));
+        return group.options.some((optionName) =>
+            isOptionVisible(
+                context?.state?.formComponents[optionName] as ConnectionDialogFormItemSpec,
+            ),
+        );
     }
 
-    function isOptionVisible(optionName: keyof IConnectionDialogProfile) {
+    function isOptionVisible(option: ConnectionDialogFormItemSpec) {
         if (searchSettingsText) {
-            return optionName.toLowerCase().includes(searchSettingsText.toLowerCase());
+            return (
+                option.label.toLowerCase().includes(searchSettingsText.toLowerCase()) ||
+                option.propertyName.toLowerCase().includes(searchSettingsText.toLowerCase())
+            );
         } else {
             return true;
         }
@@ -116,7 +123,11 @@ export const AdvancedOptionsDrawer = ({
                                     <AccordionHeader>{group.groupName}</AccordionHeader>
                                     <AccordionPanel>
                                         {group.options
-                                            .filter((optionName) => isOptionVisible(optionName))
+                                            .filter((optionName) =>
+                                                isOptionVisible(
+                                                    context.state.formComponents[optionName]!,
+                                                ),
+                                            )
                                             .map((optionName, idx) => {
                                                 return (
                                                     <FormField<

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -33,7 +33,6 @@ export class ConnectionDialogWebviewState
     public selectedInputMode: ConnectionInputMode = ConnectionInputMode.Parameters;
     public connectionComponents: ConnectionComponentsInfo = {
         mainOptions: [],
-        topAdvancedOptions: [],
         groupedAdvancedOptions: [],
     };
     public azureSubscriptions: AzureSubscriptionInfo[] = [];
@@ -94,7 +93,6 @@ export interface AzureSqlServerInfo {
 
 export interface ConnectionComponentsInfo {
     mainOptions: (keyof IConnectionDialogProfile)[];
-    topAdvancedOptions: (keyof IConnectionDialogProfile)[];
     groupedAdvancedOptions: ConnectionComponentGroup[];
 }
 

--- a/test/unit/connectionDialogWebviewController.test.ts
+++ b/test/unit/connectionDialogWebviewController.test.ts
@@ -287,13 +287,6 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 "encrypt",
             ]);
 
-            expect(controller.state.connectionComponents.topAdvancedOptions).to.deep.equal([
-                "port",
-                "applicationName",
-                "connectTimeout",
-                "multiSubnetFailover",
-            ]);
-
             expect(controller.state.selectedInputMode).to.equal(ConnectionInputMode.Parameters);
             expect(controller.state.savedConnections).to.have.lengthOf(1);
             expect(controller.state.savedConnections[0]).to.deep.include(testSavedConnection);

--- a/test/unit/connectionDialogWebviewController.test.ts
+++ b/test/unit/connectionDialogWebviewController.test.ts
@@ -241,6 +241,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 authenticationType: "SqlLogin",
                 connectTimeout: 30,
                 applicationName: "vscode-mssql",
+                applicationIntent: "ReadWrite",
             };
 
             expect(controller.state.formState).to.deep.equal(


### PR DESCRIPTION
Fixes: #18961 
Depends on #https://github.com/microsoft/sqltoolsservice/pull/2478

Default state: (General is expanded)
![image](https://github.com/user-attachments/assets/4d624138-1bb1-4be0-b8bb-3f4f7dc6f9d5)

On search text (All sections are expanded)
![image](https://github.com/user-attachments/assets/ec811194-f937-4bc1-9861-22f2be2c90dc)

If search is cleared, we go back to previously expanded selections
![image](https://github.com/user-attachments/assets/e76a0b6c-512e-42dc-bef4-322d4fda5390)

