### PR TITLE
Store column width in state

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -58,7 +58,7 @@ import { getStandardNPSQuestions, UserSurvey } from "../nps/userSurvey";
 import { ExecutionPlanOptions } from "../models/contracts/queryExecute";
 import { ObjectExplorerDragAndDropController } from "../objectExplorer/objectExplorerDragAndDropController";
 import { SchemaDesignerService } from "../services/schemaDesignerService";
-import store from "../queryResult/singletonStore";
+import store, { SubKeys } from "../queryResult/singletonStore";
 import { SchemaCompareWebViewController } from "../schemaCompare/schemaCompareWebViewController";
 import { SchemaCompare } from "../constants/locConstants";
 import { SchemaDesignerWebviewManager } from "../schemaDesigner/schemaDesignerWebviewManager";
@@ -1417,7 +1417,8 @@ export default class MainController implements vscode.Disposable {
                 return;
             }
             // Delete query result filters for the current uri when we run a new query
-            store.delete(uri);
+            store.delete(uri, SubKeys.Filter);
+            store.delete(uri, SubKeys.ColumnWidth);
 
             await self._outputContentProvider.runQuery(
                 self._statusview,
@@ -1822,7 +1823,8 @@ export default class MainController implements vscode.Disposable {
         }
 
         // Delete query result fiters for the closed uri
-        store.delete(closedDocumentUri);
+        store.delete(closedDocumentUri, SubKeys.Filter);
+        store.delete(closedDocumentUri, SubKeys.ColumnWidth);
     }
 
     private async updateUri(oldUri: string, newUri: string) {

--- a/src/queryResult/singletonStore.ts
+++ b/src/queryResult/singletonStore.ts
@@ -3,13 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export enum SubKeys {
+    Filter = "filter",
+    ColumnWidth = "columnWidth",
+}
+
 class QueryResultSingletonStore {
     private static instance: QueryResultSingletonStore;
-    private store: Map<string, any>;
+    private store: Map<string, Map<string, any>>;
 
     // Private constructor to prevent instantiation from outside
     private constructor() {
-        this.store = new Map<string, any>();
+        this.store = new Map<string, Map<string, any>>();
     }
 
     // Method to get the single instance of the store
@@ -20,29 +25,56 @@ class QueryResultSingletonStore {
         return QueryResultSingletonStore.instance;
     }
 
-    // Method to set a value in the store
-    public set(key: string, value: any): void {
-        this.store.set(key, value);
+    // Method to set a nested value in the store
+    public set(mainKey: string, subKey: string, value: any): void {
+        let nestedMap = this.store.get(mainKey);
+        if (!nestedMap) {
+            nestedMap = new Map<string, any>();
+            nestedMap.set(subKey, value);
+            this.store.set(mainKey, nestedMap);
+        } else {
+            nestedMap.set(subKey, value);
+            this.store.set(mainKey, nestedMap);
+        }
     }
 
-    // Method to get a value from the store
-    public get<T>(key: string): T | undefined {
-        return this.store.get(key);
+    // Method to get a nested value from the store
+    public get<T>(mainKey: string, subKey: string): T | undefined {
+        const nestedMap = this.store.get(mainKey);
+        return nestedMap?.get(subKey);
     }
 
-    // Method to check if a key exists
-    public has(key: string): boolean {
-        return this.store.has(key);
+    // Method to check if a nested key exists
+    public has(mainKey: string, subKey: string): boolean {
+        return this.store.get(mainKey)?.has(subKey) ?? false;
     }
 
-    // Method to delete a key-value pair
-    public delete(key: string): boolean {
-        return this.store.delete(key);
+    // Method to delete a nested key-value pair
+    public delete(mainKey: string, subKey: string): boolean {
+        const nestedMap = this.store.get(mainKey);
+        if (nestedMap) {
+            const deleted = nestedMap.delete(subKey);
+            if (nestedMap.size === 0) {
+                this.store.delete(mainKey);
+            }
+            return deleted;
+        }
+        return false;
     }
 
-    // Method to clear the store
+    // Method to clear the entire store
     public clear(): void {
         this.store.clear();
+    }
+
+    // Optional: delete entire nested map
+    public deleteMainKey(mainKey: string): boolean {
+        return this.store.delete(mainKey);
+    }
+
+    // Optional: get entire nested map
+    public getAll(mainKey: string): Map<string, any> | undefined {
+        return this.store.get(mainKey);
     }
 }
 

--- a/src/queryResult/singletonStore.ts
+++ b/src/queryResult/singletonStore.ts
@@ -8,7 +8,7 @@ export enum SubKeys {
     ColumnWidth = "columnWidth",
 }
 
-class QueryResultSingletonStore {
+export class QueryResultSingletonStore {
     private static instance: QueryResultSingletonStore;
     private store: Map<string, Map<string, any>>;
 

--- a/src/queryResult/singletonStore.ts
+++ b/src/queryResult/singletonStore.ts
@@ -12,12 +12,17 @@ class QueryResultSingletonStore {
     private static instance: QueryResultSingletonStore;
     private store: Map<string, Map<string, any>>;
 
-    // Private constructor to prevent instantiation from outside
+    /**
+     * Private constructor to prevent instantiation from outside.
+     */
     private constructor() {
         this.store = new Map<string, Map<string, any>>();
     }
 
-    // Method to get the single instance of the store
+    /**
+     * Method to get the single instance of the store.
+     * @returns The singleton instance of `QueryResultSingletonStore`.
+     */
     public static getInstance(): QueryResultSingletonStore {
         if (!QueryResultSingletonStore.instance) {
             QueryResultSingletonStore.instance = new QueryResultSingletonStore();
@@ -25,7 +30,12 @@ class QueryResultSingletonStore {
         return QueryResultSingletonStore.instance;
     }
 
-    // Method to set a nested value in the store
+    /**
+     * Method to set a nested value in the store.
+     * @param mainKey The main key in the store.
+     * @param subKey The subkey under the main key.
+     * @param value The value to set.
+     */
     public set(mainKey: string, subKey: string, value: any): void {
         let nestedMap = this.store.get(mainKey);
         if (!nestedMap) {
@@ -38,18 +48,33 @@ class QueryResultSingletonStore {
         }
     }
 
-    // Method to get a nested value from the store
+    /**
+     * Method to get a nested value from the store.
+     * @param mainKey The main key in the store.
+     * @param subKey The subkey under the main key.
+     * @returns The value associated with the subkey, or `undefined` if not found.
+     */
     public get<T>(mainKey: string, subKey: string): T | undefined {
         const nestedMap = this.store.get(mainKey);
         return nestedMap?.get(subKey);
     }
 
-    // Method to check if a nested key exists
+    /**
+     * Method to check if a nested key exists.
+     * @param mainKey The main key in the store.
+     * @param subKey The subkey under the main key.
+     * @returns `true` if the subkey exists, otherwise `false`.
+     */
     public has(mainKey: string, subKey: string): boolean {
         return this.store.get(mainKey)?.has(subKey) ?? false;
     }
 
-    // Method to delete a nested key-value pair
+    /**
+     * Method to delete a nested key-value pair.
+     * @param mainKey The main key in the store.
+     * @param subKey The subkey under the main key.
+     * @returns `true` if the key-value pair was deleted, otherwise `false`.
+     */
     public delete(mainKey: string, subKey: string): boolean {
         const nestedMap = this.store.get(mainKey);
         if (nestedMap) {
@@ -62,17 +87,27 @@ class QueryResultSingletonStore {
         return false;
     }
 
-    // Method to clear the entire store
+    /**
+     * Method to clear the entire store.
+     */
     public clear(): void {
         this.store.clear();
     }
 
-    // Optional: delete entire nested map
+    /**
+     * Method to delete an entire nested map.
+     * @param mainKey The main key in the store.
+     * @returns `true` if the main key was deleted, otherwise `false`.
+     */
     public deleteMainKey(mainKey: string): boolean {
         return this.store.delete(mainKey);
     }
 
-    // Optional: get entire nested map
+    /**
+     * Method to get an entire nested map.
+     * @param mainKey The main key in the store.
+     * @returns The nested map associated with the main key, or `undefined` if not found.
+     */
     public getAll(mainKey: string): Map<string, any> | undefined {
         return this.store.get(mainKey);
     }

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -19,7 +19,7 @@ import { sendActionEvent } from "../telemetry/telemetry";
 import * as qr from "../sharedInterfaces/queryResult";
 import { QueryResultWebviewPanelController } from "./queryResultWebviewPanelController";
 import { QueryResultWebviewController } from "./queryResultWebViewController";
-import store from "./singletonStore";
+import store, { SubKeys } from "./singletonStore";
 
 export function getNewResultPaneViewColumn(
     uri: string,
@@ -195,16 +195,25 @@ export function registerCommonRequestHandlers(
 
     // Register request handlers for query result filters
     webviewController.registerRequestHandler("getFilters", async (message) => {
-        return store.get(message.uri);
+        return store.get(message.uri, SubKeys.Filter);
     });
 
     webviewController.registerRequestHandler("setFilters", async (message) => {
-        store.set(message.uri, message.filters);
+        store.set(message.uri, SubKeys.Filter, message.filters);
         return true;
     });
 
+    webviewController.registerRequestHandler("setColumnWidths", async (message) => {
+        store.set(message.uri, SubKeys.ColumnWidth, message.columnWidths);
+        return true;
+    });
+
+    webviewController.registerRequestHandler("getColumnWidths", async (message) => {
+        return store.get(message.uri, SubKeys.ColumnWidth);
+    });
+
     webviewController.registerRequestHandler("deleteFilter", async (message) => {
-        store.delete(message.uri);
+        store.delete(message.uri, SubKeys.Filter);
         return true;
     });
 

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -124,8 +124,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
     const createTable = () => {
         const filter = async () => {
             await table.setupFilterState();
-            await table.setupColumnWidths();
-            // table.grid.setColumnWidths()
+            await table.restoreColumnWidths();
             table.rerenderGrid();
         };
         const DEFAULT_FONT_SIZE = 12;

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -123,10 +123,10 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
 
     const createTable = () => {
         const filter = async () => {
-            let hasNewFilters = await table.setupFilterState();
-            if (hasNewFilters) {
-                table.rerenderGrid();
-            }
+            await table.setupFilterState();
+            await table.setupColumnWidths();
+            // table.grid.setColumnWidths()
+            table.rerenderGrid();
         };
         const DEFAULT_FONT_SIZE = 12;
         context?.log(`resultGrid: ${context.state.fontSettings.fontSize}`);

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -122,7 +122,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
     };
 
     const createTable = () => {
-        const filter = async () => {
+        const setupState = async () => {
             await table.setupFilterState();
             await table.restoreColumnWidths();
             table.rerenderGrid();
@@ -259,7 +259,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
             tableOptions,
             props.gridParentRef,
         );
-        void filter();
+        void setupState();
         collection.setCollectionChangedCallback((startIndex, count) => {
             let refreshedRows = range(startIndex, startIndex + count);
             table.invalidateRows(refreshedRows, true);

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -225,7 +225,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         // this.registerPlugin(new MouseWheelSupport());
     }
 
-    public async setupColumnWidths(): Promise<void> {
+    public async restoreColumnWidths(): Promise<void> {
         const columnWidthArray = (await this.webViewState.extensionRpc.call("getColumnWidths", {
             uri: this.queryResultContext.state.uri,
         })) as number[];

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -200,11 +200,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         this.mapMouseEvent(this._grid.onClick);
         this.mapMouseEvent(this._grid.onDblClick);
         this._grid.onColumnsResized.subscribe(async (e, data) => {
-            console.log("oncolumnresize");
-            console.log("e", e);
-            console.log("data", data);
             if (!data) {
-                // this is from the first table render, disregard
                 return;
             }
             let columnSizes = this.grid
@@ -215,7 +211,6 @@ export class Table<T extends Slick.SlickData> implements IThemable {
                 uri: this.queryResultContext.state.uri,
             });
             if (currentColumnSizes === columnSizes) {
-                console.log("no change in column sizes");
                 return;
             }
 
@@ -231,16 +226,9 @@ export class Table<T extends Slick.SlickData> implements IThemable {
     }
 
     public async setupColumnWidths(): Promise<void> {
-        //TODO: apply column widths to grid
-        console.log("setupColumnWidths");
         const columnWidthArray = (await this.webViewState.extensionRpc.call("getColumnWidths", {
             uri: this.queryResultContext.state.uri,
         })) as number[];
-        if (!columnWidthArray) {
-            return;
-        }
-        console.log("columnWidths", columnWidthArray);
-
         if (!columnWidthArray) {
             return;
         }

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -199,7 +199,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         this.mapMouseEvent(this._grid.onContextMenu);
         this.mapMouseEvent(this._grid.onClick);
         this.mapMouseEvent(this._grid.onDblClick);
-        this._grid.onColumnsResized.subscribe(async (e, data) => {
+        this._grid.onColumnsResized.subscribe(async (_e, data) => {
             if (!data) {
                 return;
             }

--- a/test/unit/singletonStore.test.ts
+++ b/test/unit/singletonStore.test.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from "assert";
+import store, { QueryResultSingletonStore } from "../../src/queryResult/singletonStore";
+
+suite("QueryResultSingletonStore", () => {
+    let queryResultStore: QueryResultSingletonStore;
+
+    setup(() => {
+        queryResultStore = store;
+        store.clear(); // Ensure the store is cleared before each test
+    });
+
+    test("should set and get a nested value", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        const result = queryResultStore.get<string>("mainKey1", "subKey1");
+        assert.strictEqual(result, "value1", "The value should match the one set");
+    });
+
+    test("should return undefined for non-existent keys", () => {
+        const result = queryResultStore.get<string>("nonExistentMainKey", "nonExistentSubKey");
+        assert.strictEqual(
+            result,
+            undefined,
+            "The result should be undefined for non-existent keys",
+        );
+    });
+
+    test("should check if a nested key exists", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        const exists = queryResultStore.has("mainKey1", "subKey1");
+        assert.strictEqual(exists, true, "The key should exist");
+
+        const notExists = queryResultStore.has("mainKey1", "nonExistentSubKey");
+        assert.strictEqual(notExists, false, "The key should not exist");
+    });
+
+    test("should delete a nested key-value pair", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        const deleted = queryResultStore.delete("mainKey1", "subKey1");
+        assert.strictEqual(deleted, true, "The key-value pair should be deleted");
+
+        const exists = queryResultStore.has("mainKey1", "subKey1");
+        assert.strictEqual(exists, false, "The key should no longer exist");
+    });
+
+    test("should return false when deleting a non-existent key", () => {
+        const deleted = queryResultStore.delete("mainKey1", "nonExistentSubKey");
+        assert.strictEqual(deleted, false, "Deleting a non-existent key should return false");
+    });
+
+    test("should clear the entire queryResultStore", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        queryResultStore.set("mainKey2", "subKey2", "value2");
+        queryResultStore.clear();
+
+        const exists1 = queryResultStore.has("mainKey1", "subKey1");
+        const exists2 = queryResultStore.has("mainKey2", "subKey2");
+        assert.strictEqual(exists1, false, "The first key should no longer exist");
+        assert.strictEqual(exists2, false, "The second key should no longer exist");
+    });
+
+    test("should delete an entire nested map", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        queryResultStore.set("mainKey1", "subKey2", "value2");
+
+        const deleted = queryResultStore.deleteMainKey("mainKey1");
+        assert.strictEqual(deleted, true, "The main key should be deleted");
+
+        const exists = queryResultStore.getAll("mainKey1");
+        assert.strictEqual(exists, undefined, "The main key should no longer exist");
+    });
+
+    test("should return false when deleting a non-existent main key", () => {
+        const deleted = queryResultStore.deleteMainKey("nonExistentMainKey");
+        assert.strictEqual(deleted, false, "Deleting a non-existent main key should return false");
+    });
+
+    test("should get all nested values for a main key", () => {
+        queryResultStore.set("mainKey1", "subKey1", "value1");
+        queryResultStore.set("mainKey1", "subKey2", "value2");
+
+        const allValues = queryResultStore.getAll("mainKey1");
+        assert.ok(allValues, "The main key should exist");
+        assert.strictEqual(
+            allValues?.get("subKey1"),
+            "value1",
+            "The first subkey value should match",
+        );
+        assert.strictEqual(
+            allValues?.get("subKey2"),
+            "value2",
+            "The second subkey value should match",
+        );
+    });
+
+    test("should return undefined when getting all values for a non-existent main key", () => {
+        const allValues = queryResultStore.getAll("nonExistentMainKey");
+        assert.strictEqual(
+            allValues,
+            undefined,
+            "The result should be undefined for a non-existent main key",
+        );
+    });
+});


### PR DESCRIPTION
Stores column width in state, so that if a user expands a column, clicks the messages tab & then comes back to the results tab, the column width will remain the same.


![storeColumn](https://github.com/user-attachments/assets/e21d4323-8022-4975-b7b1-4c7568ec796c)

Fixes https://github.com/microsoft/vscode-mssql/issues/18554