### PR TITLE
New Feature: Get connection credentials by file uri

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -920,6 +920,19 @@ export default class ConnectionManager {
     }
 
     /**
+     * Retrieves Connection Info by file uri
+     * @param fileUri The URI of the file
+     * @returns Connection info
+     */
+    public getCredentialsByFileUri(fileUri: string): IConnectionInfo | undefined {
+        if (this.isConnected(fileUri)) {
+            return this._connections[fileUri].credentials;
+        }
+
+        return undefined;
+    }
+
+    /**
      * Retrieves the list of databases for the connection specified by the given URI.
      * @param connectionUri The URI of the connection to list the databases for
      * @returns The list of databases retrieved from the connection

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
         getServerInfo: (connectionInfo: IConnectionInfo) => {
             return controller.connectionManager.getServerInfo(connectionInfo);
         },
+        getCredentialsByFileUri: (fileUri: string) => {
+            return controller.connectionManager.getCredentialsByFileUri(fileUri);
+        },
     };
 }
 

--- a/typings/vscode-mssql.d.ts
+++ b/typings/vscode-mssql.d.ts
@@ -130,6 +130,12 @@ declare module "vscode-mssql" {
          * @returns server information
          */
         getServerInfo(connectionInfo: IConnectionInfo): IServerInfo;
+         /**
+         * Get connection credentials by file uri
+         * @param fileUri File uri
+         * @returns Connection info
+         */
+         getCredentialsByFileUri(fileUri: string): IConnectionInfo | undefined;
     }
 
     /**


### PR DESCRIPTION
New feature:

Since Azure data studio is retired soon, I'm trying to recreate SearchEverywhere extension for VS Code (https://github.com/MikhailProfile/SearchEverywhere)

In scenario of using MSSQL Api it's useful to have opportunity to get current connection for opened document. 
Could we add this feature? 
