### PR TITLE
Fix null reference for lastSavedTimer in untitled file handling

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1826,7 +1826,7 @@ export default class MainController implements vscode.Disposable {
         if (
             this._lastSavedUri &&
             closedDocumentUriScheme === LocalizedConstants.untitledScheme &&
-            this._lastSavedTimer.getDuration() < Constants.untitledSaveTimeThreshold
+            this._lastSavedTimer?.getDuration() < Constants.untitledSaveTimeThreshold
         ) {
             // Untitled file was saved and connection will be transfered
             await this.updateUri(closedDocumentUri, this._lastSavedUri);
@@ -1834,7 +1834,7 @@ export default class MainController implements vscode.Disposable {
             // If there was an openTextDoc event just before this closeTextDoc event then we know it was a rename
         } else if (
             this._lastOpenedUri &&
-            this._lastSavedTimer.getDuration() < Constants.untitledSaveTimeThreshold
+            this._lastSavedTimer?.getDuration() < Constants.untitledSaveTimeThreshold
         ) {
             await this.updateUri(closedDocumentUri, this._lastOpenedUri);
         } else {


### PR DESCRIPTION
This API appears to be triggered in various scenarios, like expanding Object Explorer. Because an initial variable wasn't set, it was causing intermittent console errors. This PR fixes that. Long term, we might want to switch to `onDidChangeVisibleTextEditors` as recommended in the docs for `onDidCloseTextDocument`.

```ts
/**
* An event that is emitted when a {@link TextDocument text document} is disposed or when the language id
* of a text document {@link languages.setTextDocumentLanguage has been changed}.
*
* *Note 1:* There is no guarantee that this event fires when an editor tab is closed, use the
* {@linkcode window.onDidChangeVisibleTextEditors onDidChangeVisibleTextEditors}-event to know when editors change.
*
 * *Note 2:* A document can be open but not shown in an editor which means this event can fire
* for a document that has not been shown in an editor.
*/
```

@cssuh 

Example of this issue:

![image](https://github.com/user-attachments/assets/c65a54a6-09bc-4831-9147-3db15fd93c28)







