### PR TITLE
Check state before initializing

### DIFF
--- a/src/controllers/reactWebviewBaseController.ts
+++ b/src/controllers/reactWebviewBaseController.ts
@@ -112,7 +112,9 @@ export abstract class ReactWebviewBaseController<State, Reducers> implements vsc
     }
 
     protected initializeBase() {
-        this.state = this._initialData;
+        if (!this.state) {
+            this.state = this._initialData;
+        }
         this._registerDefaultRequestHandlers();
         this.setupTheming();
     }


### PR DESCRIPTION
The state was getting reset if a query had been run before the react view was initialized.

Fixes https://github.com/microsoft/vscode-mssql/issues/19312