### PR TITLE
Adding password handling to connect URI handler

### DIFF
--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -867,12 +867,15 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     ): Promise<IConnectionDialogProfile> {
         // Load the password if it's saved
         if (Utils.isEmpty(connection.connectionString)) {
-            const password =
-                await this._mainController.connectionManager.connectionStore.lookupPassword(
-                    connection,
-                    false /* isConnectionString */,
-                );
-            connection.password = password;
+            if (!connection.password) {
+                // look up password in credential store if one isn't already set
+                const password =
+                    await this._mainController.connectionManager.connectionStore.lookupPassword(
+                        connection,
+                        false /* isConnectionString */,
+                    );
+                connection.password = password;
+            }
         } else {
             this.logger.logDebug(
                 "Connection string connection found in Connection Dialog initialization; should have been converted.",

--- a/test/unit/connectionDialogWebviewController.test.ts
+++ b/test/unit/connectionDialogWebviewController.test.ts
@@ -249,7 +249,38 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 "should be ready to connect when launched with a profile to edit",
             ).to.be.true;
         });
+
+        test("should initialize correctly when editing connection with password", async () => {
+            const editedConnection = {
+                profileName: "Test Server to Edit",
+                server: "SavedServer",
+                database: "SavedDatabase",
+                authenticationType: AuthenticationType.SqlLogin,
+                user: "testUser",
+                password: "testPassword",
+            } as IConnectionDialogProfile;
+
+            controller = new ConnectionDialogWebviewController(
+                mockContext.object,
+                mockVscodeWrapper.object,
+                mainController,
+                mockObjectExplorerProvider.object,
+                editedConnection,
+            );
+            await controller.initialized;
+
+            expect(controller["_connectionBeingEdited"]).to.deep.equal(
+                editedConnection,
+                "Form state should be the same as the connection being edited",
+            );
+
+            expect(
+                controller.state.readyToConnect,
+                "should be ready to connect when launched with a profile to edit",
+            ).to.be.true;
+        });
     });
+
     suite("Reducers", () => {
         suite("setConnectionInputType", () => {
             test("Should set connection input type correctly for Parameters", async () => {

--- a/test/unit/connectionDialogWebviewController.test.ts
+++ b/test/unit/connectionDialogWebviewController.test.ts
@@ -26,13 +26,9 @@ import {
     IConnectionProfileWithSource,
 } from "../../src/models/interfaces";
 import { AzureAccountService } from "../../src/services/azureAccountService";
-import { IAccount, ServiceOption } from "vscode-mssql";
+import { IAccount } from "vscode-mssql";
 import SqlToolsServerClient from "../../src/languageservice/serviceclient";
-import {
-    CapabilitiesResult,
-    ConnectionCompleteParams,
-    GetCapabilitiesRequest,
-} from "../../src/models/contracts/connection";
+import { ConnectionCompleteParams } from "../../src/models/contracts/connection";
 import * as AzureHelpers from "../../src/connectionconfig/azureHelpers";
 import {
     AzureSubscription,
@@ -42,6 +38,7 @@ import { stubTelemetry } from "./utils";
 import { TreeNodeInfo } from "../../src/objectExplorer/nodes/treeNodeInfo";
 import { CreateSessionResponse } from "../../src/models/contracts/objectExplorer/createSessionRequest";
 import { stubPromptForAzureSubscriptionFilter } from "./azureHelperStubs";
+import { mockGetCapabilitiesRequest } from "./mocks";
 
 suite("ConnectionDialogWebviewController Tests", () => {
     let sandbox: sinon.SinonSandbox;
@@ -132,89 +129,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 ]),
             );
 
-        serviceClientMock
-            .setup((s) =>
-                s.sendRequest(TypeMoq.It.isValue(GetCapabilitiesRequest.type), TypeMoq.It.isAny()),
-            )
-            .returns(() =>
-                Promise.resolve({
-                    capabilities: {
-                        connectionProvider: {
-                            groupDisplayNames: {
-                                group1: "Group 1",
-                                group2: "Group 2",
-                            },
-                            options: [
-                                {
-                                    name: "server",
-                                    displayName: "Server",
-                                    isRequired: true,
-                                    valueType: "string",
-                                },
-                                {
-                                    name: "user",
-                                    displayName: "User",
-                                    isRequired: false,
-                                    valueType: "string",
-                                },
-                                {
-                                    name: "password",
-                                    displayName: "Password",
-                                    isRequired: false,
-                                    valueType: "password",
-                                },
-                                {
-                                    name: "trustServerCertificate",
-                                    displayName: "Trust Server Certificate",
-                                    isRequired: false,
-                                    valueType: "boolean",
-                                },
-                                {
-                                    name: "authenticationType",
-                                    displayName: "Authentication Type",
-                                    isRequired: false,
-                                    valueType: "category",
-                                    categoryValues: [
-                                        AuthenticationType.SqlLogin,
-                                        AuthenticationType.Integrated,
-                                        AuthenticationType.AzureMFA,
-                                    ],
-                                },
-                                {
-                                    name: "savePassword",
-                                    displayName: "Save Password",
-                                    isRequired: false,
-                                    valueType: "boolean",
-                                },
-                                {
-                                    name: "accountId",
-                                    displayName: "Account Id",
-                                    isRequired: false,
-                                    valueType: "string",
-                                },
-                                {
-                                    name: "tenantId",
-                                    displayName: "Tenant Id",
-                                    isRequired: false,
-                                    valueType: "string",
-                                },
-                                {
-                                    name: "database",
-                                    displayName: "Database",
-                                    isRequired: false,
-                                    valueType: "string",
-                                },
-                                {
-                                    name: "encrypt",
-                                    displayName: "Encrypt",
-                                    isRequired: false,
-                                    valueType: "boolean",
-                                },
-                            ] as ServiceOption[],
-                        },
-                    },
-                } as unknown as CapabilitiesResult),
-            );
+        mockGetCapabilitiesRequest(serviceClientMock);
 
         mainController = new MainController(
             mockContext.object,

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as TypeMoq from "typemoq";
+import SqlToolsServerClient from "../../src/languageservice/serviceclient";
+import { AuthenticationType, ServiceOption } from "vscode-mssql";
+import { CapabilitiesResult, GetCapabilitiesRequest } from "../../src/models/contracts/connection";
+
+export function mockGetCapabilitiesRequest(serviceClientMock: TypeMoq.IMock<SqlToolsServerClient>) {
+    serviceClientMock
+        .setup((s) =>
+            s.sendRequest(TypeMoq.It.isValue(GetCapabilitiesRequest.type), TypeMoq.It.isAny()),
+        )
+        .returns(() =>
+            Promise.resolve({
+                capabilities: {
+                    connectionProvider: {
+                        groupDisplayNames: {
+                            group1: "Group 1",
+                            group2: "Group 2",
+                        },
+                        options: [
+                            {
+                                name: "server",
+                                displayName: "Server",
+                                isRequired: true,
+                                valueType: "string",
+                            },
+                            {
+                                name: "user",
+                                displayName: "User",
+                                isRequired: false,
+                                valueType: "string",
+                            },
+                            {
+                                name: "password",
+                                displayName: "Password",
+                                isRequired: false,
+                                valueType: "password",
+                            },
+                            {
+                                name: "trustServerCertificate",
+                                displayName: "Trust Server Certificate",
+                                isRequired: false,
+                                valueType: "boolean",
+                            },
+                            {
+                                name: "authenticationType",
+                                displayName: "Authentication Type",
+                                isRequired: false,
+                                valueType: "category",
+                                categoryValues: [
+                                    AuthenticationType.SqlLogin,
+                                    AuthenticationType.Integrated,
+                                    AuthenticationType.AzureMFA,
+                                ],
+                            },
+                            {
+                                name: "savePassword",
+                                displayName: "Save Password",
+                                isRequired: false,
+                                valueType: "boolean",
+                            },
+                            {
+                                name: "accountId",
+                                displayName: "Account Id",
+                                isRequired: false,
+                                valueType: "string",
+                            },
+                            {
+                                name: "tenantId",
+                                displayName: "Tenant Id",
+                                isRequired: false,
+                                valueType: "string",
+                            },
+                            {
+                                name: "database",
+                                displayName: "Database",
+                                isRequired: false,
+                                valueType: "string",
+                            },
+                            {
+                                name: "encrypt",
+                                displayName: "Encrypt",
+                                isRequired: false,
+                                valueType: "boolean",
+                            },
+                            {
+                                name: "connectTimeout",
+                                displayName: "Connect timeout",
+                                isRequired: false,
+                                valueType: "number",
+                            },
+                        ] as ServiceOption[],
+                    },
+                },
+            } as unknown as CapabilitiesResult),
+        );
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/18736

Though this yields some other questions about the behavior here: what should happen when a user launches the same URI multiple times?  The first time, it's new and get saves.  What does the second launch do?

Some options:
1. Launch connection dialog, and...
    1. Always make a new connection
    2. Assume I'm meaning to edit the first existing connection it finds
    3. Only assume it's editing the matching connection if there's only one that matches
    4. ...?
2. Connect directly to the existing connection (not launch the connection dialog)
    1. If there are multiple, prompt user for which?

I think I'm inclined toward 2 (with 2.1 for the multi-match scenario).