### PR TITLE
Fixing trust server certificate notification for OE and query editor. 

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1125,7 +1125,7 @@ export default class ConnectionManager {
                 const wasCreated = await addFirewallRuleController.dialogResult;
 
                 if (wasCreated === true /** dialog closed is undefined */) {
-                    await this.connect(fileUri, connection.credentials);
+                    return await this.connect(fileUri, connection.credentials);
                 } else {
                     return false;
                 }
@@ -1135,7 +1135,7 @@ export default class ConnectionManager {
                     connectionCreds as IConnectionProfile,
                 );
                 if (updatedConnection) {
-                    await this.connect(fileUri, updatedConnection);
+                    return await this.connect(fileUri, updatedConnection);
                 } else {
                     return false;
                 }

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -792,7 +792,7 @@ export default class MainController implements vscode.Disposable {
             retry = false;
             sessionCreationResult =
                 await this._objectExplorerProvider.createSession(connectionCredentials);
-            if (sessionCreationResult.shouldRetryOnFailure) {
+            if (sessionCreationResult?.shouldRetryOnFailure) {
                 retry = true;
             }
         }

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -66,6 +66,7 @@ import { DefaultWebviewNotifications } from "./reactWebviewBaseController";
 import { ConnectionNode } from "../objectExplorer/nodes/connectionNode";
 import { CopilotService } from "../services/copilotService";
 import * as Prompts from "../chat/prompts";
+import { CreateSessionResult } from "../objectExplorer/objectExplorerService";
 
 /**
  * The main controller class that initializes the extension
@@ -784,8 +785,17 @@ export default class MainController implements vscode.Disposable {
     public async createObjectExplorerSession(
         connectionCredentials?: IConnectionInfo,
     ): Promise<TreeNodeInfo> {
-        const sessionCreationResult =
-            await this._objectExplorerProvider.createSession(connectionCredentials);
+        let retry = true;
+        // There can be many reasons for the session creation to fail, so we will retry until we get a successful result or the user cancels the operation.
+        let sessionCreationResult: CreateSessionResult = undefined;
+        while (retry) {
+            retry = false;
+            sessionCreationResult =
+                await this._objectExplorerProvider.createSession(connectionCredentials);
+            if (sessionCreationResult.shouldRetryOnFailure) {
+                retry = true;
+            }
+        }
         if (sessionCreationResult) {
             const newNode = await sessionCreationResult.connectionNode;
             if (newNode) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -147,9 +147,7 @@ export class ObjectExplorerService {
      * @param profile The connection profile to reconnect.
      */
     private async reconnectProfile(profile: IConnectionProfile): Promise<void> {
-        const node = this._rootTreeNodeArray.find((n) =>
-            Utils.isSameConnectionInfo(n.connectionProfile, profile),
-        ) as ConnectionNode;
+        const node = this.getConnectionNodeFromProfile(profile);
         if (node) {
             node.updateConnectionProfile(profile);
             this.cleanNodeChildren(node);
@@ -653,9 +651,7 @@ export class ObjectExplorerService {
             return;
         }
 
-        let connectionNode = this._rootTreeNodeArray.find((node) =>
-            Utils.isSameConnectionInfo(node.connectionProfile, connectionProfile),
-        ) as ConnectionNode;
+        let connectionNode = this.getConnectionNodeFromProfile(connectionProfile);
 
         let isNewConnection = false;
         if (!connectionNode) {
@@ -691,9 +687,7 @@ export class ObjectExplorerService {
 
         return {
             sessionId: successResponse.sessionId,
-            connectionNode: this._rootTreeNodeArray.find((node) =>
-                Utils.isSameConnectionInfo(node.connectionProfile, connectionProfile),
-            ) as ConnectionNode,
+            connectionNode: this.getConnectionNodeFromProfile(connectionProfile),
         };
     }
 
@@ -725,6 +719,10 @@ export class ObjectExplorerService {
                 );
             });
             if (fixedProfile) {
+                const connectionNode = this.getConnectionNodeFromProfile(fixedProfile);
+                if (connectionNode) {
+                    connectionNode.updateConnectionProfile(fixedProfile);
+                }
                 return true;
             }
         } else if (ObjectExplorerUtils.isFirewallError(failureResponse.errorNumber)) {
@@ -964,6 +962,19 @@ export class ObjectExplorerService {
             this._client.logger.error("Node does not have a session ID");
             return ObjectExplorerUtils.getNodeUri(node); // TODO: can this removed entirely?  ideally, every node has a session ID associated with it
         }
+    }
+
+    /**
+     * Gets the connection node from the profile.
+     * @param connectionProfile The connection profile to get the node for
+     * @returns The connection node for the profile, or undefined if not found.
+     */
+    private getConnectionNodeFromProfile(
+        connectionProfile: IConnectionProfile,
+    ): ConnectionNode | undefined {
+        return this._rootTreeNodeArray.find((node) =>
+            Utils.isSameConnectionInfo(node.connectionProfile, connectionProfile),
+        ) as ConnectionNode;
     }
 
     /**

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -710,14 +710,10 @@ export class ObjectExplorerService {
             error += `: ${failureResponse.errorMessage}`;
         }
         if (errorNumber === Constants.errorSSLCertificateValidationFailed) {
-            const fixedProfile: IConnectionProfile = await new Promise((resolve) => {
-                void this._connectionManager.showInstructionTextAsWarning(
-                    connectionProfile,
-                    async (updatedProfile) => {
-                        resolve(updatedProfile);
-                    },
-                );
-            });
+            const fixedProfile: IConnectionProfile = (await this._connectionManager.handleSSLError(
+                undefined,
+                connectionProfile,
+            )) as IConnectionProfile;
             if (fixedProfile) {
                 const connectionNode = this.getConnectionNodeFromProfile(fixedProfile);
                 if (connectionNode) {


### PR DESCRIPTION
This PR fixes two issues related to the Trust server certificate prompt:

1. Object Explorer:
When the user fixes a connection profile after the prompt, we weren’t updating the internal node profile, causing an infinite loop of Trust server certificate prompts.

2. Query Editor:
Opening a disconnected editor and connecting to a profile that requires Trust server certificate (but has it disabled) causes the connection flow to repeat once and ultimately fail. This then triggers an OE session with the same invalid profile, resulting in problem 1. 