### PR TITLE
Fix extension activation by adding `prettier` to dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
         "node-fetch": "^2.6.2",
         "opener": "1.4.2",
         "plist": "^3.0.6",
+        "prettier": "^3.3.3",
         "pretty-data": "^0.40.0",
         "qs": "^6.9.1",
         "rangy": "^1.3.0",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ea27642-dd26-4547-bf91-9b533a572651)
Likely caused by: https://github.com/microsoft/vscode-mssql/pull/19338