### PR TITLE
Add inMemoryDataProcessingThreshold for filtering/sorting

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1029,6 +1029,7 @@
   "Do you want to always display query results in a new tab instead of the query pane?": "Do you want to always display query results in a new tab instead of the query pane?",
   "Always show in new tab": "Always show in new tab",
   "Keep in query pane": "Keep in query pane",
+  "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'": "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'",
   "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})/{0} is a url to learn more about the new features": {
     "message": "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1029,7 +1029,7 @@
   "Do you want to always display query results in a new tab instead of the query pane?": "Do you want to always display query results in a new tab instead of the query pane?",
   "Always show in new tab": "Always show in new tab",
   "Keep in query pane": "Keep in query pane",
-  "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'": "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'",
+  "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: mssql.resultsGrid.inMemoryDataProcessingThreshold": "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: mssql.resultsGrid.inMemoryDataProcessingThreshold",
   "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})/{0} is a url to learn more about the new features": {
     "message": "The MSSQL for VS Code extension is introducing new modern data development features! Would you like to enable them? [Learn more]({0})",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1079,8 +1079,8 @@
     <trans-unit id="++CODE++305fd6adb2295a939e62e4fed83349c610aa4e1840280503e6b64c8042dccd16">
       <source xml:lang="en">Max Length</source>
     </trans-unit>
-    <trans-unit id="++CODE++a303681c4efe069dab7df7d76ffb3c097afa4db09b2de6863f67b03d4fff3c6a">
-      <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: &apos;mssql.resultsGrid.inMemoryDataProcessingThreshold&apos;</source>
+    <trans-unit id="++CODE++3cb29430462001e8edb74afebb929c2e967e7eac89679c4d549a8305ec4a2fe7">
+      <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: mssql.resultsGrid.inMemoryDataProcessingThreshold</source>
     </trans-unit>
     <trans-unit id="++CODE++fba6c2c5d9468e741725c7dfa1ac14fb59523c74fa86744027ec0a175e6cae3f">
       <source xml:lang="en">Maximize</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1079,6 +1079,9 @@
     <trans-unit id="++CODE++305fd6adb2295a939e62e4fed83349c610aa4e1840280503e6b64c8042dccd16">
       <source xml:lang="en">Max Length</source>
     </trans-unit>
+    <trans-unit id="++CODE++a303681c4efe069dab7df7d76ffb3c097afa4db09b2de6863f67b03d4fff3c6a">
+      <source xml:lang="en">Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: &apos;mssql.resultsGrid.inMemoryDataProcessingThreshold&apos;</source>
+    </trans-unit>
     <trans-unit id="++CODE++fba6c2c5d9468e741725c7dfa1ac14fb59523c74fa86744027ec0a175e6cae3f">
       <source xml:lang="en">Maximize</source>
     </trans-unit>
@@ -2191,6 +2194,9 @@
     </trans-unit>
     <trans-unit id="extension.connections">
       <source xml:lang="en">Connections</source>
+    </trans-unit>
+    <trans-unit id="mssql.resultsGrid.inMemoryDataProcessingThreshold">
+      <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
     </trans-unit>
     <trans-unit id="mssql.copyAll">
       <source xml:lang="en">Copy All</source>

--- a/package.json
+++ b/package.json
@@ -1634,7 +1634,8 @@
                 "mssql.resultsGrid.inMemoryDataProcessingThreshold": {
                     "type": "number",
                     "default": 5000,
-                    "description": "%mssql.resultsGrid.inMemoryDataProcessingThreshold%"
+                    "description": "%mssql.resultsGrid.inMemoryDataProcessingThreshold%",
+                    "minimum": 1
                 },
                 "mssql.query.displayBitAsNumber": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1631,6 +1631,11 @@
                     "default": true,
                     "description": "%mssql.resultsGrid.autoSizeColumns%"
                 },
+                "mssql.resultsGrid.inMemoryDataProcessingThreshold": {
+                    "type": "number",
+                    "default": 5000,
+                    "description": "%mssql.resultsGrid.inMemoryDataProcessingThreshold%"
+                },
                 "mssql.query.displayBitAsNumber": {
                     "type": "boolean",
                     "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -115,6 +115,7 @@
     "mssql.format.placeSelectStatementReferencesOnNewLine": "Should references to objects in a select statements be split into separate lines? E.g. for 'SELECT C1, C2 FROM T1' both C1 and C2 will be on separate lines",
     "mssql.applyLocalization": "[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)",
     "mssql.resultsGrid.autoSizeColumns": "Automatically adjust the column widths based on the visible rows in the result set. Could have performance problems with a large number of columns or large cells",
+    "mssql.resultsGrid.inMemoryDataProcessingThreshold": "Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.",
     "mssql.query.displayBitAsNumber": "Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'",
     "mssql.intelliSense.enableIntelliSense": "Should IntelliSense be enabled",
     "mssql.intelliSense.enableErrorChecking": "Should IntelliSense error checking be enabled",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -201,6 +201,7 @@ export const configUseLegacyQueryResultExperience = "mssql.useLegacyQueryResultE
 export const configOpenQueryResultsInTabByDefaultDoNotShowPrompt =
     "mssql.openQueryResultsInTabByDefaultDoNotShowPrompt";
 export const configAutoColumnSizing = "resultsGrid.autoSizeColumns";
+export const configInMemoryDataProcessingThreshold = "resultsGrid.inMemoryDataProcessingThreshold";
 export const configAutoDisableNonTSqlLanguageService = "mssql.autoDisableNonTSqlLanguageService";
 export const copilotDebugLogging = "mssql.copilotDebugLogging";
 

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -561,6 +561,9 @@ export let openQueryResultsInTabByDefaultPrompt = l10n.t(
 );
 export let alwaysShowInNewTab = l10n.t("Always show in new tab");
 export let keepInQueryPane = l10n.t("Keep in query pane");
+export let inMemoryDataProcessingThresholdExceeded = l10n.t(
+    "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'",
+);
 
 export function enableRichExperiencesPrompt(learnMoreUrl: string) {
     return l10n.t({

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -562,7 +562,7 @@ export let openQueryResultsInTabByDefaultPrompt = l10n.t(
 export let alwaysShowInNewTab = l10n.t("Always show in new tab");
 export let keepInQueryPane = l10n.t("Keep in query pane");
 export let inMemoryDataProcessingThresholdExceeded = l10n.t(
-    "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: 'mssql.resultsGrid.inMemoryDataProcessingThreshold'",
+    "Max row count for filtering/sorting has been exceeded. To update it, navigate to User Settings and change the setting: mssql.resultsGrid.inMemoryDataProcessingThreshold",
 );
 
 export function enableRichExperiencesPrompt(learnMoreUrl: string) {

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -81,6 +81,8 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                             fontFamily: this.getFontFamilyConfig(),
                         },
                         autoSizeColumns: this.getAutoSizeColumnsConfig(),
+                        inMemoryDataProcessingThreshold:
+                            this.getInMemoryDataProcessingThresholdConfig(),
                     };
                 }
             });
@@ -116,6 +118,14 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 if (e.affectsConfiguration("mssql.resultsGrid.autoSizeColumns")) {
                     for (const [uri, state] of this._queryResultStateMap) {
                         state.autoSizeColumns = this.getAutoSizeColumnsConfig();
+                        this._queryResultStateMap.set(uri, state);
+                    }
+                }
+                if (e.affectsConfiguration("mssql.resultsGrid.inMemoryDataProcessingThreshold")) {
+                    for (const [uri, state] of this._queryResultStateMap) {
+                        state.inMemoryDataProcessingThreshold = this.vscodeWrapper
+                            .getConfiguration(Constants.extensionName)
+                            .get(Constants.configInMemoryDataProcessingThreshold);
                         this._queryResultStateMap.set(uri, state);
                     }
                 }
@@ -198,6 +208,11 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         this.registerRequestHandler("getWebviewLocation", async () => {
             return qr.QueryResultWebviewLocation.Panel;
         });
+        this.registerRequestHandler("showFilterDisabledMessage", () => {
+            this.vscodeWrapper.showInformationMessage(
+                LocalizedConstants.inMemoryDataProcessingThresholdExceeded,
+            );
+        });
         registerCommonRequestHandlers(this, this._correlationId);
     }
 
@@ -253,6 +268,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 fontFamily: this.getFontFamilyConfig(),
             },
             autoSizeColumns: this.getAutoSizeColumnsConfig(),
+            inMemoryDataProcessingThreshold: this.getInMemoryDataProcessingThresholdConfig(),
         };
         this._queryResultStateMap.set(uri, currentState);
     }
@@ -261,6 +277,12 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         return this.vscodeWrapper
             .getConfiguration(Constants.extensionName)
             .get(Constants.configAutoColumnSizing);
+    }
+
+    public getInMemoryDataProcessingThresholdConfig(): number {
+        return this.vscodeWrapper
+            .getConfiguration(Constants.extensionName)
+            .get(Constants.configInMemoryDataProcessingThreshold);
     }
 
     public getFontSizeConfig(): number {

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -38,8 +38,6 @@ declare global {
     }
 }
 
-const DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD = 5000;
-
 export interface ResultGridProps {
     loadFunc: (offset: number, count: number) => Thenable<any[]>;
     resultSetSummary?: ResultSetSummary;
@@ -127,14 +125,8 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
         const setupState = async () => {
             await table.setupFilterState();
             await table.restoreColumnWidths();
-            if (context.state.inMemoryDataProcessingThreshold) {
-                table.headerFilter.enabled =
-                    table.grid.getDataLength() < context.state.inMemoryDataProcessingThreshold;
-            } else {
-                console.debug("Using default inMemoryDataProcessingThreshold");
-                table.headerFilter.enabled =
-                    table.grid.getDataLength() < DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD;
-            }
+            table.headerFilter.enabled =
+                table.grid.getDataLength() < context.state.inMemoryDataProcessingThreshold!;
 
             table.rerenderGrid();
         };
@@ -253,9 +245,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
             },
             {
                 inMemoryDataProcessing: true,
-                inMemoryDataCountThreshold: context.state.inMemoryDataProcessingThreshold
-                    ? context.state.inMemoryDataProcessingThreshold
-                    : DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD,
+                inMemoryDataCountThreshold: context.state.inMemoryDataProcessingThreshold,
             },
             undefined,
             undefined,

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -38,6 +38,8 @@ declare global {
     }
 }
 
+const IN_MEMORY_DATA_PROCESSING_THRESHOLD = 5000;
+
 export interface ResultGridProps {
     loadFunc: (offset: number, count: number) => Thenable<any[]>;
     resultSetSummary?: ResultSetSummary;
@@ -125,6 +127,15 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
         const setupState = async () => {
             await table.setupFilterState();
             await table.restoreColumnWidths();
+            if (context.state.inMemoryDataProcessingThreshold) {
+                table.headerFilter.enabled =
+                    table.grid.getDataLength() < context.state.inMemoryDataProcessingThreshold;
+            } else {
+                console.debug("Using default inMemoryDataProcessingThreshold");
+                table.headerFilter.enabled =
+                    table.grid.getDataLength() < IN_MEMORY_DATA_PROCESSING_THRESHOLD;
+            }
+
             table.rerenderGrid();
         };
         const DEFAULT_FONT_SIZE = 12;
@@ -242,6 +253,9 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
             },
             {
                 inMemoryDataProcessing: true,
+                inMemoryDataCountThreshold: context.state.inMemoryDataProcessingThreshold
+                    ? context.state.inMemoryDataProcessingThreshold
+                    : IN_MEMORY_DATA_PROCESSING_THRESHOLD,
             },
             undefined,
             undefined,

--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -38,7 +38,7 @@ declare global {
     }
 }
 
-const IN_MEMORY_DATA_PROCESSING_THRESHOLD = 5000;
+const DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD = 5000;
 
 export interface ResultGridProps {
     loadFunc: (offset: number, count: number) => Thenable<any[]>;
@@ -133,7 +133,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
             } else {
                 console.debug("Using default inMemoryDataProcessingThreshold");
                 table.headerFilter.enabled =
-                    table.grid.getDataLength() < IN_MEMORY_DATA_PROCESSING_THRESHOLD;
+                    table.grid.getDataLength() < DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD;
             }
 
             table.rerenderGrid();
@@ -255,7 +255,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
                 inMemoryDataProcessing: true,
                 inMemoryDataCountThreshold: context.state.inMemoryDataProcessingThreshold
                     ? context.state.inMemoryDataProcessingThreshold
-                    : IN_MEMORY_DATA_PROCESSING_THRESHOLD,
+                    : DEFAULT_IN_MEMORY_DATA_PROCESSING_THRESHOLD,
             },
             undefined,
             undefined,

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -216,6 +216,10 @@ export class HeaderFilter<T extends Slick.SlickData> {
     }
 
     private async showFilter(filterButton: HTMLElement) {
+        if (!this.enabled) {
+            await this.webviewState.extensionRpc.call("showFilterDisabledMessage", {});
+            return;
+        }
         let $menuButton: JQuery<HTMLElement> | undefined;
         const target = withNullAsUndefined(filterButton);
         if (target) {
@@ -640,6 +644,10 @@ export class HeaderFilter<T extends Slick.SlickData> {
     }
 
     private async handleMenuItemClick(command: SortDirection, columnDef: Slick.Column<T>) {
+        if (!this.enabled) {
+            await this.webviewState.extensionRpc.call("showFilterDisabledMessage", {});
+            return;
+        }
         const dataView = this.grid.getData();
         if (command === "sort-asc" || command === "sort-desc") {
             this.grid.setSortColumn(columnDef.id as string, command === "sort-asc");

--- a/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
+++ b/src/reactviews/pages/QueryResult/table/plugins/headerFilter.plugin.ts
@@ -142,6 +142,10 @@ export class HeaderFilter<T extends Slick.SlickData> {
             this._eventManager.addEventListener(sortButton, "click", async (e: Event) => {
                 e.stopPropagation();
                 e.preventDefault();
+                if (!this.enabled) {
+                    await this.webviewState.extensionRpc.call("showFilterDisabledMessage", {});
+                    return;
+                }
                 this.columnDef = jQuery(sortButton).data("column"); //TODO: fix, shouldn't assign in the event handler
                 let columnFilterState: ColumnFilterState = {
                     columnDef: this.columnDef.id!,
@@ -337,23 +341,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
         jQuery(document).on("click", `#close-popup-${this.columnDef.id}`, () => {
             closePopup($popup);
             this.activePopup = null;
-        });
-
-        // Sorting button click handlers
-        jQuery(document).on("click", "#sort-ascending", (_e: JQuery.ClickEvent) => {
-            void this.handleMenuItemClick("sort-asc", this.columnDef);
-            closePopup($popup);
-            this.activePopup = null;
-            this.grid.setSortColumn(this.columnDef.id!, true);
-            this.columnDef.sorted = SortProperties.ASC;
-        });
-
-        jQuery(document).on("click", "#sort-descending", (_e: JQuery.ClickEvent) => {
-            void this.handleMenuItemClick("sort-desc", this.columnDef);
-            closePopup($popup);
-            this.activePopup = null;
-            this.grid.setSortColumn(this.columnDef.id!, false);
-            this.columnDef.sorted = SortProperties.DESC;
         });
 
         jQuery(document).on("click", `#apply-${this.columnDef.id}`, async () => {
@@ -644,10 +631,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
     }
 
     private async handleMenuItemClick(command: SortDirection, columnDef: Slick.Column<T>) {
-        if (!this.enabled) {
-            await this.webviewState.extensionRpc.call("showFilterDisabledMessage", {});
-            return;
-        }
         const dataView = this.grid.getData();
         if (command === "sort-asc" || command === "sort-desc") {
             this.grid.setSortColumn(columnDef.id as string, command === "sort-asc");

--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -66,6 +66,7 @@ export class Table<T extends Slick.SlickData> implements IThemable {
     private _container: HTMLElement;
     protected _tableContainer: HTMLElement;
     private selectionModel: CellSelectionModel<T>;
+    public headerFilter: HeaderFilter<T>;
 
     constructor(
         parent: HTMLElement,
@@ -142,14 +143,13 @@ export class Table<T extends Slick.SlickData> implements IThemable {
         this._container.appendChild(this._tableContainer);
         this.styleElement = DOM.createStyleSheet(this._container);
         this._grid = new Slick.Grid<T>(this._tableContainer, this._data, [], newOptions);
-        this.registerPlugin(
-            new HeaderFilter(
-                webViewState.themeKind,
-                this.queryResultContext,
-                this.webViewState,
-                gridId,
-            ),
+        this.headerFilter = new HeaderFilter(
+            webViewState.themeKind,
+            this.queryResultContext,
+            this.webViewState,
+            gridId,
         );
+        this.registerPlugin(this.headerFilter);
         this.registerPlugin(
             new ContextMenu(
                 this.uri,

--- a/src/sharedInterfaces/queryResult.ts
+++ b/src/sharedInterfaces/queryResult.ts
@@ -76,6 +76,7 @@ export interface QueryResultWebviewState extends ExecutionPlanWebviewState {
     executionPlanState: ExecutionPlanState;
     fontSettings: FontSettings;
     autoSizeColumns?: boolean;
+    inMemoryDataProcessingThreshold?: number;
 }
 
 export interface QueryResultReducers extends Omit<ExecutionPlanReducers, "getExecutionPlan"> {


### PR DESCRIPTION
Adds a threshold to disable filtering/sorting for large data sets.  The default is set at 5000 rows.  If a user tries to filter/sort for data sets larger than this amount, we will display this toast:
<img width="453" alt="Screenshot 2025-05-08 at 4 09 36 PM" src="https://github.com/user-attachments/assets/7b00eb64-ae4c-4bd7-b197-5f3f9ed33d87" />

Also cleaned up some code that was no longer needed.