### PR TITLE
Splitting PR and main test runs to isolate failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run unit tests for PR branch
         run: |
-          cd main
+          cd pr
           DISPLAY=:10 yarn test
 
       - name: PR Unit Test Report
@@ -143,7 +143,7 @@ jobs:
       - name: Run unit tests for main branch # for calculating coverage comparison
         continue-on-error: true
         run: |
-          cd pr
+          cd main
           DISPLAY=:10 yarn test
 
       - name: Build mappings for React Webviews
@@ -189,6 +189,16 @@ jobs:
           path: ./pr/test-results/**/
           retention-days: 7
 
+      - name: Smoke Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+            name: 'Smoke Test Report'
+            path: ./test-reports/**/smoke-results.xml
+            reporter: jest-junit
+            badge-title: 'smoke-tests'
+            working-directory: ./pr
+
       - name: Run smoke tests for main branch # for calculating coverage comparison
         continue-on-error: true
         run: |
@@ -201,16 +211,6 @@ jobs:
           PROFILE_NAME=test-server
           cd main
           DISPLAY=:10 yarn smoketest
-
-      - name: Smoke Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-            name: 'Smoke Test Report'
-            path: ./test-reports/**/smoke-results.xml
-            reporter: jest-junit
-            badge-title: 'smoke-tests'
-            working-directory: ./pr
 
       - name: Merge Smoke and Unit Test Coverage Reports
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,11 +125,9 @@ jobs:
           vsix_text_color=$(if [ $percentage_change -gt 0 ]; then echo "red"; else echo "lightgreen"; fi)
           echo "vsix_text_color=$vsix_text_color" >> $GITHUB_ENV
 
-      - name: Run unit tests
+      - name: Run unit tests for PR branch
         run: |
           cd main
-          DISPLAY=:10 yarn test
-          cd ../pr
           DISPLAY=:10 yarn test
 
       - name: PR Unit Test Report
@@ -141,6 +139,12 @@ jobs:
           reporter: jest-junit
           working-directory: ./pr
           badge-title: 'unit-tests'
+
+      - name: Run unit tests for main branch # for calculating coverage comparison
+        continue-on-error: true
+        run: |
+          cd pr
+          DISPLAY=:10 yarn test
 
       - name: Build mappings for React Webviews
         run: |
@@ -163,7 +167,7 @@ jobs:
           sudo service mssql-server start
         working-directory: ./pr
 
-      - name: Run smoke tests
+      - name: Run smoke tests for PR branch
         run: |
           VS_CODE_VERSION=stable
           SERVER_NAME=localhost
@@ -184,6 +188,19 @@ jobs:
           name: smoke-test-failure-screenshots
           path: ./pr/test-results/**/
           retention-days: 7
+
+      - name: Run smoke tests for main branch # for calculating coverage comparison
+        continue-on-error: true
+        run: |
+          VS_CODE_VERSION=stable
+          SERVER_NAME=localhost
+          AUTHENTICATION_TYPE="SQL Login"
+          USER_NAME=sa
+          PASSWORD=${{ env.PASSWORD }}
+          SAVE_PASSWORD=No
+          PROFILE_NAME=test-server
+          cd main
+          DISPLAY=:10 yarn smoketest
 
       - name: Smoke Test Report
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
* Splitting tests against main into separate step for better debuggability 
* Set tests against main to `continue-on-error` to make it easier to return them to a functional state if something upstream breaks us.

Order for tests is now:

1. tests run against PR branch
2. test reports generated
3. tests run again main branch