### PR TITLE
Prevent query runner deletion after editor close & reopen

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -708,6 +708,7 @@
   "Azure Code Grant": "Azure Code Grant",
   "Azure Device Code": "Azure Device Code",
   "Azure Logs": "Azure Logs",
+  "Query Results": "Query Results",
   "Open": "Open",
   "Ignore Tenant": "Ignore Tenant",
   "Your tenant '{0} ({1})' requires you to re-authenticate again to access {2} resources. Press Open to start the authentication process./{0} is the tenant name{1} is the tenant id{2} is the resource": {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1403,6 +1403,9 @@
     <trans-unit id="++CODE++f44ad102b5dd5df1b5691408d19d39ee92cc1c9ad20f7125845df3d961a805d3">
       <source xml:lang="en">Query Plan</source>
     </trans-unit>
+    <trans-unit id="++CODE++70e130053d5cc32db21828d00d7074434b6f8fbabb7fb0169014d2ee1714b5af">
+      <source xml:lang="en">Query Results</source>
+    </trans-unit>
     <trans-unit id="++CODE++9e83dc6d2db272ac27cc875b994f834b62b7202a49b69e885f8f4e8f9c29a452">
       <source xml:lang="en">Query executed</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -118,6 +118,7 @@ export let authTypeAzureActiveDirectory = l10n.t("Microsoft Entra Id - Universal
 export let azureAuthTypeCodeGrant = l10n.t("Azure Code Grant");
 export let azureAuthTypeDeviceCode = l10n.t("Azure Device Code");
 export let azureLogChannelName = l10n.t("Azure Logs");
+export let queryResultChannelName = l10n.t("Query Results");
 export let azureConsentDialogOpen = l10n.t("Open");
 export let azureConsentDialogIgnore = l10n.t("Ignore Tenant");
 export function azureConsentDialogBody(tenantName: string, tenantId: string, resource: string) {

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -159,6 +159,7 @@ export default class QueryRunner {
     // PUBLIC METHODS ======================================================
 
     public async cancel(): Promise<QueryCancelResult> {
+        this.logger.verbose("Send request to cancel query for URI: " + this._ownerUri);
         // Make the request to cancel the query
         let cancelParams: QueryCancelParams = { ownerUri: this._ownerUri };
         let queryCancelResult = await this._client.sendRequest(

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -560,7 +560,6 @@ export class SqlOutputContentProvider {
         }
 
         // Switch the spinner to canceling, which will be reset when the query execute sends back its completed event
-        console.log(`Canceling query for URI: ${queryRunner.uri}`);
         this._statusView.cancelingQuery(queryRunner.uri);
 
         // Cancel the query

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -544,7 +544,7 @@ export class SqlOutputContentProvider {
     public cancelQuery(input: QueryRunner | string): void {
         let self = this;
         let queryRunner: QueryRunner;
-
+        this.logger.verbose(`Canceling query for URI: ${input}`);
         if (typeof input === "string") {
             if (this._queryResultsMap.has(input)) {
                 // Option 1: The string is a results URI (the results tab has focus)
@@ -564,8 +564,9 @@ export class SqlOutputContentProvider {
 
         // Cancel the query
         queryRunner.cancel().then(
-            (success) => undefined,
+            (success) => this.logger.verbose(`Query cancel success: ${success}`),
             (error) => {
+                this.logger.verbose(`Query cancel error: ${error.message}`);
                 // On error, show error message
                 self._vscodeWrapper.showErrorMessage(
                     LocalizedConstants.msgCancelQueryFailed(error.message),


### PR DESCRIPTION
Currently, when we close a query editor, the associated query runner gets flagged for deletion, with a timer of 30 minutes.  This flag does not get reset if we re-open the same query editor and run a query, which can lead to deletion of the query runner in the middle of a long-running query (due to the 30 minute timer).  

I have added a conditional which will reset the `flaggedForDeletion` property if we are re-using an existing query runner.

Fixes https://github.com/microsoft/vscode-mssql/issues/18837