### PR TITLE
Adding notification for parital scripting errors.

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -640,7 +640,7 @@ export default class MainController implements vscode.Disposable {
 
         await vscode.window.withProgress(
             {
-                location: vscode.ProgressLocation.Window,
+                location: vscode.ProgressLocation.Notification,
                 title: LocalizedConstants.ObjectExplorer.FetchingScriptLabel(operationType),
             },
             async () => {

--- a/src/models/contracts/scripting/scriptingRequest.ts
+++ b/src/models/contracts/scripting/scriptingRequest.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestType } from "vscode-jsonrpc";
+import { NotificationType, RequestType } from "vscode-jsonrpc";
 
 export interface IConnectionInfo {
     options: { [name: string]: any };
@@ -309,5 +309,20 @@ export namespace ScriptingRequest {
      */
     export const type = new RequestType<IScriptingParams, IScriptingResult, void, void>(
         "scripting/script",
+    );
+}
+
+export interface ScriptingProgressNotificationParams {
+    scirptingObject: IScriptingObject[];
+    status: string;
+    completedCount: number;
+    totalCount: number;
+    errorDetails: string;
+    errorMessage: string;
+}
+
+export namespace ScriptingProgressNotification {
+    export const type = new NotificationType<ScriptingProgressNotificationParams, void>(
+        "scripting/scriptProgressNotification",
     );
 }

--- a/src/scripting/scriptingService.ts
+++ b/src/scripting/scriptingService.ts
@@ -23,7 +23,6 @@ export class ScriptingService {
         this._client = this._connectionManager.client;
         this._client.onNotification(ScriptingProgressNotification.type, (params) => {
             this._client.logger.verbose(JSON.stringify(params));
-            vscode.window.showErrorMessage(JSON.stringify(params));
             if (params.errorMessage) {
                 const errorText = `Scripting progress error: ${params.errorMessage} - ${params.errorDetails}`;
                 this._client.logger.error(errorText);

--- a/src/scripting/scriptingService.ts
+++ b/src/scripting/scriptingService.ts
@@ -11,14 +11,25 @@ import {
     ScriptOperation,
     IScriptingObject,
     IScriptOptions,
+    ScriptingProgressNotification,
 } from "../models/contracts/scripting/scriptingRequest";
 import { TreeNodeInfo } from "../objectExplorer/nodes/treeNodeInfo";
+import * as vscode from "vscode";
 
 export class ScriptingService {
     private _client: SqlToolsServiceClient;
 
     constructor(private _connectionManager: ConnectionManager) {
         this._client = this._connectionManager.client;
+        this._client.onNotification(ScriptingProgressNotification.type, (params) => {
+            this._client.logger.verbose(JSON.stringify(params));
+            vscode.window.showErrorMessage(JSON.stringify(params));
+            if (params.errorMessage) {
+                const errorText = `Scripting progress error: ${params.errorMessage} - ${params.errorDetails}`;
+                this._client.logger.error(errorText);
+                vscode.window.showErrorMessage(errorText);
+            }
+        });
     }
 
     public static getScriptCompatibility(serverMajorVersion: number, serverMinorVersion: number) {


### PR DESCRIPTION
Sometimes, scripting a node doesn't throw an error directly but returns a partial script while emitting errors as progress notifications. This PR ensures those errors are surfaced to the extension so users are made aware of them. Additionally, these errors are now being logged for better traceability in the extension. 

Issue: #19408

I am also changing scripting progress location from 'Window' to 'Notification'
Before:
![image](https://github.com/user-attachments/assets/df8c257b-7513-47a5-b716-1e9db332b8f8)
Now:
![image](https://github.com/user-attachments/assets/69a60d95-1eca-495b-9b5d-3f9258c195a5)
