### PR TITLE
Ensure project script files are always current for both source and target when a schema comparison is made

### DIFF
--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -1016,6 +1016,17 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
             },
         );
 
+        if (payload.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+            payload.sourceEndpointInfo.targetScripts = await this.getProjectScriptFiles(
+                payload.sourceEndpointInfo.projectFilePath,
+            );
+        }
+        if (payload.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Project) {
+            payload.targetEndpointInfo.targetScripts = await this.getProjectScriptFiles(
+                payload.targetEndpointInfo.projectFilePath,
+            );
+        }
+
         const result = await compare(
             this.operationId,
             TaskExecutionMode.execute,


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-mssql/issues/19424

The PR fixes the problem by obtaining project script files before a comparison is made to ensure that the comparison is always done with accurate script files.