### PR TITLE
Add Timeout & Graceful Failure Handling for SQL Tools Service getNextMessage Calls

### DIFF
--- a/src/chat/chatAgentRequestHandler.ts
+++ b/src/chat/chatAgentRequestHandler.ts
@@ -428,7 +428,7 @@ export const createSqlAgentRequestHandler = (
 
                 // Gracefully warn the user in markdown
                 stream.markdown(
-                    "⚠️ This message couldn't be processed. If this issue persists, please check the logs and [open an issue](https://github.com/microsoft/vscode-mssql/issues) on GitHub for this Preview release.",
+                    "⚠️ This message couldn't be processed. If this issue persists, please check the logs and [open an issue](https://aka.ms/vscode-mssql-copilot-feedback) on GitHub for this Preview release.",
                 );
 
                 result = undefined;

--- a/src/chat/chatAgentRequestHandler.ts
+++ b/src/chat/chatAgentRequestHandler.ts
@@ -287,6 +287,7 @@ export const createSqlAgentRequestHandler = (
 
                 // Process tool calls and get the result
                 const result = await processToolCalls(
+                    stream,
                     sqlTools,
                     conversationUri,
                     replyText,
@@ -362,7 +363,15 @@ export const createSqlAgentRequestHandler = (
         return { metadata: { command: "", correlationId: correlationId } };
     };
 
+    async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+        const timeout = new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("Operation timed out")), ms),
+        );
+        return Promise.race([promise, timeout]);
+    }
+
     async function processToolCalls(
+        stream: vscode.ChatResponseStream,
         sqlTools: { tool: LanguageModelChatTool; parameters: string }[],
         conversationUri: string,
         replyText: string,
@@ -386,19 +395,53 @@ export const createSqlAgentRequestHandler = (
 
         let result: GetNextMessageResponse;
         for (const toolCall of sqlTools) {
-            result = await copilotService.getNextMessage(
-                conversationUri,
-                replyText,
-                toolCall.tool,
-                toolCall.parameters,
-            );
+            try {
+                result = await withTimeout(
+                    copilotService.getNextMessage(
+                        conversationUri,
+                        replyText,
+                        toolCall.tool,
+                        toolCall.parameters,
+                    ),
+                    60000, // timeout in milliseconds
+                );
 
-            if (result.messageType === MessageType.Complete) {
-                break;
+                if (result.messageType === MessageType.Complete) {
+                    break;
+                }
+            } catch (error) {
+                console.error(`Tool call failed or timed out:`, error);
+
+                // Log telemetry for the unhandled error
+                sendErrorEvent(
+                    TelemetryViews.MssqlCopilot,
+                    TelemetryActions.Error,
+                    error instanceof Error ? error : new Error("Unknown tool call error"),
+                    true,
+                    undefined,
+                    undefined,
+                    {
+                        correlationId: correlationId,
+                        toolName: toolCall?.tool?.functionName || "Unknown",
+                    },
+                );
+
+                // Gracefully warn the user in markdown
+                stream.markdown(
+                    "⚠️ This message couldn't be processed. If this issue persists, please check the logs and [open an issue](https://github.com/microsoft/vscode-mssql/issues) on GitHub for this Preview release.",
+                );
+
+                result = undefined;
+
+                break; // Exit the loop if a tool call fails or times out
             }
         }
 
-        return result!;
+        if (!result) {
+            throw new Error("All tool calls failed or timed out.");
+        }
+
+        return result;
     }
 
     function prepareRequestMessages(

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -88,6 +88,7 @@ export enum TelemetryActions {
     AnalyzeQueryPerformance = "AnalyzeQueryPerformance",
     Error = "Error",
     ToolCall = "ToolCall",
+    ToolCallFailure = "ToolCallFailure",
     Feedback = "Feedback",
     ChatWithDatabase = "ChatWithDatabase",
     StartConversation = "StartConversation",


### PR DESCRIPTION
**Add Timeout & Graceful Failure Handling for SQL Tools Service `getNextMessage` Calls**

### Description:
This PR introduces a stop-gap mechanism to improve the resilience of `getNextMessage` calls during tool execution.

Currently, exceptions in the SQL Tools Service (STS) during tool function calls may not be properly propagated to the extension layer, resulting in user-facing hangs or silent failures. To mitigate this, a timeout has been added around each tool call. If the call fails to return within the allotted time, a user-facing message is displayed and a telemetry event is logged.

This change ensures:
- User feedback is provided when tool calls fail or time out.
- Telemetry captures the failure context without including PII.
- Error details remain accessible via STS logs for diagnostic purposes.

This is a temporary measure ahead of the Public Preview release. Post-preview, this logic will be improved to support more precise error capture and reporting, including propagation of structured error data from STS to the chat agent.

### Notes:
- Timeout currently set to **60 seconds**.
- Only basic metadata (e.g., tool name) is logged in telemetry.
- The user-facing message includes guidance to check logs or open an issue if the problem persists.

![image](https://github.com/user-attachments/assets/6ce27a93-09eb-4636-9f35-9c0af899a73f)
