### PR TITLE
Adding code lens suggestion for sql connection. 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1265,7 +1265,7 @@
     ]
   },
   "An unknown error occurred. Please try again.": "An unknown error occurred. Please try again.",
-  "$(plug)  Connect to SQL Server": "$(plug)  Connect to SQL Server",
+  "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
   "{0} ▾ (Click to change database)/{0} is the connection name": {
     "message": "{0} ▾ (Click to change database)",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1265,6 +1265,13 @@
     ]
   },
   "An unknown error occurred. Please try again.": "An unknown error occurred. Please try again.",
+  "$(plug)  Connect to SQL Server": "$(plug)  Connect to SQL Server",
+  "{0} ▾ (Click to change database)/{0} is the connection name": {
+    "message": "{0} ▾ (Click to change database)",
+    "comment": [
+      "{0} is the connection name"
+    ]
+  },
   "Azure sign in failed.": "Azure sign in failed.",
   "Select subscriptions": "Select subscriptions",
   "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1266,12 +1266,6 @@
   },
   "An unknown error occurred. Please try again.": "An unknown error occurred. Please try again.",
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
-  "{0} ▾ (Click to change database)/{0} is the connection name": {
-    "message": "{0} ▾ (Click to change database)",
-    "comment": [
-      "{0} is the connection name"
-    ]
-  },
   "Azure sign in failed.": "Azure sign in failed.",
   "Select subscriptions": "Select subscriptions",
   "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4,8 +4,8 @@
     <trans-unit id="++CODE++fd10453f63e5c663d4e640ea9cbe1adcc832b6fed0454e62686773ac486ce64d">
       <source xml:lang="en"> is required.</source>
     </trans-unit>
-    <trans-unit id="++CODE++d669b762b096faee047ad1fc9bcdfe9fe8a9e9d85b2947b46b54b3c8a16d48f0">
-      <source xml:lang="en">$(plug)  Connect to SQL Server</source>
+    <trans-unit id="++CODE++18b63db64aa0aff55a9f4784ad62abdc2b70cedb95b5e89d5551996cc9bd25ac">
+      <source xml:lang="en">$(plug)  Connect to MSSQL</source>
     </trans-unit>
     <trans-unit id="++CODE++0d7668d337e375d8ccfc1a69ca8f6e22a0b0c850a78c4770b0c4aa3b0daca630">
       <source xml:lang="en">&lt;default&gt;</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4,6 +4,9 @@
     <trans-unit id="++CODE++fd10453f63e5c663d4e640ea9cbe1adcc832b6fed0454e62686773ac486ce64d">
       <source xml:lang="en"> is required.</source>
     </trans-unit>
+    <trans-unit id="++CODE++d669b762b096faee047ad1fc9bcdfe9fe8a9e9d85b2947b46b54b3c8a16d48f0">
+      <source xml:lang="en">$(plug)  Connect to SQL Server</source>
+    </trans-unit>
     <trans-unit id="++CODE++0d7668d337e375d8ccfc1a69ca8f6e22a0b0c850a78c4770b0c4aa3b0daca630">
       <source xml:lang="en">&lt;default&gt;</source>
     </trans-unit>
@@ -2169,6 +2172,10 @@
       <source xml:lang="en">{0} {1} issues</source>
       <note>{0} is the tab name
 {1} is the number of issues</note>
+    </trans-unit>
+    <trans-unit id="++CODE++a65e8abff7bfedc0762e0ba182469a60e53114f72e4f7ce7fe3f5e314c87f852">
+      <source xml:lang="en">{0} ▾ (Click to change database)</source>
+      <note>{0} is the connection name</note>
     </trans-unit>
     <trans-unit id="++CODE++fbf6567d7b396892abbe6cccf81dca280649e099b853b805be1beb6af53d9229">
       <source xml:lang="en">{0}. {1}</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2173,10 +2173,6 @@
       <note>{0} is the tab name
 {1} is the number of issues</note>
     </trans-unit>
-    <trans-unit id="++CODE++a65e8abff7bfedc0762e0ba182469a60e53114f72e4f7ce7fe3f5e314c87f852">
-      <source xml:lang="en">{0} ▾ (Click to change database)</source>
-      <note>{0} is the connection name</note>
-    </trans-unit>
     <trans-unit id="++CODE++fbf6567d7b396892abbe6cccf81dca280649e099b853b805be1beb6af53d9229">
       <source xml:lang="en">{0}. {1}</source>
       <note>{0} is the status
@@ -2608,6 +2604,9 @@
     </trans-unit>
     <trans-unit id="mssql.format.placeSelectStatementReferencesOnNewLine">
       <source xml:lang="en">Should references to objects in a select statements be split into separate lines? E.g. for &apos;SELECT C1, C2 FROM T1&apos; both C1 and C2 will be on separate lines</source>
+    </trans-unit>
+    <trans-unit id="mssql.query.showActiveConnectionAsCodeLensSuggestion">
+      <source xml:lang="en">Show the active SQL connection details as a CodeLens suggestion at the top of the editor for quick visibility.</source>
     </trans-unit>
     <trans-unit id="mssql.walkthroughs.nextSteps.sortAndFilterQueryResults.title">
       <source xml:lang="en">Sort and Filter Query Results</source>

--- a/package.json
+++ b/package.json
@@ -1789,6 +1789,11 @@
                     "default": false,
                     "description": "%mssql.query.alwaysEncryptedParameterization%"
                 },
+                "mssql.query.showActiveConnectionAsCodeLensSuggestion": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%mssql.query.showActiveConnectionAsCodeLensSuggestion%"
+                },
                 "mssql.ignorePlatformWarning": {
                     "type": "boolean",
                     "description": "%mssql.ignorePlatformWarning%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -155,6 +155,7 @@
     "mssql.query.ansiPadding": "Enable SET ANSI_PADDING",
     "mssql.query.ansiWarnings": "Enable SET ANSI_WARNINGS",
     "mssql.query.ansiNulls": "Enable SET ANSI_NULLS",
+    "mssql.query.showActiveConnectionAsCodeLensSuggestion": "Show the active SQL connection details as a CodeLens suggestion at the top of the editor for quick visibility.",
     "mssql.query.alwaysEncryptedParameterization": "Enable Parameterization for Always Encrypted",
     "mssql.ignorePlatformWarning": "[Optional] Do not show unsupported platform warnings",
     "mssql.Configuration": "MSSQL configuration",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -205,6 +205,8 @@ export const configInMemoryDataProcessingThreshold = "resultsGrid.inMemoryDataPr
 export const configAutoDisableNonTSqlLanguageService = "mssql.autoDisableNonTSqlLanguageService";
 export const copilotDebugLogging = "mssql.copilotDebugLogging";
 export const configSelectedAzureSubscriptions = "mssql.selectedAzureSubscriptions";
+export const configShowActiveConnectionAsCodeLensSuggestion =
+    "mssql.query.showActiveConnectionAsCodeLensSuggestion";
 
 // ToolsService Constants
 export const serviceInstallingTo = "Installing SQL tools service to";

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -997,7 +997,7 @@ export class MssqlChatAgent {
 }
 
 export class QueryEditor {
-    public static codeLensConnect = l10n.t("$(plug)  Connect to SQL Server");
+    public static codeLensConnect = l10n.t("$(plug)  Connect to MSSQL");
     public static codeLensChangeDatabase = (connectionName: string) =>
         l10n.t({
             message: `{0} ▾ (Click to change database)`,

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -995,3 +995,13 @@ export class MssqlChatAgent {
     };
     public static unknownErrorOccurred = l10n.t("An unknown error occurred. Please try again.");
 }
+
+export class QueryEditor {
+    public static codeLensConnect = l10n.t("$(plug)  Connect to SQL Server");
+    public static codeLensChangeDatabase = (connectionName: string) =>
+        l10n.t({
+            message: `{0} ▾ (Click to change database)`,
+            args: [connectionName],
+            comment: ["{0} is the connection name"],
+        });
+}

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -998,10 +998,4 @@ export class MssqlChatAgent {
 
 export class QueryEditor {
     public static codeLensConnect = l10n.t("$(plug)  Connect to MSSQL");
-    public static codeLensChangeDatabase = (connectionName: string) =>
-        l10n.t({
-            message: `{0} ▾ (Click to change database)`,
-            args: [connectionName],
-            comment: ["{0} is the connection name"],
-        });
 }

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -67,6 +67,7 @@ import { ConnectionNode } from "../objectExplorer/nodes/connectionNode";
 import { CopilotService } from "../services/copilotService";
 import * as Prompts from "../chat/prompts";
 import { CreateSessionResult } from "../objectExplorer/objectExplorerService";
+import { SqlCodeLensProvider } from "../queryResult/sqlCodeLensProvider";
 
 /**
  * The main controller class that initializes the extension
@@ -276,6 +277,14 @@ export default class MainController implements vscode.Disposable {
             this._event.on(Constants.cmdDisableActualPlan, () => {
                 this.onToggleActualPlan(false);
             });
+
+            this._context.subscriptions.push(
+                vscode.languages.registerCodeLensProvider(
+                    { language: "sql" },
+                    new SqlCodeLensProvider(this._connectionMgr),
+                ),
+            );
+
             this.initializeObjectExplorer();
 
             this.registerCommandWithArgs(Constants.cmdConnectObjectExplorerProfile);

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -139,18 +139,32 @@ export function getPicklistDetails(connCreds: IConnectionInfo): string {
  */
 export function getConnectionDisplayString(creds: IConnectionInfo, trim: boolean = false): string {
     const server = creds.server;
-    const database = creds.database || LocalizedConstants.defaultDatabaseLabel;
+    const database = getConnectionDatabaseName(creds);
     const user = getUserNameOrDomainLogin(creds);
 
-    let result = user
-        ? `${server} : $(database) ${database} : ${user}`
-        : `${server} : $(database) ${database}`;
+    let result = user ? `${server} : ${database} : ${user}` : `${server} : ${database}`;
 
     if (trim && result.length > Constants.maxDisplayedStatusTextLength) {
         result = result.slice(0, Constants.maxDisplayedStatusTextLength) + " \u2026"; // add ellipsis
     }
 
     return result;
+}
+
+export function getConnectionServerName(creds: IConnectionInfo): string {
+    return creds.server;
+}
+
+export function getConnectionDatabaseName(
+    creds: IConnectionInfo,
+    includeDatabaseIcon: boolean = true,
+): string {
+    const databaseName = creds.database || LocalizedConstants.defaultDatabaseLabel;
+    if (includeDatabaseIcon) {
+        return `$(database) ${databaseName}`;
+    } else {
+        return databaseName;
+    }
 }
 
 /**

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -8,7 +8,6 @@ import * as Constants from "../constants/constants";
 import * as LocalizedConstants from "../constants/locConstants";
 import { EncryptOptions } from "../models/interfaces";
 import * as Interfaces from "./interfaces";
-import * as Utils from "./utils";
 
 /**
  * Sets sensible defaults for key connection properties, especially
@@ -138,31 +137,20 @@ export function getPicklistDetails(connCreds: IConnectionInfo): string {
  * @param conn connection
  * @returns display string that can be used in status view or other locations
  */
-export function getConnectionDisplayString(creds: IConnectionInfo): string {
-    // Update the connection text
-    let text: string = creds.server;
-    if (creds.database !== "") {
-        text = appendIfNotEmpty(text, creds.database);
-    } else {
-        text = appendIfNotEmpty(text, LocalizedConstants.defaultDatabaseLabel);
-    }
-    let user: string = getUserNameOrDomainLogin(creds);
-    text = appendIfNotEmpty(text, user);
+export function getConnectionDisplayString(creds: IConnectionInfo, trim: boolean = false): string {
+    const server = creds.server;
+    const database = creds.database || LocalizedConstants.defaultDatabaseLabel;
+    const user = getUserNameOrDomainLogin(creds);
 
-    // Limit the maximum length of displayed text
-    if (text && text.length > Constants.maxDisplayedStatusTextLength) {
-        text = text.substr(0, Constants.maxDisplayedStatusTextLength);
-        text += " \u2026"; // Ellipsis character (...)
+    let result = user
+        ? `${server} : $(database) ${database} : ${user}`
+        : `${server} : $(database) ${database}`;
+
+    if (trim && result.length > Constants.maxDisplayedStatusTextLength) {
+        result = result.slice(0, Constants.maxDisplayedStatusTextLength) + " \u2026"; // add ellipsis
     }
 
-    return text;
-}
-
-function appendIfNotEmpty(connectionText: string, value: string): string {
-    if (Utils.isNotEmpty(value)) {
-        connectionText += ` : ${value}`;
-    }
-    return connectionText;
+    return result;
 }
 
 /**

--- a/src/models/connectionInfo.ts
+++ b/src/models/connectionInfo.ts
@@ -138,8 +138,8 @@ export function getPicklistDetails(connCreds: IConnectionInfo): string {
  * @returns display string that can be used in status view or other locations
  */
 export function getConnectionDisplayString(creds: IConnectionInfo, trim: boolean = false): string {
-    const server = creds.server;
-    const database = getConnectionDatabaseName(creds);
+    const server = generateServerDisplayName(creds);
+    const database = generateDatabaseDisplayName(creds);
     const user = getUserNameOrDomainLogin(creds);
 
     let result = user ? `${server} : ${database} : ${user}` : `${server} : ${database}`;
@@ -151,11 +151,11 @@ export function getConnectionDisplayString(creds: IConnectionInfo, trim: boolean
     return result;
 }
 
-export function getConnectionServerName(creds: IConnectionInfo): string {
+export function generateServerDisplayName(creds: IConnectionInfo): string {
     return creds.server;
 }
 
-export function getConnectionDatabaseName(
+export function generateDatabaseDisplayName(
     creds: IConnectionInfo,
     includeDatabaseIcon: boolean = true,
 ): string {

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import * as Constants from "../constants/constants";
 import ConnectionManager from "../controllers/connectionManager";
 import { QueryEditor } from "../constants/locConstants";
-import { getConnectionDatabaseName, getConnectionServerName } from "../models/connectionInfo";
+import { generateDatabaseDisplayName, generateServerDisplayName } from "../models/connectionInfo";
 
 export class SqlCodeLensProvider implements vscode.CodeLensProvider {
     constructor(private _connectionManager: ConnectionManager) {}
@@ -26,11 +26,11 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
         if (connection) {
             return [
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                    title: getConnectionServerName(connection.credentials),
+                    title: generateServerDisplayName(connection.credentials),
                     command: Constants.cmdConnect,
                 }),
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                    title: getConnectionDatabaseName(connection.credentials),
+                    title: generateDatabaseDisplayName(connection.credentials),
                     command: Constants.cmdChooseDatabase,
                 }),
             ];

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import * as Constants from "../constants/constants";
 import ConnectionManager from "../controllers/connectionManager";
 import { QueryEditor } from "../constants/locConstants";
-import { getConnectionDisplayString } from "../models/connectionInfo";
+import { getConnectionDatabaseName, getConnectionServerName } from "../models/connectionInfo";
 
 export class SqlCodeLensProvider implements vscode.CodeLensProvider {
     constructor(private _connectionManager: ConnectionManager) {}
@@ -24,16 +24,14 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
         }
         const connection = this._connectionManager.getConnectionInfo(document.uri.toString());
         if (connection) {
-            const connectionName = getConnectionDisplayString(connection.credentials);
             return [
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                    title: connectionName,
+                    title: getConnectionServerName(connection.credentials),
+                    command: Constants.cmdConnect,
+                }),
+                new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+                    title: getConnectionDatabaseName(connection.credentials),
                     command: Constants.cmdChooseDatabase,
-                    arguments: [
-                        {
-                            source: "CodeLens",
-                        },
-                    ],
                 }),
             ];
         }
@@ -41,11 +39,6 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
             new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
                 title: QueryEditor.codeLensConnect,
                 command: Constants.cmdConnect,
-                arguments: [
-                    {
-                        source: "CodeLens",
-                    },
-                ],
             }),
         ];
     }

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -6,8 +6,8 @@
 import * as vscode from "vscode";
 import * as Constants from "../constants/constants";
 import ConnectionManager from "../controllers/connectionManager";
-import { getConnectionDisplayString } from "../models/connectionInfo";
 import { QueryEditor } from "../constants/locConstants";
+import { getConnectionDisplayString } from "../models/connectionInfo";
 
 export class SqlCodeLensProvider implements vscode.CodeLensProvider {
     constructor(private _connectionManager: ConnectionManager) {}
@@ -16,12 +16,18 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
         document: vscode.TextDocument,
         token: vscode.CancellationToken,
     ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+        const shouldShowActiveConnection = vscode.workspace
+            .getConfiguration()
+            .get<boolean>(Constants.configShowActiveConnectionAsCodeLensSuggestion);
+        if (!shouldShowActiveConnection) {
+            return [];
+        }
         const connection = this._connectionManager.getConnectionInfo(document.uri.toString());
         if (connection) {
             const connectionName = getConnectionDisplayString(connection.credentials);
             return [
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                    title: QueryEditor.codeLensChangeDatabase(connectionName),
+                    title: connectionName,
                     command: Constants.cmdChooseDatabase,
                     arguments: [
                         {

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -23,7 +23,11 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
                     title: QueryEditor.codeLensChangeDatabase(connectionName),
                     command: Constants.cmdChooseDatabase,
-                    arguments: [document.uri],
+                    arguments: [
+                        {
+                            source: "CodeLens",
+                        },
+                    ],
                 }),
             ];
         }
@@ -31,7 +35,11 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
             new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
                 title: QueryEditor.codeLensConnect,
                 command: Constants.cmdConnect,
-                arguments: [document.uri],
+                arguments: [
+                    {
+                        source: "CodeLens",
+                    },
+                ],
             }),
         ];
     }

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import * as Constants from "../constants/constants";
+import ConnectionManager from "../controllers/connectionManager";
+import { getConnectionDisplayString } from "../models/connectionInfo";
+import { QueryEditor } from "../constants/locConstants";
+
+export class SqlCodeLensProvider implements vscode.CodeLensProvider {
+    constructor(private _connectionManager: ConnectionManager) {}
+
+    public provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken,
+    ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+        console.log("provideCodeLenses");
+        const connection = this._connectionManager.getConnectionInfo(document.uri.toString());
+        if (connection) {
+            const connectionName = getConnectionDisplayString(connection.credentials);
+            return [
+                new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+                    title: QueryEditor.codeLensChangeDatabase(connectionName),
+                    command: Constants.cmdChooseDatabase,
+                    arguments: [document.uri],
+                }),
+            ];
+        }
+        return [
+            new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+                title: QueryEditor.codeLensConnect,
+                command: Constants.cmdConnect,
+                arguments: [document.uri],
+            }),
+        ];
+    }
+
+    public resolveCodeLens?(
+        codeLens: vscode.CodeLens,
+        token: vscode.CancellationToken,
+    ): vscode.CodeLens | Thenable<vscode.CodeLens> {
+        console.log("resolveCodeLens");
+        return new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+            title: "Go",
+            command: "go.run",
+            arguments: [],
+        });
+    }
+}

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -23,24 +23,24 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
             return [];
         }
         const connection = this._connectionManager.getConnectionInfo(document.uri.toString());
+
+        const items: vscode.CodeLens[] = [
+            new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
+                title: connection
+                    ? generateServerDisplayName(connection.credentials)
+                    : QueryEditor.codeLensConnect,
+                command: Constants.cmdConnect,
+            }),
+        ];
         if (connection) {
-            return [
-                new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                    title: generateServerDisplayName(connection.credentials),
-                    command: Constants.cmdConnect,
-                }),
+            items.push(
                 new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
                     title: generateDatabaseDisplayName(connection.credentials),
                     command: Constants.cmdChooseDatabase,
                 }),
-            ];
+            );
         }
-        return [
-            new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-                title: QueryEditor.codeLensConnect,
-                command: Constants.cmdConnect,
-            }),
-        ];
+        return items;
     }
 
     public resolveCodeLens?(

--- a/src/queryResult/sqlCodeLensProvider.ts
+++ b/src/queryResult/sqlCodeLensProvider.ts
@@ -16,7 +16,6 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
         document: vscode.TextDocument,
         token: vscode.CancellationToken,
     ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-        console.log("provideCodeLenses");
         const connection = this._connectionManager.getConnectionInfo(document.uri.toString());
         if (connection) {
             const connectionName = getConnectionDisplayString(connection.credentials);
@@ -41,11 +40,6 @@ export class SqlCodeLensProvider implements vscode.CodeLensProvider {
         codeLens: vscode.CodeLens,
         token: vscode.CancellationToken,
     ): vscode.CodeLens | Thenable<vscode.CodeLens> {
-        console.log("resolveCodeLens");
-        return new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
-            title: "Go",
-            command: "go.run",
-            arguments: [],
-        });
+        return undefined;
     }
 }

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -186,7 +186,7 @@ export default class StatusView implements vscode.Disposable {
     ): void {
         let bar = this.getStatusBar(fileUri);
         bar.statusConnection.command = Constants.cmdChooseDatabase;
-        bar.statusConnection.text = `$(check) ${ConnInfo.getConnectionDisplayString(connCreds)}`;
+        bar.statusConnection.text = `$(check) ${ConnInfo.getConnectionDisplayString(connCreds, true)}`;
         bar.statusConnection.tooltip = ConnInfo.getTooltip(connCreds, serverInfo);
         this.showStatusBarItem(fileUri, bar.statusConnection);
         this.sqlCmdModeChanged(fileUri, false);


### PR DESCRIPTION
## Description

This adds codelense items for sql files that mentions the active connection and the active database. Clicking on active connection let you change the server connection and the database lets you change active database for the connection. 
![image](https://github.com/user-attachments/assets/48b0df09-383a-42bf-9f06-9e156f816770)

On a disconnected sql file, the codelense item lets user connect to a server. 

![image](https://github.com/user-attachments/assets/77c1ff8e-580d-4e6d-8716-fd82272c3100)

 The reason for adding this is to make the connected server more visible to the user. 

https://github.com/user-attachments/assets/8e36527d-0ee5-494f-8641-9740a4d17908

Settings toggle for this feature:
<img width="946" alt="image" src="https://github.com/user-attachments/assets/e44a7d69-5bc8-4aa1-a238-8a10f1d4a097" />
 

This also fixes unnecessary string trim we do for quick pick items. 
Before:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/c1a9653c-4fd5-4df6-a91a-57176870ab8d" />
Now:
<img width="616" alt="image" src="https://github.com/user-attachments/assets/21e35f81-28ab-486a-b1a8-7d238248d84c" />

We are still trimming the string in status view
<img width="305" alt="image" src="https://github.com/user-attachments/assets/5567c2b7-82c2-41e3-ba98-530c1b4dc2ad" />





## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

