### PR TITLE
Add unique ID generation for TreeNodeInfo and corresponding tests

### DIFF
--- a/src/objectExplorer/nodes/treeNodeInfo.ts
+++ b/src/objectExplorer/nodes/treeNodeInfo.ts
@@ -10,6 +10,7 @@ import { ObjectExplorerUtils } from "../objectExplorerUtils";
 import * as Constants from "../../constants/constants";
 import { ITreeNodeInfo, ObjectMetadata } from "vscode-mssql";
 import { IConnectionProfile } from "../../models/interfaces";
+import { generateGuid } from "../../models/utils";
 
 export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
     private _nodePath: string;
@@ -68,9 +69,9 @@ export class TreeNodeInfo extends vscode.TreeItem implements ITreeNodeInfo {
         this.id = this.generateId();
     }
 
-    // Gernating a unique ID for the node
+    // Generating a unique ID for the node
     protected generateId(): string {
-        return `${this._connectionProfile?.id}-${this._nodePath}-${Date.now()}`;
+        return `${this._connectionProfile?.id}-${this._nodePath}-${generateGuid()}`;
     }
 
     public static fromNodeInfo(

--- a/test/unit/treeNodeInfo.test.ts
+++ b/test/unit/treeNodeInfo.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { TreeNodeInfo } from "../../src/objectExplorer/nodes/treeNodeInfo";
+
+suite("TreeNodeInfo", () => {
+    let treeNodeInfo: TreeNodeInfo;
+
+    test("When creating multiple TreeNodeInfo in quick succession, the nodePath should be unique", () => {
+        const node1 = new TreeNodeInfo(
+            "node_label",
+            undefined,
+            undefined,
+            "node_path",
+            undefined,
+            undefined,
+            "session_id",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+        );
+
+        const node2 = new TreeNodeInfo(
+            "node_label",
+            undefined,
+            undefined,
+            "node_path",
+            undefined,
+            undefined,
+            "session_id",
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+        );
+        expect(node1.id).to.not.equal(node2.id, "Node IDs should be unique");
+    });
+});


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR fixes #19479 
Previously when creating nodes in quick succession, `Data.now()` was returning the same millisecond value causing conflicts if 2 items have the same label under the same parent. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

