### PR TITLE
Fix big schema rendering behavior in schema designer. 

### DIFF
--- a/src/reactviews/pages/SchemaDesigner/graph/SchemaDiagramFlow.tsx
+++ b/src/reactviews/pages/SchemaDesigner/graph/SchemaDiagramFlow.tsx
@@ -241,6 +241,7 @@ export const SchemaDesignerFlow = () => {
                 onEdgesChange={onEdgesChange}
                 onConnect={handleConnect}
                 onConnectEnd={handleConnectEnd}
+                onlyRenderVisibleElements={true}
                 proOptions={{
                     hideAttribution: true,
                 }}

--- a/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
+++ b/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
@@ -18,7 +18,7 @@ import {
 import * as FluentIcons from "@fluentui/react-icons";
 import { locConstants } from "../../../common/locConstants";
 import { Handle, NodeProps, Position } from "@xyflow/react";
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
 import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import eventBus from "../schemaDesignerEvents";

--- a/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
+++ b/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
@@ -161,34 +161,26 @@ const TableHeaderActions = ({ table }: { table: SchemaDesigner.Table }) => {
 // TableHeader component for the table title and subtitle
 const TableHeader = ({ table }: { table: SchemaDesigner.Table }) => {
     const styles = useStyles();
-    const [searchText, setSearchText] = useState<string>("");
-
-    useEffect(() => {
-        // Store the search text in state when the event is triggered
-        const handleSearch = (text: string) => {
-            setSearchText(text);
-        };
-        eventBus.on("onFindWidgetValueChange", handleSearch);
-        return () => {
-            eventBus.off("onFindWidgetValueChange", handleSearch);
-        };
-    });
+    const context = useContext(SchemaDesignerContext);
 
     // Function to highlight text based on search
     const highlightText = (text: string) => {
-        if (!searchText || searchText.trim() === "") {
+        if (!context.findTableText || context.findTableText.trim() === "") {
             return <span>{text}</span>;
         }
 
         // Case insensitive search
-        const regex = new RegExp(`(${searchText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
+        const regex = new RegExp(
+            `(${context.findTableText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+            "gi",
+        );
         const parts = text.split(regex);
 
         return (
             <>
                 {parts.map((part, index) => {
                     // Check if this part matches the search text (case insensitive)
-                    const isMatch = part.toLowerCase() === searchText.toLowerCase();
+                    const isMatch = part.toLowerCase() === context.findTableText.toLowerCase();
                     return isMatch ? (
                         <span
                             key={index}

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerFindTables.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerFindTables.tsx
@@ -8,7 +8,6 @@ import { Node, useReactFlow } from "@xyflow/react";
 import { SchemaDesigner } from "../../../sharedInterfaces/schemaDesigner";
 import { SchemaDesignerContext } from "./schemaDesignerStateProvider";
 import { locConstants } from "../../common/locConstants";
-import eventBus from "./schemaDesignerEvents";
 import { SearchableItem, FindWidget } from "../../common/findWidget.component";
 // Adapter to make a flow Node compatible with SearchableItem
 class TableNodeItem implements SearchableItem {
@@ -63,7 +62,9 @@ export const SchemaDesignerFindTableWidget = ({
             onItemSelected={handleItemSelected}
             searchLabel={locConstants.common.find}
             width="200px"
-            emitSearchEvent={(searchText) => eventBus.emit("onFindWidgetValueChange", searchText)}
+            emitSearchEvent={(searchText) => {
+                context.setFindTableText(searchText);
+            }}
             parentRef={parentRef}
         />
     );

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -20,6 +20,8 @@ export interface SchemaDesignerContextProps
     extensionRpc: WebviewRpc<SchemaDesigner.SchemaDesignerReducers>;
     schemaNames: string[];
     datatypes: string[];
+    findTableText: string;
+    setFindTableText: (text: string) => void;
     getScript: () => Promise<string>;
     initializeSchemaDesigner: () => Promise<{
         nodes: Node<SchemaDesigner.Table>[];
@@ -77,6 +79,7 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
     const [schemaNames, setSchemaNames] = useState<string[]>([]);
     const reactFlow = useReactFlow();
     const [isInitialized, setIsInitialized] = useState(false);
+    const [findTableText, setFindTableText] = useState<string>("");
 
     useEffect(() => {
         const handleScript = () => {
@@ -415,6 +418,8 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
                 themeKind: themeKind,
                 schemaNames,
                 datatypes,
+                findTableText,
+                setFindTableText,
                 getScript,
                 initializeSchemaDesigner,
                 saveAsFile,

--- a/src/reactviews/pages/SchemaDesigner/toolbar/exportDiagramButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/exportDiagramButton.tsx
@@ -27,7 +27,7 @@ export function ExportDiagramButton() {
         const computedStyle = getComputedStyle(reactFlowContainer);
         const graphBackgroundColor = computedStyle.getPropertyValue("--vscode-editor-background");
 
-        const nodesBounds = getNodesBounds(getNodes());
+        const nodesBounds = getNodesBounds(getNodes().filter((node) => !node.hidden));
         const viewport = getViewportForBounds(
             nodesBounds,
             nodesBounds.width,

--- a/src/reactviews/pages/SchemaDesigner/toolbar/filterTablesButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/filterTablesButton.tsx
@@ -16,8 +16,9 @@ import * as FluentIcons from "@fluentui/react-icons";
 import { useContext, useEffect, useState } from "react";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
 import { locConstants } from "../../../common/locConstants";
-import { useReactFlow } from "@xyflow/react";
+import { Edge, Node, useReactFlow } from "@xyflow/react";
 import eventBus from "../schemaDesignerEvents";
+import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 
 export function FilterTablesButton() {
     const context = useContext(SchemaDesignerContext);
@@ -46,11 +47,18 @@ export function FilterTablesButton() {
     }
 
     useEffect(() => {
-        const nodes = reactFlow.getNodes();
+        const nodes = reactFlow.getNodes() as Node<SchemaDesigner.Table>[];
+        const edges = reactFlow.getEdges() as Edge<SchemaDesigner.ForeignKey>[];
         if (selectedTables.length === 0) {
             nodes.forEach((node) => {
                 reactFlow.updateNode(node.id, {
                     ...node,
+                    hidden: false,
+                });
+            });
+            edges.forEach((edge) => {
+                reactFlow.updateEdge(edge.id, {
+                    ...edge,
                     hidden: false,
                 });
             });
@@ -65,6 +73,26 @@ export function FilterTablesButton() {
                 } else {
                     reactFlow.updateNode(node.id, {
                         ...node,
+                        hidden: true,
+                    });
+                }
+            });
+            edges.forEach((edge) => {
+                const sourceNode = reactFlow.getNode(edge.source);
+                const targetNode = reactFlow.getNode(edge.target);
+                if (
+                    sourceNode &&
+                    targetNode &&
+                    selectedTables.includes(`${sourceNode.data.schema}.${sourceNode.data.name}`) &&
+                    selectedTables.includes(`${targetNode.data.schema}.${targetNode.data.name}`)
+                ) {
+                    reactFlow.updateEdge(edge.id, {
+                        ...edge,
+                        hidden: false,
+                    });
+                } else {
+                    reactFlow.updateEdge(edge.id, {
+                        ...edge,
                         hidden: true,
                     });
                 }


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

1. This PR enables an option in react flow component for schema designer to only render visible nodes. Helps in render times and overall responsiveness for the component. 

Due to this change, I had to change the find node functionality from being event based to a having the query text stored in context. 

As it was event based, unrendered nodes never received the event. Now I don't have to worry about it since the actual value is fetched from the context. 

2. Fixes the export button to get bounds of only visible nodes.
3. Fixes Filter button to hide edges of hidden nodes.



## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

