### PR TITLE
Add connection labels to Copilot chat response

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1229,6 +1229,13 @@
   "No model found.": "No model found.",
   "No tools to process.": "No tools to process.",
   "You are not connected to any database.": "You are not connected to any database.",
+  "Connected to {0},{1}/{0} is the server name{1} is the database name": {
+    "message": "Connected to {0},{1}",
+    "comment": [
+      "{0} is the server name",
+      "{1} is the database name"
+    ]
+  },
   "Using {0} ({1}).../{0} is the model name{1} is whether the model can send requests": {
     "message": "Using {0} ({1})...",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -460,6 +460,11 @@
 {1} is the document name
 {2} is the server info</note>
     </trans-unit>
+    <trans-unit id="++CODE++6ccdc08e4a3a9e8601ec0530c38b9c21ce7e1e7740a52446dd8924c8aa41af2c">
+      <source xml:lang="en">Connected to {0},{1}</source>
+      <note>{0} is the server name
+{1} is the database name</note>
+    </trans-unit>
     <trans-unit id="++CODE++d403c686f6a1048014bdd230f59963271b0123ea48245754fc9f264b962a2182">
       <source xml:lang="en">Connecting</source>
     </trans-unit>

--- a/src/chat/chatAgentRequestHandler.ts
+++ b/src/chat/chatAgentRequestHandler.ts
@@ -38,6 +38,8 @@ const MODEL_SELECTOR: vscode.LanguageModelChatSelector = {
     vendor: "copilot",
     family: "gpt-4o",
 };
+const DISCONNECTED_LABEL_PREFIX = "> ⚠️";
+const CONNECTED_LABEL_PREFIX = "> 🟢";
 
 export const createSqlAgentRequestHandler = (
     copilotService: CopilotService,
@@ -233,12 +235,13 @@ export const createSqlAgentRequestHandler = (
                 );
             }
 
-            if (!connectionUri) {
+            const connection = controller.connectionManager.getConnectionInfo(connectionUri);
+            if (!connectionUri || !connection) {
                 activity.update({
                     correlationId: correlationId,
                     message: "No connection URI found. Sending prompt to default language model.",
                 });
-                stream.markdown("⚠️ " + loc.notConnected);
+                stream.markdown(`${DISCONNECTED_LABEL_PREFIX} ${loc.notConnected}\n\n`);
                 await sendToDefaultLanguageModel(
                     prompt,
                     model,
@@ -250,9 +253,7 @@ export const createSqlAgentRequestHandler = (
                 return { metadata: { command: "", correlationId: correlationId } };
             }
 
-            const connection = controller.connectionManager.getConnectionInfo(connectionUri);
-
-            var connectionMessage = `> 🟢 ${loc.connectionLabel(generateServerDisplayName(connection.credentials), generateDatabaseDisplayName(connection.credentials, false))}\n\n`;
+            var connectionMessage = `${CONNECTED_LABEL_PREFIX} ${loc.connectionLabel(generateServerDisplayName(connection.credentials), generateDatabaseDisplayName(connection.credentials, false))}\n\n`;
             stream.markdown(connectionMessage);
 
             const success = await copilotService.startConversation(

--- a/src/chat/chatAgentRequestHandler.ts
+++ b/src/chat/chatAgentRequestHandler.ts
@@ -24,6 +24,8 @@ import {
 } from "../sharedInterfaces/telemetry";
 import { getErrorMessage } from "../utils/utils";
 import { MssqlChatAgent as loc } from "../constants/locConstants";
+import { generateDatabaseDisplayName, generateServerDisplayName } from "../models/connectionInfo";
+import MainController from "../controllers/mainController";
 
 export interface ISqlChatResult extends vscode.ChatResult {
     metadata: {
@@ -41,6 +43,7 @@ export const createSqlAgentRequestHandler = (
     copilotService: CopilotService,
     vscodeWrapper: VscodeWrapper,
     context: vscode.ExtensionContext,
+    controller: MainController,
 ): vscode.ChatRequestHandler => {
     const getNextConversationUri = (() => {
         let idCounter = 1;
@@ -246,6 +249,11 @@ export const createSqlAgentRequestHandler = (
                 );
                 return { metadata: { command: "", correlationId: correlationId } };
             }
+
+            const connection = controller.connectionManager.getConnectionInfo(connectionUri);
+
+            var connectionMessage = `> 🟢 ${loc.connectionLabel(generateServerDisplayName(connection.credentials), generateDatabaseDisplayName(connection.credentials, false))}\n\n`;
+            stream.markdown(connectionMessage);
 
             const success = await copilotService.startConversation(
                 conversationUri,

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -929,6 +929,13 @@ export class MssqlChatAgent {
     public static noModelFound = l10n.t("No model found.");
     public static noToolsToProcess = l10n.t("No tools to process.");
     public static notConnected = l10n.t("You are not connected to any database.");
+    public static connectionLabel = (serverName: string, databaseName: string) => {
+        return l10n.t({
+            message: "Connected to {0},{1}",
+            args: [serverName, databaseName],
+            comment: ["{0} is the server name", "{1} is the database name"],
+        });
+    };
     public static usingModel = (modelName: string, canSendRequest: boolean | undefined) => {
         return l10n.t({
             message: "Using {0} ({1})...",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     await controller.activate();
     const participant = vscode.chat.createChatParticipant(
         "mssql.agent",
-        createSqlAgentRequestHandler(controller.copilotService, vscodeWrapper, context),
+        createSqlAgentRequestHandler(controller.copilotService, vscodeWrapper, context, controller),
     );
 
     const receiveFeedbackDisposable = participant.onDidReceiveFeedback(


### PR DESCRIPTION
## Description
This PR adds connection status labels to the chat response in Copilot chat.
<img width="480" alt="image" src="https://github.com/user-attachments/assets/0a84e4e1-d3ae-4b8e-bc8e-8e304366848f" />

One more change I made was to add an extra connection check for the disconnected case, previously we were only checking the existence of the connection URI, now we also check if the connection object exists.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

