### PR TITLE
[Port] Add connection labels to Copilot chat response (#19508)

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1217,6 +1217,19 @@
   "No model found.": "No model found.",
   "No tools to process.": "No tools to process.",
   "You are not connected to any database.": "You are not connected to any database.",
+  "Connected to:": "Connected to:",
+  "Server - {0}/{0} is the server name": {
+    "message": "Server - {0}",
+    "comment": [
+      "{0} is the server name"
+    ]
+  },
+  "Database - {0}/{0} is the database name": {
+    "message": "Database - {0}",
+    "comment": [
+      "{0} is the database name"
+    ]
+  },
   "Using {0} ({1}).../{0} is the model name{1} is whether the model can send requests": {
     "message": "Using {0} ({1})...",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -451,6 +451,9 @@
 {1} is the document name
 {2} is the server info</note>
     </trans-unit>
+    <trans-unit id="++CODE++00aaa2ec4a2146b807cc64a6f59880630adc5d451cd1a68a80e2d2ccf2d21bbc">
+      <source xml:lang="en">Connected to:</source>
+    </trans-unit>
     <trans-unit id="++CODE++d403c686f6a1048014bdd230f59963271b0123ea48245754fc9f264b962a2182">
       <source xml:lang="en">Connecting</source>
     </trans-unit>
@@ -567,6 +570,10 @@
     </trans-unit>
     <trans-unit id="++CODE++fa7fe67124e94375d97e50896e0c32f44b03bb7ed5e9fb026341b55da724126b">
       <source xml:lang="en">Database</source>
+    </trans-unit>
+    <trans-unit id="++CODE++84a2b1ae34166a218282ec6156f3af9c67f4ccb6c03ec1cc0a03d9b3792069aa">
+      <source xml:lang="en">Database - {0}</source>
+      <note>{0} is the database name</note>
     </trans-unit>
     <trans-unit id="++CODE++667dd91d86c6b574073536489e39f0c5ab034846a63d946e8ef9f7bedeb1f4fb">
       <source xml:lang="en">Database Project</source>
@@ -1665,6 +1672,10 @@
     </trans-unit>
     <trans-unit id="++CODE++aef7de28d52977f1b5cd0fecfdc151717610adf41e0aa33b4d9f7522a43337ef">
       <source xml:lang="en">Server</source>
+    </trans-unit>
+    <trans-unit id="++CODE++f6cd8550a42862c96bedf199eb6415f9f6859b49211e35694080e73978042cf8">
+      <source xml:lang="en">Server - {0}</source>
+      <note>{0} is the server name</note>
     </trans-unit>
     <trans-unit id="++CODE++1c53883708ab16a3743793905feb38c8e77c295d846ff276491831e1de69b6e1">
       <source xml:lang="en">Server connection in progress. Do you want to cancel?</source>

--- a/src/chat/chatAgentRequestHandler.ts
+++ b/src/chat/chatAgentRequestHandler.ts
@@ -24,7 +24,6 @@ import {
 } from "../sharedInterfaces/telemetry";
 import { getErrorMessage } from "../utils/utils";
 import { MssqlChatAgent as loc } from "../constants/locConstants";
-import { generateDatabaseDisplayName, generateServerDisplayName } from "../models/connectionInfo";
 import MainController from "../controllers/mainController";
 
 export interface ISqlChatResult extends vscode.ChatResult {
@@ -40,6 +39,7 @@ const MODEL_SELECTOR: vscode.LanguageModelChatSelector = {
 };
 const DISCONNECTED_LABEL_PREFIX = "> ⚠️";
 const CONNECTED_LABEL_PREFIX = "> 🟢";
+const SERVER_DATABASE_LABEL_PREFIX = "> ➖";
 
 export const createSqlAgentRequestHandler = (
     copilotService: CopilotService,
@@ -255,8 +255,8 @@ export const createSqlAgentRequestHandler = (
 
             var connectionMessage =
                 `${CONNECTED_LABEL_PREFIX} ${loc.connectedTo}  \n` +
-                `> &nbsp;&nbsp;&nbsp;&nbsp; ${loc.server(generateServerDisplayName(connection.credentials))}  \n` +
-                `> &nbsp;&nbsp;&nbsp;&nbsp; ${loc.database(generateDatabaseDisplayName(connection.credentials, false))}\n\n`;
+                `${SERVER_DATABASE_LABEL_PREFIX} ${loc.server(connection.credentials.server)}  \n` +
+                `${SERVER_DATABASE_LABEL_PREFIX} ${loc.database(connection.credentials.database)}\n\n`;
             stream.markdown(connectionMessage);
 
             const success = await copilotService.startConversation(

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -930,6 +930,21 @@ export class MssqlChatAgent {
     public static noModelFound = l10n.t("No model found.");
     public static noToolsToProcess = l10n.t("No tools to process.");
     public static notConnected = l10n.t("You are not connected to any database.");
+    public static connectedTo = l10n.t("Connected to:");
+    public static server = (serverName: string) => {
+        return l10n.t({
+            message: "Server - {0}",
+            args: [serverName],
+            comment: ["{0} is the server name"],
+        });
+    };
+    public static database = (databaseName: string) => {
+        return l10n.t({
+            message: "Database - {0}",
+            args: [databaseName],
+            comment: ["{0} is the database name"],
+        });
+    };
     public static usingModel = (modelName: string, canSendRequest: boolean | undefined) => {
         return l10n.t({
             message: "Using {0} ({1})...",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     await controller.activate();
     const participant = vscode.chat.createChatParticipant(
         "mssql.agent",
-        createSqlAgentRequestHandler(controller.copilotService, vscodeWrapper, context),
+        createSqlAgentRequestHandler(controller.copilotService, vscodeWrapper, context, controller),
     );
 
     const receiveFeedbackDisposable = participant.onDidReceiveFeedback(


### PR DESCRIPTION
Port #19514 and #19508 to `release/1.32`, note that the test change is not included in this port as the test file itself was added to main after the branch split and doesn't exist in this branch
Fixes #19501 