### PR TITLE
Connection Group Fit and Finish

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1111,8 +1111,16 @@
   "Execute": "Execute",
   "Alter": "Alter",
   "Signing in to Azure...": "Signing in to Azure...",
-  "Are you sure you want to delete {0}?  This will also delete all connections in this group./{0} is the group name": {
-    "message": "Are you sure you want to delete {0}?  This will also delete all connections in this group.",
+  "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root./{0} is the group name": {
+    "message": "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.",
+    "comment": [
+      "{0} is the group name"
+    ]
+  },
+  "Delete Contents": "Delete Contents",
+  "Move to Root": "Move to Root",
+  "Are you sure you want to delete {0}?/{0} is the group name": {
+    "message": "Are you sure you want to delete {0}?",
     "comment": [
       "{0} is the group name"
     ]

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1140,7 +1140,7 @@
   "Sign in": "Sign in",
   "Additional parameters": "Additional parameters",
   "<Default>": "<Default>",
-  "Create Connection Group": "Create Connection Group",
+  "+ Create Connection Group": "+ Create Connection Group",
   "Select a connection group": "Select a connection group",
   "Search connection groups": "Search connection groups",
   "Error loading Azure databases for subscription {0} ({1}).  Confirm that you have permission./{0} is the subscription name{1} is the subscription id": {
@@ -1552,6 +1552,7 @@
   },
   "Schema visualization opened.": "Schema visualization opened.",
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
+  "Create Connection Group": "Create Connection Group",
   "Edit Connection Group - {0}/{0} is the connection group name": {
     "message": "Edit Connection Group - {0}",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1133,6 +1133,8 @@
   "Additional parameters": "Additional parameters",
   "<Default>": "<Default>",
   "Create Connection Group": "Create Connection Group",
+  "Select a connection group": "Select a connection group",
+  "Search connection groups": "Search connection groups",
   "Error loading Azure databases for subscription {0} ({1}).  Confirm that you have permission./{0} is the subscription name{1} is the subscription id": {
     "message": "Error loading Azure databases for subscription {0} ({1}).  Confirm that you have permission.",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1111,8 +1111,8 @@
   "Execute": "Execute",
   "Alter": "Alter",
   "Signing in to Azure...": "Signing in to Azure...",
-  "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root./{0} is the group name": {
-    "message": "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.",
+  "Are you sure you want to delete {0}?  You can delete its connections as well, or move them to the root folder./{0} is the group name": {
+    "message": "Are you sure you want to delete {0}?  You can delete its connections as well, or move them to the root folder.",
     "comment": [
       "{0} is the group name"
     ]

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -153,8 +153,8 @@
       <source xml:lang="en">Are you sure you want to delete {0}?</source>
       <note>{0} is the group name</note>
     </trans-unit>
-    <trans-unit id="++CODE++385283976b8f0e8427fe325fc18ae89e1da67c82ab64b4be415709193ae5b385">
-      <source xml:lang="en">Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.</source>
+    <trans-unit id="++CODE++26c70151bceb55fb84b8e652a205659bd5736420cfa72a4e3fa92bdaa5a3b526">
+      <source xml:lang="en">Are you sure you want to delete {0}?  You can delete its connections as well, or move them to the root folder.</source>
       <note>{0} is the group name</note>
     </trans-unit>
     <trans-unit id="++CODE++3d283f80f43f1833dcab882ad9efc24a86c0b17b0febb10fc37336590a7016e1">

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -13,6 +13,9 @@
     <trans-unit id="++CODE++0d7668d337e375d8ccfc1a69ca8f6e22a0b0c850a78c4770b0c4aa3b0daca630">
       <source xml:lang="en">&lt;default&gt;</source>
     </trans-unit>
+    <trans-unit id="++CODE++dbfb6fb3f275d24e8e32113cbbabeffe9d78165e6bdaf5b82c0fede5881451b5">
+      <source xml:lang="en">+ Create Connection Group</source>
+    </trans-unit>
     <trans-unit id="++CODE++08fef8ce26bbc554c749504c8d169642c3039345674331079add345b808e96a7">
       <source xml:lang="en">A SQL editor must have focus before executing this command</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -149,8 +149,12 @@
     <trans-unit id="++CODE++dc1158b4986e0eadcc929a35b9de0147ca4e8e317ec963db232cb2516688ed79">
       <source xml:lang="en">Are you sure you want to delete the selected items?</source>
     </trans-unit>
-    <trans-unit id="++CODE++06f1783b8fa5a8be694c26e8cea5b2bd668dd7beb434d1271155bae4e7f4a736">
-      <source xml:lang="en">Are you sure you want to delete {0}?  This will also delete all connections in this group.</source>
+    <trans-unit id="++CODE++64f0ebe202fcbb5561671715f3bff0cf6b5219648ffe9bca961824b243d4c5bc">
+      <source xml:lang="en">Are you sure you want to delete {0}?</source>
+      <note>{0} is the group name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++385283976b8f0e8427fe325fc18ae89e1da67c82ab64b4be415709193ae5b385">
+      <source xml:lang="en">Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.</source>
       <note>{0} is the group name</note>
     </trans-unit>
     <trans-unit id="++CODE++3d283f80f43f1833dcab882ad9efc24a86c0b17b0febb10fc37336590a7016e1">
@@ -747,6 +751,9 @@
     </trans-unit>
     <trans-unit id="++CODE++2860bf10bd8d01c604f713ea3f60ccea6ef028fd2e7074a400fac50c569aa45c">
       <source xml:lang="en">Delete Confirmation</source>
+    </trans-unit>
+    <trans-unit id="++CODE++129eabad7bcc761eb7966091c2bc01163b650ca0613f42c58db97eae5420a7bb">
+      <source xml:lang="en">Delete Contents</source>
     </trans-unit>
     <trans-unit id="++CODE++ce719226a83119822d8c5e6c1981ecfe801b8324890fce617664184849c24491">
       <source xml:lang="en">Delete saved connection</source>
@@ -1438,6 +1445,9 @@
     </trans-unit>
     <trans-unit id="++CODE++1359626e7b6964345896285446db7977e67469251bb0cc52808db2a85ed940c1">
       <source xml:lang="en">Move Up</source>
+    </trans-unit>
+    <trans-unit id="++CODE++27b4c707cf413882a14ef7b762694ed52bbf69755646afa8cf1972dec4cf3c92">
+      <source xml:lang="en">Move to Root</source>
     </trans-unit>
     <trans-unit id="++CODE++fb329000228cc5a24c264c57139de8bf854fc86fc18bf1c04ab61a2b5cb4b921">
       <source xml:lang="en">NULL</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1954,6 +1954,9 @@
     <trans-unit id="++CODE++f6a9305d2a22223e43e016e6ed4d342a8a4a249c1202322338ee3e0d5f26e596">
       <source xml:lang="en">Script copied to clipboard</source>
     </trans-unit>
+    <trans-unit id="++CODE++4f5103123c8a9080ba6c1595ab5f058a1aa4715fe8c1aa2b956b6512f28cc365">
+      <source xml:lang="en">Search connection groups</source>
+    </trans-unit>
     <trans-unit id="++CODE++49ff54ad141b9f4b74b176a98807c6b9a1282dfe026c3f38015dd596c54c4a84">
       <source xml:lang="en">Search options...</source>
     </trans-unit>
@@ -1977,6 +1980,9 @@
     </trans-unit>
     <trans-unit id="++CODE++bdd155896fd28608c15efbc9269fc433a1838ca35f20e4dc656f20ffe2aff773">
       <source xml:lang="en">Select Target</source>
+    </trans-unit>
+    <trans-unit id="++CODE++c4300a3eee24147d9593a09a659650b44b4733e2979fef9cae3e3db10f116831">
+      <source xml:lang="en">Select a connection group</source>
     </trans-unit>
     <trans-unit id="++CODE++ebe0dbee443b4562c7925a01e3bc69a3d5d0a3b0e8b3e11041c69fa067b65ef7">
       <source xml:lang="en">Select a tenant</source>

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -24,6 +24,7 @@ import {
     ConnectionDialogFormItemSpec,
     ConnectionStringDialogProps,
     CreateConnectionGroupDialogProps,
+    CREATE_NEW_GROUP_ID,
 } from "../sharedInterfaces/connectionDialog";
 import { ConnectionCompleteParams } from "../models/contracts/connection";
 import { FormItemActionButton, FormItemOptions } from "../sharedInterfaces/form";
@@ -165,7 +166,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             getAccounts(this._mainController.azureAccountService, this.logger),
             this.getAzureActionButtons(),
             this.getConnectionGroups(),
-            this.getConnectionGroupButton(),
         );
 
         this.state.connectionComponents = {
@@ -344,6 +344,15 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             this.updateState(state);
 
             return await this.connectHelper(state);
+        });
+
+        this.registerReducer("openCreateConnectionGroupDialog", async (state) => {
+            state.dialog = {
+                type: "createConnectionGroup",
+                props: {},
+            } as CreateConnectionGroupDialogProps;
+
+            return state;
         });
 
         this.registerReducer("closeDialog", async (state) => {
@@ -1018,23 +1027,12 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 displayName: Loc.default,
                 value: rootId,
             },
+            {
+                displayName: Loc.createConnectionGroup,
+                value: CREATE_NEW_GROUP_ID,
+            },
             ...result,
         ];
-    }
-
-    private async getConnectionGroupButton(): Promise<FormItemActionButton> {
-        return {
-            label: Loc.createConnectionGroup,
-            id: "createConnectionGroup",
-            callback: async () => {
-                this.state.dialog = {
-                    type: "createConnectionGroup",
-                    props: {},
-                } as CreateConnectionGroupDialogProps;
-
-                this.updateState();
-            },
-        };
     }
 
     private async getAzureActionButtons(): Promise<FormItemActionButton[]> {

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -974,13 +974,52 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     }
 
     private async getConnectionGroups(): Promise<FormItemOptions[]> {
-        const connectionGroups =
-            await this._mainController.connectionManager.connectionStore.readAllConnectionGroups();
         const rootId = this._mainController.connectionManager.connectionStore.rootGroupId;
-        return connectionGroups.map((g) => ({
-            displayName: g.id === rootId ? Loc.default : g.name,
-            value: g.id,
-        }));
+        let connectionGroups =
+            await this._mainController.connectionManager.connectionStore.readAllConnectionGroups();
+        connectionGroups = connectionGroups.filter((g) => g.id !== rootId);
+
+        // Count occurrences of group names to handle naming conflicts
+        const nameOccurrences = new Map<string, number>();
+        for (const group of connectionGroups) {
+            const count = nameOccurrences.get(group.name) || 0;
+            nameOccurrences.set(group.name, count + 1);
+        }
+
+        // Create a map of group IDs to their full paths
+        const groupById = new Map(connectionGroups.map((g) => [g.id, g]));
+
+        // Helper function to get parent path
+        const getParentPath = (group: IConnectionGroup): string => {
+            if (!group.parentId || group.parentId === rootId) {
+                return group.name;
+            }
+            const parent = groupById.get(group.parentId);
+            if (!parent) {
+                return group.name;
+            }
+            return `${getParentPath(parent)} > ${group.name}`;
+        };
+
+        const result = connectionGroups
+            .map((g) => {
+                // If there are naming conflicts, use the full path
+                const displayName = nameOccurrences.get(g.name) > 1 ? getParentPath(g) : g.name;
+
+                return {
+                    displayName,
+                    value: g.id,
+                };
+            })
+            .sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+        return [
+            {
+                displayName: Loc.default,
+                value: rootId,
+            },
+            ...result,
+        ];
     }
 
     private async getConnectionGroupButton(): Promise<FormItemActionButton> {

--- a/src/connectionconfig/connectionconfig.ts
+++ b/src/connectionconfig/connectionconfig.ts
@@ -227,44 +227,94 @@ export class ConnectionConfig implements IConnectionConfig {
         return this.writeConnectionGroupsToSettings(groups);
     }
 
-    public async removeGroup(id: string): Promise<boolean> {
+    /**
+     * Remove a connection group and handle its contents.
+     * @param id The ID of the group to remove
+     * @param deleteContents If true, delete all connections and subgroups in this group.
+     *                      If false, move immediate child connections and groups to root, preserving their hierarchies.
+     * @returns true if the group was removed, false if the group wasn't found.
+     */
+    public async removeGroup(
+        id: string,
+        contentAction: "delete" | "move" = "delete",
+    ): Promise<boolean> {
         const connections = this.getConnectionsFromSettings();
         const groups = this.getGroupsFromSettings();
+        const rootGroup = this.getRootGroup();
 
-        // Find all subgroup IDs recursively
-        const groupsToRemove = new Set<string>();
-        const findChildGroups = (groupId: string) => {
-            groupsToRemove.add(groupId);
+        if (!rootGroup) {
+            throw new Error("Root group not found when removing group");
+        }
+
+        // Find all subgroup IDs recursively for the delete case
+        const getAllSubgroupIds = (groupId: string): Set<string> => {
+            const subgroupIds = new Set<string>();
+            subgroupIds.add(groupId);
             for (const group of groups) {
                 if (group.parentId === groupId) {
-                    findChildGroups(group.id);
+                    const childSubgroups = getAllSubgroupIds(group.id);
+                    childSubgroups.forEach((id) => subgroupIds.add(id));
                 }
             }
+            return subgroupIds;
         };
-        findChildGroups(id);
 
-        // Remove all connections in the groups being removed
-        let connectionRemoved = false;
-        const remainingConnections = connections.filter((conn) => {
-            if (groupsToRemove.has(conn.groupId)) {
-                this._logger.verbose(
-                    `Removing connection '${conn.id}' because its group '${conn.groupId}' was removed`,
-                );
-                connectionRemoved = true;
-                return false;
-            }
-            return true;
-        });
+        let connectionModified = false;
+        let remainingConnections: IConnectionProfile[];
+        let remainingGroups: IConnectionGroup[];
 
-        // Remove all groups that were marked for removal
-        const remainingGroups = groups.filter((g) => !groupsToRemove.has(g.id));
+        if (contentAction === "delete") {
+            // Get all nested subgroups to remove
+            const groupsToRemove = getAllSubgroupIds(id);
+
+            // Remove all connections in the groups being removed
+            remainingConnections = connections.filter((conn) => {
+                if (groupsToRemove.has(conn.groupId)) {
+                    this._logger.verbose(
+                        `Removing connection '${conn.id}' because its group '${conn.groupId}' was removed`,
+                    );
+                    connectionModified = true;
+                    return false;
+                }
+                return true;
+            });
+
+            // Remove all groups that were marked for removal
+            remainingGroups = groups.filter((g) => !groupsToRemove.has(g.id));
+        } else {
+            // Move immediate child connections to root
+            remainingConnections = connections.map((conn) => {
+                if (conn.groupId === id) {
+                    this._logger.verbose(
+                        `Moving connection '${conn.id}' to root group because its immediate parent group '${id}' was removed`,
+                    );
+                    connectionModified = true;
+                    return { ...conn, groupId: rootGroup.id };
+                }
+                return conn;
+            });
+
+            // First remove the target group
+            remainingGroups = groups.filter((g) => g.id !== id);
+
+            // Then reparent immediate children to root
+            remainingGroups = remainingGroups.map((g) => {
+                if (g.parentId === id) {
+                    this._logger.verbose(
+                        `Moving group '${g.id}' to root group because its immediate parent group '${id}' was removed`,
+                    );
+                    return { ...g, parentId: rootGroup.id };
+                }
+                return g;
+            });
+        }
 
         if (remainingGroups.length === groups.length) {
             this._logger.error(`Connection group with ID '${id}' not found when removing.`);
             return false;
         }
 
-        if (connectionRemoved) {
+        if (connectionModified) {
             await this.writeConnectionsToSettings(remainingConnections);
         }
 

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -31,7 +31,6 @@ export async function generateConnectionComponents(
     azureAccountOptions: Promise<FormItemOptions[]>,
     azureActionButtons: Promise<FormItemActionButton[]>,
     connectionGroupOptions: Promise<FormItemOptions[]>,
-    connectionGroupButton: Promise<FormItemActionButton>,
 ): Promise<Record<keyof IConnectionDialogProfile, ConnectionDialogFormItemSpec>> {
     // get list of connection options from Tools Service
     const capabilitiesResult: CapabilitiesResult = await connectionManager.client.sendRequest(
@@ -86,7 +85,6 @@ export async function generateConnectionComponents(
         await azureAccountOptions,
         await azureActionButtons,
         await connectionGroupOptions,
-        await connectionGroupButton,
     );
 
     return result;
@@ -200,7 +198,6 @@ export async function completeFormComponents(
     azureAccountOptions: FormItemOptions[],
     azureActionButtons: FormItemActionButton[],
     connectionGroupOptions: FormItemOptions[],
-    connectionGroupButton: FormItemActionButton,
 ) {
     // Add additional components that are not part of the connection options
     components["profileName"] = {
@@ -217,7 +214,6 @@ export async function completeFormComponents(
         required: false,
         type: FormItemType.SearchableDropdown,
         options: connectionGroupOptions,
-        actionButtons: [connectionGroupButton],
         isAdvancedOption: false,
         placeholder: Loc.selectConnectionGroup,
         searchBoxPlaceholder: Loc.searchConnectionGroups,

--- a/src/connectionconfig/formComponentHelpers.ts
+++ b/src/connectionconfig/formComponentHelpers.ts
@@ -215,10 +215,12 @@ export async function completeFormComponents(
         propertyName: "groupId",
         label: Loc.connectionGroup,
         required: false,
-        type: FormItemType.Dropdown,
+        type: FormItemType.SearchableDropdown,
         options: connectionGroupOptions,
         actionButtons: [connectionGroupButton],
         isAdvancedOption: false,
+        placeholder: Loc.selectConnectionGroup,
+        searchBoxPlaceholder: Loc.searchConnectionGroups,
     };
 
     components["savePassword"] = {

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -614,7 +614,7 @@ export class ObjectExplorer {
     public static ConnectionGroupDeletionConfirmationWithContents(groupName: string) {
         return l10n.t({
             message:
-                "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.",
+                "Are you sure you want to delete {0}?  You can delete its connections as well, or move them to the root folder.",
             args: [groupName],
             comment: ["{0} is the group name"],
         });

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -651,7 +651,7 @@ export class ConnectionDialog {
     public static additionalParameters = l10n.t("Additional parameters");
     public static connect = l10n.t("Connect");
     public static default = l10n.t("<Default>");
-    public static createConnectionGroup = l10n.t("Create Connection Group");
+    public static createConnectionGroup = l10n.t("+ Create Connection Group");
     public static selectConnectionGroup = l10n.t("Select a connection group");
     public static searchConnectionGroups = l10n.t("Search connection groups");
 

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -641,6 +641,8 @@ export class ConnectionDialog {
     public static connect = l10n.t("Connect");
     public static default = l10n.t("<Default>");
     public static createConnectionGroup = l10n.t("Create Connection Group");
+    public static selectConnectionGroup = l10n.t("Select a connection group");
+    public static searchConnectionGroups = l10n.t("Search connection groups");
 
     public static errorLoadingAzureDatabases(subscriptionName: string, subscriptionId: string) {
         return l10n.t({

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -611,10 +611,21 @@ export class ObjectExplorer {
     public static ScriptAlterLabel = l10n.t("Alter");
     public static AzureSignInMessage = l10n.t("Signing in to Azure...");
 
-    public static ConnectionGroupDeletionConfirmation(groupName: string) {
+    public static ConnectionGroupDeletionConfirmationWithContents(groupName: string) {
         return l10n.t({
             message:
-                "Are you sure you want to delete {0}?  This will also delete all connections in this group.",
+                "Are you sure you want to delete {0}?  Choose whether to delete all contents or move them to root.",
+            args: [groupName],
+            comment: ["{0} is the group name"],
+        });
+    }
+
+    public static ConnectionGroupDeleteContents = l10n.t("Delete Contents");
+    public static ConnectionGroupMoveContents = l10n.t("Move to Root");
+
+    public static ConnectionGroupDeletionConfirmationWithoutContents(groupName: string) {
+        return l10n.t({
+            message: "Are you sure you want to delete {0}?",
             args: [groupName],
             comment: ["{0} is the group name"],
         });

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -1086,16 +1086,42 @@ export default class MainController implements vscode.Disposable {
 
         this.registerCommandWithArgs(Constants.cmdConnectionGroupDelete);
         this._event.on(Constants.cmdConnectionGroupDelete, async (node: ConnectionGroupNode) => {
-            const result = await vscode.window.showInformationMessage(
-                LocalizedConstants.ObjectExplorer.ConnectionGroupDeletionConfirmation(
-                    typeof node.label === "string" ? node.label : node.label.label,
-                ),
-                { modal: true },
-                LocalizedConstants.Common.delete,
-            );
-            if (result === LocalizedConstants.Common.delete) {
+            if (!(node instanceof ConnectionGroupNode)) {
+                return;
+            }
+
+            let result = undefined;
+
+            if (node.children.length > 0) {
+                result = await vscode.window.showInformationMessage(
+                    LocalizedConstants.ObjectExplorer.ConnectionGroupDeletionConfirmationWithContents(
+                        typeof node.label === "string" ? node.label : node.label.label,
+                    ),
+                    { modal: true },
+                    LocalizedConstants.ObjectExplorer.ConnectionGroupDeleteContents,
+                    LocalizedConstants.ObjectExplorer.ConnectionGroupMoveContents,
+                );
+            } else {
+                result = await vscode.window.showInformationMessage(
+                    LocalizedConstants.ObjectExplorer.ConnectionGroupDeletionConfirmationWithoutContents(
+                        typeof node.label === "string" ? node.label : node.label.label,
+                    ),
+                    { modal: true },
+                    LocalizedConstants.Common.delete,
+                );
+            }
+            if (
+                result === LocalizedConstants.ObjectExplorer.ConnectionGroupDeleteContents ||
+                result === LocalizedConstants.Common.delete
+            ) {
                 void this.connectionManager.connectionStore.connectionConfig.removeGroup(
                     node.connectionGroup.id,
+                    "delete",
+                );
+            } else if (result === LocalizedConstants.ObjectExplorer.ConnectionGroupMoveContents) {
+                void this.connectionManager.connectionStore.connectionConfig.removeGroup(
+                    node.connectionGroup.id,
+                    "move",
                 );
             }
         });

--- a/src/reactviews/common/forms/form.component.tsx
+++ b/src/reactviews/common/forms/form.component.tsx
@@ -25,6 +25,7 @@ import {
     FormState,
 } from "../../../sharedInterfaces/form";
 import { useEffect, useState } from "react";
+import { SearchableDropdown } from "../searchableDropdown.component";
 
 export const FormInput = <
     TForm,
@@ -277,6 +278,41 @@ export function generateFormComponent<
                         );
                     })}
                 </Dropdown>
+            );
+        case FormItemType.SearchableDropdown:
+            if (component.options === undefined) {
+                throw new Error("Dropdown component must have options");
+            }
+            const selectedOption = component.options.find(
+                (option) => option.value === formState[component.propertyName],
+            );
+            return (
+                <SearchableDropdown
+                    options={component.options.map((opt) => ({
+                        value: opt.value,
+                        text: opt.displayName,
+                    }))}
+                    placeholder={component.placeholder}
+                    searchBoxPlaceholder={component.searchBoxPlaceholder}
+                    selectedOption={
+                        selectedOption
+                            ? {
+                                  value: selectedOption.value,
+                                  text: selectedOption.displayName,
+                              }
+                            : undefined
+                    }
+                    onSelect={(option) => {
+                        context?.formAction({
+                            propertyName: component.propertyName,
+                            isAction: false,
+                            value: option.value,
+                        });
+                    }}
+                    size="small"
+                    clearable={true}
+                    {...props}
+                />
             );
         case FormItemType.Checkbox:
             return (

--- a/src/reactviews/common/forms/form.component.tsx
+++ b/src/reactviews/common/forms/form.component.tsx
@@ -303,11 +303,15 @@ export function generateFormComponent<
                             : undefined
                     }
                     onSelect={(option) => {
-                        context?.formAction({
-                            propertyName: component.propertyName,
-                            isAction: false,
-                            value: option.value,
-                        });
+                        if (props.onSelect) {
+                            props.onSelect(option.value);
+                        } else {
+                            context?.formAction({
+                                propertyName: component.propertyName,
+                                isAction: false,
+                                value: option.value,
+                            });
+                        }
                     }}
                     size="small"
                     clearable={true}

--- a/src/reactviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
@@ -66,6 +66,9 @@ const ConnectionDialogStateProvider: React.FC<ConnectionDialogProviderProps> = (
                         connectionGroupSpec,
                     });
                 },
+                openCreateConnectionGroupDialog: function (): void {
+                    webviewState.extensionRpc.action("openCreateConnectionGroupDialog");
+                },
                 closeDialog: function (): void {
                     webviewState?.extensionRpc.action("closeDialog");
                 },

--- a/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/connectionPageContainer.tsx
@@ -12,6 +12,7 @@ import {
     ConnectionDialogWebviewState,
     ConnectionInputMode,
     ConnectionStringDialogProps,
+    CREATE_NEW_GROUP_ID,
     CreateConnectionGroupDialogProps,
     IConnectionDialogProfile,
     TrustServerCertDialogProps,
@@ -32,6 +33,7 @@ import { themeType } from "../../common/utils";
 import { AddFirewallRuleDialog } from "../AddFirewallRule/addFirewallRule.component";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
 import { ConnectionGroupDialog } from "../ConnectionGroup/connectionGroup.component";
+import { SearchableDropdownOptions } from "../../common/searchableDropdown.component";
 
 function renderContent(connectionDialogContext: ConnectionDialogContextProps): ReactNode {
     switch (connectionDialogContext?.state.selectedInputMode) {
@@ -123,6 +125,19 @@ export const ConnectionInfoFormContainer = () => {
                     }
                     idx={0}
                     props={{ orientation: "horizontal" }}
+                    componentProps={{
+                        onSelect: (option: SearchableDropdownOptions) => {
+                            if (option.value === CREATE_NEW_GROUP_ID) {
+                                context.openCreateConnectionGroupDialog();
+                            } else {
+                                context.formAction({
+                                    propertyName: "groupId",
+                                    isAction: false,
+                                    value: option.value,
+                                });
+                            }
+                        },
+                    }}
                 />
 
                 <div className={formStyles.formComponentDiv}>

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -160,6 +160,7 @@ export interface ConnectionDialogContextProps
     loadAzureServers: (subscriptionId: string) => void;
     closeDialog: () => void;
     addFirewallRule: (firewallRuleSpec: FirewallRuleSpec) => void;
+    openCreateConnectionGroupDialog: () => void;
     createConnectionGroup: (connectionGroupSpec: ConnectionGroupSpec) => void;
     filterAzureSubscriptions: () => void;
     refreshConnectionsList: () => void;
@@ -179,6 +180,8 @@ export enum AuthenticationType {
     AzureMFA = "AzureMFA",
 }
 
+export const CREATE_NEW_GROUP_ID = "CREATE_NEW_GROUP";
+
 export interface ConnectionDialogReducers extends FormReducers<IConnectionDialogProfile> {
     setConnectionInputType: {
         inputMode: ConnectionInputMode;
@@ -196,6 +199,7 @@ export interface ConnectionDialogReducers extends FormReducers<IConnectionDialog
     createConnectionGroup: {
         connectionGroupSpec: ConnectionGroupSpec;
     };
+    openCreateConnectionGroupDialog: {};
     closeDialog: {};
     filterAzureSubscriptions: {};
     refreshConnectionsList: {};

--- a/src/sharedInterfaces/form.ts
+++ b/src/sharedInterfaces/form.ts
@@ -73,6 +73,10 @@ export interface FormItemSpec<
      */
     placeholder?: string;
     /**
+     * Placeholder text for the search box in a searchable dropdown
+     */
+    searchBoxPlaceholder?: string;
+    /**
      * Validation callback for the form item
      */
     validate?: (state: TState, value: string | boolean | number) => FormItemValidationState;
@@ -139,4 +143,5 @@ export enum FormItemType {
     Password = "password",
     Button = "button",
     TextArea = "textarea",
+    SearchableDropdown = "searchableDropdown",
 }

--- a/test/unit/connectionConfig.test.ts
+++ b/test/unit/connectionConfig.test.ts
@@ -412,7 +412,7 @@ suite("ConnectionConfig Tests", () => {
                 const connConfig = new ConnectionConfig(mockVscodeWrapper.object);
                 await connConfig.initialized;
 
-                const result = await connConfig.removeGroup(testGroup.id);
+                const result = await connConfig.removeGroup(testGroup.id, "delete");
 
                 expect(result, "Group should have been found and removed").to.be.true;
                 const savedGroups = mockGlobalConfigData.get(
@@ -422,7 +422,7 @@ suite("ConnectionConfig Tests", () => {
                 expect(savedGroups[0].name).to.equal("ROOT");
             });
 
-            test("removeGroup removes child groups and their connections recursively", async () => {
+            test("removeGroup with delete option removes child groups and their connections recursively", async () => {
                 // Set up test groups: Group A with children B and C
                 const groupA = { name: "Group A", id: "group-a", parentId: rootGroupId };
                 const groupB = { name: "Group B", id: "group-b", parentId: "group-a" };
@@ -438,7 +438,7 @@ suite("ConnectionConfig Tests", () => {
                 // Set up test connections: one in Group B, one in Group A
                 const conn1 = {
                     id: "conn1",
-                    groupId: "group-b",
+                    groupId: "group-a",
                     server: "server1",
                     authenticationType: "Integrated",
                     profileName: "Connection 1",
@@ -446,7 +446,7 @@ suite("ConnectionConfig Tests", () => {
 
                 const conn2 = {
                     id: "conn2",
-                    groupId: "group-a",
+                    groupId: "group-b",
                     server: "server2",
                     authenticationType: "Integrated",
                     profileName: "Connection 2",
@@ -458,7 +458,7 @@ suite("ConnectionConfig Tests", () => {
                 await connConfig.initialized;
 
                 // Remove Group A
-                const result = await connConfig.removeGroup(groupA.id);
+                const result = await connConfig.removeGroup(groupA.id, "delete");
 
                 expect(result, "Group should have been found and removed").to.be.true;
 
@@ -474,6 +474,76 @@ suite("ConnectionConfig Tests", () => {
                     Constants.connectionsArrayName,
                 ) as IConnectionProfile[];
                 expect(savedConnections).to.have.lengthOf(0, "All connections should be removed");
+            });
+
+            test("removeGroup with move option moves immediate children to root and removes subgroups", async () => {
+                // Set up test groups: Group A with children B and C
+                const groupA = { name: "Group A", id: "group-a", parentId: rootGroupId };
+                const groupB = { name: "Group B", id: "group-b", parentId: "group-a" };
+                const groupC = { name: "Group C", id: "group-c", parentId: "group-a" };
+
+                mockGlobalConfigData.set(Constants.connectionGroupsArrayName, [
+                    { name: "ROOT", id: rootGroupId },
+                    groupA,
+                    groupB,
+                    groupC,
+                ]);
+
+                // Set up test connections: one in Group A (immediate child), one in Group B (nested)
+                const conn1 = {
+                    id: "conn1",
+                    groupId: "group-a",
+                    server: "server1",
+                    authenticationType: "Integrated",
+                    profileName: "Connection 1",
+                } as IConnectionProfile;
+
+                const conn2 = {
+                    id: "conn2",
+                    groupId: "group-b",
+                    server: "server2",
+                    authenticationType: "Integrated",
+                    profileName: "Connection 2",
+                } as IConnectionProfile;
+
+                mockGlobalConfigData.set(Constants.connectionsArrayName, [conn1, conn2]);
+
+                const connConfig = new ConnectionConfig(mockVscodeWrapper.object);
+                await connConfig.initialized;
+
+                // Remove Group A with move option
+                const result = await connConfig.removeGroup(groupA.id, "move");
+
+                expect(result, "Group should have been found and removed").to.be.true;
+
+                // Verify group A was removed and immediate children (B and C) were moved to root
+                const savedGroups = mockGlobalConfigData.get(
+                    Constants.connectionGroupsArrayName,
+                ) as IConnectionGroup[];
+                expect(savedGroups).to.have.lengthOf(3, "ROOT and two child groups should remain");
+
+                // Verify group hierarchy
+                const groupB_Saved = savedGroups.find((g) => g.id === groupB.id);
+                const groupC_Saved = savedGroups.find((g) => g.id === groupC.id);
+                expect(groupB_Saved.parentId).to.equal(
+                    rootGroupId,
+                    "Group B should be moved to root",
+                );
+                expect(groupC_Saved.parentId).to.equal(
+                    rootGroupId,
+                    "Group C should be moved to root",
+                );
+
+                // Verify immediate child connection was moved to root, keeping its internal hierarchy
+                const savedConnections = mockGlobalConfigData.get(
+                    Constants.connectionsArrayName,
+                ) as IConnectionProfile[];
+                const conn1_Saved = savedConnections.find((c) => c.id === conn1.id);
+                expect(conn1_Saved).to.not.be.undefined;
+                expect(conn1_Saved.groupId).to.equal(
+                    rootGroupId,
+                    "Connection 1 should be moved to root",
+                );
             });
 
             test("getGroups returns all connection groups", async () => {


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/19585

Fit and finish for connection group feature:
* Removing groups now supports either deletion or reparenting of connections and subgroups, allowing users to either delete contents or move them to the root group.
* Connection Dialog group list now handles naming conflicts and display full paths for groups with duplicate names
* Changed Connection Dialog from a button for "Create connection group" to a cleaner-looking dropdown item
* Changed Connection Dialog group list to a searchable dropdown

Before:
![image](https://github.com/user-attachments/assets/6c550e67-c7ea-4109-95e3-e542f6394ac9)
![image](https://github.com/user-attachments/assets/022c73bf-f2f1-4ef4-83d7-2fa3d7fae621)

After:
![image](https://github.com/user-attachments/assets/1b443b5a-28fc-4c1a-9899-c98c1e3e72fe)
![image](https://github.com/user-attachments/assets/b34ef457-3e96-4e69-baba-0c8444403c24)

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

