### PR TITLE
[Port] Fixes some local containers bugs (#19562)

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1299,6 +1299,7 @@
   "Your Docker Engine currently runs Windows containers. SQL Server only supports Linux containers. Would you like to switch to Linux containers?": "Your Docker Engine currently runs Windows containers. SQL Server only supports Linux containers. Would you like to switch to Linux containers?",
   "Switching to Linux containers was canceled. SQL Server only supports Linux containers.": "Switching to Linux containers was canceled. SQL Server only supports Linux containers.",
   "Failed to start SQL Server container. Please check the error message for more details, and then try again.": "Failed to start SQL Server container. Please check the error message for more details, and then try again.",
+  "Container does not exist. Would you like to remove the connection?": "Container does not exist. Would you like to remove the connection?",
   "How likely it is that you would recommend the MSSQL extension to a friend or colleague?": "How likely it is that you would recommend the MSSQL extension to a friend or colleague?",
   "What can we do to improve?": "What can we do to improve?",
   "Take Survey": "Take Survey",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -615,6 +615,9 @@
     <trans-unit id="++CODE++ca0fa7ee8e0d9d4e742094db2e8d59b963dce003cc884c8573d64d59fcfe16dd">
       <source xml:lang="en">Container Name</source>
     </trans-unit>
+    <trans-unit id="++CODE++06659b52e63599b06c4386ad5423c3dc67b010f0dbbd03cba2f48b68ed1b62f5">
+      <source xml:lang="en">Container does not exist. Would you like to remove the connection?</source>
+    </trans-unit>
     <trans-unit id="++CODE++8ad8440f3fcfd714e6310b217eaae7d43f1100a0730348dff4116c3aa3f08fcd">
       <source xml:lang="en">Container failed to start within the timeout period. Please wait a few minutes and try again.</source>
     </trans-unit>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -142,7 +142,6 @@ export const outputServiceLocalhost = "http://localhost:";
 export const localhost = "localhost";
 export const localhostIP = "127.0.0.1";
 export const defaultContainerName = "sql_server_container";
-export const defaultContainerPort = 1433;
 export const msgContentProviderSqlOutputHtml = "dist/html/sqlOutput.ejs";
 export const contentProviderMinFile = "dist/js/app.min.js";
 export const untitledSaveTimeThreshold = 50.0;

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -20,6 +20,7 @@ export class Common {
             comment: ["{0} is the action being confirmed"],
         });
     public static accept = l10n.t("Accept");
+    public static error = l10n.t("Error");
 }
 
 export let viewMore = l10n.t("View More");
@@ -896,6 +897,9 @@ export class ContainerDeployment {
     );
     public static startSqlServerContainerError = l10n.t(
         "Failed to start SQL Server container. Please check the error message for more details, and then try again.",
+    );
+    public static containerDoesNotExistError = l10n.t(
+        "Container does not exist. Would you like to remove the connection?",
     );
 }
 

--- a/src/containerDeployment/containerDeploymentWebviewController.ts
+++ b/src/containerDeployment/containerDeploymentWebviewController.ts
@@ -7,7 +7,7 @@ import * as cd from "../sharedInterfaces/containerDeploymentInterfaces";
 import * as vscode from "vscode";
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { platform } from "os";
-import { defaultContainerPort, localhost, sa, sqlAuthentication } from "../constants/constants";
+import { defaultPortNumber, localhost, sa, sqlAuthentication } from "../constants/constants";
 import { FormItemType, FormItemSpec, FormItemOptions } from "../sharedInterfaces/form";
 import MainController from "../controllers/mainController";
 import { FormWebviewController } from "../forms/formWebviewController";
@@ -67,8 +67,11 @@ export class ContainerDeploymentWebviewController extends FormWebviewController<
 
     private async initialize() {
         this.state.loadState = ApiStatus.Loading;
+        this.state.platform = platform();
+        const versions = await dockerUtils.getSqlServerContainerVersions();
+        this.state.formComponents = this.setFormComponents(versions);
         this.state.formState = {
-            version: "",
+            version: versions[0].value,
             password: "",
             savePassword: false,
             profileName: "",
@@ -77,9 +80,6 @@ export class ContainerDeploymentWebviewController extends FormWebviewController<
             hostname: "",
             acceptEula: false,
         } as cd.DockerConnectionProfile;
-        this.state.platform = platform();
-        const versions = await dockerUtils.getSqlServerContainerVersions();
-        this.state.formComponents = this.setFormComponents(versions);
         this.state.dockerSteps = dockerUtils.initializeDockerSteps();
         this.registerRpcHandlers();
         this.state.loadState = ApiStatus.Loaded;
@@ -159,7 +159,7 @@ export class ContainerDeploymentWebviewController extends FormWebviewController<
             }
 
             if (!state.formState.port) {
-                state.formState.port = await dockerUtils.findAvailablePort(defaultContainerPort);
+                state.formState.port = await dockerUtils.findAvailablePort(defaultPortNumber);
             }
 
             state.isDockerProfileValid = state.formErrors.length === 0;

--- a/src/containerDeployment/dockerUtils.ts
+++ b/src/containerDeployment/dockerUtils.ts
@@ -10,7 +10,7 @@ import { DockerCommandParams, DockerStep } from "../sharedInterfaces/containerDe
 import { ApiStatus } from "../sharedInterfaces/webview";
 import {
     defaultContainerName,
-    defaultContainerPort,
+    defaultPortNumber,
     localhost,
     localhostIP,
     Platform,
@@ -58,6 +58,7 @@ export const COMMANDS = {
     },
     SWITCH_ENGINE: (path: string) => `powershell -Command "& \\"${path}\\" -SwitchLinuxEngine"`,
     GET_CONTAINERS: `docker ps -a --format "{{.ID}}"`,
+    GET_CONTAINERS_BY_NAME: `docker ps -a --format "{{.Names}}"`,
     INSPECT: (id: string) => `docker inspect ${id}`,
     START_SQL_SERVER: (
         name: string,
@@ -66,7 +67,7 @@ export const COMMANDS = {
         version: number,
         hostname: string,
     ) =>
-        `docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=${password}" -p ${port}:${defaultContainerPort} --name ${name} ${hostname ? `--hostname ${hostname}` : ""} -d mcr.microsoft.com/mssql/server:${version}-latest`,
+        `docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=${password}" -p ${port}:${defaultPortNumber} --name ${name} ${hostname ? `--hostname ${hostname}` : ""} -d mcr.microsoft.com/mssql/server:${version}-latest`,
     CHECK_CONTAINER_RUNNING: (name: string) =>
         `docker ps --filter "name=${name}" --filter "status=running" --format "{{.Names}}"`,
     VALIDATE_CONTAINER_NAME: 'docker ps -a --format "{{.Names}}"',
@@ -423,7 +424,6 @@ export async function startDocker(): Promise<DockerCommandParams> {
 export async function restartContainer(containerName: string): Promise<boolean> {
     sendActionEvent(TelemetryViews.ContainerDeployment, TelemetryActions.StartContainer);
 
-    await startDocker();
     const isContainerRunning = await isDockerContainerRunning(containerName);
     if (isContainerRunning) return true; // Container is already running
     dockerLogger.appendLine(`Restarting container: ${containerName}`);
@@ -540,6 +540,9 @@ async function getUsedPortsFromContainers(containerIds: string[]): Promise<Set<n
  * It inspects each container to find a match with the server name.
  */
 async function findContainerByPort(containerIds: string[], serverName: string): Promise<string> {
+    if (serverName === localhost || serverName === localhostIP) {
+        serverName += `,${defaultPortNumber}`;
+    }
     for (const id of containerIds) {
         try {
             const inspect = await execCommand(COMMANDS.INSPECT_CONTAINER(id));
@@ -627,6 +630,42 @@ export async function getSqlServerContainerVersions(): Promise<FormItemOptions[]
             `Error fetching SQL Server container versions: ${getErrorMessage(e)}`,
         );
         return [];
+    }
+}
+/**
+ * Prepares the given Docker container for command execution.
+ * This function checks if Docker is running and if the specified container exists.
+ */
+export async function prepareForDockerContainerCommand(
+    containerName: string,
+): Promise<DockerCommandParams> {
+    const startDockerResult = await startDocker();
+    if (!startDockerResult.success) return startDockerResult;
+
+    const containerExists = await checkContainerExists(containerName);
+
+    if (!containerExists) {
+        return {
+            success: false,
+            error: ContainerDeployment.containerDoesNotExistError,
+        };
+    }
+    return {
+        success: true,
+    };
+}
+
+/**
+ * Checks if a Docker container with the specified name exists.
+ */
+export async function checkContainerExists(name: string): Promise<boolean> {
+    try {
+        const stdout = await execCommand(COMMANDS.GET_CONTAINERS_BY_NAME);
+        const containers = stdout.split("\n").map((c) => c.trim());
+        return containers.includes(name);
+    } catch (e) {
+        dockerLogger.appendLine(`Error checking if container exists: ${getErrorMessage(e)}`);
+        return false;
     }
 }
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -75,7 +75,11 @@ import { DisconnectTool } from "../copilot/tools/disconnectTool";
 import { ConnectionGroupNode } from "../objectExplorer/nodes/connectionGroupNode";
 import { ConnectionGroupWebviewController } from "./connectionGroupWebviewController";
 import { ContainerDeploymentWebviewController } from "../containerDeployment/containerDeploymentWebviewController";
-import { deleteContainer, stopContainer } from "../containerDeployment/dockerUtils";
+import {
+    deleteContainer,
+    prepareForDockerContainerCommand,
+    stopContainer,
+} from "../containerDeployment/dockerUtils";
 
 /**
  * The main controller class that initializes the extension
@@ -1309,7 +1313,13 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdStartContainer,
                 async (node: TreeNodeInfo) => {
-                    if (!node) return;
+                    if (
+                        !node ||
+                        !node.connectionProfile ||
+                        !(await this.isContainerReadyForCommands(node))
+                    ) {
+                        return;
+                    }
                     try {
                         // doing it this way instead of directly calling startContainer
                         // allows for the object explorer item loading UI to show
@@ -1345,10 +1355,15 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdStopContainer,
                 async (node: TreeNodeInfo) => {
-                    if (!node) return;
+                    if (
+                        !node ||
+                        !node.connectionProfile ||
+                        !(await this.isContainerReadyForCommands(node))
+                    ) {
+                        return;
+                    }
 
                     const containerName = node.connectionProfile.containerName;
-
                     node.loadingLabel =
                         LocalizedConstants.ContainerDeployment.stoppingContainerLoadingLabel;
                     await this._objectExplorerProvider.setNodeLoading(node);
@@ -1382,7 +1397,13 @@ export default class MainController implements vscode.Disposable {
             vscode.commands.registerCommand(
                 Constants.cmdDeleteContainer,
                 async (node: TreeNodeInfo) => {
-                    if (!node) return;
+                    if (
+                        !node ||
+                        !node.connectionProfile ||
+                        !(await this.isContainerReadyForCommands(node))
+                    ) {
+                        return;
+                    }
 
                     const confirmation = await vscode.window.showInformationMessage(
                         LocalizedConstants.ContainerDeployment.deleteContainerConfirmation(
@@ -2633,6 +2654,30 @@ export default class MainController implements vscode.Disposable {
         } else {
             return false;
         }
+    }
+
+    private async isContainerReadyForCommands(node: TreeNodeInfo): Promise<boolean> {
+        const containerName = node.connectionProfile?.containerName;
+        const prepResult = await prepareForDockerContainerCommand(containerName);
+        if (!prepResult.success) {
+            if (
+                prepResult.error ===
+                LocalizedConstants.ContainerDeployment.containerDoesNotExistError
+            ) {
+                node.loadingLabel = LocalizedConstants.Common.error;
+                const confirmation = await vscode.window.showInformationMessage(
+                    prepResult.error,
+                    { modal: true },
+                    LocalizedConstants.RemoveProfileLabel,
+                );
+                if (confirmation === LocalizedConstants.RemoveProfileLabel) {
+                    await this._objectExplorerProvider.removeNode(node as ConnectionNode, false);
+                }
+            } else {
+                vscode.window.showErrorMessage(prepResult.error);
+            }
+        }
+        return prepResult.success;
     }
 
     public removeAadAccount(prompter: IPrompter): void {

--- a/src/objectExplorer/nodes/connectionNode.ts
+++ b/src/objectExplorer/nodes/connectionNode.ts
@@ -53,15 +53,13 @@ export class ConnectionNode extends TreeNodeInfo {
             undefined,
             undefined,
         );
-        if (connectionProfile.database) {
+        if (connectionProfile.containerName) {
+            this.iconPath = ObjectExplorerUtils.iconPath(ICON_DOCKER_SERVER_DISCONNECTED);
+            this.loadingLabel = ContainerDeployment.startingContainerLoadingLabel;
+        } else if (connectionProfile.database) {
             this.iconPath = ObjectExplorerUtils.iconPath(ICON_DATABASE_DISCONNECTED);
         } else {
-            let iconName = ICON_SERVER_DISCONNECTED;
-            if (connectionProfile.containerName) {
-                iconName = ICON_DOCKER_SERVER_DISCONNECTED;
-                this.loadingLabel = ContainerDeployment.startingContainerLoadingLabel;
-            }
-            this.iconPath = ObjectExplorerUtils.iconPath(iconName);
+            this.iconPath = ObjectExplorerUtils.iconPath(ICON_SERVER_DISCONNECTED);
         }
     }
 
@@ -83,10 +81,10 @@ export class ConnectionNode extends TreeNodeInfo {
             type: SERVER_NODE_CONNECTED,
             filterable: nodeInfo.filterableProperties?.length > 0,
             hasFilters: false,
-            subType: connectionProfile.database
-                ? DATABASE_SUBTYPE
-                : connectionProfile.containerName
-                  ? dockerContainer
+            subType: connectionProfile.containerName
+                ? dockerContainer
+                : connectionProfile.database
+                  ? DATABASE_SUBTYPE
                   : "",
         };
         this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
@@ -99,14 +97,14 @@ export class ConnectionNode extends TreeNodeInfo {
         this.filterableProperties = nodeInfo.filterableProperties;
         this.updateMetadata(nodeInfo.metadata);
 
-        // Update the icon based on whether this is a database or server connection
-        if (connectionProfile.database) {
+        // Update the icon based on connection type
+        if (connectionProfile.containerName) {
+            this.iconPath = ObjectExplorerUtils.iconPath(ICON_DOCKER_SERVER_CONNECTED);
+            this.loadingLabel = ContainerDeployment.startingContainerLoadingLabel;
+        } else if (connectionProfile.database) {
             this.iconPath = ObjectExplorerUtils.iconPath(ICON_DATABASE_CONNECTED);
         } else {
-            let iconName = ICON_SERVER_CONNECTED;
-            if (connectionProfile.containerName) iconName = ICON_DOCKER_SERVER_CONNECTED;
-
-            this.iconPath = ObjectExplorerUtils.iconPath(iconName);
+            this.iconPath = ObjectExplorerUtils.iconPath(ICON_SERVER_CONNECTED);
         }
     }
 


### PR DESCRIPTION
Fixes #19523 , #19524, #19565, #19550, #19553

When a user deletes a container outside of the extension, and then tries to interact with its corresponding connection within the extension, the extension will now notify the user that the container does not exist, and prompt them to remove the connection.
![deleteContainerBug](https://github.com/user-attachments/assets/7ec08d0c-1afd-4702-a50e-b3faa8261fcb)


Original PR: https://github.com/microsoft/vscode-mssql/pull/19562

---------

# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

