### PR TITLE
Allowing container checks to fail gracefully

### DIFF
--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -63,6 +63,7 @@ import { ConnectionNode } from "./nodes/connectionNode";
 import { ConnectionGroupNode } from "./nodes/connectionGroupNode";
 import { getConnectionDisplayName } from "../models/connectionInfo";
 import { AddLocalContainerConnectionTreeNode } from "../containerDeployment/addLocalContainerConnectionTreeNode";
+import { getErrorMessage } from "../utils/utils";
 
 export interface CreateSessionResult {
     sessionId?: string;
@@ -748,8 +749,19 @@ export class ObjectExplorerService {
                 TelemetryViews.ContainerDeployment,
                 TelemetryActions.ConnectToContainer,
             );
-            // start docker and docker container
-            await restartContainer(connectionProfile.containerName);
+            try {
+                // start docker and docker container
+                const alreadyRunning = await restartContainer(connectionProfile.containerName);
+                this._logger.verbose(
+                    alreadyRunning
+                        ? `Docker container "${connectionProfile.containerName}" is already running.`
+                        : `Docker container "${connectionProfile.containerName}" has been restarted.`,
+                );
+            } catch (error) {
+                this._logger.error(
+                    `Error when attempting to ensure container "${connectionProfile.containerName}" is started.  Attempting to proceed normally.\n\nError:\n${getErrorMessage(error)}`,
+                );
+            }
         }
         if (connectionProfile.connectionString) {
             if (connectionProfile.savePassword) {

--- a/test/unit/objectExplorerService.test.ts
+++ b/test/unit/objectExplorerService.test.ts
@@ -47,6 +47,7 @@ import {
     SessionCreatedParameters,
 } from "../../src/models/contracts/objectExplorer/createSessionRequest";
 import { ObjectExplorerUtils } from "../../src/objectExplorer/objectExplorerUtils";
+import * as DockerUtils from "../../src/containerDeployment/dockerUtils";
 import { FirewallService } from "../../src/firewall/firewallService";
 import { ConnectionCredentials } from "../../src/models/connectionCredentials";
 import providerSettings from "../../src/azure/providerSettings";
@@ -945,6 +946,40 @@ suite("OE Service Tests", () => {
                 mockConnectionUI.promptForPassword.called,
                 "Connection UI should not prompt for password",
             ).to.be.false;
+        });
+
+        test("prepareConnectionProfile should proceed if container connection throws when attempting to check container status", async () => {
+            // Create a mock SQL Login profile with empty password but savePassword=true
+            const mockProfile: IConnectionProfile = {
+                id: "test-id",
+                server: "testServer",
+                database: "testDB",
+                authenticationType: "SqlLogin",
+                user: "testUser",
+                password: "", // Empty password
+                savePassword: true,
+                containerName: "someContainer",
+            } as IConnectionProfile;
+
+            // Setup connection store to return a saved password
+            const savedPassword = generateUUID(); //random password
+            mockConnectionStore.lookupPassword.resolves(savedPassword);
+
+            const containerStub = sinon
+                .stub(DockerUtils, "restartContainer")
+                .throws(new Error("Failed to restart container"));
+
+            // Call the method with the mock profile
+            const result = await (objectExplorerService as any).prepareConnectionProfile(
+                mockProfile,
+            );
+
+            expect(containerStub.called, "Container restart should be attempted").to.be.true;
+
+            // Verify the result has the saved password
+            expect(result.password, "Result password should match saved password").to.equal(
+                savedPassword,
+            );
         });
 
         test("prepareConnectionProfile should prompt for password for SQL Login with no saved password", async () => {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Allows connection attempt to proceed if the attempt to check container status throws an error instead of a definitive confirmation that the container is running.  Previously, if a connection had a `containerName` property but docker was not accessible, all connection attempts would fail, both in OE and the connection dialog.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

