### PR TITLE
Stop long source names from overlapping with checkbox

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
@@ -10,6 +10,7 @@ import {
     useFluent,
     TableBody,
     TableCell,
+    TableCellLayout,
     TableRow,
     Table,
     TableHeader,
@@ -310,18 +311,32 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                     onClick={() => onDiffSelected(index)}
                     appearance={appearance}
                     className={index === selectedDiffId ? classes.selectedRow : undefined}>
-                    <TableCell>{item.name}</TableCell>
-                    <TableCell>{formatName(item.sourceValue)}</TableCell>
                     <TableCell>
-                        <Checkbox
-                            checked={item.included}
-                            onClick={() => handleIncludeExcludeNode(item, !item.included)}
-                            onKeyDown={(e) => toggleKeyDown(e, item, !item.included)}
-                            disabled={context.state.isIncludeExcludeAllOperationInProgress}
-                        />
+                        <TableCellLayout style={{ width: "100px !important" }}>
+                            {item.name}
+                        </TableCellLayout>
                     </TableCell>
-                    <TableCell>{getLabelForAction(item.updateAction as number)}</TableCell>
-                    <TableCell>{formatName(item.targetValue)}</TableCell>
+                    <TableCell>
+                        <TableCellLayout truncate>{formatName(item.sourceValue)}</TableCellLayout>
+                    </TableCell>
+                    <TableCell>
+                        <TableCellLayout>
+                            <Checkbox
+                                checked={item.included}
+                                onClick={() => handleIncludeExcludeNode(item, !item.included)}
+                                onKeyDown={(e) => toggleKeyDown(e, item, !item.included)}
+                                disabled={context.state.isIncludeExcludeAllOperationInProgress}
+                            />
+                        </TableCellLayout>
+                    </TableCell>
+                    <TableCell>
+                        <TableCellLayout>
+                            {getLabelForAction(item.updateAction as number)}
+                        </TableCellLayout>
+                    </TableCell>
+                    <TableCell>
+                        <TableCellLayout truncate>{formatName(item.targetValue)}</TableCellLayout>
+                    </TableCell>
                 </TableRow>
             );
         };


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/19178

The PR resolves the error by truncating long names, so that they do not overlap with the checkbox in the diff list.

Before:
![image](https://github.com/user-attachments/assets/658a9545-f39a-49e0-a5f7-952f8be2268b)

After:
![image](https://github.com/user-attachments/assets/99d8bf2f-b7e7-4a7d-8780-070fab76a60e)


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

