### PR TITLE
Improve Schema Compare Differences List

### DIFF
--- a/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
+++ b/src/reactviews/pages/SchemaCompare/components/SchemaDifferences.tsx
@@ -14,7 +14,6 @@ import {
     DataGridHeaderCell,
     Text,
     TableColumnSizingOptions,
-    mergeClasses,
 } from "@fluentui/react-components";
 import {
     DataGridBody,
@@ -81,9 +80,6 @@ const useStyles = makeStyles({
     },
     dataGridHeader: {
         backgroundColor: "var(--vscode-keybindingTable-headerBackground)",
-    },
-    dataGridRowHeight: {
-        height: "30px !important",
     },
 });
 
@@ -309,17 +305,11 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
         };
 
         const renderRow: RowRenderer<DiffEntry> = ({ item, rowId }, style) => {
-            const newStyle = { ...style, height: 30, top: item.position * 30 }; // Set a fixed height for the row
-            console.log(style);
             return (
                 <DataGridRow<DiffEntry>
                     key={rowId}
-                    className={
-                        item.position === selectedDiffId
-                            ? mergeClasses(classes.selectedRow, classes.dataGridRowHeight)
-                            : classes.dataGridRowHeight
-                    }
-                    style={newStyle}
+                    className={item.position === selectedDiffId ? classes.selectedRow : undefined}
+                    style={style}
                     onClick={() => {
                         if (item.position !== undefined) {
                             onDiffSelected(item.position);


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
I'm aware of the new rule surrounding a single PR fixing a single issue, but by replacing the table components with the datagrid component, I was able to fix these issues with a single change.

This PR fixes https://github.com/microsoft/vscode-mssql/issues/19365
This PR fixes https://github.com/microsoft/vscode-mssql/issues/19178
This PR fixes https://github.com/microsoft/vscode-mssql/issues/19182

This PR replaces the Table Fluent UI component that was previously used to list all schema comparison differences with the DataGrid Fluent UI component. The DataGrid component features long text truncation, features a better layout for consistent checkbox alignment, and built in keyboard accessibility.

### Improved keyboard navigation
![keyboard-accessibility](https://github.com/user-attachments/assets/568056aa-3e73-4054-be69-e57b98a82e98)

### Checkbox alignment:

Before:
Previously when the schema comparison differences list was small, a scrollbar wouldn't appear which would cause table body rows to shift to the right and get out of alignment.
![image](https://github.com/user-attachments/assets/e69de577-8976-459f-8f63-7be5df7503db)

But if the differences list contained a scroll bar then rows would appear correctly aligned:
![image](https://github.com/user-attachments/assets/e001f9d8-aa1a-4121-8914-01a6dc233e52)

After:
With the changes in this PR that alignment issue with checkboxes is fixed as seen here with a small differences list:
![image](https://github.com/user-attachments/assets/90ca7ea0-1df5-498e-a3c9-285a0604d285)

And here with a differences list that contains a scroll bar: 
![image](https://github.com/user-attachments/assets/e10f5f60-6eaf-4f67-930f-4bcef4b3fc75)

### Long source/target names no longer overlap with checkboxes.

Before:
Long text overlaps with checkboxes in the schema compare differences.
![image](https://github.com/user-attachments/assets/dd0e54fd-0084-42d1-a9f5-c38c8064d2d0)

After:
Long names are truncated, so that they don't overlap with the checkboxes like they did previously:
![image](https://github.com/user-attachments/assets/bc128f8f-d96c-4a7e-8a92-308910f59534)

### Compacted row height:
![image](https://github.com/user-attachments/assets/ab28a928-4ab5-4169-a63d-dbdc67dbf97b)

### Fixed spinner alignment issue:
In the gif, the spinner appears slightly to the left of the checkboxes, but that is now fixed as seen here:
![image](https://github.com/user-attachments/assets/2ba00ade-7af2-4f7f-9f3f-e31b7911c2d7)




*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

