### PR TITLE
Add a few more agent tools for connection

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1592,6 +1592,18 @@
       "{1} is the database name"
     ]
   },
+  "Successfully changed to database: {0}/{0} is the database name": {
+    "message": "Successfully changed to database: {0}",
+    "comment": [
+      "{0} is the database name"
+    ]
+  },
+  "Failed to connect to database: {0}/{0} is the database name": {
+    "message": "Failed to connect to database: {0}",
+    "comment": [
+      "{0} is the database name"
+    ]
+  },
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
   "Create Connection Group": "Create Connection Group",
   "Edit Connection Group - {0}/{0} is the connection group name": {

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1551,6 +1551,47 @@
     ]
   },
   "Schema visualization opened.": "Schema visualization opened.",
+  "Get Connection Details": "Get Connection Details",
+  "Get connection details for connection '{0}'?/{0} is the connection ID": {
+    "message": "Get connection details for connection '{0}'?",
+    "comment": [
+      "{0} is the connection ID"
+    ]
+  },
+  "Getting connection details for connection '{0}'/{0} is the connection ID": {
+    "message": "Getting connection details for connection '{0}'",
+    "comment": [
+      "{0} is the connection ID"
+    ]
+  },
+  "List Databases": "List Databases",
+  "List databases for connection '{0}'?/{0} is the connection ID": {
+    "message": "List databases for connection '{0}'?",
+    "comment": [
+      "{0} is the connection ID"
+    ]
+  },
+  "Listing databases for connection '{0}'/{0} is the connection ID": {
+    "message": "Listing databases for connection '{0}'",
+    "comment": [
+      "{0} is the connection ID"
+    ]
+  },
+  "Change Database": "Change Database",
+  "Change database to '{1}' for connection '{0}'?/{0} is the connection ID{1} is the database name": {
+    "message": "Change database to '{1}' for connection '{0}'?",
+    "comment": [
+      "{0} is the connection ID",
+      "{1} is the database name"
+    ]
+  },
+  "Changing database to '{1}' for connection '{0}'/{0} is the connection ID{1} is the database name": {
+    "message": "Changing database to '{1}' for connection '{0}'",
+    "comment": [
+      "{0} is the connection ID",
+      "{1} is the database name"
+    ]
+  },
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
   "Create Connection Group": "Create Connection Group",
   "Edit Connection Group - {0}/{0} is the connection group name": {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1009,6 +1009,10 @@
       <source xml:lang="en">Failed to apply changes: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the publish changes operation</note>
     </trans-unit>
+    <trans-unit id="++CODE++6e543be4255a8c4362baca16d0850278f1d95a7df9cd38f4b94ecbda4abe57e5">
+      <source xml:lang="en">Failed to connect to database: {0}</source>
+      <note>{0} is the database name</note>
+    </trans-unit>
     <trans-unit id="++CODE++d6ca257a745c3035dfd24b1cf8bddd511b93f0c4ae8036dc0d88ece8501d4d13">
       <source xml:lang="en">Failed to connect to server.</source>
     </trans-unit>
@@ -2225,6 +2229,10 @@
     </trans-unit>
     <trans-unit id="++CODE++5443b1422a140475d5703c916c7686007233ea92292881588670e73409a7f1cd">
       <source xml:lang="en">Succeeded with warning</source>
+    </trans-unit>
+    <trans-unit id="++CODE++2e71037756b80741dc7aff95ef179d5a25c08df7a40cd7b16af9a5edb6f64047">
+      <source xml:lang="en">Successfully changed to database: {0}</source>
+      <note>{0} is the database name</note>
     </trans-unit>
     <trans-unit id="++CODE++fbd52c8b91de95b69593d008ca2108476ccb1ea5a45657b3393d878499e3fe1f">
       <source xml:lang="en">Successfully connected to server.</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -324,6 +324,14 @@
     <trans-unit id="++CODE++c0bf75bd78bf9572596720d596bd5a20a5b9145cde0fe50dec1e783cb184d69b">
       <source xml:lang="en">Change</source>
     </trans-unit>
+    <trans-unit id="++CODE++6bd09f9171ad9aa3824a8e54ea5edf59d28c768124be9dc7f9d2c5c7eee6780b">
+      <source xml:lang="en">Change Database</source>
+    </trans-unit>
+    <trans-unit id="++CODE++00aecebb859a5ba020dd5aa5ffb71e7f9a4279e35f9c94e6d34ebf7c889a3f7e">
+      <source xml:lang="en">Change database to &apos;{1}&apos; for connection &apos;{0}&apos;?</source>
+      <note>{0} is the connection ID
+{1} is the database name</note>
+    </trans-unit>
     <trans-unit id="++CODE++aa115b472e9ca1287d8404ed9c69fb8612db771dfcb9ec5f560662fd0a7d653b">
       <source xml:lang="en">Changed Tables</source>
     </trans-unit>
@@ -346,6 +354,11 @@
       <note>{0} is the database name
 {1} is the server name
 {2} is the document name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++5cca02706714579b1ebf65a02aa3db359c9533120430137485af41e5ec1ab285">
+      <source xml:lang="en">Changing database to &apos;{1}&apos; for connection &apos;{0}&apos;</source>
+      <note>{0} is the connection ID
+{1} is the database name</note>
     </trans-unit>
     <trans-unit id="++CODE++c8cabf4a998e678eb3213d46a3e9e80217b7839fb5f3537ee550a65e3b2202c9">
       <source xml:lang="en">Check Constraint</source>
@@ -1168,11 +1181,22 @@
     <trans-unit id="++CODE++019c93d8e0baa64c24b53c1e6f34c8faa0fcac26a0ac69fdaa46b788f6c05912">
       <source xml:lang="en">Generating report, this might take a while...</source>
     </trans-unit>
+    <trans-unit id="++CODE++fddd3d1537452414b2a4c7bb1b231ca37398b9f211c1e0d8d80e6f69a7f58f2d">
+      <source xml:lang="en">Get Connection Details</source>
+    </trans-unit>
     <trans-unit id="++CODE++983f311018642b0ae60c71253b5735579906d43d260ea926ebe5e815b1c97abb">
       <source xml:lang="en">Get Started</source>
     </trans-unit>
+    <trans-unit id="++CODE++833b64c15a94f939c4123ec646882d4b8943eb80c95ce91fffb06a7e95a82b61">
+      <source xml:lang="en">Get connection details for connection &apos;{0}&apos;?</source>
+      <note>{0} is the connection ID</note>
+    </trans-unit>
     <trans-unit id="++CODE++455754ccf3a6df55b0fe352903062c9adb22d5ce025f6c0b0b8b2a59c6e3a7fc">
       <source xml:lang="en">Getting Docker Ready...</source>
+    </trans-unit>
+    <trans-unit id="++CODE++2a8c8cd4e7c7142bffa09b893aaf7ab5886407a22a7ef9b2ee4f60f46fad7bf0">
+      <source xml:lang="en">Getting connection details for connection &apos;{0}&apos;</source>
+      <note>{0} is the connection ID</note>
     </trans-unit>
     <trans-unit id="++CODE++407c9ce5c11270b1d15836456ad1efdbe70f71f3c845186e535f82f02112be4e">
       <source xml:lang="en">Getting container ready for connections</source>
@@ -1328,8 +1352,19 @@
     <trans-unit id="++CODE++4ffa355be76c7d5e9f39081d405b5a1d2d9cae27b4016b7588b4b812f2146556">
       <source xml:lang="en">List Connections</source>
     </trans-unit>
+    <trans-unit id="++CODE++b993796f53424becc0d08d41a72c0c3381ee7691cc518bc8bdccc8d4013ad4ef">
+      <source xml:lang="en">List Databases</source>
+    </trans-unit>
     <trans-unit id="++CODE++b77fb88f6365c7aa62b75d120b96e1859e449166ac52bd58301306032102daf0">
       <source xml:lang="en">List all connections registered with the mssql extension?</source>
+    </trans-unit>
+    <trans-unit id="++CODE++abfc45dd4a240e3758d4d22759dd9fc99cc5e1d16aec7594708638c368bddb3d">
+      <source xml:lang="en">List databases for connection &apos;{0}&apos;?</source>
+      <note>{0} is the connection ID</note>
+    </trans-unit>
+    <trans-unit id="++CODE++b96793f36b682b832b59fce2ab2fbfbe394de6c913abd6f389f8c19273f040a5">
+      <source xml:lang="en">Listing databases for connection &apos;{0}&apos;</source>
+      <note>{0} is the connection ID</note>
     </trans-unit>
     <trans-unit id="++CODE++5404755c79ce81c6dba13bc9b7f3cbea8d096f40ff5fb69bfce1a9b2f7a07d4f">
       <source xml:lang="en">Listing server connections</source>

--- a/package.json
+++ b/package.json
@@ -2026,7 +2026,7 @@
         "languageModelTools": [
             {
                 "name": "mssql_show_schema",
-                "modelDescription": "Open an interactive schema designer for a MSSQL database. This tool requires an active db connection from the current active editor. This tool opens a graphical view of the database schema, including tables and relationships.",
+                "modelDescription": "Open an interactive schema designer for a MSSQL database. This tool takes a connection ID as input and opens a graphical view of the database schema, including tables and relationships.",
                 "tags": [
                     "databases",
                     "mssql",

--- a/package.json
+++ b/package.json
@@ -2054,7 +2054,7 @@
             },
             {
                 "name": "mssql_connect",
-                "modelDescription": "Connect to an MSSQL database server using a server name, an optional database name, and an optional profileId. The server name must be retrieved from mssql_list_servers. The profileId should be used ONLY when the user explicitly mentions a profile name, profile ID, or wants to connect 'using profile X'. Returns a connection ID that is used to interact with the database with other mssql tools. If a specific database is given and the connection fails, use $mssql_list_databases against a connection to the default database to find the correct database name. The connection ID is a string formatted as 'mssql/{server name}[/{database name}]', where if no database name is present it's the default database for the server.",
+                "modelDescription": "Connect to an MSSQL database server using a server name, an optional database name, and an optional profileId. The server name must be retrieved from mssql_list_servers. The profileId should be used ONLY when the user explicitly mentions a profile name, profile ID, or wants to connect 'using profile X'. Returns a connection ID that is used to interact with the database with other mssql tools. If a specific database is given and the connection fails, use $mssql_list_databases against a connection to the default database to find the correct database name. The connection ID is a UUID",
                 "tags": [
                     "databases",
                     "mssql",

--- a/package.json
+++ b/package.json
@@ -2144,6 +2144,95 @@
                 "displayName": "List MSSQL Servers",
                 "toolReferenceName": "mssql_list_servers",
                 "userDescription": "List all available MSSQL servers."
+            },
+            {
+                "name": "mssql_list_databases",
+                "modelDescription": "List all available databases for a connected MSSQL server. Returns a list of database names.",
+                "tags": [
+                    "databases",
+                    "mssql",
+                    "list"
+                ],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "connectionId": {
+                            "description": "Connection ID to list databases for.",
+                            "title": "Connection ID",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "connectionId"
+                    ]
+                },
+                "canBeReferencedInPrompt": true,
+                "displayName": "List MSSQL Databases",
+                "toolReferenceName": "mssql_list_databases",
+                "userDescription": "List all available databases for a connected MSSQL server.",
+                "icon": "$(database)"
+            },
+            {
+                "name": "mssql_get_connection_details",
+                "modelDescription": "Get connection details for a specific connection ID. Returns connection information including server, database, authentication type, and user details.",
+                "tags": [
+                    "databases",
+                    "mssql",
+                    "connection",
+                    "details"
+                ],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "connectionId": {
+                            "description": "Connection ID to get details for.",
+                            "title": "Connection ID",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "connectionId"
+                    ]
+                },
+                "canBeReferencedInPrompt": true,
+                "displayName": "Get MSSQL Connection Details",
+                "toolReferenceName": "mssql_get_connection_details",
+                "userDescription": "Get connection details for a specific MSSQL connection.",
+                "icon": "$(info)"
+            },
+            {
+                "name": "mssql_change_database",
+                "modelDescription": "Change the database for an existing MSSQL connection. Disconnects from current database and reconnects to the specified database using the same connection credentials.",
+                "tags": [
+                    "databases",
+                    "mssql",
+                    "connection",
+                    "change"
+                ],
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "connectionId": {
+                            "description": "Connection ID to change database for.",
+                            "title": "Connection ID",
+                            "type": "string"
+                        },
+                        "database": {
+                            "description": "Database name to switch to.",
+                            "title": "Database Name",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "connectionId",
+                        "database"
+                    ]
+                },
+                "canBeReferencedInPrompt": true,
+                "displayName": "Change MSSQL Database",
+                "toolReferenceName": "mssql_change_database",
+                "userDescription": "Change the database for an existing MSSQL connection.",
+                "icon": "$(arrow-swap)"
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -2054,7 +2054,7 @@
             },
             {
                 "name": "mssql_connect",
-                "modelDescription": "Connect to an MSSQL database server using a server name, an optional database name, and an optional profileId. The server name must be retrieved from mssql_list_servers. The profileId should be used ONLY when the user explicitly mentions a profile name, profile ID, or wants to connect 'using profile X'. Returns a connection ID that is used to interact with the database with other mssql tools. If a specific database is given and the connection fails, use $mssql_list_databases against a connection to the default database to find the correct database name. The connection ID is a UUID",
+                "modelDescription": "Connect to an MSSQL database server using a server name, an optional database name, and an optional profileId. The server name must be retrieved from mssql_list_servers. The profileId should be used ONLY when the user explicitly mentions a profile name, profile ID, or wants to connect 'using profile X'. Returns a connection ID that is used to interact with the database with other mssql tools. If a specific database is given and the connection fails, use mssql_list_databases against a connection to the default database to find the correct database name. The connection ID is a UUID.",
                 "tags": [
                     "databases",
                     "mssql",
@@ -2202,7 +2202,7 @@
             },
             {
                 "name": "mssql_change_database",
-                "modelDescription": "Change the database for an existing MSSQL connection. Disconnects from current database and reconnects to the specified database using the same connection credentials.",
+                "modelDescription": "Change the database for an existing MSSQL connection. Before changing, consider using mssql_list_databases to show available database options to the user. Disconnects from current database and reconnects to the specified database using the same connection credentials.",
                 "tags": [
                     "databases",
                     "mssql",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -178,7 +178,10 @@ export const msalCacheFileName = "accessTokenCache";
 export const copilotConnectToolName = "mssql_connect";
 export const copilotDisconnectToolName = "mssql_disconnect";
 export const copilotListServersToolName = "mssql_list_servers";
+export const copilotListDatabasesToolName = "mssql_list_databases";
+export const copilotChangeDatabaseToolName = "mssql_change_database";
 export const copilotShowSchemaToolName = "mssql_show_schema";
+export const copilotGetConnectionDetailsToolName = "mssql_get_connection_details";
 
 // Configuration Constants
 export const copyIncludeHeaders = "copyIncludeHeaders";

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1362,6 +1362,20 @@ export class MssqlChatAgent {
             comment: ["{0} is the connection ID", "{1} is the database name"],
         });
     };
+    public static changeDatabaseToolSuccessMessage = (database: string) => {
+        return l10n.t({
+            message: "Successfully changed to database: {0}",
+            args: [database],
+            comment: ["{0} is the database name"],
+        });
+    };
+    public static changeDatabaseToolFailMessage = (database: string) => {
+        return l10n.t({
+            message: "Failed to connect to database: {0}",
+            args: [database],
+            comment: ["{0} is the database name"],
+        });
+    };
 }
 
 export class QueryEditor {

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1303,7 +1303,7 @@ export class MssqlChatAgent {
             comment: ["{0} is the connection ID"],
         });
     };
-    public static showSchemaToolNoConnectionError = (connectionId: string) => {
+    public static noConnectionError = (connectionId: string) => {
         return l10n.t({
             message: "No connection found for connectionId: {0}",
             args: [connectionId],
@@ -1311,6 +1311,57 @@ export class MssqlChatAgent {
         });
     };
     public static showSchemaToolSuccessMessage = l10n.t("Schema visualization opened.");
+    public static getConnectionDetailsToolConfirmationTitle = l10n.t("Get Connection Details");
+    public static getConnectionDetailsToolConfirmationMessage = (connectionId: string) => {
+        return l10n.t({
+            message: "Get connection details for connection '{0}'?",
+            args: [connectionId],
+            comment: ["{0} is the connection ID"],
+        });
+    };
+    public static getConnectionDetailsToolInvocationMessage = (connectionId: string) => {
+        return l10n.t({
+            message: "Getting connection details for connection '{0}'",
+            args: [connectionId],
+            comment: ["{0} is the connection ID"],
+        });
+    };
+    public static listDatabasesToolConfirmationTitle = l10n.t("List Databases");
+    public static listDatabasesToolConfirmationMessage = (connectionId: string) => {
+        return l10n.t({
+            message: "List databases for connection '{0}'?",
+            args: [connectionId],
+            comment: ["{0} is the connection ID"],
+        });
+    };
+    public static listDatabasesToolInvocationMessage = (connectionId: string) => {
+        return l10n.t({
+            message: "Listing databases for connection '{0}'",
+            args: [connectionId],
+            comment: ["{0} is the connection ID"],
+        });
+    };
+    public static changeDatabaseToolConfirmationTitle = l10n.t("Change Database");
+    public static changeDatabaseToolConfirmationMessage = (
+        connectionId: string,
+        database: string,
+    ) => {
+        return l10n.t({
+            message: "Change database to '{1}' for connection '{0}'?",
+            args: [connectionId, database],
+            comment: ["{0} is the connection ID", "{1} is the database name"],
+        });
+    };
+    public static changeDatabaseToolInvocationMessage = (
+        connectionId: string,
+        database: string,
+    ) => {
+        return l10n.t({
+            message: "Changing database to '{1}' for connection '{0}'",
+            args: [connectionId, database],
+            comment: ["{0} is the connection ID", "{1} is the database name"],
+        });
+    };
 }
 
 export class QueryEditor {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -462,7 +462,7 @@ export default class MainController implements vscode.Disposable {
                     }
                     vscode.commands.executeCommand(
                         "workbench.action.chat.openAgent",
-                        `Connect to ${connectionCredentials.server},${connectionCredentials.database}.`,
+                        `Connect to ${connectionCredentials.server},${connectionCredentials.database}${connectionCredentials.profileName ? ` using profile ${connectionCredentials.profileName}` : ""}.`,
                     );
                 },
             );

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -71,6 +71,9 @@ import { ShowSchemaTool } from "../copilot/tools/showSchemaTool";
 import { ConnectTool } from "../copilot/tools/connectTool";
 import { ListServersTool } from "../copilot/tools/listServersTool";
 import { DisconnectTool } from "../copilot/tools/disconnectTool";
+import { GetConnectionDetailsTool } from "../copilot/tools/getConnectionDetailsTool";
+import { ChangeDatabaseTool } from "../copilot/tools/changeDatabaseTool";
+import { ListDatabasesTool } from "../copilot/tools/listDatabasesTool";
 import { ConnectionGroupNode } from "../objectExplorer/nodes/connectionGroupNode";
 import { ConnectionGroupWebviewController } from "./connectionGroupWebviewController";
 import { ContainerDeploymentWebviewController } from "../containerDeployment/containerDeploymentWebviewController";
@@ -572,45 +575,79 @@ export default class MainController implements vscode.Disposable {
                 this.onDidChangeConfiguration(params),
             );
 
-            this._context.subscriptions.push(
-                vscode.lm.registerTool(
-                    "mssql_show_schema",
-                    new ShowSchemaTool(
-                        this.connectionManager,
-                        async (connectionUri: string, database: string) => {
-                            const designer =
-                                await SchemaDesignerWebviewManager.getInstance().getSchemaDesigner(
-                                    this._context,
-                                    this._vscodeWrapper,
-                                    this,
-                                    this.schemaDesignerService,
-                                    database,
-                                    undefined,
-                                    connectionUri,
-                                );
-                            designer.revealToForeground();
-                        },
-                    ),
-                ),
-            );
-            this._context.subscriptions.push(
-                vscode.lm.registerTool("mssql_connect", new ConnectTool(this.connectionManager)),
-            );
-            this._context.subscriptions.push(
-                vscode.lm.registerTool(
-                    "mssql_disconnect",
-                    new DisconnectTool(this.connectionManager),
-                ),
-            );
-            this._context.subscriptions.push(
-                vscode.lm.registerTool(
-                    "mssql_list_servers",
-                    new ListServersTool(this.connectionManager),
-                ),
-            );
+            this.registerLanguageModelTools();
 
             return true;
         }
+    }
+
+    /**
+     * Helper method to register all language model tools
+     */
+    private registerLanguageModelTools(): void {
+        // Register mssql_connect tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool("mssql_connect", new ConnectTool(this.connectionManager)),
+        );
+
+        // Register mssql_disconnect tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool("mssql_disconnect", new DisconnectTool(this.connectionManager)),
+        );
+
+        // Register mssql_list_servers tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool(
+                "mssql_list_servers",
+                new ListServersTool(this.connectionManager),
+            ),
+        );
+
+        // Register mssql_list_databases tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool(
+                "mssql_list_databases",
+                new ListDatabasesTool(this.connectionManager),
+            ),
+        );
+
+        // Register mssql_get_connection_details tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool(
+                "mssql_get_connection_details",
+                new GetConnectionDetailsTool(this.connectionManager),
+            ),
+        );
+
+        // Register mssql_change_database tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool(
+                "mssql_change_database",
+                new ChangeDatabaseTool(this.connectionManager),
+            ),
+        );
+        // Register mssql_show_schema tool
+        this._context.subscriptions.push(
+            vscode.lm.registerTool(
+                "mssql_show_schema",
+                new ShowSchemaTool(
+                    this.connectionManager,
+                    async (connectionUri: string, database: string) => {
+                        const designer =
+                            await SchemaDesignerWebviewManager.getInstance().getSchemaDesigner(
+                                this._context,
+                                this._vscodeWrapper,
+                                this,
+                                this.schemaDesignerService,
+                                database,
+                                undefined,
+                                connectionUri,
+                            );
+                        designer.revealToForeground();
+                    },
+                ),
+            ),
+        );
     }
 
     /**

--- a/src/copilot/tools/changeDatabaseTool.ts
+++ b/src/copilot/tools/changeDatabaseTool.ts
@@ -42,12 +42,36 @@ export class ChangeDatabaseTool extends ToolBase<ChangeDatabaseToolParams> {
                 });
             }
 
-            // TODO: Implement actual database change logic
-            console.log(`TODO: Change to database: ${database}`);
+            // Check if the connection is currently connected
+            if (!this.connectionManager.isConnected(connectionId)) {
+                return JSON.stringify({
+                    success: false,
+                    message: loc.noConnectionError(connectionId),
+                });
+            }
 
-            return JSON.stringify({
-                success: true,
-            } as ChangeDatabaseToolResult);
+            // Create new connection credentials with the new database
+            const newConnectionCreds = { ...connCreds };
+            newConnectionCreds.database = database;
+
+            // Disconnect from current database and reconnect to new one
+            await this.connectionManager.disconnect(connectionId);
+            const connectResult = await this.connectionManager.connect(
+                connectionId,
+                newConnectionCreds,
+            );
+
+            if (connectResult) {
+                return JSON.stringify({
+                    success: true,
+                    message: loc.changeDatabaseToolSuccessMessage(database),
+                } as ChangeDatabaseToolResult);
+            } else {
+                return JSON.stringify({
+                    success: false,
+                    message: loc.changeDatabaseToolFailMessage(database),
+                } as ChangeDatabaseToolResult);
+            }
         } catch (err) {
             return JSON.stringify({
                 success: false,

--- a/src/copilot/tools/connectTool.ts
+++ b/src/copilot/tools/connectTool.ts
@@ -9,6 +9,7 @@ import ConnectionManager from "../../controllers/connectionManager";
 import * as Constants from "../../constants/constants";
 import { MssqlChatAgent as loc } from "../../constants/locConstants";
 import { getErrorMessage } from "../../utils/utils";
+import { randomUUID } from "crypto";
 
 /** Parameters for the connect tool. */
 export interface ConnectToolParams {
@@ -119,14 +120,9 @@ export class ConnectTool extends ToolBase<ConnectToolParams> {
             } as ConnectToolResult);
         }
 
-        // Determine the connection ID and database to use
-        const targetServer = result.profile.server;
+        // Determine the database to use
         const targetDatabase = database || result.profile.database;
-
-        let connectionId = `${Constants.extensionName}/${targetServer}`;
-        if (targetDatabase) {
-            connectionId += `/${targetDatabase}`;
-        }
+        let connectionId = randomUUID();
 
         let success: boolean;
         let message: string;

--- a/src/copilot/tools/getConnectionDetailsTool.ts
+++ b/src/copilot/tools/getConnectionDetailsTool.ts
@@ -23,7 +23,15 @@ export interface GetConnectionDetailsToolResult {
 
 type IConnectionInfoSubset = Pick<
     IConnectionInfo,
-    "server" | "database" | "authenticationType" | "user" | "email" | "accountId" | "tenantId"
+    | "server"
+    | "database"
+    | "authenticationType"
+    | "user"
+    | "email"
+    | "accountId"
+    | "tenantId"
+    | "trustServerCertificate"
+    | "applicationIntent"
 >;
 
 export class GetConnectionDetailsTool extends ToolBase<GetConnectionDetailsToolParams> {
@@ -47,7 +55,17 @@ export class GetConnectionDetailsTool extends ToolBase<GetConnectionDetailsToolP
                     message: loc.noConnectionError(connectionId),
                 } as GetConnectionDetailsToolResult);
             }
-            const res = { ...connCreds } as IConnectionInfoSubset;
+            const res: IConnectionInfoSubset = {
+                server: connCreds.server,
+                database: connCreds.database,
+                authenticationType: connCreds.authenticationType,
+                user: connCreds.user,
+                email: connCreds.email,
+                accountId: connCreds.accountId,
+                tenantId: connCreds.tenantId,
+                trustServerCertificate: connCreds.trustServerCertificate,
+                applicationIntent: connCreds.applicationIntent,
+            };
 
             return JSON.stringify({
                 success: true,


### PR DESCRIPTION
## Description

This PR adds 3 more agent tools in the connection area:
1. `get_connection_details`
2. `list_databases`
3. `change_database`

A few miscellaneous fixes: 
1. Updates the connection ID generation logic to use UUID in the existing `connect` tool to support changing database action.
2. Updates model description for a few tools

A chat transcript using the newly added tools is provided at the end of this description.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)


## Transcript
<details>
<summary>Chat transcript with the new tools</summary>

```md
caohai: Connect to localhost, using profile local-sql-server.

GitHub Copilot: I'll help you connect to localhost using the profile "local-sql-server". Let me first check what servers are available and then connect using the specified profile. Perfect! I can see the "local-sql-server" profile is available. Now I'll connect to localhost using this profile. Great! I've successfully connected to localhost using the "local-sql-server" profile. The connection has been established with connection ID `089d3579-53f3-471d-bc6c-54ef1c1713cd`.

You can now run SQL queries against this connection. The profile connected to the localhost server without specifying a particular database, so you'll be connected to the default database. If you need to work with a specific database, I can help you list the available databases or change to a different one.

caohai: tell me about the connection

GitHub Copilot: I'll get the details about your current connection to provide you with comprehensive information. Here are the details about your current SQL Server connection:

**Connection Information:**
- **Server**: localhost
- **Database**: master (default database)
- **Authentication Type**: Integrated (Windows Authentication)
- **User**: Using your Windows credentials
- **Trust Server Certificate**: Yes
- **Connection ID**: 089d3579-53f3-471d-bc6c-54ef1c1713cd
- **Profile Used**: local-sql-server

You're currently connected to the `master` database on your local SQL Server instance using Windows Authentication. The `master` database is the system database that contains system-level information for the SQL Server instance.

If you'd like to see what other databases are available on this server or switch to a different database, I can help you with that. You can also start writing SQL queries in your current file to interact with the database.

caohai: change to the DW database

GitHub Copilot: I'll help you change to the DW database. First, let me check what databases are available on your server to make sure the DW database exists. I can see there's an "AdventureWorksDW2022" database available, which appears to be the data warehouse database you're referring to. Let me change your connection to that database. Perfect! I've successfully changed your connection to the **AdventureWorksDW2022** database. You're now connected to the data warehouse database and can run queries against its tables and views.

The AdventureWorksDW2022 is a sample data warehouse database that contains dimensional modeling structures typically used for business intelligence and reporting purposes. You can now write SQL queries in your current file to explore and analyze the data warehouse.

caohai: tell me about this connection

GitHub Copilot: I'll get the updated connection details to show you the current state of your connection. Here are the updated details about your current SQL Server connection:

**Connection Information:**
- **Server**: localhost
- **Database**: AdventureWorksDW2022 (Data Warehouse)
- **Authentication Type**: Integrated (Windows Authentication)
- **User**: Using your Windows credentials
- **Trust Server Certificate**: Yes
- **Connection ID**: 089d3579-53f3-471d-bc6c-54ef1c1713cd
- **Profile Used**: local-sql-server

**About AdventureWorksDW2022:**
This is Microsoft's sample data warehouse database, designed for business intelligence and analytics scenarios. It contains:
- Dimensional tables (DimCustomer, DimProduct, DimDate, etc.)
- Fact tables (FactInternetSales, FactResellerSales, etc.)
- Data warehouse structures optimized for reporting and analysis
- Sample data spanning multiple years of business operations

You're now ready to run data warehouse queries, create reports, or perform business intelligence analysis using this connection. The database contains pre-built dimensional modeling structures that are perfect for learning and practicing SQL analytics and reporting queries.

caohai: show schema of it

GitHub Copilot: I'll open the schema designer to show you a visual representation of the AdventureWorksDW2022 database schema. Perfect! I've opened the interactive schema designer for the AdventureWorksDW2022 database. This will show you a graphical view of:

- **All tables and their relationships**
- **Dimension tables** (like DimCustomer, DimProduct, DimDate, DimGeography, etc.)
- **Fact tables** (like FactInternetSales, FactResellerSales, etc.)
- **Foreign key relationships** between tables
- **Table structures** with column names and data types

The schema designer provides an interactive visual representation where you can:
- See how tables are connected through relationships
- Explore the star/snowflake schema design typical of data warehouses
- Click on tables to see their column details
- Understand the dimensional modeling structure

This visual representation will help you understand the data warehouse structure and plan your queries effectively. The AdventureWorksDW2022 follows a typical dimensional modeling approach with fact tables at the center connected to various dimension tables.
```
</details>


