### PR TITLE
Fix issue with loading DB name for schema compare open

### DIFF
--- a/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/src/schemaCompare/schemaCompareWebViewController.ts
@@ -142,13 +142,10 @@ export class SchemaCompareWebViewController extends ReactWebviewPanelController<
     ): Promise<void> {
         let source: mssql.SchemaCompareEndpointInfo;
 
-        let connectionProfile: IConnectionProfile | undefined = sourceContext
-            ? (sourceContext.connectionInfo as IConnectionProfile)
-            : undefined;
-
-        if (connectionProfile) {
+        const node = sourceContext as TreeNodeInfo;
+        if (node.connectionProfile) {
             source = await this.getEndpointInfoFromConnectionProfile(
-                connectionProfile,
+                node.connectionProfile,
                 sourceContext,
             );
         } else if (


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
This PR fixes an issue with the schema compare dialog not loading the source endpoint when it is opened by right clicking on a database node.

### Before
![LoadSourceDbOnOpenMissing](https://github.com/user-attachments/assets/e03f2236-d22a-4f72-8b37-691c1ec77d80)


### After
![LoadSourceDbOnOpen](https://github.com/user-attachments/assets/d5d8d15a-9c06-4f32-8637-fba9ab2501ea)


*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

