### PR TITLE
Fixing early disposal of schema designer

### DIFF
--- a/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -311,7 +311,9 @@ export class SchemaDesignerWebviewController extends ReactWebviewPanelController
     }
 
     override async dispose(): Promise<void> {
-        this.updateCacheItem(this.schemaDesignerDetails!.schema);
+        if (this.schemaDesignerDetails) {
+            this.updateCacheItem(this.schemaDesignerDetails!.schema);
+        }
         super.dispose();
     }
 }

--- a/src/schemaDesigner/schemaDesignerWebviewManager.ts
+++ b/src/schemaDesigner/schemaDesignerWebviewManager.ts
@@ -82,7 +82,7 @@ export class SchemaDesignerWebviewManager {
         }
 
         const key = `${connectionString}-${databaseName}`;
-        if (!this.schemaDesigners.has(key)) {
+        if (!this.schemaDesigners.has(key) || this.schemaDesigners.get(key)?.isDisposed) {
             const schemaDesigner = new SchemaDesignerWebviewController(
                 context,
                 vscodeWrapper,
@@ -126,9 +126,15 @@ export class SchemaDesignerWebviewManager {
                         );
                     }
                 }
-                schemaDesignerService.disposeSession({
-                    sessionId: this.schemaDesignerCache.get(key).schemaDesignerDetails.sessionId,
-                });
+                // Ignoring errors here as we don't want to block the disposal process
+                try {
+                    schemaDesignerService.disposeSession({
+                        sessionId:
+                            this.schemaDesignerCache.get(key).schemaDesignerDetails.sessionId,
+                    });
+                } catch (error) {
+                    console.error(`Error disposing schema designer session: ${error}`);
+                }
                 this.schemaDesignerCache.delete(key);
             });
             this.schemaDesigners.set(key, schemaDesigner);


### PR DESCRIPTION
…disposal

# Pull Request Template – vscode-mssql

## Description

Previously, if we closed the Schema Designer before it finished initializing, the Schema Designer Manager would get stuck referencing a disposed instance. As a result, trying to reopen the Schema Designer later would fail because the cache attempted to use the already-disposed instance.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

