### PR TITLE
Using correct Synapse endpoint information in Azure Browse UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
         "@azure/arm-resources": "^5.0.0",
         "@azure/arm-sql": "^9.0.0",
         "@azure/arm-subscriptions": "^5.0.0",
+        "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/msal-common": "^14.14.0",
         "@azure/msal-node": "^2.12.0",
         "@microsoft/ads-extension-telemetry": "^3.0.2",

--- a/src/azure/providerSettings.ts
+++ b/src/azure/providerSettings.ts
@@ -5,6 +5,8 @@
 
 import { IProviderSettings } from "../models/contracts/azure";
 
+// TODO: source these values from ms-rest-azure-env package where possible
+
 const publicAzureSettings: IProviderSettings = {
     displayName: "publicCloudDisplayName",
     id: "azure_publicCloud",
@@ -27,6 +29,8 @@ const publicAzureSettings: IProviderSettings = {
             id: "sql",
             resource: "Sql",
             endpoint: "https://database.windows.net/",
+            dnsSuffix: "database.windows.net",
+            analyticsDnsSuffix: "sql.azuresynapse.net",
         },
         azureKeyVaultResource: {
             id: "vault",

--- a/src/connectionconfig/azureHelpers.ts
+++ b/src/connectionconfig/azureHelpers.ts
@@ -260,6 +260,7 @@ export async function fetchServersFromAzure(sub: AzureSubscription): Promise<Azu
             location: server.location,
             resourceGroup: extractFromResourceId(server.id, "resourceGroups"),
             subscription: `${sub.name} (${sub.subscriptionId})`,
+            kind: server.kind,
         });
     }
 

--- a/src/connectionconfig/azureHelpers.ts
+++ b/src/connectionconfig/azureHelpers.ts
@@ -5,8 +5,6 @@
 
 import * as vscode from "vscode";
 import { l10n } from "vscode";
-import { Azure as Loc } from "../constants/locConstants";
-
 import {
     AzureSubscription,
     AzureTenant,
@@ -14,6 +12,8 @@ import {
 } from "@microsoft/vscode-azext-azureauth";
 import { GenericResourceExpanded, ResourceManagementClient } from "@azure/arm-resources";
 
+import { Azure as Loc } from "../constants/locConstants";
+import providerSettings from "../azure/providerSettings";
 import { IAccount, ITenant } from "../models/contracts/azure";
 import { FormItemOptions } from "../sharedInterfaces/form";
 import { AzureAccountService } from "../services/azureAccountService";
@@ -463,8 +463,8 @@ export function extractFromResourceId(resourceId: string, property: string): str
 
 export function buildServerUri(serverResource: GenericResourceExpanded): string {
     const suffix = serverResource.kind.includes("analytics")
-        ? "sql.azuresynapse.net"
-        : "database.windows.net";
+        ? providerSettings.resources.databaseResource.analyticsDnsSuffix
+        : providerSettings.resources.databaseResource.dnsSuffix;
 
     // Construct the URI based on the server kind
     return `${serverResource.name}.${suffix}`;

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -34,7 +34,6 @@ import {
     refreshTokenLabel,
 } from "../constants/locConstants";
 import {
-    fetchServersFromAzure,
     getAccounts,
     getTenants,
     promptForAzureSubscriptionFilter,
@@ -1287,7 +1286,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         const stateSub = state.azureSubscriptions.find((s) => s.id === subscriptionId);
 
         try {
-            const servers = await fetchServersFromAzure(azSub);
+            const servers = await VsCodeAzureHelper.fetchServersFromAzure(azSub);
             state.azureServers.push(...servers);
             stateSub.loaded = true;
             this.updateState();

--- a/src/models/contracts/azure.ts
+++ b/src/models/contracts/azure.ts
@@ -136,7 +136,7 @@ export interface IProviderResources {
     windowsManagementResource: IAADResource;
     azureManagementResource: IAADResource;
     graphResource?: IAADResource;
-    databaseResource?: IAADResource;
+    databaseResource?: IAADResource & { analyticsDnsSuffix?: string };
     ossRdbmsResource?: IAADResource;
     azureKeyVaultResource?: IAADResource;
     azureDevopsResource?: IAADResource;
@@ -146,7 +146,9 @@ export interface IAADResource {
     id: string;
     resource: string;
     endpoint: string;
+    dnsSuffix?: string;
 }
+
 /**
  * Error to be used when the user has cancelled the prompt or refresh methods. When
  * AccountProvider.refresh or AccountProvider.prompt are rejected with this error, the error

--- a/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -46,14 +46,14 @@ export const azureLogoColor = () => {
 
 export const AzureBrowsePage = () => {
     const context = useContext(ConnectionDialogContext);
+    if (context === undefined) {
+        return undefined;
+    }
+
     const formStyles = useFormStyles();
     const styles = useStyles();
 
     const [isAdvancedDrawerOpen, setIsAdvancedDrawerOpen] = useState(false);
-
-    if (context === undefined) {
-        return undefined;
-    }
 
     const [subscriptions, setSubscriptions] = useState<string[]>([]);
     const [selectedSubscription, setSelectedSubscription] = useState<string | undefined>(undefined);
@@ -83,7 +83,15 @@ export const AzureBrowsePage = () => {
         }
 
         setSelectedServer(server);
-        setConnectionProperty("server", server ? server + ".database.windows.net" : "");
+
+        let serverUri = "";
+
+        if (server) {
+            const srv = context?.state.azureServers.find((s) => s.server === server);
+            serverUri = srv?.uri || "";
+        }
+
+        setConnectionProperty("server", serverUri);
     }
 
     // #region Effects

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -100,7 +100,7 @@ export interface AzureSqlServerInfo {
     location: string;
     resourceGroup: string;
     subscription: string;
-    kind?: string;
+    uri: string;
 }
 
 export interface ConnectionComponentsInfo {

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -100,6 +100,7 @@ export interface AzureSqlServerInfo {
     location: string;
     resourceGroup: string;
     subscription: string;
+    kind?: string;
 }
 
 export interface ConnectionComponentsInfo {

--- a/test/unit/azureHelperStubs.ts
+++ b/test/unit/azureHelperStubs.ts
@@ -10,6 +10,7 @@ import { AzureSubscription, AzureTenant } from "@microsoft/vscode-azext-azureaut
 import * as AzureHelpers from "../../src/connectionconfig/azureHelpers";
 import { AzureSqlServerInfo } from "../../src/sharedInterfaces/connectionDialog";
 import { MssqlVSCodeAzureSubscriptionProvider } from "../../src/azure/MssqlVSCodeAzureSubscriptionProvider";
+import { GenericResourceExpanded } from "@azure/arm-resources";
 
 export const mockSubscriptions = [
     {
@@ -55,6 +56,56 @@ export const mockAccounts = [
     },
 ] as vscode.AuthenticationSessionAccountInformation[];
 
+const mockServerName = "testServer";
+
+export const mockAzureResources = {
+    azureSqlDbServer: {
+        id: `/subscriptions/${mockSubscriptions[0].subscriptionId}/resourceGroups/DefaultResourceGroup/providers/Microsoft.Sql/servers/${mockServerName}`,
+        name: mockServerName,
+        type: "Microsoft.Sql/servers",
+        location: "eastus2",
+        tags: {},
+        kind: "v12.0",
+    } as GenericResourceExpanded,
+    azureSqlDbDatabase1: {
+        id: `/subscriptions/${mockSubscriptions[0].subscriptionId}/resourceGroups/DefaultResourceGroup/providers/Microsoft.Sql/servers/${mockServerName}/databases/master`,
+        name: `${mockServerName}/master`,
+        type: "Microsoft.Sql/servers/databases",
+        location: "eastus2",
+        kind: "v12.0,system",
+    } as GenericResourceExpanded,
+    azureSqlDbDatabase2: {
+        id: `/subscriptions/${mockSubscriptions[0].subscriptionId}/resourceGroups/DefaultResourceGroup/providers/Microsoft.Sql/servers/${mockServerName}/databases/testDatabase`,
+        name: `${mockServerName}/testDatabase`,
+        type: "Microsoft.Sql/servers/databases",
+        location: "eastus2",
+        tags: {},
+        kind: "v12.0,user,vcore,serverless",
+    } as GenericResourceExpanded,
+    azureSynapseAnalyticsServer: {
+        id: `/subscriptions/${mockSubscriptions[0].subscriptionId}/resourceGroups/synapseworkspace-managedrg-c84a69f0-b14e-4c86-b27a-1cefe6d68262/providers/Microsoft.Sql/servers/${mockServerName}-synapse`,
+        name: `${mockServerName}-synapse`,
+        type: "Microsoft.Sql/servers",
+        location: "eastus2",
+        kind: "v12.0,analytics",
+    } as GenericResourceExpanded,
+    nonDatabaseResource: {
+        id: `/subscriptions/${mockSubscriptions[0].subscriptionId}/resourceGroups/DefaultResourceGroup/providers/Microsoft.Storage/storageAccounts/testStorage`,
+        name: `testStorage`,
+        type: "Microsoft.Storage/storageAccounts",
+        location: "eastus2",
+        kind: "StorageV2",
+    } as GenericResourceExpanded,
+};
+
+export const mockAzureResourceList = [
+    mockAzureResources.azureSqlDbServer,
+    mockAzureResources.azureSqlDbDatabase1,
+    mockAzureResources.azureSqlDbDatabase2,
+    mockAzureResources.azureSynapseAnalyticsServer,
+    mockAzureResources.nonDatabaseResource,
+];
+
 export function stubIsSignedIn(sandbox: Sinon.SinonSandbox, result: boolean) {
     return sandbox.stub(AzureHelpers.VsCodeAzureHelper, "isSignedIn").resolves(result);
 }
@@ -73,7 +124,7 @@ export function stubVscodeAzureHelperGetAccounts(sandbox: sinon.SinonSandbox) {
 
 export function stubFetchServersFromAzure(sandbox: sinon.SinonSandbox) {
     return sandbox
-        .stub(AzureHelpers, "fetchServersFromAzure")
+        .stub(AzureHelpers.VsCodeAzureHelper, "fetchServersFromAzure")
         .callsFake(async (sub: AzureSubscription) => {
             return [
                 {


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/vscode-mssql/issues/19635

Detecting whether a server exposed from Azure resource listing is a dedicated SQL endpoint for an Azure Synapse Analytics server, and using the appropriate DNS suffix if so.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

