### PR TITLE
Correcting command categories and cleaning up palette list

### DIFF
--- a/package.json
+++ b/package.json
@@ -757,6 +757,10 @@
                 {
                     "command": "mssql.connectionGroups.delete",
                     "when": "false"
+                },
+                {
+                    "command": "mssql.editConnection",
+                    "when": "false"
                 }
             ],
             "webview/context": [


### PR DESCRIPTION
## Description

* Fixing some unaligned command palette groups (`MSSQL` instead of `MS SQL`)
* Removing some commands from the command palette that must be launched from OE

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

