### PR TITLE
Upgrading to TS 5.8 and ES2024 compile targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
         "systemjs-plugin-json": "^0.2.0",
         "ts-node": "^10.9.2",
         "typemoq": "^1.7.0",
-        "typescript": "^5.6.2",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0",
         "uglify-js": "mishoo/UglifyJS2#harmony-v2.8.22",
         "vite": "^6.2.7",

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1157,10 +1157,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             this._azureSubscriptions = new Map(
                 (await auth.getSubscriptions(shouldUseFilter)).map((s) => [s.subscriptionId, s]),
             );
-            const tenantSubMap = this.groupBy<string, AzureSubscription>(
-                Array.from(this._azureSubscriptions.values()),
-                "tenantId",
-            ); // TODO: replace with Object.groupBy once ES2024 is supported
+            const tenantSubMap = Map.groupBy(this._azureSubscriptions.values(), (s) => s.tenantId);
 
             const subs: AzureSubscriptionInfo[] = [];
 
@@ -1292,17 +1289,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         )) {
             component.validation = undefined;
         }
-    }
-
-    private groupBy<K, V>(values: V[], key: keyof V): Map<K, V[]> {
-        return values.reduce((rv, x) => {
-            const keyValue = x[key] as K;
-            if (!rv.has(keyValue)) {
-                rv.set(keyValue, []);
-            }
-            rv.get(keyValue)!.push(x);
-            return rv;
-        }, new Map<K, V[]>());
     }
 
     private async hydrateConnectionDetailsFromProfile(

--- a/tsconfig.extension.json
+++ b/tsconfig.extension.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "outDir": "out",
         "module": "CommonJS",
-        "target": "es2024",
-        "lib": ["es6", "ES2024", "dom"],
+        "target": "ES2024",
+        "lib": ["ES2024", "dom"],
         "sourceMap": true,
         "allowUnusedLabels": false,
         "allowSyntheticDefaultImports": true,

--- a/tsconfig.extension.json
+++ b/tsconfig.extension.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "outDir": "out",
         "module": "CommonJS",
-        "target": "ES6",
-        "lib": ["es6", "ES2020", "dom"],
+        "target": "es2024",
+        "lib": ["es6", "ES2024", "dom"],
         "sourceMap": true,
         "allowUnusedLabels": false,
         "allowSyntheticDefaultImports": true,

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
-        "target": "ES2020",
+        "target": "ES2024",
         "useDefineForClassFields": true,
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "lib": ["ES2024", "DOM", "DOM.Iterable"],
         "module": "ESNext",
         "skipLibCheck": true,
         /* Bundler mode */

--- a/yarn.lock
+++ b/yarn.lock
@@ -12838,10 +12838,10 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Upgrading to `ES2024` target - which in turn required upgrading to TypeScript 5.8 - to be able to use new library functions, like `Map.groupBy()`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

