### PR TITLE
Adding an overlay on related tables for filtered nodes. 

### DIFF
--- a/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
+++ b/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
@@ -89,6 +89,14 @@ const useStyles = makeStyles({
     actionButton: {
         marginLeft: "auto",
     },
+    tableOverlay: {
+        position: "absolute",
+        inset: 0,
+        backgroundColor: "var(--vscode-editor-background)",
+        opacity: 0.3,
+        pointerEvents: "none",
+        zIndex: 10,
+    },
 });
 
 // TableHeaderActions component for the edit button and menu
@@ -288,6 +296,7 @@ export const SchemaDesignerTableNode = (props: NodeProps) => {
 
     return (
         <div className={styles.tableNodeContainer}>
+            {(props.data?.dimmed as boolean) && <div className={styles.tableOverlay} />}
             <TableHeader table={table} />
             <Divider />
             <TableColumns columns={table.columns} table={table} />

--- a/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
+++ b/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles({
         position: "absolute",
         inset: 0,
         backgroundColor: "var(--vscode-editor-background)",
-        opacity: 0.3,
+        opacity: 0.4,
         pointerEvents: "none",
         zIndex: 10,
     },

--- a/src/reactviews/pages/SchemaDesigner/toolbar/filterTablesButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/filterTablesButton.tsx
@@ -46,7 +46,7 @@ export function FilterTablesButton() {
             setSelectedTables([]);
         } else {
             const visibleTables = nodes
-                .filter((node) => !node.hidden && node.style?.opacity !== 0.6)
+                .filter((node) => !node.hidden && node.data.dimmed !== true)
                 .map((node) => `${node.data.schema}.${node.data.name}`);
             setSelectedTables(visibleTables);
         }
@@ -112,19 +112,21 @@ export function FilterTablesButton() {
                     const isSelectedTable = selectedTables.includes(tableName);
                     const isRelatedTable = relatedTables.includes(tableName);
 
-                    // Apply reduced opacity to related tables that are not explicitly selected
-                    const opacity = isSelectedTable || !isRelatedTable ? 1 : 0.6;
+                    const dimmed = !isSelectedTable && isRelatedTable;
 
                     reactFlow.updateNode(node.id, {
                         ...node,
                         hidden: false,
-                        style: { ...node.style, opacity },
+                        data: {
+                            ...node.data,
+                            dimmed,
+                        },
                     });
                 } else {
                     reactFlow.updateNode(node.id, {
                         ...node,
                         hidden: true,
-                        style: { ...node.style, opacity: 1 },
+                        data: { ...node.data, dimmed: false },
                     });
                 }
             });


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Switched to using a `div`-based overlay for related tables of filtered nodes instead of changing the node's CSS opacity directly. This approach keeps the node background opaque while visually graying out the unrelated nodes.

Before:
<img width="631" height="447" alt="image" src="https://github.com/user-attachments/assets/82eb4b11-d48d-4ffa-9fcb-0ca0cc76b6aa" />



Now:
<img width="1211" height="515" alt="image" src="https://github.com/user-attachments/assets/49022ba7-eca2-4d42-9ff2-4311bfc7d64b" />


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

