### PR TITLE
move sqlcmd toggle to context menu, fix command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -392,6 +392,11 @@
                     "group": "0_mssql"
                 },
                 {
+                    "command": "mssql.toggleSqlCmd",
+                    "when": "editorLangId == sql",
+                    "group": "0_mssql"
+                },
+                {
                     "submenu": "mssql.copilot.editorSubmenu",
                     "when": "editorLangId == sql && mssql.copilot.isGHCInstalled",
                     "group": "0_mssql"
@@ -713,10 +718,6 @@
                 {
                     "command": "mssql.disconnectObjectExplorerNode",
                     "when": "view == objectExplorer && viewItem =~ /\\btype=(Server)\\b/"
-                },
-                {
-                    "command": "mssql.toggleSqlCmd",
-                    "when": "editorFocus && editorLangId == 'sql'"
                 },
                 {
                     "command": "mssql.startQueryHistoryCapture",

--- a/package.json
+++ b/package.json
@@ -392,11 +392,6 @@
                     "group": "0_mssql"
                 },
                 {
-                    "command": "mssql.toggleSqlCmd",
-                    "when": "editorLangId == sql",
-                    "group": "0_mssql"
-                },
-                {
                     "submenu": "mssql.copilot.editorSubmenu",
                     "when": "editorLangId == sql && mssql.copilot.isGHCInstalled",
                     "group": "0_mssql"


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

resolves https://github.com/microsoft/vscode-mssql/issues/18127

puts sqlcmd toggle in the editor context menu **(removed in https://github.com/microsoft/vscode-mssql/pull/19755/commits/a97abeb18d3050ec0d48bf444e137e23b464958f)**

<img width="255" height="233" alt="image" src="https://github.com/user-attachments/assets/4e856e39-a71b-4341-a585-4bee03ff0e61" />


and in the command palette

<img width="622" height="241" alt="image" src="https://github.com/user-attachments/assets/233d0289-3129-437f-b868-04819f32fb2b" />


## Code Changes Checklist

- [ x ] New or updated **unit tests** added
- [ x ] All existing tests pass (`npm run test`)
- [ x ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ x ] Telemetry/logging updated if relevant
- [ x ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

