### PR TITLE
Bump STS version that uses updated Azure.Core dependency

### DIFF
--- a/src/configurations/config.json
+++ b/src/configurations/config.json
@@ -1,7 +1,7 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        "version": "5.0.20250715.2",
+        "version": "5.0.20250715.3",
         "downloadFileNames": {
             "Windows_86": "win-x86-net8.0.zip",
             "Windows_64": "win-x64-net8.0.zip",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR is associated with this issue: https://github.com/microsoft/vscode-mssql/issues/19773

The PR bumps the SQL Tools Service version to a version that uses the Azure.Core 1.41.0 dependency.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

