### PR TITLE
Fixing firewall rule dialog account selection reset upon submission

### DIFF
--- a/src/reactviews/pages/AddFirewallRule/addFirewallRule.component.tsx
+++ b/src/reactviews/pages/AddFirewallRule/addFirewallRule.component.tsx
@@ -87,6 +87,13 @@ export const AddFirewallRuleDialog = ({
     // Update selected tenant when state.tenants changes
     useEffect(() => {
         if (state.accounts.length > 0) {
+            if (
+                selectedAccountId &&
+                state.accounts.find((account) => account.accountId === selectedAccountId)
+            ) {
+                return; // Currently-selected account is still valid; no need to reset selections
+            }
+
             const accountId = state.accounts[0].accountId;
 
             setSelectedAccountId(accountId);

--- a/src/reactviews/pages/AddFirewallRule/addFirewallRule.component.tsx
+++ b/src/reactviews/pages/AddFirewallRule/addFirewallRule.component.tsx
@@ -98,7 +98,7 @@ export const AddFirewallRuleDialog = ({
                 setTenantDisplayText(formatTenant(tenant));
             }
         }
-    }, [state.accounts, state.tenants]);
+    }, [JSON.stringify(state.accounts), JSON.stringify(state.tenants)]);
 
     useEffect(() => {
         if (state.clientIp) {


### PR DESCRIPTION
## Description

Because arrays were used as the triggers for the account refresh/selection effect and the references were changing upon state refresh, the dialog was automatically re-selecting first account in the list.  While this didn't impact the firewall rule creation at all, it's odd to see for users.

## Code Changes Checklist

- [n/a] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

