### PR TITLE
[PORT] Bump slickgrid.ads to 2.3.48 (#19778)

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
         "remap-istanbul": "0.9.6",
         "rxjs": "5.0.0-beta.12",
         "sinon": "^14.0.0",
-        "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.46",
+        "slickgrid": "github:Microsoft/SlickGrid.ADS#2.3.48",
         "source-map-support": "^0.5.21",
         "systemjs": "0.19.40",
         "systemjs-builder": "^0.15.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11682,9 +11682,9 @@ slice-ansi@^7.1.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
-"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.46":
-  version "2.3.46"
-  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/7768663102f64e22fe5dfd9afa4a368c85a28778"
+"slickgrid@github:Microsoft/SlickGrid.ADS#2.3.48":
+  version "2.3.48"
+  resolved "https://codeload.github.com/Microsoft/SlickGrid.ADS/tar.gz/11995e29965581791571f4e7e432dee533a86137"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR is a port request of #19778 

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

