### PR TITLE
Problematic String Conversion when doing cryptography on Credentials

### DIFF
--- a/src/azure/fileEncryptionHelper.ts
+++ b/src/azure/fileEncryptionHelper.ts
@@ -84,10 +84,11 @@ export class FileEncryptionHelper {
         if (!this._keyBuffer || !this._ivBuffer) {
             await this.init();
         }
+        // Use Buffer objects directly for key and IV
         const cipherIv = crypto.createCipheriv(
             this._algorithm,
-            this._keyBuffer!.toString(),
-            this._ivBuffer!.toString(),
+            new Uint8Array(this._keyBuffer!),
+            new Uint8Array(this._ivBuffer!),
         );
         let cipherText = `${cipherIv.update(content, "utf8", this._binaryEncoding)}${cipherIv.final(this._binaryEncoding)}`;
         return cipherText;
@@ -99,10 +100,11 @@ export class FileEncryptionHelper {
                 await this.init();
             }
             let plaintext = content;
+            // Use Buffer objects directly for key and IV
             const decipherIv = crypto.createDecipheriv(
                 this._algorithm,
-                this._keyBuffer!.toString(),
-                this._ivBuffer!.toString(),
+                new Uint8Array(this._keyBuffer!),
+                new Uint8Array(this._ivBuffer!),
             );
             return `${decipherIv.update(plaintext, this._binaryEncoding, "utf8")}${decipherIv.final("utf8")}`;
         } catch (ex) {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

Avoids string conversion by passing buffer objects as Uint8Array to cryptographic methods, ensuring correct key and IV formats and preventing potential encoding errors. This is the only way I could get Microsoft Entra to authenticate successfully in my local build. Windows 11, Latest versions of Node and npm (v22.17.0 and 11.5.2 respectively)

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

