### PR TITLE
Updating node types to 22, changing file encryption IV generation back to buffer from string

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "@types/jquery": "^3.3.31",
         "@types/lockfile": "^1.0.2",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.14.8",
+        "@types/node": "^22.13.14",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/react-resizable": "^3.0.8",

--- a/src/azure/fileEncryptionHelper.ts
+++ b/src/azure/fileEncryptionHelper.ts
@@ -29,12 +29,12 @@ export class FileEncryptionHelper {
         this._bufferEncoding = "utf16le";
         this._binaryEncoding = "base64";
 
-        this.ivCredId = `${this._fileName}-iv`;
-        this.keyCredId = `${this._fileName}-key`;
+        this._ivCredId = `${this._fileName}-iv`;
+        this._keyCredId = `${this._fileName}-key`;
     }
 
-    private readonly ivCredId: string;
-    private readonly keyCredId: string;
+    private readonly _ivCredId: string;
+    private readonly _keyCredId: string;
 
     private _algorithm: string;
     private _bufferEncoding: BufferEncoding;
@@ -43,8 +43,8 @@ export class FileEncryptionHelper {
     private _keyBuffer: Buffer | undefined;
 
     public async init(): Promise<void> {
-        const iv = await this.readEncryptionKey(this.ivCredId);
-        const key = await this.readEncryptionKey(this.keyCredId);
+        const iv = await this.readEncryptionKey(this._ivCredId);
+        const key = await this.readEncryptionKey(this._keyCredId);
 
         if (!iv || !key) {
             this._ivBuffer = crypto.randomBytes(16);
@@ -52,11 +52,11 @@ export class FileEncryptionHelper {
 
             if (
                 !(await this.saveEncryptionKey(
-                    this.ivCredId,
+                    this._ivCredId,
                     this._ivBuffer.toString(this._bufferEncoding),
                 )) ||
                 !(await this.saveEncryptionKey(
-                    this.keyCredId,
+                    this._keyCredId,
                     this._keyBuffer.toString(this._bufferEncoding),
                 ))
             ) {
@@ -84,11 +84,7 @@ export class FileEncryptionHelper {
         if (!this._keyBuffer || !this._ivBuffer) {
             await this.init();
         }
-        const cipherIv = crypto.createCipheriv(
-            this._algorithm,
-            this._keyBuffer!.toString(),
-            this._ivBuffer!.toString(),
-        );
+        const cipherIv = crypto.createCipheriv(this._algorithm, this._keyBuffer!, this._ivBuffer!);
         let cipherText = `${cipherIv.update(content, "utf8", this._binaryEncoding)}${cipherIv.final(this._binaryEncoding)}`;
         return cipherText;
     };
@@ -101,8 +97,8 @@ export class FileEncryptionHelper {
             let plaintext = content;
             const decipherIv = crypto.createDecipheriv(
                 this._algorithm,
-                this._keyBuffer!.toString(),
-                this._ivBuffer!.toString(),
+                this._keyBuffer!,
+                this._ivBuffer!,
             );
             return `${decipherIv.update(plaintext, this._binaryEncoding, "utf8")}${decipherIv.final("utf8")}`;
         } catch (ex) {
@@ -168,8 +164,8 @@ export class FileEncryptionHelper {
     }
 
     public async clearEncryptionKeys(): Promise<void> {
-        await this.deleteEncryptionKey(this.ivCredId);
-        await this.deleteEncryptionKey(this.keyCredId);
+        await this.deleteEncryptionKey(this._ivCredId);
+        await this.deleteEncryptionKey(this._keyCredId);
         this._ivBuffer = undefined;
         this._keyBuffer = undefined;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,12 +2399,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.0.tgz#94c47b9217bbac49d4a67a967fdcdeed89ebb7d0"
   integrity sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==
 
-"@types/node@^20.14.8":
-  version "20.14.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.13.tgz#bf4fe8959ae1c43bc284de78bd6c01730933736b"
-  integrity sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==
+"@types/node@^22.13.14":
+  version "22.17.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.17.0.tgz#e8c9090e957bd4d9860efb323eb92d297347eac7"
+  integrity sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/prop-types@*":
   version "15.7.12"
@@ -7955,7 +7955,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8534,10 +8534,10 @@ underscore@^1.12.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unified@^11.0.0:
   version "11.0.5"


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Fixes an issue cause by https://github.com/microsoft/vscode-mssql/pull/19747 where previously-saved credentials were not getting decrypted correctly.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

