### PR TITLE
Improvement (not fix) for Bug #18837:  Query Cancellation and Disposal Now Handled Correctly

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -692,8 +692,6 @@
   "Previous step failed. Please check the error message and try again.": "Previous step failed. Please check the error message and try again.",
   "Object Explorer Filter": "Object Explorer Filter",
   "{0} (filtered)": "{0} (filtered)",
-  "Cancel failed: ": "Cancel failed: ",
-  "Failed disposing query: ": "Failed disposing query: ",
   "Remind Me Later": "Remind Me Later",
   "Don't Show Again": "Don't Show Again",
   "Learn More": "Learn More",
@@ -1725,6 +1723,18 @@
     ]
   },
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
+  "Cancel failed: {0}/{0} is the error message": {
+    "message": "Cancel failed: {0}",
+    "comment": [
+      "{0} is the error message"
+    ]
+  },
+  "Failed disposing query: {0}/{0} is the error message": {
+    "message": "Failed disposing query: {0}",
+    "comment": [
+      "{0} is the error message"
+    ]
+  },
   "The extension '{0}' is requesting access to your SQL Server connections. This will allow it to execute queries and access your database./{0} is the extension name": {
     "message": "The extension '{0}' is requesting access to your SQL Server connections. This will allow it to execute queries and access your database.",
     "comment": [

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -692,6 +692,8 @@
   "Previous step failed. Please check the error message and try again.": "Previous step failed. Please check the error message and try again.",
   "Object Explorer Filter": "Object Explorer Filter",
   "{0} (filtered)": "{0} (filtered)",
+  "Cancel failed: ": "Cancel failed: ",
+  "Failed disposing query: ": "Failed disposing query: ",
   "Remind Me Later": "Remind Me Later",
   "Don't Show Again": "Don't Show Again",
   "Learn More": "Learn More",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -292,6 +292,9 @@
     <trans-unit id="++CODE++19766ed6ccb2f4a32778eed80d1928d2c87a18d7c275ccb163ec6709d3eb2e27">
       <source xml:lang="en">Cancel</source>
     </trans-unit>
+    <trans-unit id="++CODE++48b81a6ff3d64d3e5397cdcf02c979b239d0f88c390bf3a479ebb5653356ccf6">
+      <source xml:lang="en">Cancel failed: </source>
+    </trans-unit>
     <trans-unit id="++CODE++d6efd131712ed1115d720d4cfdb68b1819ad1de1587f4c2176c9c055c7c03a67">
       <source xml:lang="en">Cancel schema compare failed: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the cancel operation</note>
@@ -1060,6 +1063,9 @@
     </trans-unit>
     <trans-unit id="++CODE++031a8f0f659df890dfd53c92e45295b0f14c997185bae46e168831e403b273f7">
       <source xml:lang="en">Failed</source>
+    </trans-unit>
+    <trans-unit id="++CODE++26abc4d7e0333f433f39080ee2d0bf6c2012bedda5089485ded90115ed070e42">
+      <source xml:lang="en">Failed disposing query: </source>
     </trans-unit>
     <trans-unit id="++CODE++65b387854eab2ea5751dfeaf4b61e988e28642ef25dc8c09b8bd4e4ee99f6372">
       <source xml:lang="en">Failed to apply changes: &apos;{0}&apos;</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -292,8 +292,9 @@
     <trans-unit id="++CODE++19766ed6ccb2f4a32778eed80d1928d2c87a18d7c275ccb163ec6709d3eb2e27">
       <source xml:lang="en">Cancel</source>
     </trans-unit>
-    <trans-unit id="++CODE++48b81a6ff3d64d3e5397cdcf02c979b239d0f88c390bf3a479ebb5653356ccf6">
-      <source xml:lang="en">Cancel failed: </source>
+    <trans-unit id="++CODE++a6dab3e65af40b4f3bca5c056278a22a48972adfa26a46fa3cc16aa4e07e86e0">
+      <source xml:lang="en">Cancel failed: {0}</source>
+      <note>{0} is the error message</note>
     </trans-unit>
     <trans-unit id="++CODE++d6efd131712ed1115d720d4cfdb68b1819ad1de1587f4c2176c9c055c7c03a67">
       <source xml:lang="en">Cancel schema compare failed: &apos;{0}&apos;</source>
@@ -1064,8 +1065,9 @@
     <trans-unit id="++CODE++031a8f0f659df890dfd53c92e45295b0f14c997185bae46e168831e403b273f7">
       <source xml:lang="en">Failed</source>
     </trans-unit>
-    <trans-unit id="++CODE++26abc4d7e0333f433f39080ee2d0bf6c2012bedda5089485ded90115ed070e42">
-      <source xml:lang="en">Failed disposing query: </source>
+    <trans-unit id="++CODE++2332577de7a1ae1c1fdad89cd3a54570fcafcfcf1e149fda9dc0c42d4f88fbdb">
+      <source xml:lang="en">Failed disposing query: {0}</source>
+      <note>{0} is the error message</note>
     </trans-unit>
     <trans-unit id="++CODE++65b387854eab2ea5751dfeaf4b61e988e28642ef25dc8c09b8bd4e4ee99f6372">
       <source xml:lang="en">Failed to apply changes: &apos;{0}&apos;</source>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1485,6 +1485,24 @@ export class MssqlChatAgent {
 
 export class QueryEditor {
     public static codeLensConnect = l10n.t("$(plug)  Connect to MSSQL");
+    // public static cancelCleanupPrefix = l10n.t("Cancel failed: ");
+    // public static disposeCleanupPrefix = l10n.t("Failed disposing query: ");
+
+    public static queryCancelFailed(errorMessage: string) {
+        return l10n.t({
+            message: "Cancel failed: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message"],
+        });
+    }
+
+    public static queryDisposeFailed(errorMessage: string) {
+        return l10n.t({
+            message: "Failed disposing query: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message"],
+        });
+    }
 }
 
 export class ConnectionSharing {

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1485,9 +1485,6 @@ export class MssqlChatAgent {
 
 export class QueryEditor {
     public static codeLensConnect = l10n.t("$(plug)  Connect to MSSQL");
-    // public static cancelCleanupPrefix = l10n.t("Cancel failed: ");
-    // public static disposeCleanupPrefix = l10n.t("Failed disposing query: ");
-
     public static queryCancelFailed(errorMessage: string) {
         return l10n.t({
             message: "Cancel failed: {0}",
@@ -1495,7 +1492,6 @@ export class QueryEditor {
             comment: ["{0} is the error message"],
         });
     }
-
     public static queryDisposeFailed(errorMessage: string) {
         return l10n.t({
             message: "Failed disposing query: {0}",

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -69,6 +69,8 @@ export default class QueryRunner {
     private _uriToQueryPromiseMap = new Map<string, Deferred<boolean>>();
     private _uriToQueryStringMap = new Map<string, string>();
     private static _runningQueries = [];
+    private _cancelCleanupPrefix: String;
+    private _disposeCleanupPrefix: String;
 
     // CONSTRUCTOR /////////////////////////////////////////////////////////
 
@@ -96,6 +98,8 @@ export default class QueryRunner {
         this._isExecuting = false;
         this._totalElapsedMilliseconds = 0;
         this._hasCompleted = false;
+        this._cancelCleanupPrefix = vscode.l10n.t("Cancel failed: ");
+        this._disposeCleanupPrefix = vscode.l10n.t("Failed disposing query: ");
     }
 
     // PROPERTIES //////////////////////////////////////////////////////////
@@ -160,7 +164,7 @@ export default class QueryRunner {
                 cancelParams,
             );
         } catch (error) {
-            this._handleCancelDisposeCleanup("Cancel failed: ", error);
+            this._handleCancelDisposeCleanup(this._cancelCleanupPrefix, error);
             return;
         }
         this._handleCancelDisposeCleanup();
@@ -507,7 +511,7 @@ export default class QueryRunner {
         try {
             await this._client.sendRequest(QueryDisposeRequest.type, disposeDetails);
         } catch (error) {
-            this._handleCancelDisposeCleanup("Failed disposing query: ", error);
+            this._handleCancelDisposeCleanup(this._disposeCleanupPrefix, error);
             return;
         }
         this._handleCancelDisposeCleanup();

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -41,6 +41,7 @@ import { ISlickRange, ISelectionData, IResultMessage } from "../models/interface
 import * as Constants from "../constants/constants";
 import * as LocalizedConstants from "../constants/locConstants";
 import * as Utils from "./../models/utils";
+import { getErrorMessage } from "../utils/utils";
 import * as os from "os";
 import { Deferred } from "../protocol";
 import { sendActionEvent } from "../telemetry/telemetry";
@@ -175,7 +176,7 @@ export default class QueryRunner {
                 true,
             );
             this._statusView.executedQuery(this._ownerUri);
-            this._vscodeWrapper.showErrorMessage("Cancel failed: " + error.message);
+            this._vscodeWrapper.showErrorMessage("Cancel failed: " + getErrorMessage(error));
             return;
         }
         // Always reset state after cancel


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

Issue #18837. 

- Ensures consistent state reset and cleanup after errors during query cancellation and disposal. 
- Removes references to non-existent runner unregistration. 
- Enhances feedback and event emission on failures to prevent orphaned promises and incomplete executions. 
- Multiple times a day I need to restart VS Code because this issue randomly breaks the editor and query execution, making it one of the biggest turn offs to using the extension currently. This should make considerable progress towards fixing the issue.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

