### PR TITLE
Fix: replace hardcoded gpt-4o with dynamic model selection

### DIFF
--- a/src/copilot/chatAgentRequestHandler.ts
+++ b/src/copilot/chatAgentRequestHandler.ts
@@ -34,10 +34,6 @@ export interface ISqlChatResult extends vscode.ChatResult {
     };
 }
 
-const MODEL_SELECTOR: vscode.LanguageModelChatSelector = {
-    vendor: "copilot",
-    family: "gpt-4o",
-};
 const DISCONNECTED_LABEL_PREFIX = "> ⚠️";
 const CONNECTED_LABEL_PREFIX = "> 🟢";
 const SERVER_DATABASE_LABEL_PREFIX = "> ➖";
@@ -256,7 +252,7 @@ export const createSqlAgentRequestHandler = (
         }
 
         const prompt = request.prompt.trim();
-        const [model] = await vscode.lm.selectChatModels(MODEL_SELECTOR);
+        const model = request.model;
 
         try {
             if (!model) {


### PR DESCRIPTION
## Description

This PR removes MODEL_SELECTOR constant and uses `request.model` directly to prevent breakage when specific models become unavailable.
https://github.blog/changelog/2025-08-06-deprecation-of-gpt-4o-in-copilot-chat/ `gpt-4o` has been deprecated in GitHub Copilot.

Current:
<img width="637" height="258" alt="image" src="https://github.com/user-attachments/assets/30299556-bdf0-4047-9e35-a2510f154502" />

With the fix:
<img width="641" height="1323" alt="image" src="https://github.com/user-attachments/assets/f688b766-6768-4ff4-9853-575cccda9e5f" />


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

