### PR TITLE
New setting for connection groups to collapse/expand on load by default in the UI

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3138,6 +3138,9 @@
     <trans-unit id="mssql.userFeedback">
       <source xml:lang="en">Give Feedback</source>
     </trans-unit>
+    <trans-unit id="mssql.connectionGroupsExpandedByDefault.description">
+      <source xml:lang="en">If true, connection groups in the SQL Server Connections view will be expanded by default. If false, all groups will be collapsed by default.</source>
+    </trans-unit>
     <trans-unit id="mssql.copilot.editorSubmenu">
       <source xml:lang="en">MSSQL Copilot (Preview)</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -1898,6 +1898,12 @@
                     "minimum": 1,
                     "description": "%mssql.objectExplorer.expandTimeout%"
                 },
+                "mssql.connectionGroupsExpandedByDefault": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%mssql.connectionGroupsExpandedByDefault.description%",
+                    "scope": "window"
+                },
                 "mssql.statusBar.connectionInfoMaxLength": {
                     "type": "number",
                     "default": -1,

--- a/package.nls.json
+++ b/package.nls.json
@@ -57,6 +57,7 @@
     "mssql.maxRecentConnections": "The maximum number of recently used connections to store in the connection list.",
     "mssql.connections": "Connection profiles defined in 'User Settings' are shown under 'MS SQL: Connect' command in the command palette.",
     "mssql.connectionGroups": "Connection groups",
+    "mssql.connectionGroupsExpandedByDefault.description": "If true, connection groups in the SQL Server Connections view will be expanded by default. If false, all groups will be collapsed by default.",
     "mssql.connection.server": "[Required] Specify the server name to connect to. Use 'hostname instance' or '<server>.database.windows.net' for Azure SQL Database.",
     "mssql.connection.database": "[Optional] Specify the database name to connect to. If database is not specified, the default user database setting is used, typically 'master'.",
     "mssql.connection.user": "[Optional] Specify the user name for SQL Server authentication. If user name is not specified, when you connect, you will be asked again.",

--- a/src/objectExplorer/nodes/connectionGroupNode.ts
+++ b/src/objectExplorer/nodes/connectionGroupNode.ts
@@ -22,11 +22,15 @@ export class ConnectionGroupNode extends TreeNodeInfo {
     public children: TreeNodeInfo[];
     private _connectionGroup: IConnectionGroup;
 
-    constructor(connectionGroup: IConnectionGroup) {
+    constructor(
+        connectionGroup: IConnectionGroup,
+        collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState
+            .Expanded,
+    ) {
         super(
             connectionGroup.name,
             createConnectionGroupContextValue(),
-            vscode.TreeItemCollapsibleState.Expanded,
+            collapsibleState,
             connectionGroup.id,
             undefined,
             CONNECTION_GROUP_NODE_TYPE,

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -412,9 +412,19 @@ export class ObjectExplorerService {
         const newConnectionGroupNodes = new Map<string, ConnectionGroupNode>();
         const newConnectionNodes = new Map<string, ConnectionNode>();
 
+        // Read user setting for default expansion state
+        const config = this._vscodeWrapper.getConfiguration("mssql");
+        const expandGroupsByDefault = config.get<boolean>(
+            "connectionGroupsExpandedByDefault",
+            true,
+        );
+        const defaultCollapsibleState = expandGroupsByDefault
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.Collapsed;
+
         // Add all group nodes from settings first
         for (const group of serverGroups) {
-            const groupNode = new ConnectionGroupNode(group);
+            const groupNode = new ConnectionGroupNode(group, defaultCollapsibleState);
 
             if (this._connectionGroupNodes.has(group.id)) {
                 groupNode.id = this._connectionGroupNodes.get(group.id).id;


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

This pull request implements a new MSSQL setting that, when enabled, makes the connection groups load expanded in the UI by default (which is the only option currently) but disabling the setting makes all connection groups instead load collapsed in the UI by default.

As someone who uses connection groups to organize databases from different projects, there are many connections I don't need to see while working in a particular workspace. It's a minor nuisance, but I have to collapse all of the connection groups I don't need everytime I open vs code, so I figured having the option to load all of the connection groups collapsed would mean I only ever have to expand the 1 or 2 connection groups I need. 

Additionally, when many connections and connection groups exist, they take up space in the editor window.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

