### PR TITLE
Fixing password handling logic and adding temp session password for unsaved password conns. 

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3345,6 +3345,9 @@
     <trans-unit id="mssql.walkthroughs.getStarted.createNewTable.altText">
       <source xml:lang="en">Table Designer</source>
     </trans-unit>
+    <trans-unit id="mssql.connectionManagement.rememberPasswordsUntilRestart">
+      <source xml:lang="en">Temporarily store passwords for connections with &apos;Saved Passwords&apos; disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session.</source>
+    </trans-unit>
     <trans-unit id="mssql.connectionGroup.color">
       <source xml:lang="en">The color of the connection group.</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -1902,6 +1902,11 @@
                     "type": "number",
                     "default": -1,
                     "description": "%mssql.statusBar.connectionInfoMaxLength.description%"
+                },
+                "mssql.connectionManagement.rememberPasswordsUntilRestart": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%mssql.connectionManagement.rememberPasswordsUntilRestart%"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -221,5 +221,6 @@
     "mssql.connectionSharing.editConnectionSharingPermissions": "Edit Connection Sharing Permissions",
     "mssql.connectionSharing.clearAllConnectionSharingPermissions": "Clear All Connection Sharing Permissions",
     "mssql.statusBar.connectionInfoMaxLength.description": "The maximum number of characters to display for the connection info in the status bar. Set to -1 for no limit.",
-    "mssql.schemaDesigner.enableExpandCollapseButtons": "Enable expand/collapse buttons in Schema Designer table nodes when tables have more than 10 columns"
+    "mssql.schemaDesigner.enableExpandCollapseButtons": "Enable expand/collapse buttons in Schema Designer table nodes when tables have more than 10 columns",
+    "mssql.connectionManagement.rememberPasswordsUntilRestart": "Temporarily store passwords for connections with 'Saved Passwords' disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session."
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -235,6 +235,8 @@ export const configStatusBarConnectionInfoMaxLength = "statusBar.connectionInfoM
 export const configStatusBarEnableConnectionColor = "mssql.statusBar.enableConnectionColor";
 export const configSchemaDesignerEnableExpandCollapseButtons =
     "mssql.schemaDesigner.enableExpandCollapseButtons";
+export const configSavePasswordsUntilRestart =
+    "mssql.connectionManagement.rememberPasswordsUntilRestart";
 
 // ToolsService Constants
 export const serviceInstallingTo = "Installing SQL tools service to";

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1277,7 +1277,6 @@ export default class ConnectionManager {
             let password = connectionCreds.password;
 
             if (Utils.isEmpty(password)) {
-                // Try to get saved password first
                 password = await this.connectionStore.lookupPassword(connectionCreds);
 
                 if (!password) {
@@ -1285,8 +1284,6 @@ export default class ConnectionManager {
                     if (!password) {
                         return false;
                     }
-
-                    // Set password but don't save yet - wait for successful connection
                     connectionCreds.password = password;
                 } else {
                     connectionCreds.password = password;

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1297,7 +1297,6 @@ export default class ConnectionManager {
                 // Try to get saved password first
                 password = await this.connectionStore.lookupPassword(connectionCreds);
 
-                // If no saved password, prompt for it
                 if (!password) {
                     password = await this.connectionUI.promptForPassword();
                     if (!password) {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -185,10 +185,6 @@ export default class MainController implements vscode.Disposable {
     public async deactivate(): Promise<void> {
         Utils.logDebug("de-activated.");
         await this.onDisconnect();
-
-        // Clear session passwords on deactivation
-        this.connectionManager.connectionStore.clearAllSessionPasswords();
-
         this._statusview.dispose();
     }
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -185,6 +185,10 @@ export default class MainController implements vscode.Disposable {
     public async deactivate(): Promise<void> {
         Utils.logDebug("de-activated.");
         await this.onDisconnect();
+
+        // Clear session passwords on deactivation
+        this.connectionManager.connectionStore.clearAllSessionPasswords();
+
         this._statusview.dispose();
     }
 

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -134,7 +134,7 @@ export class ConnectionStore {
     /**
      * Creates a formatted credential usable for uniquely identifying a SQL Connection.
      * This string can be decoded but is not optimized for this.
-     * @static
+     * @deprecated
      * @param server name of the server - required
      * @param database name of the database - optional
      * @param user name of the user - optional
@@ -322,8 +322,10 @@ export class ConnectionStore {
      * @param password Password to store
      */
     public storeSessionPassword(connectionCredentials: IConnectionInfo, password: string): void {
-        const sessionKey = this.getSessionPasswordKey(connectionCredentials);
-        this._sessionPasswords.set(sessionKey, password);
+        if (ConnectionStore.shouldSavePasswordUntilRestart) {
+            const sessionKey = this.getSessionPasswordKey(connectionCredentials);
+            this._sessionPasswords.set(sessionKey, password);
+        }
     }
 
     /**

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -338,13 +338,6 @@ export class ConnectionStore {
     }
 
     /**
-     * Clear all session passwords (called on extension restart)
-     */
-    public clearAllSessionPasswords(): void {
-        this._sessionPasswords.clear();
-    }
-
-    /**
      * Generate a session key for password storage
      * @param connectionCredentials Connection credentials
      * @returns Session storage key

--- a/src/models/connectionStore.ts
+++ b/src/models/connectionStore.ts
@@ -86,6 +86,12 @@ export class ConnectionStore {
         return CredentialsQuickPickItemType[CredentialsQuickPickItemType.Mru];
     }
 
+    public static get shouldSavePasswordUntilRestart(): boolean {
+        return vscode.workspace
+            .getConfiguration()
+            .get<boolean>(Constants.configSavePasswordsUntilRestart);
+    }
+
     public static formatCredentialIdForCred(
         creds: IConnectionInfo,
         itemType?: CredentialsQuickPickItemType,
@@ -257,7 +263,7 @@ export class ConnectionStore {
         let savedCredential: Contracts.Credential;
 
         // First, try to get password from session storage for non-saved passwords
-        if (!profile.savePassword) {
+        if (!profile.savePassword && ConnectionStore.shouldSavePasswordUntilRestart) {
             const sessionKey = this.getSessionPasswordKey(connectionCredentials);
             const sessionPassword = this._sessionPasswords.get(sessionKey);
             if (sessionPassword) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -868,25 +868,7 @@ export class ObjectExplorerService {
             this.addConnectionNode(connectionNode);
         }
 
-        // Save password on successful connection based on savePassword preference
-        if (connectionProfile.password) {
-            if (connectionProfile.savePassword) {
-                // Save to credential store for connections with savePassword = true
-                await this._connectionManager.connectionStore
-                    .saveProfilePasswordIfNeeded(connectionProfile)
-                    .catch((error) => {
-                        this._logger.error(
-                            `Failed to save profile password on success in OE: ${error}`,
-                        );
-                    });
-            } else {
-                // Store in session for connections with savePassword = false
-                this._connectionManager.connectionStore.storeSessionPassword(
-                    connectionProfile,
-                    connectionProfile.password,
-                );
-            }
-        }
+        await this._connectionManager.handlePasswordStorageOnConnect(connectionProfile);
 
         // remove the sign in node once the session is created
         if (this._treeNodeToChildrenMap.has(connectionNode)) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -777,32 +777,10 @@ export class ObjectExplorerService {
             }
         }
 
-        if (ConnectionCredentials.isPasswordBasedCredential(connectionProfile)) {
-            // show password prompt if SQL Login and password isn't saved
-            let password = connectionProfile.password;
-            if (Utils.isEmpty(password)) {
-                // Try to get saved password first (this now includes session passwords and migration)
-                password =
-                    await this._connectionManager.connectionStore.lookupPassword(connectionProfile);
-
-                // If no saved password, prompt for it
-                if (!password) {
-                    password = await this._connectionManager.connectionUI.promptForPassword();
-                    if (!password) {
-                        return undefined;
-                    }
-
-                    // Set password but don't save yet - wait for successful connection
-                    connectionProfile.password = password;
-                } else {
-                    connectionProfile.password = password;
-                }
-
-                if (connectionProfile.authenticationType !== Constants.azureMfa) {
-                    connectionProfile.azureAccountToken = undefined;
-                }
-            }
-            return connectionProfile;
+        const passwordHandled =
+            await this._connectionManager.handlePasswordBasedCredentials(connectionProfile);
+        if (!passwordHandled) {
+            return undefined;
         }
 
         if (


### PR DESCRIPTION
## Description
1. Using conn ids to store and fetch password. To reduce conflicts between profiles that have very similar creds 
2. Migrating old ids to new ids when a conn is successfully established using old ids
3. Using a temp session cache to store passwords for connections with no saved password(savePassword = false) to prevent the extension asking passwords for those connections when they have been succesfully connected before. This is cleared after vscode exit. Fixes 

Removes
## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

