### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 36521: Build ID 184893522

### DIFF
--- a/localization/xliff/vscode-mssql.de.xlf
+++ b/localization/xliff/vscode-mssql.de.xlf
@@ -4572,10 +4572,6 @@ Sie können auch auf die Schaltfläche „In neuer Registerkarte öffnen“ klic
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Optional] Konfigurationsoptionen für das Kopieren von Ergebnissen aus der Ergebnisansicht.</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Optional] Konfigurationsoptionen für die Lokalisierung in das von VS Code konfigurierte Gebietsschema (VS Code muss neu gestartet werden, damit diese Einstellungen wirksam werden).</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Optional] Konfigurationsoptionen zur Festlegung, in welcher Spalte neue Ergebnisansichten geöffnet werden.</target>

--- a/localization/xliff/vscode-mssql.es.xlf
+++ b/localization/xliff/vscode-mssql.es.xlf
@@ -4572,10 +4572,6 @@ También puedes hacer clic en el botón 'Abrir en nueva pestaña' para ver los r
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Opcional] Opciones de configuración para copiar los resultados de la vista de resultados.</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Opcional] Opciones de configuración para localizar en la configuración regional establecida de VSCode (debe reiniciarse VSCode para que la configuración entre en vigencia).</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Opcional] Opciones de configuración en las que deben abrirse los paneles de resultados nuevos de columna</target>

--- a/localization/xliff/vscode-mssql.fr.xlf
+++ b/localization/xliff/vscode-mssql.fr.xlf
@@ -4572,10 +4572,6 @@ Vous pouvez également cliquer sur le bouton « Ouvrir dans un nouvel onglet �
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Facultatif] Options de configuration pour copier les résultats à partir de la vue Résultats</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Facultatif] Options de configuration pour effectuer la localisation dans les paramètres régionaux configurés dans VSCode (vous devez redémarrer VSCode pour appliquer les paramètres)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Facultatif] Options de configuration pour définir la colonne dans laquelle les nouveaux volets de résultats doivent s’ouvrir</target>

--- a/localization/xliff/vscode-mssql.it.xlf
+++ b/localization/xliff/vscode-mssql.it.xlf
@@ -4572,10 +4572,6 @@ Puoi anche fare clic sul pulsante 'Apri in nuova scheda' per visualizzare i risu
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Facoltativo] Opzioni di configurazione per copiare i risultati dalla Visualizzazione risultati</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Facoltativo] Opzioni di configurazione per la localizzazione delle impostazioni locali configurate di VSCode (è necessario riavviare VSCode per rendere effettive le impostazioni)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Facoltativo] Opzioni di configurazione per determinare la colonna in cui aprire i nuovi riquadri dei risultati</target>

--- a/localization/xliff/vscode-mssql.ja.xlf
+++ b/localization/xliff/vscode-mssql.ja.xlf
@@ -4572,10 +4572,6 @@ You can also click the 'Open in New Tab' button to view your query results in th
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[省略可能] 結果を結果ビューからコピーするための構成オプション</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[省略可能] VSCode の構成済みロケールにローカライズするための構成オプション (設定を有効にするには VSCode を再起動する必要があります)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[省略可能] どの列を新しい結果ウィンドウで開く必要があるかについての設定オプション</target>

--- a/localization/xliff/vscode-mssql.ko.xlf
+++ b/localization/xliff/vscode-mssql.ko.xlf
@@ -4572,10 +4572,6 @@ You can also click the 'Open in New Tab' button to view your query results in th
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[옵션] 결과 뷰에서 결과를 복사하기 위한 구성 옵션</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[옵션] VSCode의 구성된 로캘로 지역화하기 위한 구성 옵션(설정을 적용하려면 VSCode를 다시 시작해야 함)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[옵션] 새 결과 창이 열리는 열의 구성 옵션</target>

--- a/localization/xliff/vscode-mssql.pt-BR.xlf
+++ b/localization/xliff/vscode-mssql.pt-BR.xlf
@@ -4572,10 +4572,6 @@ Você também pode clicar no botão "Abrir na Nova Guia" para ver os resultados 
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Opcional] Opções de configuração para copiar os resultados da Visualização dos Resultados</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Opcional] Opções de configuração para localização na localidade configurada do VS Code (o VS Code deve ser reiniciado para que as configurações entrem em vigor)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Opcional] Opções de configuração para as quais a coluna Novos painéis de resultados deve ser aberta</target>

--- a/localization/xliff/vscode-mssql.ru.xlf
+++ b/localization/xliff/vscode-mssql.ru.xlf
@@ -4572,10 +4572,6 @@ You can also click the 'Open in New Tab' button to view your query results in th
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[Необязательно] Параметры конфигурации для копирования результатов из представления результатов</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[Необязательно] Параметры конфигурации для перехода на языковой стандарт, указанных в параметрах VSCode. (Чтобы эти параметры вступили в силу, необходимо перезапустить VSCode.)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[Необязательно] Параметры конфигурации, определяющие, для какого столбца должны открываться новые области результатов</target>

--- a/localization/xliff/vscode-mssql.zh-Hans.xlf
+++ b/localization/xliff/vscode-mssql.zh-Hans.xlf
@@ -4572,10 +4572,6 @@ You can also click the 'Open in New Tab' button to view your query results in th
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[可选] 用于从结果视图复制结果的配置选项</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[可选] 用于本地化为 VSCode 的已配置区域设置的配置选项(必须重启 VSCode，设置才能生效)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[可选] 用于指示新结果窗格应在哪一列打开的配置选项</target>

--- a/localization/xliff/vscode-mssql.zh-Hant.xlf
+++ b/localization/xliff/vscode-mssql.zh-Hant.xlf
@@ -4572,10 +4572,6 @@ You can also click the 'Open in New Tab' button to view your query results in th
         <source xml:lang="en">[Optional] Configuration options for copying results from the Results View</source>
         <target state="translated">[選用] 從結果檢視內複製結果的組態選項</target>
       </trans-unit>
-      <trans-unit id="mssql.applyLocalization">
-        <source xml:lang="en">[Optional] Configuration options for localizing into VSCode's configured locale (must restart VSCode for settings to take effect)</source>
-        <target state="translated">[選用] 設定採用當地語系 的 VSCode 地區組態設定 (必須重新啟動 VSCode 設定才會生效)</target>
-      </trans-unit>
       <trans-unit id="mssql.splitPaneSelection">
         <source xml:lang="en">[Optional] Configuration options for which column new result panes should open in</source>
         <target state="translated">[選用] 哪一個資料行應該開啟新結果窗格的組態選項</target>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.