### PR TITLE
Not copying connections for sql files opened from internal extension …

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2363,7 +2363,7 @@ export default class MainController implements vscode.Disposable {
         const currentDocUri = vscode.window.activeTextEditor
             ? vscode.window.activeTextEditor.document.uri.toString(true)
             : undefined;
-        const newEditor = await this._untitledSqlDocumentService.newQuery(content, false);
+        const newEditor = await this._untitledSqlDocumentService.newQuery(content, true);
         const newDocUri = newEditor.document.uri.toString(true);
 
         // Case 1: User right-clicked on an OE node and selected "New Query"
@@ -2560,14 +2560,15 @@ export default class MainController implements vscode.Disposable {
         }
         this._connectionMgr.onDidOpenTextDocument(doc);
 
-        await this.untitledSqlDocumentService.waitForAllOperations();
-        const isOpenedFromUntitledService =
-            await this._untitledSqlDocumentService.isUriTrackedByService(doc.uri.toString(true));
+        await this.untitledSqlDocumentService.waitForOngoingCreates();
+        const skipCopyConnection = await this._untitledSqlDocumentService.shouldSkipCopyConnection(
+            doc.uri.toString(true),
+        );
 
         if (
             this._previousActiveDocument &&
             doc.languageId === Constants.languageId &&
-            !isOpenedFromUntitledService
+            !skipCopyConnection
         ) {
             void this._connectionMgr.copyConnectionToFile(
                 this._previousActiveDocument.uri.toString(true),

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2561,7 +2561,7 @@ export default class MainController implements vscode.Disposable {
         this._connectionMgr.onDidOpenTextDocument(doc);
 
         await this.untitledSqlDocumentService.waitForOngoingCreates();
-        const skipCopyConnection = await this._untitledSqlDocumentService.shouldSkipCopyConnection(
+        const skipCopyConnection = this._untitledSqlDocumentService.shouldSkipCopyConnection(
             doc.uri.toString(true),
         );
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2363,7 +2363,7 @@ export default class MainController implements vscode.Disposable {
         const currentDocUri = vscode.window.activeTextEditor
             ? vscode.window.activeTextEditor.document.uri.toString(true)
             : undefined;
-        const newEditor = await this._untitledSqlDocumentService.newQuery(content);
+        const newEditor = await this._untitledSqlDocumentService.newQuery(content, false);
         const newDocUri = newEditor.document.uri.toString(true);
 
         // Case 1: User right-clicked on an OE node and selected "New Query"
@@ -2560,8 +2560,9 @@ export default class MainController implements vscode.Disposable {
         }
         this._connectionMgr.onDidOpenTextDocument(doc);
 
+        await this.untitledSqlDocumentService.waitForAllOperations();
         const isOpenedFromUntitledService =
-            await this._untitledSqlDocumentService.isUriOpenedFromService(doc.uri.toString(true));
+            await this._untitledSqlDocumentService.isUriTrackedByService(doc.uri.toString(true));
 
         if (
             this._previousActiveDocument &&

--- a/src/controllers/untitledSqlDocumentService.ts
+++ b/src/controllers/untitledSqlDocumentService.ts
@@ -10,13 +10,31 @@ import VscodeWrapper from "./vscodeWrapper";
  * Service for creating untitled documents for SQL query
  */
 export default class UntitledSqlDocumentService {
+    public openedUris: Set<string> = new Set();
+
+    public isOpening = false;
+
     constructor(private vscodeWrapper: VscodeWrapper) {}
+
+    public isUriOpenedFromService(uri: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            const checkUri = () => {
+                if (!this.isOpening && this.openedUris.has(uri)) {
+                    resolve(true);
+                } else {
+                    setTimeout(checkUri, 100);
+                }
+            };
+            checkUri();
+        });
+    }
 
     /**
      * Creates new untitled document for SQL query and opens in new editor tab
      * with optional content
      */
     public async newQuery(content?: string): Promise<vscode.TextEditor> {
+        this.isOpening = true;
         // Open an untitled document. So the  file doesn't have to exist in disk
         let doc = await this.vscodeWrapper.openMsSqlTextDocument(content);
         // Show the new untitled document in the editor's first tab and change the focus to it.
@@ -25,6 +43,8 @@ export default class UntitledSqlDocumentService {
             preserveFocus: false,
             preview: false,
         });
+        this.openedUris.add(editor.document.uri.toString());
+        this.isOpening = false;
         return editor;
     }
 }

--- a/src/controllers/untitledSqlDocumentService.ts
+++ b/src/controllers/untitledSqlDocumentService.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from "vscode";
 import VscodeWrapper from "./vscodeWrapper";
-import { resolve } from "path";
 
 /**
  * Service for creating untitled documents for SQL query

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -102,9 +102,9 @@ suite("MainController Tests", function () {
     });
 
     // Renamed file event test
-    test("onDidCloseTextDocument should call renamedDoc function when rename occurs", (done) => {
+    test("onDidCloseTextDocument should call renamedDoc function when rename occurs", async (done) => {
         // A renamed doc constitutes an openDoc event directly followed by a closeDoc event
-        mainController.onDidOpenTextDocument(newDocument);
+        await mainController.onDidOpenTextDocument(newDocument);
         void mainController.onDidCloseTextDocument(document);
 
         // Verify renameDoc function was called
@@ -122,10 +122,10 @@ suite("MainController Tests", function () {
     });
 
     // Closed document event called to test rename and untitled save file event timeouts
-    test("onDidCloseTextDocument should propogate to the connectionManager even if a special event occured before it", (done) => {
+    test("onDidCloseTextDocument should propogate to the connectionManager even if a special event occured before it", async (done) => {
         // Call both special cases
-        mainController.onDidSaveTextDocument(newDocument);
-        mainController.onDidOpenTextDocument(newDocument);
+        await mainController.onDidSaveTextDocument(newDocument);
+        await mainController.onDidOpenTextDocument(newDocument);
 
         // Cause event time out (above 10 ms should work)
         setTimeout(() => {
@@ -155,9 +155,9 @@ suite("MainController Tests", function () {
     });
 
     // Open document event test
-    test("onDidOpenTextDocument should propogate the function to the connectionManager", (done) => {
+    test("onDidOpenTextDocument should propogate the function to the connectionManager", async (done) => {
         // Call onDidOpenTextDocument to test it side effects
-        mainController.onDidOpenTextDocument(document);
+        await mainController.onDidOpenTextDocument(document);
         try {
             connectionManager.verify(
                 (x) => x.onDidOpenTextDocument(TypeMoq.It.isAny()),
@@ -190,7 +190,7 @@ suite("MainController Tests", function () {
         }
     });
 
-    test("TextDocument Events should handle non-initialized connection manager", (done) => {
+    test("TextDocument Events should handle non-initialized connection manager", async (done) => {
         let vscodeWrapperMock: TypeMoq.IMock<VscodeWrapper> = TypeMoq.Mock.ofType(VscodeWrapper);
         let controller: MainController = new MainController(
             TestExtensionContext.object,
@@ -199,7 +199,7 @@ suite("MainController Tests", function () {
         );
 
         // None of the TextDocument events should throw exceptions, they should cleanly exit instead.
-        controller.onDidOpenTextDocument(document);
+        await controller.onDidOpenTextDocument(document);
         controller.onDidSaveTextDocument(document);
         void controller.onDidCloseTextDocument(document);
         done();
@@ -341,7 +341,7 @@ suite("MainController Tests", function () {
         );
 
         // verify that the connection manager transfers the connection from SQL file to SQL file
-        controller.onDidOpenTextDocument(script2);
+        await controller.onDidOpenTextDocument(script2);
 
         expect(
             controller["_previousActiveDocument"],
@@ -356,7 +356,7 @@ suite("MainController Tests", function () {
         setupConnectionManagerMocks(connectionManager);
 
         // verify that the connection manager does not transfer the connection from SQL file to non-SQL file
-        controller.onDidOpenTextDocument(textFile);
+        await controller.onDidOpenTextDocument(textFile);
 
         expect(
             controller["_previousActiveDocument"],
@@ -369,7 +369,7 @@ suite("MainController Tests", function () {
         );
 
         // verify that the connection manager does not transfer the connection from SQL file to non-SQL file
-        controller.onDidOpenTextDocument(script1);
+        await controller.onDidOpenTextDocument(script1);
 
         expect(
             controller["_previousActiveDocument"],

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -115,10 +115,10 @@ suite("MainController Tests", function () {
         mainController["_previousActiveDocument"] = document;
         // Use the existing untitledSqlDocumentService mock instead of creating a new one
         untitledSqlDocumentService
-            .setup((x) => x.waitForAllOperations())
+            .setup((x) => x.waitForOngoingCreates())
             .returns(() => Promise.resolve(undefined));
         untitledSqlDocumentService
-            .setup((x) => x.isUriTrackedByService(TypeMoq.It.isAny()))
+            .setup((x) => x.shouldSkipCopyConnection(TypeMoq.It.isAny()))
             .returns(() => false);
 
         // Reset the callback variables before the test
@@ -146,8 +146,8 @@ suite("MainController Tests", function () {
         const untitleDocumentServiceStub = sandbox.createStubInstance(UntitledSqlDocumentService);
         mainController.untitledSqlDocumentService = untitleDocumentServiceStub;
 
-        untitleDocumentServiceStub.waitForAllOperations.resolves(undefined);
-        untitleDocumentServiceStub.isUriTrackedByService.returns(false);
+        untitleDocumentServiceStub.waitForOngoingCreates.resolves(undefined);
+        untitleDocumentServiceStub.shouldSkipCopyConnection.returns(false);
 
         // Call both special cases
         await mainController.onDidSaveTextDocument(newDocument);
@@ -182,8 +182,8 @@ suite("MainController Tests", function () {
 
         mainController.untitledSqlDocumentService = untitleDocumentServiceStub;
 
-        untitleDocumentServiceStub.waitForAllOperations.resolves(undefined);
-        untitleDocumentServiceStub.isUriTrackedByService.returns(false);
+        untitleDocumentServiceStub.waitForOngoingCreates.resolves(undefined);
+        untitleDocumentServiceStub.shouldSkipCopyConnection.returns(false);
 
         // Call onDidOpenTextDocument to test it side effects
         await mainController.onDidOpenTextDocument(document);
@@ -201,8 +201,8 @@ suite("MainController Tests", function () {
 
         mainController.untitledSqlDocumentService = untitleDocumentServiceStub;
 
-        untitleDocumentServiceStub.waitForAllOperations.resolves(undefined);
-        untitleDocumentServiceStub.isUriTrackedByService.returns(false);
+        untitleDocumentServiceStub.waitForOngoingCreates.resolves(undefined);
+        untitleDocumentServiceStub.shouldSkipCopyConnection.returns(false);
 
         // Call onDidOpenTextDocument to test it side effects
         mainController.onDidSaveTextDocument(newDocument);
@@ -223,8 +223,8 @@ suite("MainController Tests", function () {
 
         mainController.untitledSqlDocumentService = untitleDocumentServiceStub;
 
-        untitleDocumentServiceStub.waitForAllOperations.resolves(undefined);
-        untitleDocumentServiceStub.isUriTrackedByService.returns(false);
+        untitleDocumentServiceStub.waitForOngoingCreates.resolves(undefined);
+        untitleDocumentServiceStub.shouldSkipCopyConnection.returns(false);
 
         let vscodeWrapperMock: TypeMoq.IMock<VscodeWrapper> = TypeMoq.Mock.ofType(VscodeWrapper);
         let controller: MainController = new MainController(

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -247,7 +247,7 @@ suite("MainController Tests", function () {
             .returns(() => Promise.reject(new Error("boom")));
 
         // No need to "returns" here; but if you do, return a real value, not It.isAny()
-        connectionManager.setup((x) => x.onNewConnection()).returns(() => Promise.resolve());
+        connectionManager.setup((x) => x.onNewConnection()).returns(() => Promise.resolve() as any);
 
         // Act + assert reject
         await assert.rejects(() => mainController.onNewQuery(undefined, undefined), /boom/);

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -320,6 +320,13 @@ suite("MainController Tests", function () {
             document: script1,
         } as unknown as vscode.TextEditor;
 
+        untitledSqlDocumentService
+            .setup((x) => x.waitForOngoingCreates())
+            .returns(() => Promise.resolve() as any);
+        untitledSqlDocumentService
+            .setup((x) => x.shouldSkipCopyConnection(TypeMoq.It.isAnyString()))
+            .returns(() => false);
+
         const controller: MainController = new MainController(
             TestExtensionContext.object,
             connectionManager.object,
@@ -355,7 +362,7 @@ suite("MainController Tests", function () {
         );
 
         // verify that the connection manager transfers the connection from SQL file to SQL file
-        void controller.onDidOpenTextDocument(script2);
+        await controller.onDidOpenTextDocument(script2);
 
         expect(
             controller["_previousActiveDocument"],
@@ -375,7 +382,7 @@ suite("MainController Tests", function () {
         setupConnectionManagerMocks(connectionManager);
 
         // verify that the connection manager does not transfer the connection from SQL file to non-SQL file
-        void controller.onDidOpenTextDocument(textFile);
+        await controller.onDidOpenTextDocument(textFile);
 
         expect(
             controller["_previousActiveDocument"],
@@ -388,7 +395,7 @@ suite("MainController Tests", function () {
         );
 
         // verify that the connection manager does not transfer the connection from SQL file to non-SQL file
-        void controller.onDidOpenTextDocument(script1);
+        await controller.onDidOpenTextDocument(script1);
 
         expect(
             controller["_previousActiveDocument"],

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -67,6 +67,8 @@ suite("MainController Tests", function () {
 
     teardown(() => {
         sandbox.restore();
+        docUriCallback = "";
+        newDocUriCallback = "";
     });
 
     // Standard closed document event test


### PR DESCRIPTION
## Description

A few releases ago, we introduced a feature that automatically copied the SQL connection from the last active file to any newly opened SQL file. This saved users from repeatedly connecting new files to the same SQL Server they were already working with.
[https://github.com/microsoft/vscode-mssql/pull/19503](https://github.com/microsoft/vscode-mssql/pull/19503)

However, this caused problems for SQL files opened within the extension itself. Many of these files are already connected when opened. For example, in Object Explorer (OE), scripting an object opens an untitled editor with the corresponding CREATE/UPDATE/DELETE script and uses the object’s parent connection. The new feature would overwrite this with the last active connection, which could be different, resulting in errors when the script referenced objects that didn’t exist in that server.

In some cases, the issue was even worse: the editor would be connected to two different servers simultaneously
1. one from the scripting logic 
2. another from the “copy last active connection” logic

creating a race condition over which connection would be active.

While the example above uses scripting, this bug also affects other untitled SQL editors opened from features like Table Designer, Schema Designer, and more.

Fixes: #19930

This PR adds a temporary workaround that tracks a set of URIs where the “copy last active connection” feature should be skipped. If a URI is in this set, the last active connection will not be applied to it.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

