### PR TITLE
Setting database to it original value when saving (fix for bug 18992)

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -847,7 +847,7 @@ export default class ConnectionManager {
             try {
                 // if the connection was originally for an empty database, the database should be empty when being saved to match the original connection
                 if (saveAsDefaultDatabase) {
-                    connectionToSave.database = undefined;
+                    connectionToSave = { ...connectionToSave, database: undefined };
                 }
                 await this._connectionStore.addRecentlyUsed(connectionToSave);
                 connection.connectHandler(true);


### PR DESCRIPTION
## Description

Database value is being updated after a successful connection; however, this is making the items saved to MRU list (recent connections) have a different value than the original saved connections. So it displays the database name it was last connected to; while the value should be <default>. 

SQL Server doesn't have a <default> database, and the actual database it connects to when the database name is not supplied might change, between connections attempts. So recent connections should not save a particular value as it might change later.

Fix for #18992 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

