### PR TITLE
[Port] Fix for pulling broken sql server 2025 image on macs

### DIFF
--- a/src/containerDeployment/containerDeploymentWebviewController.ts
+++ b/src/containerDeployment/containerDeploymentWebviewController.ts
@@ -96,17 +96,13 @@ export class ContainerDeploymentWebviewController extends FormWebviewController<
 
     private registerRpcHandlers() {
         this.registerReducer("formAction", async (state, payload) => {
-            (this.state.formState[
-                payload.event.propertyName
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ] as any) = payload.event.value;
+            (state.formState as any)[payload.event.propertyName] = payload.event.value;
 
             const newState = await this.validateDockerConnectionProfile(
                 state,
                 this.state.formState,
                 payload.event.propertyName,
             );
-            this.updateState(newState);
             return newState;
         });
         this.registerReducer("completeDockerStep", async (state, payload) => {

--- a/test/unit/containerDeploymentWebviewController.test.ts
+++ b/test/unit/containerDeploymentWebviewController.test.ts
@@ -293,7 +293,6 @@ suite("ContainerDeploymentWebviewController", () => {
             controller as any,
             "validateDockerConnectionProfile",
         );
-        const updateStateSpy = sandbox.spy(controller as any, "updateState");
 
         const callState = controller["state"];
 
@@ -306,8 +305,6 @@ suite("ContainerDeploymentWebviewController", () => {
         });
 
         assert.ok(validateProfileSpy.calledOnce, "profile validation should be called once");
-        assert.ok(updateStateSpy.calledOnce, "updateState should be called once within formAction");
-
         assert.equal(newState.isValidContainerName, true);
     });
 


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
Original PR: https://github.com/microsoft/vscode-mssql/pull/19918
Temporarily pull working Sql Server 2025 for mac and linux environments, until this bug is fixed: https://github.com/microsoft/mssql-docker/issues/940#issue

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

