### PR TITLE
New setting for connection groups to collapse/expand on load by default in the UI (v2.0)

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3454,14 +3454,14 @@
     <trans-unit id="mssql.walkthroughs.nextSteps.viewQueryPlan.title">
       <source xml:lang="en">Visualize a Query Plan</source>
     </trans-unit>
+    <trans-unit id="mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription">
+      <source xml:lang="en">When enabled, all connection groups in the Object Explorer will collapse on startup instead of showing them expanded.</source>
+    </trans-unit>
     <trans-unit id="mssql.statusBar.enableConnectionColor">
       <source xml:lang="en">When enabled, colorizes the connection status bar item with the color of the connection group. This setting is disabled by default.  This uses the connection group folder&apos;s color directly, and does not alter it in order to ensure contrast with the current VS Code theme. Users should choose connection group colors that work well with their theme.</source>
     </trans-unit>
     <trans-unit id="mssql.objectExplorer.groupBySchema">
       <source xml:lang="en">When enabled, the database objects in Object Explorer will be categorized by schema.</source>
-    </trans-unit>
-    <trans-unit id="mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription">
-      <source xml:lang="en">When enableld, collapse all connection groups in Object Explorer on startup instead of showing them expanded.</source>
     </trans-unit>
     <trans-unit id="mssql.walkthroughs.getStarted.runQueries.description">
       <source xml:lang="en">Write a SQL query, and run it against your database.&#10;You can also click the &apos;Open in New Tab&apos; button to view your query results in their own tab, and optionally set that as the default behavior.</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3454,11 +3454,11 @@
     <trans-unit id="mssql.walkthroughs.nextSteps.viewQueryPlan.title">
       <source xml:lang="en">Visualize a Query Plan</source>
     </trans-unit>
-    <trans-unit id="mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription">
-      <source xml:lang="en">When enabled, all connection groups in the Object Explorer will collapse on startup instead of showing them expanded.</source>
-    </trans-unit>
     <trans-unit id="mssql.statusBar.enableConnectionColor">
       <source xml:lang="en">When enabled, colorizes the connection status bar item with the color of the connection group. This setting is disabled by default.  This uses the connection group folder&apos;s color directly, and does not alter it in order to ensure contrast with the current VS Code theme. Users should choose connection group colors that work well with their theme.</source>
+    </trans-unit>
+    <trans-unit id="mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription">
+      <source xml:lang="en">When enabled, connection groups will be collapsed instead of expanded at startup.</source>
     </trans-unit>
     <trans-unit id="mssql.objectExplorer.groupBySchema">
       <source xml:lang="en">When enabled, the database objects in Object Explorer will be categorized by schema.</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3460,6 +3460,9 @@
     <trans-unit id="mssql.objectExplorer.groupBySchema">
       <source xml:lang="en">When enabled, the database objects in Object Explorer will be categorized by schema.</source>
     </trans-unit>
+    <trans-unit id="mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription">
+      <source xml:lang="en">When enableld, collapse all connection groups in Object Explorer on startup instead of showing them expanded.</source>
+    </trans-unit>
     <trans-unit id="mssql.walkthroughs.getStarted.runQueries.description">
       <source xml:lang="en">Write a SQL query, and run it against your database.&#10;You can also click the &apos;Open in New Tab&apos; button to view your query results in their own tab, and optionally set that as the default behavior.</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -1928,7 +1928,7 @@
                 },
                 "mssql.objectExplorer.connectionGroupsCollapsedOnStartup": {
                     "type": "boolean",
-                    "description": "Connection Groups Collapsed on Startup",
+                    "description": "%mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription%",
                     "default": false,
                     "scope": "window"
                 },

--- a/package.json
+++ b/package.json
@@ -1926,6 +1926,12 @@
                     "description": "%mssql.objectExplorer.groupBySchema%",
                     "default": false
                 },
+                "mssql.objectExplorer.connectionGroupsCollapsedOnStartup": {
+                    "type": "boolean",
+                    "description": "Connection Groups Collapsed on Startup",
+                    "default": false,
+                    "scope": "window"
+                },
                 "mssql.objectExplorer.expandTimeout": {
                     "type": "number",
                     "default": 45,

--- a/package.json
+++ b/package.json
@@ -1926,9 +1926,9 @@
                     "description": "%mssql.objectExplorer.groupBySchema%",
                     "default": false
                 },
-                "mssql.objectExplorer.connectionGroupsCollapsedOnStartup": {
+                "mssql.objectExplorer.collapseConnectionGroupsOnStartup": {
                     "type": "boolean",
-                    "description": "%mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription%",
+                    "description": "%mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription%",
                     "default": false,
                     "scope": "window"
                 },

--- a/package.nls.json
+++ b/package.nls.json
@@ -167,6 +167,7 @@
     "mssql.chooseAuthMethod": "Chooses which Authentication method to use",
     "mssql.authCodeGrant.description": "Prompts users to sign in using their browser.",
     "mssql.deviceCode.description": "Allows users to sign in to input-constrained devices.",
+    "mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription": "When enableld, collapse all connection groups in Object Explorer on startup instead of showing them expanded.",
     "mssql.objectExplorer.groupBySchema": "When enabled, the database objects in Object Explorer will be categorized by schema.",
     "mssql.objectExplorer.enableGroupBySchema": "Enable Group By Schema",
     "mssql.objectExplorer.disableGroupBySchema": "Disable Group By Schema",

--- a/package.nls.json
+++ b/package.nls.json
@@ -167,7 +167,7 @@
     "mssql.chooseAuthMethod": "Chooses which Authentication method to use",
     "mssql.authCodeGrant.description": "Prompts users to sign in using their browser.",
     "mssql.deviceCode.description": "Allows users to sign in to input-constrained devices.",
-    "mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription": "When enableld, collapse all connection groups in Object Explorer on startup instead of showing them expanded.",
+    "mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription": "When enabled, all connection groups in the Object Explorer will collapse on startup instead of showing them expanded.",
     "mssql.objectExplorer.groupBySchema": "When enabled, the database objects in Object Explorer will be categorized by schema.",
     "mssql.objectExplorer.enableGroupBySchema": "Enable Group By Schema",
     "mssql.objectExplorer.disableGroupBySchema": "Disable Group By Schema",

--- a/package.nls.json
+++ b/package.nls.json
@@ -167,7 +167,7 @@
     "mssql.chooseAuthMethod": "Chooses which Authentication method to use",
     "mssql.authCodeGrant.description": "Prompts users to sign in using their browser.",
     "mssql.deviceCode.description": "Allows users to sign in to input-constrained devices.",
-    "mssql.objectExplorer.connectionGroupsCollapsedOnStartupDescription": "When enabled, all connection groups in the Object Explorer will collapse on startup instead of showing them expanded.",
+    "mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription": "When enabled, connection groups will be collapsed instead of expanded at startup.",
     "mssql.objectExplorer.groupBySchema": "When enabled, the database objects in Object Explorer will be categorized by schema.",
     "mssql.objectExplorer.enableGroupBySchema": "Enable Group By Schema",
     "mssql.objectExplorer.disableGroupBySchema": "Disable Group By Schema",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -77,7 +77,7 @@ export const cmdObjectExplorerEnableGroupBySchemaCommand =
 export const cmdObjectExplorerDisableGroupBySchemaCommand =
     "mssql.objectExplorer.disableGroupBySchema";
 export const cmdObjectExplorerCollapseOrExpandByDefault =
-    "objectExplorer.connectionGroupsCollapsedOnStartup";
+    "objectExplorer.collapseConnectionGroupsOnStartup";
 export const cmdEnableRichExperiencesCommand = "mssql.enableRichExperiences";
 export const cmdScriptSelect = "mssql.scriptSelect";
 export const cmdScriptCreate = "mssql.scriptCreate";

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -76,6 +76,8 @@ export const cmdObjectExplorerEnableGroupBySchemaCommand =
     "mssql.objectExplorer.enableGroupBySchema";
 export const cmdObjectExplorerDisableGroupBySchemaCommand =
     "mssql.objectExplorer.disableGroupBySchema";
+export const cmdObjectExplorerCollapseOrExpandByDefault =
+    "objectExplorer.connectionGroupsCollapsedOnStartup";
 export const cmdEnableRichExperiencesCommand = "mssql.enableRichExperiences";
 export const cmdScriptSelect = "mssql.scriptSelect";
 export const cmdScriptCreate = "mssql.scriptCreate";

--- a/src/objectExplorer/nodes/connectionGroupNode.ts
+++ b/src/objectExplorer/nodes/connectionGroupNode.ts
@@ -22,11 +22,15 @@ export class ConnectionGroupNode extends TreeNodeInfo {
     public children: TreeNodeInfo[];
     private _connectionGroup: IConnectionGroup;
 
-    constructor(connectionGroup: IConnectionGroup) {
+    constructor(
+        connectionGroup: IConnectionGroup,
+        collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState
+            .Expanded,
+    ) {
         super(
             connectionGroup.name,
             createConnectionGroupContextValue(),
-            vscode.TreeItemCollapsibleState.Expanded,
+            collapsibleState,
             connectionGroup.id,
             undefined,
             CONNECTION_GROUP_NODE_TYPE,

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -413,8 +413,19 @@ export class ObjectExplorerService {
         const newConnectionNodes = new Map<string, ConnectionNode>();
 
         // Add all group nodes from settings first
+        // Read the user setting for collapsed/expanded state
+        const config = vscode.workspace.getConfiguration("mssql");
+        const collapseGroups = config.get<boolean>(
+            "objectExplorer.connectionGroupsCollapsedOnStartup",
+            false,
+        );
+
         for (const group of serverGroups) {
-            const groupNode = new ConnectionGroupNode(group);
+            // Pass the desired collapsible state to the ConnectionGroupNode constructor
+            const initialState = collapseGroups
+                ? vscode.TreeItemCollapsibleState.Collapsed
+                : vscode.TreeItemCollapsibleState.Expanded;
+            const groupNode = new ConnectionGroupNode(group, initialState);
 
             if (this._connectionGroupNodes.has(group.id)) {
                 groupNode.id = this._connectionGroupNodes.get(group.id).id;
@@ -1035,7 +1046,7 @@ export class ObjectExplorerService {
             }
         };
 
-        return await new Promise<boolean>((resolve, reject) => {
+        return await new Promise<boolean>((resolve) => {
             vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -414,9 +414,9 @@ export class ObjectExplorerService {
 
         // Add all group nodes from settings first
         // Read the user setting for collapsed/expanded state
-        const config = vscode.workspace.getConfiguration("mssql");
+        const config = vscode.workspace.getConfiguration(Constants.extensionName);
         const collapseGroups = config.get<boolean>(
-            "objectExplorer.connectionGroupsCollapsedOnStartup",
+            Constants.cmdObjectExplorerCollapseOrExpandByDefault,
             false,
         );
 


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

This pull request implements a new MSSQL setting that, when enabled, makes the connection groups load expanded in the UI by default (which is the only option currently) but disabling the setting makes all connection groups instead load collapsed in the UI by default.

As someone who uses connection groups to organize databases from different projects, there are many connections I don't need to see while working in a particular workspace. It's a minor nuisance, but I have to collapse all of the connection groups I don't need everytime I open vs code, so I figured having the option to load all of the connection groups collapsed already would help me and a few others.

Additionally, when many connections and connection groups exist, they take up space in the editor window.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

