### PR TITLE
Automatically prune invalid/corrupted Entra account entries in global state

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1237,6 +1237,12 @@
       "{1} is the error message"
     ]
   },
+  "{0} invalid Entra accounts have been removed; you may need to run `MS SQL: Clear Microsoft Entra account token cache` and log in again./{0} is the number of invalid accounts that have been removed": {
+    "message": "{0} invalid Entra accounts have been removed; you may need to run `MS SQL: Clear Microsoft Entra account token cache` and log in again.",
+    "comment": [
+      "{0} is the number of invalid accounts that have been removed"
+    ]
+  },
   "Count: {0}  Distinct Count: {1}  Null Count: {2}/{0} is the count, {1} is the distinct count, and {2} is the null count": {
     "message": "Count: {0}  Distinct Count: {1}  Null Count: {2}",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2846,6 +2846,10 @@
       <source xml:lang="en">{0} has been closed. Would you like to restore it?</source>
       <note>{0} is the webview name</note>
     </trans-unit>
+    <trans-unit id="++CODE++dde734013704b68f0d2d57a1385773d7e4bfbae374a67c150f3f06d8abb95f9d">
+      <source xml:lang="en">{0} invalid Entra accounts have been removed; you may need to run `MS SQL: Clear Microsoft Entra account token cache` and log in again.</source>
+      <note>{0} is the number of invalid accounts that have been removed</note>
+    </trans-unit>
     <trans-unit id="++CODE++e3620e8a37371c6057d768faed05a7608c6e5ee783372a58b137b047300e8b7a">
       <source xml:lang="en">{0} issue</source>
       <note>{0} is the number of issues</note>

--- a/src/azure/accountStore.ts
+++ b/src/azure/accountStore.ts
@@ -17,8 +17,14 @@ export class AccountStore {
     public getAccounts(): IAccount[] {
         let configValues =
             this._context.globalState.get<IAccount[]>(Constants.configAzureAccount) ?? [];
+
+        // TODO: remove; mocking incomplete account info for debugging
+        if (configValues.length > 0) {
+            configValues[0].displayInfo = undefined;
+        }
+
         this._logger.verbose(
-            `Retreived ${configValues?.length} Azure accounts from account store.`,
+            `Retrieved ${configValues?.length} Azure accounts from account store.`,
         );
         return configValues;
     }

--- a/src/azure/accountStore.ts
+++ b/src/azure/accountStore.ts
@@ -3,37 +3,56 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as os from "os";
 import * as vscode from "vscode";
-import { IAccount } from "../models/contracts/azure";
 import * as Constants from "../constants/constants";
+import * as Loc from "../constants/locConstants";
+import { IAccount } from "../models/contracts/azure";
 import { Logger } from "../models/logger";
+import { Deferred } from "../protocol";
+import { getErrorMessage } from "../utils/utils";
+import VscodeWrapper from "../controllers/vscodeWrapper";
 
 export class AccountStore {
+    public readonly initialized: Deferred<void> = new Deferred<void>();
+    private readonly _logger: Logger;
+
     constructor(
         private _context: vscode.ExtensionContext,
-        private _logger: Logger,
-    ) {}
+        private _vscodeWrapper: VscodeWrapper,
+    ) {
+        this._logger = Logger.create(this._vscodeWrapper.outputChannel, "AccountStore");
 
-    public getAccounts(): IAccount[] {
-        let configValues =
-            this._context.globalState.get<IAccount[]>(Constants.configAzureAccount) ?? [];
-
-        // TODO: remove; mocking incomplete account info for debugging
-        if (configValues.length > 0) {
-            configValues[0].displayInfo = undefined;
-        }
-
-        this._logger.verbose(
-            `Retrieved ${configValues?.length} Azure accounts from account store.`,
-        );
-        return configValues;
+        void this.initialize().then(() => {
+            this.initialized.resolve();
+        });
     }
 
+    private async initialize(): Promise<void> {
+        await this.pruneInvalidAccounts();
+    }
+
+    /**
+     * Gets all saved Entra accounts from the global state
+     */
+    public async getAccounts(): Promise<IAccount[]> {
+        await this.initialized;
+        let accounts =
+            this._context.globalState.get<IAccount[]>(Constants.configAzureAccount) ?? [];
+
+        this._logger.info(`Retrieved ${accounts.length} Entra accounts from account store.`);
+        return accounts;
+    }
+
+    /**
+     * Gets a specific Entra account from the global state cache
+     * @param key Account key to look up by.  Recommended to be `IAccount.key.id`
+     */
     public getAccount(key: string): IAccount | undefined {
         let account: IAccount | undefined;
         let configValues = this._context.globalState.get<IAccount[]>(Constants.configAzureAccount);
         if (!configValues) {
-            throw new Error("No Azure accounts stored");
+            throw new Error("No Entra accounts stored");
         }
         for (let value of configValues) {
             // Compare account IDs considering multi-tenant account ID format with MSAL.
@@ -49,57 +68,104 @@ export class AccountStore {
         return account;
     }
 
-    public removeAccount(key: string): void {
+    /**
+     * Removes a specific Entra account from the global state cache
+     * @param key Account key to look up by.  Recommended to be `IAccount.key.id`
+     */
+    public async removeAccount(key: string): Promise<void> {
         if (!key) {
-            this._logger.error("Azure Account key not received for removal request.");
+            this._logger.error("Key must be specified for Entra account removal");
         }
-        let configValues = this.getAccounts();
+
+        await this.initialized;
+
+        let configValues = await this.getAccounts();
         configValues = configValues.filter((val) => val.key.id !== key);
-        this._context.globalState.update(Constants.configAzureAccount, configValues);
+        await this._context.globalState.update(Constants.configAzureAccount, configValues);
         return;
     }
 
     /**
-     * Adds an account to the account store.
-     *
-     * @param account the account to add
-     * @returns a Promise that returns when the account was saved
+     * Adds an Entra account to the account store.
+     * @returns a boolean indicating if the account was successfully added
      */
-    public async addAccount(account: IAccount): Promise<void> {
-        if (account) {
-            let configValues = this.getAccounts();
-            // remove element if already present in map
-            if (configValues.length > 0) {
-                configValues = configValues.filter((val) => val.key.id !== account.key.id);
-            } else {
-                configValues = [];
-            }
-            configValues.unshift(account);
-            await this._context.globalState.update(Constants.configAzureAccount, configValues);
-        } else {
-            this._logger.error("Empty Azure Account cannot be added to account store.");
+    public async addAccount(account: IAccount): Promise<boolean> {
+        if (!account) {
+            this._logger.error("Empty Entra Account cannot be added to account store.");
+            return false;
         }
+
+        if (!account.key?.id || !account.displayInfo?.displayName) {
+            this._logger.error(
+                `Attemped to add incomplete Entra account: ${JSON.stringify(account)}`,
+            );
+            return false;
+        }
+
+        await this.initialized;
+
+        let configValues = await this.getAccounts();
+
+        // remove account if already present in store
+        if (configValues.length > 0) {
+            configValues = configValues.filter((val) => val.key.id !== account.key.id);
+        } else {
+            configValues = [];
+        }
+
+        configValues.unshift(account);
+        await this._context.globalState.update(Constants.configAzureAccount, configValues);
+
+        return true;
     }
 
-    public async pruneAccounts(): Promise<void> {
-        let configValues = this.getAccounts();
-        configValues = configValues.filter((val) => {
-            if (val.key) {
-                return true;
-            } else {
+    /**
+     * Removes all Entra accounts that are incomplete because they are missing either a key ID or a display information
+     */
+    public async pruneInvalidAccounts(): Promise<void> {
+        // Because this runs during initialization and the public CRUD calls check for initialization,
+        // this method must work directly with the globalState API.
+
+        let accounts =
+            this._context.globalState.get<IAccount[]>(Constants.configAzureAccount) ?? [];
+        let numRemoved = 0;
+
+        accounts = accounts.filter((val) => {
+            try {
+                if (val.key?.id && val.displayInfo?.displayName) {
+                    return true;
+                } else {
+                    numRemoved++;
+                    this._logger.info(
+                        `Unexpected incomplete Entra account; missing either key ID or display info. Removing account from account store: ${JSON.stringify(val)}`,
+                    );
+                    return false;
+                }
+            } catch (err) {
+                numRemoved++;
                 this._logger.info(
-                    "Unexpected empty account key, removing account from account store.",
+                    `Unexpected incomplete Entra account; removing account from account store.${os.EOL}Error:${os.EOL}${getErrorMessage(err)}${os.EOL + os.EOL}Account:${os.EOL}${JSON.stringify(val)}`,
                 );
                 return false;
             }
         });
-        await this._context.globalState.update(Constants.configAzureAccount, configValues);
+
+        if (numRemoved > 0) {
+            await this._context.globalState.update(Constants.configAzureAccount, accounts);
+            this._vscodeWrapper.showInformationMessage(
+                Loc.Accounts.invalidEntraAccountsRemoved(numRemoved),
+            );
+        }
+
         return;
     }
 
+    /**
+     * Removes all saved Entra auth accounts
+     */
     public async clearAccounts(): Promise<void> {
         let configValues = [];
         await this._context.globalState.update(Constants.configAzureAccount, configValues);
-        this._logger.verbose("Cleared all saved Azure accounts");
+        this._logger.info("Cleared all saved Entra accounts");
     }
 }

--- a/src/connectionconfig/azureHelpers.ts
+++ b/src/connectionconfig/azureHelpers.ts
@@ -343,6 +343,7 @@ export async function getTenants(
 
     if (!accountId) {
         logger.error("getTenants(): undefined accountId passed.");
+        return [];
     }
 
     try {

--- a/src/connectionconfig/azureHelpers.ts
+++ b/src/connectionconfig/azureHelpers.ts
@@ -302,8 +302,8 @@ export async function getAccounts(
         accounts = await azureAccountService.getAccounts();
         return accounts.map((account) => {
             return {
-                displayName: account.displayInfo.displayName,
-                value: account.displayInfo.userId,
+                displayName: account.displayInfo?.displayName,
+                value: account.key.id,
             };
         });
     } catch (error) {
@@ -330,16 +330,23 @@ export async function getAccounts(
     }
 }
 
+/**
+ * Retrieves the tenants for a given Azure account.
+ * @param accountId The ID of the account to retrieve tenants for.  Recommended to be `IAccount.key.id`.
+ */
 export async function getTenants(
     azureAccountService: AzureAccountService,
     accountId: string,
     logger: Logger,
 ): Promise<FormItemOptions[]> {
     let tenants: ITenant[] = [];
+
+    if (!accountId) {
+        logger.error("getTenants(): undefined accountId passed.");
+    }
+
     try {
-        const account = (await azureAccountService.getAccounts()).find(
-            (account) => account.displayInfo?.userId === accountId,
-        );
+        const account = await azureAccountService.getAccount(accountId);
 
         if (!account?.properties?.tenants) {
             const missingProp = !account

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1170,17 +1170,20 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 if (firstOption) {
                     this.state.connectionProfile.accountId = firstOption.value;
                 }
-                tenants = await getTenants(
-                    this._mainController.azureAccountService,
-                    this.state.connectionProfile.accountId,
-                    this.logger,
-                );
-                if (tenantComponent) {
-                    tenantComponent.options = tenants;
-                    if (tenants && tenants.length > 0) {
-                        this.state.connectionProfile.tenantId = tenants[0].value;
+                if (this.state.connectionProfile.accountId) {
+                    tenants = await getTenants(
+                        this._mainController.azureAccountService,
+                        this.state.connectionProfile.accountId,
+                        this.logger,
+                    );
+                    if (tenantComponent) {
+                        tenantComponent.options = tenants;
+                        if (tenants && tenants.length > 0) {
+                            this.state.connectionProfile.tenantId = tenants[0].value;
+                        }
                     }
                 }
+
                 accountComponent.actionButtons = await this.getAzureActionButtons();
                 break;
         }

--- a/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/src/connectionconfig/connectionDialogWebviewController.ts
@@ -163,7 +163,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private async initializeDialog(
         connectionToEdit: IConnectionInfo,
         initialConnectionGroup?: IConnectionGroup,
-    ) {
+    ): Promise<void> {
         // Load connection form components
         this.state.formComponents = await generateConnectionComponents(
             this._mainController.connectionManager,
@@ -611,13 +611,18 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             hiddenProperties.push("accountId", "tenantId");
         }
         if (this.state.connectionProfile.authenticationType === AuthenticationType.AzureMFA) {
-            // Hide tenantId if accountId has only one tenant
-            const tenants = await getTenants(
-                this._mainController.azureAccountService,
-                this.state.connectionProfile.accountId,
-                this.logger,
-            );
-            if (tenants.length === 1) {
+            let tenants = [];
+
+            if (this.state.connectionProfile.accountId !== undefined) {
+                tenants = await getTenants(
+                    this._mainController.azureAccountService,
+                    this.state.connectionProfile.accountId,
+                    this.logger,
+                );
+            }
+
+            // Hide tenantId if not signed in or accountId has only one tenant
+            if (tenants.length < 2) {
                 hiddenProperties.push("tenantId");
             }
         }

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -727,6 +727,17 @@ export class Azure {
     };
 }
 
+export class Accounts {
+    public static invalidEntraAccountsRemoved = (numRemoved: number) => {
+        return l10n.t({
+            message:
+                "{0} invalid Entra accounts have been removed; you may need to run `MS SQL: Clear Microsoft Entra account token cache` and log in again.",
+            args: [numRemoved],
+            comment: ["{0} is the number of invalid accounts that have been removed"],
+        });
+    };
+}
+
 export class QueryResult {
     public static nonNumericSelectionSummary = (
         count: number,

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1218,7 +1218,7 @@ export default class ConnectionManager {
         let profile: ConnectionProfile;
 
         if (connectionInfo.accountId) {
-            account = this.accountStore.getAccount(connectionInfo.accountId);
+            account = await this.accountStore.getAccount(connectionInfo.accountId);
             profile = new ConnectionProfile(connectionInfo);
         } else {
             throw new Error(LocalizedConstants.cannotConnect);

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -166,7 +166,7 @@ export default class ConnectionManager {
         }
 
         if (!this._accountStore) {
-            this._accountStore = new AccountStore(context, this._logger);
+            this._accountStore = new AccountStore(context, this.vscodeWrapper);
         }
 
         if (!this._connectionUI) {
@@ -1649,7 +1649,7 @@ export default class ConnectionManager {
     public async removeAccount(prompter: IPrompter): Promise<void> {
         // list options for accounts to remove
         let questions: IQuestion[] = [];
-        let azureAccountChoices = ConnectionProfile.getAccountChoices(this._accountStore);
+        let azureAccountChoices = await ConnectionProfile.getAccountChoices(this._accountStore);
 
         if (azureAccountChoices.length > 0) {
             questions.push({
@@ -1663,9 +1663,9 @@ export default class ConnectionManager {
                 if (answers?.account) {
                     try {
                         if (answers.account.key) {
-                            this._accountStore.removeAccount(answers.account.key.id);
+                            await this._accountStore.removeAccount(answers.account.key.id);
                         } else {
-                            await this._accountStore.pruneAccounts();
+                            await this._accountStore.pruneInvalidAccounts();
                         }
                         void this.azureController.removeAccount(answers.account);
                         this.vscodeWrapper.showInformationMessage(
@@ -1843,7 +1843,7 @@ export default class ConnectionManager {
         const activeEditorConnection =
             this._connections[this._vscodeWrapper.activeTextEditorUri]?.credentials;
         const currentAccountId = activeEditorConnection?.accountId;
-        const accounts = this._accountStore.getAccounts();
+        const accounts = await this._accountStore.getAccounts();
 
         const quickPickItems = this.createAccountQuickPickItems(accounts, currentAccountId);
         const selectedAccount = await this.showAccountQuickPick(quickPickItems);

--- a/src/models/connectionProfile.ts
+++ b/src/models/connectionProfile.ts
@@ -74,7 +74,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
             profile.authenticationType = authOptions[0].value;
         }
         let azureAccountChoices: INameValueChoice[] =
-            ConnectionProfile.getAccountChoices(accountStore);
+            await ConnectionProfile.getAccountChoices(accountStore);
         let accountAnswer: IAccount;
         azureAccountChoices.unshift({
             name: LocalizedConstants.azureAddAccount,
@@ -248,8 +248,8 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
         return choices;
     }
 
-    public static getAccountChoices(accountStore: AccountStore): INameValueChoice[] {
-        let accounts = accountStore.getAccounts();
+    public static async getAccountChoices(accountStore: AccountStore): Promise<INameValueChoice[]> {
+        let accounts = await accountStore.getAccounts();
         let choices: Array<INameValueChoice> = [];
 
         if (accounts.length > 0) {

--- a/src/objectExplorer/objectExplorerService.ts
+++ b/src/objectExplorer/objectExplorerService.ts
@@ -793,7 +793,7 @@ export class ObjectExplorerService {
 
         if (connectionProfile.authenticationType === Constants.azureMfa) {
             let azureController = this._connectionManager.azureController;
-            let account = this._connectionManager.accountStore.getAccount(
+            let account = await this._connectionManager.accountStore.getAccount(
                 connectionProfile.accountId,
             );
             let needsRefresh = false;
@@ -964,7 +964,7 @@ export class ObjectExplorerService {
             this.needsAccountRefresh(failureResponse, connectionProfile.user)
         ) {
             this._logger.verbose(`Refreshing account token for ${connectionProfile.accountId}}`);
-            let account = this._connectionManager.accountStore.getAccount(
+            let account = await this._connectionManager.accountStore.getAccount(
                 connectionProfile.accountId,
             );
 

--- a/src/services/azureAccountService.ts
+++ b/src/services/azureAccountService.ts
@@ -20,7 +20,7 @@ export class AzureAccountService implements IAzureAccountService {
     }
 
     public async getAccounts(): Promise<IAccount[]> {
-        return this._accountStore.getAccounts();
+        return await this._accountStore.getAccounts();
     }
 
     /**

--- a/src/services/azureAccountService.ts
+++ b/src/services/azureAccountService.ts
@@ -20,7 +20,16 @@ export class AzureAccountService implements IAzureAccountService {
     }
 
     public async getAccounts(): Promise<IAccount[]> {
-        return await this._accountStore.getAccounts();
+        return this._accountStore.getAccounts();
+    }
+
+    /**
+     * Retrieves an Azure account by its key.
+     * @param key The key of the account to retrieve.  Use `IAccount.key.id` if available.
+     * @returns The Azure account, or undefined if not found.
+     */
+    public async getAccount(key: string): Promise<IAccount> {
+        return this._accountStore.getAccount(key);
     }
 
     public async getAccountSecurityToken(

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -621,7 +621,7 @@ export class ConnectionUI {
             // TODO: Access account which firewall error needs to be added from:
             // Try to match accountId to an account in account storage
             if (profile.accountId) {
-                let account = this._accountStore.getAccount(profile.accountId);
+                let account = await this._accountStore.getAccount(profile.accountId);
                 this.connectionManager.accountService.setAccount(account);
                 // take that account from account storage and refresh tokens and create firewall rule
             } else {
@@ -638,7 +638,7 @@ export class ConnectionUI {
                             providerSettings.resources.azureManagementResource,
                         );
                 }
-                let account = this._accountStore.getAccount(profile.accountId);
+                let account = await this._accountStore.getAccount(profile.accountId);
                 this.connectionManager.accountService.setAccount(account!);
             }
 

--- a/src/views/connectionUI.ts
+++ b/src/views/connectionUI.ts
@@ -799,7 +799,7 @@ export class ConnectionUI {
             );
         }
 
-        let azureAccountChoices: INameValueChoice[] = ConnectionProfile.getAccountChoices(
+        let azureAccountChoices: INameValueChoice[] = await ConnectionProfile.getAccountChoices(
             this._accountStore,
         );
         let tenantChoices: INameValueChoice[] = [];

--- a/test/unit/azureHelpers.test.ts
+++ b/test/unit/azureHelpers.test.ts
@@ -140,18 +140,16 @@ suite("Azure Helpers", () => {
     });
 
     test("getTenants handles error cases", async () => {
-        const getAccountsStub = mockAzureAccountService.getAccounts as sinon.SinonStub;
+        const getAccountStub = mockAzureAccountService.getAccount as sinon.SinonStub;
         // undefined tenants
-        getAccountsStub.resolves([
-            {
-                displayInfo: {
-                    userId: "test-user-id",
-                },
-                properties: {
-                    tenants: undefined,
-                },
-            } as IAccount,
-        ]);
+        getAccountStub.resolves({
+            displayInfo: {
+                userId: "test-user-id",
+            },
+            properties: {
+                tenants: undefined,
+            },
+        } as IAccount);
 
         let result = await azureHelpers.getTenants(
             mockAzureAccountService,
@@ -165,18 +163,16 @@ suite("Azure Helpers", () => {
         ).to.be.true;
 
         // reset mocks for next case
-        getAccountsStub.reset();
+        getAccountStub.reset();
         (mockLogger.error as sinon.SinonStub).resetHistory();
 
         // undefined properties
-        getAccountsStub.resolves([
-            {
-                displayInfo: {
-                    userId: "test-user-id",
-                },
-                properties: undefined,
-            } as IAccount,
-        ]);
+        getAccountStub.resolves({
+            displayInfo: {
+                userId: "test-user-id",
+            },
+            properties: undefined,
+        } as IAccount);
 
         result = await azureHelpers.getTenants(mockAzureAccountService, "test-user-id", mockLogger);
         expect(result).to.be.an("array").that.is.empty;

--- a/test/unit/connectionProfile.test.ts
+++ b/test/unit/connectionProfile.test.ts
@@ -17,7 +17,6 @@ import { ConnectionCredentials } from "../../src/models/connectionCredentials";
 import { ConnectionProfile } from "../../src/models/connectionProfile";
 import { ConnectionStore } from "../../src/models/connectionStore";
 import { AuthenticationTypes, IConnectionProfile } from "../../src/models/interfaces";
-import { Logger } from "../../src/models/logger";
 import { INameValueChoice, IPrompter, IQuestion } from "../../src/prompts/question";
 import { ConnectionUI } from "../../src/views/connectionUI";
 import { TestPrompter } from "./stubs";
@@ -74,7 +73,7 @@ suite("Connection Profile tests", () => {
     let mockAzureController: AzureController;
     let mockContext: TypeMoq.IMock<vscode.ExtensionContext>;
     let mockPrompter: TypeMoq.IMock<IPrompter>;
-    let mockLogger: TypeMoq.IMock<Logger>;
+    let mockVscodeWrapper: TypeMoq.IMock<VscodeWrapper>;
     let globalstate: TypeMoq.IMock<
         vscode.Memento & { setKeysForSync(keys: readonly string[]): void }
     >;
@@ -85,14 +84,14 @@ suite("Connection Profile tests", () => {
         >();
         mockContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
         mockPrompter = TypeMoq.Mock.ofType<IPrompter>();
-        mockLogger = TypeMoq.Mock.ofType<Logger>();
+        mockVscodeWrapper = TypeMoq.Mock.ofType<VscodeWrapper>();
         mockContext.setup((c) => c.globalState).returns(() => globalstate.object);
         mockAzureController = new MsalAzureController(
             mockContext.object,
             mockPrompter.object,
             undefined,
         );
-        mockAccountStore = new AccountStore(mockContext.object, mockLogger.object);
+        mockAccountStore = new AccountStore(mockContext.object, mockVscodeWrapper.object);
     });
 
     test("CreateProfile should ask questions in correct order", async () => {

--- a/test/unit/connectionUI.test.ts
+++ b/test/unit/connectionUI.test.ts
@@ -18,7 +18,6 @@ import { ConnectionProfile } from "../../src/models/connectionProfile";
 import { ConnectionCredentials } from "../../src/models/connectionCredentials";
 import * as LocalizedConstants from "../../src/constants/locConstants";
 import { AccountStore } from "../../src/azure/accountStore";
-import { Logger } from "../../src/models/logger";
 import * as sinon from "sinon";
 
 suite("Connection UI tests", () => {
@@ -32,7 +31,6 @@ suite("Connection UI tests", () => {
     let connectionStore: TypeMoq.IMock<ConnectionStore>;
     let connectionManager: TypeMoq.IMock<ConnectionManager>;
     let mockAccountStore: AccountStore;
-    let mockLogger: TypeMoq.IMock<Logger>;
     let mockContext: TypeMoq.IMock<vscode.ExtensionContext>;
     let globalstate: TypeMoq.IMock<
         vscode.Memento & { setKeysForSync(keys: readonly string[]): void }
@@ -72,8 +70,7 @@ suite("Connection UI tests", () => {
         globalstate = TypeMoq.Mock.ofType<
             vscode.Memento & { setKeysForSync(keys: readonly string[]): void }
         >();
-        mockLogger = TypeMoq.Mock.ofType<Logger>();
-        mockAccountStore = new AccountStore(mockContext.object, mockLogger.object);
+        mockAccountStore = new AccountStore(mockContext.object, vscodeWrapper.object);
         connectionUI = new ConnectionUI(
             connectionManager.object,
             mockContext.object,

--- a/test/unit/objectExplorerService.test.ts
+++ b/test/unit/objectExplorerService.test.ts
@@ -1016,7 +1016,7 @@ suite("OE Service Tests", () => {
             } as IConnectionProfile;
 
             // Setup account store to return the mock account
-            mockAccountStore.getAccount.withArgs("account-id").returns(mockAccount);
+            mockAccountStore.getAccount.withArgs("account-id").resolves(mockAccount);
 
             // Setup Azure controller
             mockAzureController.isSqlAuthProviderEnabled.returns(true);
@@ -1092,7 +1092,7 @@ suite("OE Service Tests", () => {
             } as IConnectionProfile;
 
             // Setup account store to return the mock account
-            mockAccountStore.getAccount.withArgs("account-id").returns(mockAccount);
+            mockAccountStore.getAccount.withArgs("account-id").resolves(mockAccount);
 
             // Setup Azure controller - account NOT in cache
             mockAzureController.isSqlAuthProviderEnabled.returns(true);
@@ -1194,7 +1194,7 @@ suite("OE Service Tests", () => {
             } as IConnectionProfile;
 
             // Setup account store to return the mock account
-            mockAccountStore.getAccount.withArgs("account-id").returns(mockAccount);
+            mockAccountStore.getAccount.withArgs("account-id").resolves(mockAccount);
 
             // Setup Azure controller - SQL auth provider disabled
             mockAzureController.isSqlAuthProviderEnabled.returns(false);
@@ -1247,7 +1247,7 @@ suite("OE Service Tests", () => {
             } as IConnectionProfile;
 
             // Setup account store to return the mock account
-            mockAccountStore.getAccount.withArgs("account-id").returns(mockAccount);
+            mockAccountStore.getAccount.withArgs("account-id").resolves(mockAccount);
 
             // Setup Azure controller - SQL auth provider enabled, account in cache
             mockAzureController.isSqlAuthProviderEnabled.returns(true);
@@ -1695,7 +1695,7 @@ suite("OE Service Tests", () => {
             const mockAccount = createMockAccount("azure-account-id");
 
             // Setup account store to return the mock account
-            mockAccountStore.getAccount.withArgs("azure-account-id").returns(mockAccount);
+            mockAccountStore.getAccount.withArgs("azure-account-id").resolves(mockAccount);
 
             // Setup refreshAccount to return success
             sandbox.stub(objectExplorerService as any, "refreshAccount").resolves(true);


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/19839

The saved Entra account list can potentially have an invalid entry written to it due to no checks being done on the shape of data at runtime.  Based on the corrupted entry I was able to source from someone hitting this issue, it may be related to the auth window getting cancelled.  This fix adds logic to clean up this entry upon launch, and adds validation of entries when they're added.

Sample corrupted entry:
```
{
    "azureAccount": [
        {
            "canceled": false
        }
    ]
}
```

Sample correct entry:
```
{
    "azureAccount": [
        {
            "key": {
                "providerId": "azure_publicCloud",
                "id": "<GUID>.<GUID>",
                "accountVersion": "2.0"
            },
            "name": "Your Name - yourName@microsoft.com",
            "displayInfo": {
                "accountType": "work_school",
                "userId": "<GUID>.<GUID>",
                "contextualDisplayName": "Microsoft Corp",
                "displayName": "Your Name - yourName@microsoft.com",
                "email": "yourName@microsoft.com",
                "name": "Your Name"
            },
            "properties": {
                "providerSettings": { ... },
                    "scopes": [ ... ]
                },
                "isMsAccount": false,
                "owningTenant": { ... },
                "tenants": [
                    {
                        "id": "<GUID>",
                        "displayName": "Microsoft",
                        "tenantCategory": "Home"
                    }
                ],
                "azureAuthType": 0
            },
            "isStale": false
        }
    ],
}
```

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

