### PR TITLE
Removing trailing space in ToS link for Local Container

### DIFF
--- a/src/containerDeployment/containerDeploymentWebviewController.ts
+++ b/src/containerDeployment/containerDeploymentWebviewController.ts
@@ -479,9 +479,7 @@ export class ContainerDeploymentWebviewController extends FormWebviewController<
                         <a
                             href="https://go.microsoft.com/fwlink/?LinkId=746388"
                             target="_blank"
-                        >
-                            ${ContainerDeployment.termsAndConditions}
-                        </a>
+                        >${ContainerDeployment.termsAndConditions}</a>
                     </span>`,
                 required: true,
                 tooltip: ContainerDeployment.acceptSqlServerEulaTooltip,


### PR DESCRIPTION
## Description

Removing trailing space in ToS link for Local Container:

Before:
<img width="376" height="192" alt="image" src="https://github.com/user-attachments/assets/605ee518-0f4a-48df-a04b-50118edb0f02" />

After:
<img width="376" height="192" alt="image" src="https://github.com/user-attachments/assets/95f8b03e-c3fa-4725-8cac-31e291b477c7" />


## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

