### PR TITLE
Adding ability to filter unit tests.

### DIFF
--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -108,6 +108,21 @@ export async function run(): Promise<void> {
         },
     });
 
+    const rawPattern = process.env.TEST_PATTERN || process.env.MOCHA_GREP;
+    const invert = /^true$/i.test(process.env.TEST_INVERT || process.env.MOCHA_INVERT || "");
+    if (rawPattern) {
+        let rx: RegExp;
+        try {
+            rx = new RegExp(rawPattern);
+        } catch {
+            const esc = rawPattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            rx = new RegExp(esc);
+        }
+        mocha.grep(rx);
+        if (invert) mocha.invert();
+        console.log(`🔎 Filtering tests with pattern: ${rx}${invert ? " (inverted)" : ""}`);
+    }
+
     // Add all files to the test suite
     const files = glob.sync("**/*.test.js", { cwd: testsRoot });
     files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));

--- a/test/unit/runTest.ts
+++ b/test/unit/runTest.ts
@@ -7,6 +7,23 @@ import * as path from "path";
 
 import { runTests } from "@vscode/test-electron";
 
+function parsePatternArg(argv: string[]): string | undefined {
+    // Supports: --testPattern "<regex>", --pattern "<regex>", --grep "<regex>"
+    const keys = new Set(["--testPattern", "--pattern", "--grep"]);
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (keys.has(arg)) {
+            return argv[i + 1]; // next token as value
+        }
+        // also allow --testPattern=foo
+        const [k, v] = arg.split("=", 2);
+        if (keys.has(k) && v) {
+            return v;
+        }
+    }
+    return undefined;
+}
+
 async function main() {
     try {
         // The folder containing the Extension Manifest package.json
@@ -17,11 +34,28 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, "./index");
 
+        // Parse optional test pattern
+        const patternFromArgs = parsePatternArg(process.argv.slice(2));
+        // Allow env override too
+        const testPattern = patternFromArgs ?? process.env.TEST_PATTERN;
+
+        if (testPattern) {
+            console.log(`Using test pattern (grep): ${testPattern}`);
+        } else {
+            console.log("No test pattern provided; running full test suite.");
+        }
+
         // Download VS Code, unzip it and run the integration test
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [],
+            extensionTestsEnv: {
+                ...process.env,
+                TEST_PATTERN: testPattern ?? "",
+                // Some runners read MOCHA_GREP; set it too for convenience
+                MOCHA_GREP: testPattern ?? "",
+            },
         });
     } catch (err) {
         console.error("Failed to run tests", err);


### PR DESCRIPTION
Adding ability to filter unit tests to help agent run targeted tests (for fixing and iterating). This will help us save tokens. 

Usage 
```
yarn test --grep "<pattern>"
```


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

