### PR TITLE
Fixing sts installer file. 

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -37,7 +37,7 @@ async function installSqlToolsService(platform = null) {
   logger.step('Installing SQL Tools Service...');
 
   try {
-    const install = require('../out/src/languageservice/serviceInstallerUtil');
+    const install = require('../dist/serviceInstallerUtil');
     await install.installService(platform);
     logger.success('SQL Tools Service installed');
   } catch (error) {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Previously, I was using the wrong file for installing sts for packaging. This file extracted sts in out/src/.../sqltoolservice. Since we ignore the out folder the vsix bundles were created without sts installed. 

Now, I am correctly installing the sts by using the right js file and installing it in <root>/sqltoolservice



## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

