### PR TITLE
Fix flaky Azure token validation test

### DIFF
--- a/test/unit/azureController.test.ts
+++ b/test/unit/azureController.test.ts
@@ -5,9 +5,20 @@
 
 import { AzureController } from "../../src/azure/azureController";
 import * as assert from "assert";
+import * as sinon from "sinon";
 
 suite("Azure Controller Tests", () => {
-    const currentTime = Date.now() / 1000;
+    const currentTime = 1600000000; // Fixed timestamp to avoid timing issues
+    let dateStub: sinon.SinonStub;
+
+    setup(() => {
+        // Mock Date.now() to return consistent timestamp
+        dateStub = sinon.stub(Date, "now").returns(currentTime * 1000);
+    });
+
+    teardown(() => {
+        dateStub.restore();
+    });
 
     test("isTokenValid should return false for undefined token", () => {
         const actual = AzureController.isTokenValid(undefined, currentTime);


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

1. Test calculated currentTime at suite
  initialization using Date.now()
2. Implementation calculated currentTime at runtime
  inside isTokenExpired()
3. If test execution was delayed, the token would
  appear expired, causing false negatives

  Solution
- Replaced dynamic Date.now() with fixed timestamp
  1600000000
-  Added sinon stub to mock Date.now() for consistent
  behavior across all token validation tests

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

