### PR TITLE
Remove 30 mins delete timeout for query runners.

### DIFF
--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -334,6 +334,10 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
     public removePanel(uri: string): void {
         if (this._queryResultWebviewPanelControllerMap.has(uri)) {
             this._queryResultWebviewPanelControllerMap.delete(uri);
+            /**
+             * Remove the corresponding query runner on panel closed
+             */
+            this._sqlOutputContentProvider.cleanupRunner(uri);
         }
     }
 


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Previously, query runners were kept alive for 30 minutes after a SQL file was closed to ensure the results panel could still fetch rows from STS.

This has been updated:

1. **SQL file close:** Query runners are now deleted immediately if results are shown in the webview view. 
2. **Webview panel close:** Query runners are deleted when the panel itself is closed.


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

