### PR TITLE
Fix select an account state issue

### DIFF
--- a/src/reactviews/pages/ConnectionDialog/fabricBrowsePage.tsx
+++ b/src/reactviews/pages/ConnectionDialog/fabricBrowsePage.tsx
@@ -93,8 +93,16 @@ export const FabricBrowsePage = () => {
         ) {
             setAccounts(context.state.azureAccounts);
 
-            // Set the first account as selected if available
-            if (context.state.azureAccounts.length > 0 && !context.state.selectedAccountId) {
+            // Sync selectedAccountName with the globally stored selectedAccountId
+            if (context.state.selectedAccountId) {
+                const selectedAccount = context.state.azureAccounts.find(
+                    (account) => account.id === context.state.selectedAccountId,
+                );
+                if (selectedAccount) {
+                    setSelectedAccountName(selectedAccount.name);
+                }
+            } else if (context.state.azureAccounts.length > 0) {
+                // Set the first account as selected if no account is currently selected
                 handleAccountChange({} as any, {
                     optionText: context.state.azureAccounts[0].name,
                     optionValue: context.state.azureAccounts[0].id,
@@ -102,7 +110,11 @@ export const FabricBrowsePage = () => {
                 });
             }
         }
-    }, [context.state.loadingAzureAccountsStatus, context.state.azureAccounts]);
+    }, [
+        context.state.loadingAzureAccountsStatus,
+        context.state.azureAccounts,
+        context.state.selectedAccountId,
+    ]);
 
     function setSelectedServerWithFormState(server: string | undefined) {
         if (server === undefined && context?.state.formState.server === "") {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

When switching between "Browse Azure" and "Browse Fabric" radio options, the selected account name in the Fabric dropdown was reset to an empty string. This PR fixes that by synchronizing between the local component state and the persistent global context state.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

