### PR TITLE
Make explorer header sticky

### DIFF
--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
@@ -66,6 +66,12 @@ export const useStyles = makeStyles({
         paddingLeft: "4px",
         paddingRight: "4px",
     },
+    workspaceSearchBox: {
+        marginTop: "4px",
+        marginBottom: "8px",
+        paddingLeft: "4px",
+        paddingRight: "4px",
+    },
     workspaceItem: {
         ...shorthands.padding("4px", "8px", "4px", "24px"),
         cursor: "pointer",

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
@@ -21,9 +21,8 @@ export const useStyles = makeStyles({
         minWidth: "160px",
         height: "100%",
         borderRight: "1px solid var(--vscode-panel-border)",
-        ...shorthands.padding("4px"),
         transition: "width 0.2s ease-in-out",
-        overflow: "auto",
+        overflow: "hidden",
         backgroundColor: "var(--vscode-sideBar-background)",
     },
     workspaceExplorerCollapsed: {
@@ -40,8 +39,8 @@ export const useStyles = makeStyles({
     },
     workspaceGrid: {
         flexGrow: 1,
-        overflow: "hidden",
-        ...shorthands.padding("8px"),
+        overflow: "auto",
+        ...shorthands.padding("8px", "8px", "16px", "8px"),
         height: "100%",
         display: "flex",
         flexDirection: "column",
@@ -52,6 +51,20 @@ export const useStyles = makeStyles({
         marginBottom: "8px",
         paddingLeft: "8px",
         paddingTop: "4px",
+        paddingRight: "4px",
+        flexShrink: 0,
+    },
+    workspaceListContainer: {
+        flexGrow: 1,
+        overflow: "auto",
+        paddingLeft: "4px",
+        paddingRight: "4px",
+    },
+    workspaceHeader: {
+        flexShrink: 0,
+        paddingTop: "4px",
+        paddingLeft: "4px",
+        paddingRight: "4px",
     },
     workspaceItem: {
         ...shorthands.padding("4px", "8px", "4px", "24px"),

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
@@ -19,6 +19,7 @@ import {
     Label,
     Spinner,
     Tooltip,
+    Input,
 } from "@fluentui/react-components";
 import {
     FabricWorkspaceInfo,
@@ -30,6 +31,7 @@ import {
     ChevronDoubleRightFilled,
     ErrorCircleRegular,
     PeopleTeamRegular,
+    SearchRegular,
 } from "@fluentui/react-icons";
 import { locConstants as Loc } from "../../../common/locConstants";
 import { Keys } from "../../../common/keys";
@@ -175,6 +177,7 @@ export const FabricWorkspaceViewer = ({
     const [isExplorerCollapsed, setIsExplorerCollapsed] = useState(false);
     const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | undefined>(undefined);
     const [selectedRowId, setSelectedRowId] = useState<string | undefined>(undefined);
+    const [workspaceSearchFilter, setWorkspaceSearchFilter] = useState("");
 
     useEffect(() => {
         if (
@@ -184,6 +187,16 @@ export const FabricWorkspaceViewer = ({
             setSelectedWorkspaceId(fabricWorkspaces[0].id);
         }
     }, [fabricWorkspaces.length]);
+
+    const filteredWorkspaces = useMemo(() => {
+        if (!workspaceSearchFilter.trim()) {
+            return fabricWorkspaces;
+        }
+        const searchTerm = workspaceSearchFilter.toLowerCase();
+        return fabricWorkspaces.filter((workspace) =>
+            workspace.displayName.toLowerCase().includes(searchTerm),
+        );
+    }, [fabricWorkspaces, workspaceSearchFilter]);
 
     const selectedWorkspace = useMemo(() => {
         return fabricWorkspaces.find((w) => w.id === selectedWorkspaceId);
@@ -341,6 +354,16 @@ export const FabricWorkspaceViewer = ({
                                     }}
                                 />
                             </div>
+                            <div className={styles.workspaceSearchBox}>
+                                <Input
+                                    placeholder="Search workspaces..."
+                                    value={workspaceSearchFilter}
+                                    onChange={(e) => setWorkspaceSearchFilter(e.target.value)}
+                                    contentBefore={<SearchRegular />}
+                                    size="small"
+                                    style={{ width: "100%" }}
+                                />
+                            </div>
                             <div className={styles.workspaceTitle}>
                                 {Loc.connectionDialog.workspaces}
                             </div>
@@ -353,7 +376,7 @@ export const FabricWorkspaceViewer = ({
                             )}
                             {fabricWorkspacesLoadStatus === ApiStatus.Loaded && (
                                 <WorkspacesList
-                                    workspaces={fabricWorkspaces}
+                                    workspaces={filteredWorkspaces}
                                     onWorkspaceSelect={handleWorkspaceSelect}
                                     selectedWorkspace={selectedWorkspace}
                                 />

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
@@ -311,50 +311,54 @@ export const FabricWorkspaceViewer = ({
                     />
                 ) : (
                     <>
-                        <div className={styles.collapseButton}>
-                            <Text style={{ fontWeight: "600" }}>
-                                {Loc.connectionDialog.explorer}
-                            </Text>
-                            <Button
-                                appearance="subtle"
-                                size="small"
-                                icon={
-                                    <ChevronDoubleLeftFilled
-                                        className={styles.collapseButtonIcon}
-                                    />
-                                }
-                                onClick={toggleExplorer}
-                                onKeyDown={(e) => {
-                                    if (e.key === Keys.Enter || e.key === Keys.Space) {
-                                        toggleExplorer();
-                                        e.preventDefault();
+                        <div className={styles.workspaceHeader}>
+                            <div className={styles.collapseButton}>
+                                <Text style={{ fontWeight: "600" }}>
+                                    {Loc.connectionDialog.explorer}
+                                </Text>
+                                <Button
+                                    appearance="subtle"
+                                    size="small"
+                                    icon={
+                                        <ChevronDoubleLeftFilled
+                                            className={styles.collapseButtonIcon}
+                                        />
                                     }
-                                }}
-                                aria-label={Loc.connectionDialog.collapseWorkspaceExplorer}
-                                title={Loc.connectionDialog.collapse}
-                                style={{
-                                    minWidth: "24px",
-                                    display: "flex",
-                                    justifyContent: "center",
-                                    padding: "0 4px",
-                                }}
-                            />
-                        </div>
-                        <div className={styles.workspaceTitle}>
-                            {Loc.connectionDialog.workspaces}
-                        </div>
-                        {fabricWorkspacesLoadStatus === ApiStatus.Loading && (
-                            <div>
-                                <Spinner size="medium" />
+                                    onClick={toggleExplorer}
+                                    onKeyDown={(e) => {
+                                        if (e.key === Keys.Enter || e.key === Keys.Space) {
+                                            toggleExplorer();
+                                            e.preventDefault();
+                                        }
+                                    }}
+                                    aria-label={Loc.connectionDialog.collapseWorkspaceExplorer}
+                                    title={Loc.connectionDialog.collapse}
+                                    style={{
+                                        minWidth: "24px",
+                                        display: "flex",
+                                        justifyContent: "center",
+                                        padding: "0 4px",
+                                    }}
+                                />
                             </div>
-                        )}
-                        {fabricWorkspacesLoadStatus === ApiStatus.Loaded && (
-                            <WorkspacesList
-                                workspaces={fabricWorkspaces}
-                                onWorkspaceSelect={handleWorkspaceSelect}
-                                selectedWorkspace={selectedWorkspace}
-                            />
-                        )}
+                            <div className={styles.workspaceTitle}>
+                                {Loc.connectionDialog.workspaces}
+                            </div>
+                        </div>
+                        <div className={styles.workspaceListContainer}>
+                            {fabricWorkspacesLoadStatus === ApiStatus.Loading && (
+                                <div>
+                                    <Spinner size="medium" />
+                                </div>
+                            )}
+                            {fabricWorkspacesLoadStatus === ApiStatus.Loaded && (
+                                <WorkspacesList
+                                    workspaces={fabricWorkspaces}
+                                    onWorkspaceSelect={handleWorkspaceSelect}
+                                    selectedWorkspace={selectedWorkspace}
+                                />
+                            )}
+                        </div>
                     </>
                 )}
             </div>
@@ -441,9 +445,9 @@ export const FabricWorkspaceViewer = ({
                         size="small"
                         focusMode="composite"
                         style={{
-                            flexGrow: 0,
-                            height: "auto",
-                            marginTop: "-8px",
+                            flexGrow: 1,
+                            height: "100%",
+                            overflow: "auto",
                         }}>
                         <DataGridHeader>
                             <DataGridRow>


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

The scroll bar appears below the workspace explorer header to ensure that it's always at the top.
<img width="163" height="88" alt="image" src="https://github.com/user-attachments/assets/26eb847c-2c41-450d-9ea2-3e410c78e224" />


*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

