### PR TITLE
Add Selection Highlighting to Workspace Explorer 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -230,6 +230,7 @@
       "{0} is the IP address of the client"
     ]
   },
+  "Search workspaces...": "Search workspaces...",
   "Loading Fabric Accounts": "Loading Fabric Accounts",
   "Fabric Account": "Fabric Account",
   "Select an account": "Select an account",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2234,6 +2234,9 @@
     <trans-unit id="++CODE++771f5d2c0599dcf4194e3fdddd9a5212d6392f4703d29971575bb455b5287a84">
       <source xml:lang="en">Search tables...</source>
     </trans-unit>
+    <trans-unit id="++CODE++5c192a3e6f23b125cfaa70c46f6fcd47a2081fa7270e7687687ea8596d2e012f">
+      <source xml:lang="en">Search workspaces...</source>
+    </trans-unit>
     <trans-unit id="++CODE++7f55382219f0202c1b4f56deb099e2fedcec87ee73fe2edb2105df5447323bc6">
       <source xml:lang="en">Search...</source>
     </trans-unit>

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -198,6 +198,7 @@ export class LocConstants {
 
     public get connectionDialog() {
         return {
+            searchWorkspaces: l10n.t("Search workspaces..."),
             loadingFabricAccounts: l10n.t("Loading Fabric Accounts"),
             fabricAccount: l10n.t("Fabric Account"),
             selectAnAccount: l10n.t("Select an account"),

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.styles.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { makeStyles, shorthands } from "@fluentui/react-components";
+import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
 
 export const useStyles = makeStyles({
     container: {
@@ -89,10 +89,15 @@ export const useStyles = makeStyles({
         },
     },
     workspaceItemSelected: {
-        backgroundColor: "var(--vscode-list-activeSelectionBackground)",
+        backgroundColor: tokens.colorSubtleBackgroundSelected,
         color: "var(--vscode-list-activeSelectionForeground)",
+        fontWeight: "600",
+        "@media (forced-colors:active)": {
+            background: "Highlight",
+            color: "HighlightText",
+        },
         "&:hover": {
-            backgroundColor: "var(--vscode-list-activeSelectionBackground)",
+            backgroundColor: tokens.colorSubtleBackgroundSelected,
         },
     },
     collapseButton: {

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
@@ -16,31 +16,24 @@ import {
     TableColumnDefinition,
     createTableColumn,
     Text,
-    List,
-    ListItem,
-    Label,
     Spinner,
-    Tooltip,
     Input,
-    mergeClasses,
-    SelectionItemId,
 } from "@fluentui/react-components";
 import {
     FabricWorkspaceInfo,
     SqlArtifactTypes,
 } from "../../../../sharedInterfaces/connectionDialog";
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
     ChevronDoubleLeftFilled,
     ChevronDoubleRightFilled,
-    ErrorCircleRegular,
-    PeopleTeamRegular,
     SearchRegular,
 } from "@fluentui/react-icons";
 import { locConstants as Loc } from "../../../common/locConstants";
 import { Keys } from "../../../common/keys";
 import { useStyles } from "./fabricWorkspaceViewer.styles";
 import { ApiStatus } from "../../../../sharedInterfaces/webview";
+import { WorkspacesList } from "./fabricWorkspacesList";
 
 // Icon imports for database types
 const sqlDatabaseIcon = require("../../../../reactviews/media/sql_db.svg");
@@ -76,113 +69,12 @@ interface Props {
     typeFilter?: string[];
 }
 
-type WorkspacesListProps = {
-    workspaces: FabricWorkspaceInfo[];
-    onWorkspaceSelect: (workspace: FabricWorkspaceInfo) => void;
-    selectedWorkspace?: FabricWorkspaceInfo;
-};
-
 type SqlDbItem = {
     id: string;
     name: string;
     typeDisplayName: string;
     type: string;
     location: string;
-};
-
-const WorkspacesList = ({
-    workspaces,
-    onWorkspaceSelect,
-    selectedWorkspace,
-}: WorkspacesListProps) => {
-    const styles = useStyles();
-
-    if (!workspaces || workspaces.length === 0) {
-        return <Label>{Loc.connectionDialog.noWorkspacesAvailable}</Label>;
-    }
-
-    const selectedItems: SelectionItemId[] = selectedWorkspace ? [selectedWorkspace.id] : [];
-
-    const onSelectionChange = useCallback(
-        (_: React.SyntheticEvent | Event, data: { selectedItems: SelectionItemId[] }) => {
-            if (data.selectedItems.length > 0) {
-                const selectedId = data.selectedItems[0] as string;
-                const workspace = workspaces.find((w) => w.id === selectedId);
-                if (workspace) {
-                    onWorkspaceSelect(workspace);
-                }
-            }
-        },
-        [workspaces, onWorkspaceSelect],
-    );
-
-    return (
-        <List
-            role="listbox"
-            aria-label={Loc.connectionDialog.workspaces}
-            selectionMode="single"
-            navigationMode="composite"
-            selectedItems={selectedItems}
-            onSelectionChange={onSelectionChange}>
-            {workspaces.map((workspace) => (
-                <ListItem
-                    key={workspace.id}
-                    value={workspace.id}
-                    className={mergeClasses(
-                        styles.workspaceItem,
-                        selectedItems.includes(workspace.id) && styles.workspaceItemSelected,
-                    )}
-                    aria-label={workspace.displayName}
-                    title={workspace.displayName}
-                    checkmark={null}>
-                    <div style={{ display: "flex", alignItems: "center", minHeight: "20px" }}>
-                        {/* Icon container with consistent styling */}
-                        <div
-                            style={{
-                                width: "16px",
-                                height: "16px",
-                                marginRight: "8px",
-                                flexShrink: 0,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                            }}>
-                            {/* display error if workspace status is errored */}
-                            {workspace.status === ApiStatus.Error && (
-                                <Tooltip
-                                    content={workspace.errorMessage ?? ""}
-                                    relationship="label">
-                                    <ErrorCircleRegular style={{ width: "100%", height: "100%" }} />
-                                </Tooltip>
-                            )}
-                            {/* display loading spinner */}
-                            {workspace.status === ApiStatus.Loading && (
-                                <Spinner
-                                    size="extra-tiny"
-                                    style={{ width: "100%", height: "100%" }}
-                                />
-                            )}
-                            {/* display workspace icon */}
-                            {(workspace.status === ApiStatus.Loaded ||
-                                workspace.status === ApiStatus.NotStarted) && (
-                                <PeopleTeamRegular style={{ width: "100%", height: "100%" }} />
-                            )}
-                        </div>
-
-                        <Text
-                            style={{
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                                whiteSpace: "nowrap",
-                                flex: 1,
-                            }}>
-                            {workspace.displayName}
-                        </Text>
-                    </div>
-                </ListItem>
-            ))}
-        </List>
-    );
 };
 
 export const FabricWorkspaceViewer = ({

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as React from "react";
+
 import {
     DataGrid,
     DataGridHeader,
@@ -20,12 +22,14 @@ import {
     Spinner,
     Tooltip,
     Input,
+    mergeClasses,
+    SelectionItemId,
 } from "@fluentui/react-components";
 import {
     FabricWorkspaceInfo,
     SqlArtifactTypes,
 } from "../../../../sharedInterfaces/connectionDialog";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import {
     ChevronDoubleLeftFilled,
     ChevronDoubleRightFilled,
@@ -97,25 +101,40 @@ const WorkspacesList = ({
         return <Label>{Loc.connectionDialog.noWorkspacesAvailable}</Label>;
     }
 
+    const selectedItems: SelectionItemId[] = selectedWorkspace ? [selectedWorkspace.id] : [];
+
+    const onSelectionChange = useCallback(
+        (_: React.SyntheticEvent | Event, data: { selectedItems: SelectionItemId[] }) => {
+            if (data.selectedItems.length > 0) {
+                const selectedId = data.selectedItems[0] as string;
+                const workspace = workspaces.find((w) => w.id === selectedId);
+                if (workspace) {
+                    onWorkspaceSelect(workspace);
+                }
+            }
+        },
+        [workspaces, onWorkspaceSelect],
+    );
+
     return (
-        <List role="listbox" aria-label={Loc.connectionDialog.workspaces}>
+        <List
+            role="listbox"
+            aria-label={Loc.connectionDialog.workspaces}
+            selectionMode="single"
+            navigationMode="composite"
+            selectedItems={selectedItems}
+            onSelectionChange={onSelectionChange}>
             {workspaces.map((workspace) => (
                 <ListItem
                     key={workspace.id}
-                    className={`${styles.workspaceItem} ${
-                        selectedWorkspace?.id === workspace.id ? styles.workspaceItemSelected : ""
-                    }`}
-                    onClick={() => onWorkspaceSelect(workspace)}
-                    onKeyDown={(e) => {
-                        if (e.key === Keys.Enter || e.key === Keys.Space) {
-                            onWorkspaceSelect(workspace);
-                            e.preventDefault();
-                        }
-                    }}
-                    tabIndex={0}
-                    role="option"
-                    aria-selected={selectedWorkspace?.id === workspace.id}
-                    title={workspace.displayName}>
+                    value={workspace.id}
+                    className={mergeClasses(
+                        styles.workspaceItem,
+                        selectedItems.includes(workspace.id) && styles.workspaceItemSelected,
+                    )}
+                    aria-label={workspace.displayName}
+                    title={workspace.displayName}
+                    checkmark={null}>
                     <div style={{ display: "flex", alignItems: "center", minHeight: "20px" }}>
                         {/* Icon container with consistent styling */}
                         <div

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspaceViewer.tsx
@@ -356,7 +356,7 @@ export const FabricWorkspaceViewer = ({
                             </div>
                             <div className={styles.workspaceSearchBox}>
                                 <Input
-                                    placeholder="Search workspaces..."
+                                    placeholder={Loc.connectionDialog.searchWorkspaces}
                                     value={workspaceSearchFilter}
                                     onChange={(e) => setWorkspaceSearchFilter(e.target.value)}
                                     contentBefore={<SearchRegular />}

--- a/src/reactviews/pages/ConnectionDialog/components/fabricWorkspacesList.tsx
+++ b/src/reactviews/pages/ConnectionDialog/components/fabricWorkspacesList.tsx
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import {
+    List,
+    ListItem,
+    Label,
+    Spinner,
+    Tooltip,
+    Text,
+    mergeClasses,
+    SelectionItemId,
+} from "@fluentui/react-components";
+import { useCallback } from "react";
+import { ErrorCircleRegular, PeopleTeamRegular } from "@fluentui/react-icons";
+import { locConstants as Loc } from "../../../common/locConstants";
+import { useStyles } from "./fabricWorkspaceViewer.styles";
+import { ApiStatus } from "../../../../sharedInterfaces/webview";
+import { FabricWorkspaceInfo } from "../../../../sharedInterfaces/connectionDialog";
+
+interface Props {
+    workspaces: FabricWorkspaceInfo[];
+    onWorkspaceSelect: (workspace: FabricWorkspaceInfo) => void;
+    selectedWorkspace?: FabricWorkspaceInfo;
+}
+
+export const WorkspacesList = ({ workspaces, onWorkspaceSelect, selectedWorkspace }: Props) => {
+    const styles = useStyles();
+
+    if (!workspaces || workspaces.length === 0) {
+        return <Label>{Loc.connectionDialog.noWorkspacesAvailable}</Label>;
+    }
+
+    const selectedItems: SelectionItemId[] = selectedWorkspace ? [selectedWorkspace.id] : [];
+
+    const onSelectionChange = useCallback(
+        (_: React.SyntheticEvent | Event, data: { selectedItems: SelectionItemId[] }) => {
+            if (data.selectedItems.length > 0) {
+                const selectedId = data.selectedItems[0] as string;
+                const workspace = workspaces.find((w) => w.id === selectedId);
+                if (workspace) {
+                    onWorkspaceSelect(workspace);
+                }
+            }
+        },
+        [workspaces, onWorkspaceSelect],
+    );
+
+    return (
+        <List
+            role="listbox"
+            aria-label={Loc.connectionDialog.workspaces}
+            selectionMode="single"
+            navigationMode="composite"
+            selectedItems={selectedItems}
+            onSelectionChange={onSelectionChange}>
+            {workspaces.map((workspace) => (
+                <ListItem
+                    key={workspace.id}
+                    value={workspace.id}
+                    className={mergeClasses(
+                        styles.workspaceItem,
+                        selectedItems.includes(workspace.id) && styles.workspaceItemSelected,
+                    )}
+                    aria-label={workspace.displayName}
+                    title={workspace.displayName}
+                    checkmark={null}>
+                    <div style={{ display: "flex", alignItems: "center", minHeight: "20px" }}>
+                        {/* Icon container with consistent styling */}
+                        <div
+                            style={{
+                                width: "16px",
+                                height: "16px",
+                                marginRight: "8px",
+                                flexShrink: 0,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                            }}>
+                            {/* display error if workspace status is errored */}
+                            {workspace.status === ApiStatus.Error && (
+                                <Tooltip
+                                    content={workspace.errorMessage ?? ""}
+                                    relationship="label">
+                                    <ErrorCircleRegular style={{ width: "100%", height: "100%" }} />
+                                </Tooltip>
+                            )}
+                            {/* display loading spinner */}
+                            {workspace.status === ApiStatus.Loading && (
+                                <Spinner
+                                    size="extra-tiny"
+                                    style={{ width: "100%", height: "100%" }}
+                                />
+                            )}
+                            {/* display workspace icon */}
+                            {(workspace.status === ApiStatus.Loaded ||
+                                workspace.status === ApiStatus.NotStarted) && (
+                                <PeopleTeamRegular style={{ width: "100%", height: "100%" }} />
+                            )}
+                        </div>
+
+                        <Text
+                            style={{
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                                flex: 1,
+                            }}>
+                            {workspace.displayName}
+                        </Text>
+                    </div>
+                </ListItem>
+            ))}
+        </List>
+    );
+};


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Adds highlighting to the fabric workspace explorer, adds localizations, and some clean up
<img width="65" height="411" alt="image" src="https://github.com/user-attachments/assets/aee95ca5-74fd-4a28-be7e-8a2595ed5f75" />


*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

