### PR TITLE
Dev/benjin/add fabric helper support

### DIFF
--- a/src/fabric/fabricHelper.ts
+++ b/src/fabric/fabricHelper.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import { FabricSqlDbInfo, IWorkspace, IFabricError } from "../sharedInterfaces/connectionDialog";
+import { HttpHelper } from "../http/httpHelper";
+
+export class FabricHelper {
+    static readonly fabricUriBase = vscode.Uri.parse("https://api.fabric.microsoft.com/v1/");
+    constructor() {}
+
+    public static async getFabricWorkspaces(tenantId: string): Promise<IWorkspace[]> {
+        const response = await this.fetchFromFabric<{ value: IWorkspace[] }>(
+            "workspaces",
+            `listing Fabric workspaces for tenant '${tenantId}'`,
+            tenantId,
+        );
+
+        return response.value;
+    }
+
+    public static async getFabricWorkspace(
+        workspaceId: string,
+        tenantId: string,
+    ): Promise<IWorkspace> {
+        const response = await this.fetchFromFabric<IWorkspace>(
+            `workspaces/${workspaceId}`,
+            `getting Fabric workspace '${workspaceId}'`,
+            tenantId,
+        );
+
+        return response;
+    }
+
+    public static async getFabricDatabases(
+        workspace: IWorkspace | string,
+        tenantId?: string,
+    ): Promise<FabricSqlDbInfo[]> {
+        const workspacePromise =
+            typeof workspace === "string"
+                ? this.getFabricWorkspace(workspace, tenantId)
+                : workspace;
+
+        const workspaceId = typeof workspace === "string" ? workspace : workspace.id;
+
+        const result: FabricSqlDbInfo[] = [];
+
+        try {
+            const response = await this.fetchFromFabric<{ value: ISqlDbArtifact[] }>(
+                `workspaces/${workspaceId}/sqlDatabases`,
+                `Listing Fabric SQL Databases for workspace '${workspaceId}'`,
+                tenantId,
+            );
+
+            const resolvedWorkspace = await workspacePromise;
+
+            result.push(
+                ...response.value.map((db) => {
+                    return {
+                        id: db.id,
+                        server: db.properties.serverFqdn,
+                        displayName: db.displayName,
+                        database: db.properties.databaseName,
+                        workspaceName: resolvedWorkspace.displayName,
+                        type: db.type,
+                    } as FabricSqlDbInfo;
+                }),
+            );
+        } catch (error) {
+            console.error("Error processing Fabric databases:", error);
+            throw error;
+        }
+
+        return result;
+    }
+
+    public static async getFabricSqlEndpoints(workspace: IWorkspace | string, tenantId?: string) {
+        const workspacePromise =
+            typeof workspace === "string"
+                ? this.getFabricWorkspace(workspace, tenantId)
+                : workspace;
+
+        const workspaceId = typeof workspace === "string" ? workspace : workspace.id;
+
+        const result: FabricSqlDbInfo[] = [];
+
+        try {
+            const response = await this.fetchFromFabric<{ value: ISqlEndpointArtifact[] }>(
+                `workspaces/${workspaceId}/sqlEndpoints`,
+                `Listing Fabric SQL Endpoints for workspace '${workspaceId}'`,
+                tenantId,
+            );
+
+            const resolvedWorkspace = await workspacePromise;
+
+            result.push(
+                ...response.value.map((endpoint) => {
+                    return {
+                        id: endpoint.id,
+                        server: undefined, // requires a second Fabric API call to populate; fill later to avoid throttling
+                        displayName: endpoint.displayName,
+                        database: "TO VALIDATE", // TODO: validate that warehouses don't have a database
+                        workspaceName: resolvedWorkspace.displayName,
+                        type: endpoint.type,
+                    } as FabricSqlDbInfo;
+                }),
+            );
+        } catch (error) {
+            console.error("Error processing Fabric SQL Endpoints:", error);
+            throw error;
+        }
+
+        return result;
+    }
+
+    public static async fetchFromFabric<TResponse>(
+        api: string,
+        reason: string,
+        tenantId: string,
+    ): Promise<TResponse> {
+        const uri = vscode.Uri.joinPath(this.fabricUriBase, api);
+        const httpHelper = new HttpHelper();
+
+        const scopes = ["https://analysis.windows.net/powerbi/api/.default"];
+
+        if (tenantId) {
+            scopes.push(`VSCODE_TENANT:${tenantId}`);
+        }
+
+        const session = await this.getSession("microsoft", scopes, {
+            createIfNone: true,
+            requestReason: reason,
+        });
+        let token = session?.accessToken;
+
+        const response = await httpHelper.makeGetRequest<TResponse>(uri.toString(), token);
+        const result = response.data;
+
+        if (isFabricError(result)) {
+            const errorMessage = `Fabric API error occurred (${result.errorCode}): ${result.message}`;
+            throw new Error(errorMessage);
+        }
+
+        return result;
+    }
+
+    // Logic copied from vscode-fabric's TokenService
+    private static async getSession(
+        providerId: string,
+        scopes: string[],
+        options: TokenRequestOptions,
+    ) {
+        if (!options || !options.requestReason.trim()) {
+            throw new Error("RequestReason required in TokenRequestOptions");
+        }
+
+        // In case there a session is not found, we would like to add a request reason to the modal dialog that will request it,
+        // so we replace createIfNone with forceNewSession that behaves identically in this situation,
+        // but allows us to pass the request reason for display to the user.
+        if (options.createIfNone && !options.forceNewSession) {
+            const session = await vscode.authentication.getSession(providerId, scopes, {
+                silent: true,
+            });
+            if (session) {
+                return session;
+            } else {
+                options.createIfNone = false;
+                options.forceNewSession = true;
+            }
+        }
+
+        if (options.forceNewSession === true) {
+            options.forceNewSession = { detail: options.requestReason };
+        }
+
+        return await vscode.authentication.getSession(providerId, scopes, options);
+    }
+}
+
+export interface TokenRequestOptions extends vscode.AuthenticationGetSessionOptions {
+    /**
+     * Identifier of caller partner (ex. NuGet or AvailabilityService) that would be used for telemetry.
+     */
+    callerId?: string;
+
+    /**
+     * Reason to request session from customer. This string could be displayed to customer in the future, so ideally should be localized.
+     */
+    requestReason: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isFabricError(obj: any): obj is IFabricError {
+    return (
+        obj &&
+        typeof obj === "object" &&
+        typeof obj.errorCode === "string" &&
+        typeof obj.message === "string"
+    );
+}
+
+/**
+ * IArtifact as seen in api responses
+ */
+export interface IArtifact {
+    id: string;
+    type: string;
+    displayName: string;
+    description: string | undefined;
+    workspaceId: string;
+    properties: unknown;
+}
+
+export interface ISqlDbArtifact extends IArtifact {
+    properties: {
+        connectionInfo: string;
+        connectionString: string;
+        databaseName: string;
+        serverFqdn: string;
+    };
+}
+
+export interface ISqlEndpointArtifact extends IArtifact {}

--- a/src/http/httpHelper.ts
+++ b/src/http/httpHelper.ts
@@ -1,0 +1,250 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import * as tunnel from "tunnel";
+import * as http from "http";
+import * as https from "https";
+import * as url from "url";
+import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
+import { Url } from "url";
+
+import * as LocalizedConstants from "../constants/locConstants";
+import { Logger } from "../models/logger";
+
+export class HttpHelper {
+    constructor(private logger?: Logger) {}
+
+    public async makeGetRequest<TResponse>(
+        requestUrl: string,
+        token: string,
+    ): Promise<AxiosResponse<TResponse>> {
+        const config: AxiosRequestConfig = {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            validateStatus: () => true, // Never throw
+        };
+
+        const httpConfig = vscode.workspace.getConfiguration("http");
+        let proxy: string | undefined = httpConfig["proxy"] as string;
+        if (!proxy) {
+            this.logger?.verbose(
+                "Workspace HTTP config didn't contain a proxy endpoint. Checking environment variables.",
+            );
+
+            proxy = this.loadEnvironmentProxyValue();
+        }
+
+        if (proxy) {
+            this.logger?.verbose(
+                "Proxy endpoint found in environment variables or workspace configuration.",
+            );
+
+            // Turning off automatic proxy detection to avoid issues with tunneling agent by setting proxy to false.
+            // https://github.com/axios/axios/blob/bad6d8b97b52c0c15311c92dd596fc0bff122651/lib/adapters/http.js#L85
+            config.proxy = false;
+
+            const agent = this.createProxyAgent(requestUrl, proxy, httpConfig["proxyStrictSSL"]);
+            if (agent.isHttps) {
+                config.httpsAgent = agent.agent;
+            } else {
+                config.httpAgent = agent.agent;
+            }
+
+            const HTTPS_PORT = 443;
+            const HTTP_PORT = 80;
+            const parsedRequestUrl = url.parse(requestUrl);
+            const port = parsedRequestUrl.protocol?.startsWith("https") ? HTTPS_PORT : HTTP_PORT;
+
+            // Request URL will include HTTPS port 443 ('https://management.azure.com:443/tenants?api-version=2019-11-01'), so
+            // that Axios doesn't try to reach this URL with HTTP port 80 on HTTP proxies, which result in an error. See https://github.com/axios/axios/issues/925
+            const requestUrlWithPort = `${parsedRequestUrl.protocol}//${parsedRequestUrl.hostname}:${port}${parsedRequestUrl.path}`;
+            const response: AxiosResponse = await axios.get<TResponse>(requestUrlWithPort, config);
+            this.logger?.piiSanitized(
+                "GET request ",
+                [
+                    {
+                        name: "response",
+                        objOrArray:
+                            (response.data?.value as TResponse) ??
+                            (response.data as { value: TResponse }),
+                    },
+                ],
+                [],
+                requestUrl,
+            );
+            return response;
+        }
+
+        const response: AxiosResponse = await axios.get<TResponse>(requestUrl, config);
+        this.logger?.piiSanitized(
+            "GET request ",
+            [
+                {
+                    name: "response",
+                    objOrArray:
+                        (response.data?.value as TResponse) ??
+                        (response.data as { value: TResponse }),
+                },
+            ],
+            [],
+            requestUrl,
+        );
+        return response;
+    }
+
+    private loadEnvironmentProxyValue(): string | undefined {
+        const HTTP_PROXY = "HTTP_PROXY";
+        const HTTPS_PROXY = "HTTPS_PROXY";
+
+        if (!process) {
+            this.logger?.verbose(
+                "No process object found, unable to read environment variables for proxy.",
+            );
+            return undefined;
+        }
+
+        if (process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()]) {
+            this.logger?.verbose("Loading proxy value from HTTP_PROXY environment variable.");
+
+            return process.env[HTTP_PROXY] || process.env[HTTP_PROXY.toLowerCase()];
+        } else if (process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()]) {
+            this.logger?.verbose("Loading proxy value from HTTPS_PROXY environment variable.");
+
+            return process.env[HTTPS_PROXY] || process.env[HTTPS_PROXY.toLowerCase()];
+        }
+
+        this.logger?.verbose(
+            "No proxy value found in either HTTPS_PROXY or HTTP_PROXY environment variables.",
+        );
+
+        return undefined;
+    }
+
+    private createProxyAgent(
+        requestUrl: string,
+        proxy: string,
+        proxyStrictSSL: boolean,
+    ): ProxyAgent {
+        const agentOptions = this.getProxyAgentOptions(
+            url.parse(requestUrl),
+            proxy,
+            proxyStrictSSL,
+        );
+        if (!agentOptions || !agentOptions.host || !agentOptions.port) {
+            this.logger?.error("Unable to read proxy agent options to create proxy agent.");
+            throw new Error(LocalizedConstants.unableToGetProxyAgentOptionsToGetTenants);
+        }
+
+        let tunnelOptions: tunnel.HttpsOverHttpsOptions = {};
+        if (typeof agentOptions.auth === "string" && agentOptions.auth) {
+            tunnelOptions = {
+                proxy: {
+                    proxyAuth: agentOptions.auth,
+                    host: agentOptions.host,
+                    port: Number(agentOptions.port),
+                },
+            };
+        } else {
+            tunnelOptions = {
+                proxy: {
+                    host: agentOptions.host,
+                    port: Number(agentOptions.port),
+                },
+            };
+        }
+
+        const isHttpsRequest = requestUrl.startsWith("https");
+        const isHttpsProxy = proxy.startsWith("https");
+        const proxyAgent = {
+            isHttps: isHttpsProxy,
+            agent: this.createTunnelingAgent(isHttpsRequest, isHttpsProxy, tunnelOptions),
+        } as ProxyAgent;
+
+        return proxyAgent;
+    }
+
+    private createTunnelingAgent(
+        isHttpsRequest: boolean,
+        isHttpsProxy: boolean,
+        tunnelOptions: tunnel.HttpsOverHttpsOptions,
+    ): http.Agent | https.Agent {
+        if (isHttpsRequest && isHttpsProxy) {
+            this.logger?.verbose("Creating https request over https proxy tunneling agent");
+            return tunnel.httpsOverHttps(tunnelOptions);
+        } else if (isHttpsRequest && !isHttpsProxy) {
+            this.logger?.verbose("Creating https request over http proxy tunneling agent");
+            return tunnel.httpsOverHttp(tunnelOptions);
+        } else if (!isHttpsRequest && isHttpsProxy) {
+            this.logger?.verbose("Creating http request over https proxy tunneling agent");
+            return tunnel.httpOverHttps(tunnelOptions);
+        } else {
+            this.logger?.verbose("Creating http request over http proxy tunneling agent");
+            return tunnel.httpOverHttp(tunnelOptions);
+        }
+    }
+
+    /*
+     * Returns the proxy agent using the proxy url in the parameters or the system proxy. Returns null if no proxy found
+     */
+    private getProxyAgentOptions(
+        requestURL: Url,
+        proxy?: string,
+        strictSSL?: boolean,
+    ): ProxyAgentOptions | undefined {
+        const proxyURL = proxy || this.getSystemProxyURL(requestURL);
+
+        if (!proxyURL) {
+            return undefined;
+        }
+
+        const proxyEndpoint = url.parse(proxyURL);
+
+        if (!/^https?:$/.test(proxyEndpoint.protocol!)) {
+            return undefined;
+        }
+
+        const opts: ProxyAgentOptions = {
+            host: proxyEndpoint.hostname,
+            port: Number(proxyEndpoint.port),
+            auth: proxyEndpoint.auth,
+            rejectUnauthorized: typeof strictSSL === "boolean",
+        };
+
+        return opts;
+    }
+
+    private getSystemProxyURL(requestURL: Url): string | undefined {
+        if (requestURL.protocol === "http:") {
+            return process.env.HTTP_PROXY || process.env.http_proxy || undefined;
+        } else if (requestURL.protocol === "https:") {
+            return (
+                process.env.HTTPS_PROXY ||
+                process.env.https_proxy ||
+                process.env.HTTP_PROXY ||
+                process.env.http_proxy ||
+                undefined
+            );
+        }
+
+        return undefined;
+    }
+}
+
+interface ProxyAgent {
+    isHttps: boolean;
+    agent: http.Agent | https.Agent;
+}
+
+interface ProxyAgentOptions {
+    auth: string | null;
+    secureProxy?: boolean;
+    host?: string | null;
+    path?: string | null;
+    port?: string | number | null;
+    rejectUnauthorized: boolean;
+}

--- a/src/sharedInterfaces/connectionDialog.ts
+++ b/src/sharedInterfaces/connectionDialog.ts
@@ -6,7 +6,7 @@
 import * as vscodeMssql from "vscode-mssql";
 import { FormItemSpec, FormContextProps, FormState, FormReducers } from "./form";
 import { FirewallRuleSpec } from "./firewallRule";
-import { ApiStatus } from "./webview";
+import { ApiStatus, Status } from "./webview";
 import { AddFirewallRuleState } from "./addFirewallRule";
 import { ConnectionGroupSpec, ConnectionGroupState } from "./connectionGroup";
 import { RequestType } from "vscode-jsonrpc/browser";
@@ -102,6 +102,50 @@ export interface AzureSqlServerInfo {
     resourceGroup: string;
     subscription: string;
     uri: string;
+}
+
+export interface FabricSqlDbInfo {
+    id: string;
+    server: string;
+    displayName: string;
+    database: string;
+    type: string;
+    workspaceName: string;
+}
+
+export interface FabricWorkspaceInfo {
+    id: string;
+    displayName: string;
+    tenantId: string;
+    databases: FabricSqlDbInfo[];
+    loadStatus: Status;
+}
+
+export enum SqlArtifactTypes {
+    SqlDatabase = "SQLDatabase",
+    SqlAnalyticsEndpoint = "SQLEndpoint",
+}
+
+/**
+ * IWorkspace Fabric workspace as seen in api responses
+ */
+export interface IWorkspace {
+    id: string;
+    capacityId?: string; // supplied when getting a single workspace, but only sometimes when getting all workspaces (perhaps newer workspaces?)
+    type: string;
+    displayName: string;
+    description: string;
+    databases: string[];
+    sqlAnalyticsEndpoints: string[];
+    workspace: {
+        name: string;
+        id: string;
+    };
+}
+
+export interface IFabricError {
+    errorCode: string;
+    message: string;
 }
 
 export interface ConnectionComponentsInfo {

--- a/src/sharedInterfaces/webview.ts
+++ b/src/sharedInterfaces/webview.ts
@@ -15,6 +15,11 @@ export enum ApiStatus {
     Error = "error",
 }
 
+export interface Status {
+    status: ApiStatus;
+    message?: string;
+}
+
 export interface WebviewTelemetryActionEvent {
     /**
      * The view in which the event occurred.


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Adding a Fabric Helper that handles Fabric REST API calls related to SQL databases and Analytics endpoints.  For these operations, a token will be acquired from the vscode account system, depending on the tenant specified in the call.

This change also moves all proxy-related HTTP methods into a shareable helper class.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

