### PR TITLE
Adding types to core rpcs and fixing schema designer state provider.

### DIFF
--- a/src/reactviews/common/utils.ts
+++ b/src/reactviews/common/utils.ts
@@ -5,6 +5,7 @@
 
 import {
     ColorThemeKind,
+    CoreRPCs,
     LoggerLevel,
     WebviewTelemetryActionEvent,
     WebviewTelemetryErrorEvent,
@@ -76,7 +77,7 @@ export function deepClone<T>(obj: T): T {
 
 export function getCoreRPCs<TState, TReducers>(
     webviewContext: VscodeWebviewContext<TState, TReducers>,
-): any {
+): CoreRPCs {
     return {
         log(message: string, level?: LoggerLevel) {
             webviewContext.extensionRpc.log(message, level);

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -28,13 +28,9 @@ export interface SchemaDesignerContextProps
         edges: Edge<SchemaDesigner.ForeignKey>[];
     }>;
     saveAsFile: (fileProps: SchemaDesigner.ExportFileOptions) => void;
-    getReport: () => Promise<{
-        report: SchemaDesigner.GetReportResponse;
-        error?: string;
-    }>;
+    getReport: () => Promise<SchemaDesigner.GetReportWebviewResponse | undefined>;
     openInEditor: (text: string) => void;
     openInEditorWithConnection: () => void;
-    setSelectedTable: (selectedTable: SchemaDesigner.Table) => void;
     copyToClipboard: (text: string) => void;
     extractSchema: () => SchemaDesigner.Schema;
     addTable: (table: SchemaDesigner.Table) => Promise<boolean>;
@@ -199,18 +195,13 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
         });
     };
 
-    const openInEditor = (text: string) => {
-        void extensionRpc.sendNotification(SchemaDesigner.OpenInEditorNotification.type, {
-            text: text,
-        });
+    const openInEditor = () => {
+        void extensionRpc.sendNotification(SchemaDesigner.OpenInEditorNotification.type);
     };
 
-    const openInEditorWithConnection = (text: string) => {
+    const openInEditorWithConnection = () => {
         void extensionRpc.sendNotification(
             SchemaDesigner.OpenInEditorWithConnectionNotification.type,
-            {
-                text: text,
-            },
         );
     };
 
@@ -366,6 +357,7 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
         }
         void reactFlow.deleteElements({ nodes: [node] });
         eventBus.emit("pushState");
+        return true;
     };
 
     /**

--- a/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -93,19 +93,19 @@ export function PublishChangesDialogButton() {
                     });
                     setPublishButtonDisabled(true);
                     const getReportResponse = await context.getReport();
-                    if (getReportResponse.error) {
+                    if (getReportResponse?.error) {
                         setState({
                             ...state,
                             currentStage: PublishDialogStages.ReportError,
                             reportError: getReportResponse.error,
                         });
                     } else {
-                        if (!getReportResponse.report.hasSchemaChanged) {
+                        if (!getReportResponse?.report.hasSchemaChanged) {
                             setState({
                                 ...state,
                                 currentStage: PublishDialogStages.ReportSuccessNoChanges,
                                 reportError: undefined,
-                                report: getReportResponse.report,
+                                report: getReportResponse?.report,
                             });
                         } else {
                             setState({

--- a/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -259,59 +259,54 @@ export class SchemaDesignerWebviewController extends ReactWebviewPanelController
             });
         });
 
-        this.onNotification(
-            SchemaDesigner.OpenInEditorWithConnectionNotification.type,
-            (params) => {
-                const generateScriptActivity = startActivity(
-                    TelemetryViews.SchemaDesigner,
-                    TelemetryActions.GenerateScript,
-                    undefined,
-                );
-                vscode.window.withProgress(
-                    {
-                        location: vscode.ProgressLocation.Notification,
-                        title: LocConstants.SchemaDesigner.OpeningPublishScript,
-                        cancellable: false,
-                    },
-                    async () => {
-                        try {
-                            const result = await this.schemaDesignerService.generateScript({
-                                sessionId: this._sessionId,
-                            });
-                            generateScriptActivity.end(
-                                ActivityStatus.Succeeded,
-                                undefined,
-                                result?.script
-                                    ? { scriptLength: result?.script?.length }
-                                    : { scriptLength: 0 },
-                            );
-                            // Open the document in the editor with the connection
-                            if (this.treeNode) {
-                                void this.mainController.onNewQuery(this.treeNode, result?.script);
-                            } else if (this.connectionUri) {
-                                const editor =
-                                    await this.mainController.untitledSqlDocumentService.newQuery(
-                                        result?.script,
-                                    );
-                                await this.mainController.connectionManager.connect(
-                                    editor.document.uri.toString(true),
-                                    this.mainController.connectionManager.getConnectionInfo(
-                                        this.connectionUri,
-                                    ).credentials,
+        this.onNotification(SchemaDesigner.OpenInEditorWithConnectionNotification.type, () => {
+            const generateScriptActivity = startActivity(
+                TelemetryViews.SchemaDesigner,
+                TelemetryActions.GenerateScript,
+                undefined,
+            );
+            vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: LocConstants.SchemaDesigner.OpeningPublishScript,
+                    cancellable: false,
+                },
+                async () => {
+                    try {
+                        const result = await this.schemaDesignerService.generateScript({
+                            sessionId: this._sessionId,
+                        });
+                        generateScriptActivity.end(
+                            ActivityStatus.Succeeded,
+                            undefined,
+                            result?.script
+                                ? { scriptLength: result?.script?.length }
+                                : { scriptLength: 0 },
+                        );
+                        // Open the document in the editor with the connection
+                        if (this.treeNode) {
+                            void this.mainController.onNewQuery(this.treeNode, result?.script);
+                        } else if (this.connectionUri) {
+                            const editor =
+                                await this.mainController.untitledSqlDocumentService.newQuery(
+                                    result?.script,
                                 );
-                            }
-                        } catch (error) {
-                            generateScriptActivity.endFailed(error, false);
-                            vscode.window.showErrorMessage(
-                                LocConstants.SchemaDesigner.PublishScriptFailed(
-                                    getErrorMessage(error),
-                                ),
+                            await this.mainController.connectionManager.connect(
+                                editor.document.uri.toString(true),
+                                this.mainController.connectionManager.getConnectionInfo(
+                                    this.connectionUri,
+                                ).credentials,
                             );
                         }
-                    },
-                );
-            },
-        );
+                    } catch (error) {
+                        generateScriptActivity.endFailed(error, false);
+                        vscode.window.showErrorMessage(
+                            LocConstants.SchemaDesigner.PublishScriptFailed(getErrorMessage(error)),
+                        );
+                    }
+                },
+            );
+        });
 
         this.onNotification(SchemaDesigner.CloseSchemaDesignerNotification.type, () => {
             // Close the schema designer panel

--- a/src/sharedInterfaces/schemaDesigner.ts
+++ b/src/sharedInterfaces/schemaDesigner.ts
@@ -418,7 +418,7 @@ export namespace SchemaDesigner {
     }
 
     export namespace OpenInEditorWithConnectionNotification {
-        export const type = new NotificationType<OpenInEditorParams>("openInEditorWithConnection");
+        export const type = new NotificationType<void>("openInEditorWithConnection");
     }
     export namespace OpenInEditorNotification {
         export const type = new NotificationType<OpenInEditorOptions>("openInEditor");

--- a/src/sharedInterfaces/webview.ts
+++ b/src/sharedInterfaces/webview.ts
@@ -266,3 +266,9 @@ export interface PendingRequest {
 export namespace GetEOLRequest {
     export const type = new RequestType<void, string, void>("getEOL");
 }
+
+export interface CoreRPCs {
+    log(message: string, level?: LoggerLevel): void;
+    sendActionEvent(event: WebviewTelemetryActionEvent): void;
+    sendErrorEvent(event: WebviewTelemetryErrorEvent): void;
+}


### PR DESCRIPTION
## Description

The core RPC helper previously used `any`, which prevented type errors from being properly detected in the Schema Designer state provider.

This PR:

1. Introduces stronger type definitions.
2. Fixes related compilation issues.
3. Removes an unused method.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

