### PR TITLE
Adding a new webview state provider to use only a slice of entire state. 

### DIFF
--- a/src/reactviews/common/acquireVsCodeApi.ts
+++ b/src/reactviews/common/acquireVsCodeApi.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebviewApi } from "vscode-webview";
+
+class VsCodeApiFetcher {
+    public vscodeApiInstance: WebviewApi<unknown>;
+
+    constructor() {
+        this.vscodeApiInstance = acquireVsCodeApi<unknown>();
+    }
+}
+
+export const vsCodeApiInstance = new VsCodeApiFetcher();

--- a/src/reactviews/common/rpc.ts
+++ b/src/reactviews/common/rpc.ts
@@ -82,11 +82,19 @@ export class WebviewRpc<Reducers> {
     }
 
     private constructor(_vscodeApi: WebviewApi<unknown>) {
-        //this._setupMessageListener();
         this.connection = createMessageConnection(
             new WebviewRpcMessageReader(),
             new WebviewRpcMessageWriter(_vscodeApi),
         );
+
+        this.connection.onError((error) => {
+            console.error("WebviewRpc connection error:", error);
+        });
+
+        this.connection.onClose(() => {
+            console.warn("WebviewRpc connection closed");
+        });
+
         this.connection.listen();
     }
 

--- a/src/reactviews/common/useVscodeSelector.ts
+++ b/src/reactviews/common/useVscodeSelector.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useCallback, useContext, useRef, useSyncExternalStore } from "react";
+import { VscodeWebviewContext2, VscodeWebviewContext2Props } from "./vscodeWebviewProvider2";
+
+/**
+ * Read a tiny slice of the webview state without causing whole-app re-renders.
+ * Example:
+ *   const propValue = useVscodeSelector<MyState, MyReducers, string|undefined>(s => s.prop);
+ */
+export function useVscodeSelector<State, Reducers, T>(
+    selector: (s: State) => T,
+    equals: (a: T, b: T) => boolean = Object.is,
+) {
+    const ctx = useContext(VscodeWebviewContext2) as unknown as VscodeWebviewContext2Props<
+        State,
+        Reducers
+    >;
+    if (!ctx) throw new Error("useVscodeSelector must be used within a VscodeWebviewProvider");
+
+    // Use a server snapshot function that handles undefined state gracefully
+    const getServerSnapshot = useCallback(() => {
+        const snapshot = ctx.getSnapshot();
+        return snapshot || ({} as State);
+    }, [ctx]);
+
+    const snap = useSyncExternalStore(ctx.subscribe, ctx.getSnapshot, getServerSnapshot);
+
+    // Safely handle selection when state might be uninitialized
+    const selected = snap ? selector(snap) : (undefined as T);
+    const ref = useRef(selected);
+
+    // Only update ref if we have a valid selection and it's different
+    if (selected !== undefined && !equals(ref.current, selected)) {
+        ref.current = selected;
+    }
+
+    return ref.current;
+}

--- a/src/reactviews/common/utils.ts
+++ b/src/reactviews/common/utils.ts
@@ -10,6 +10,7 @@ import {
     WebviewTelemetryActionEvent,
     WebviewTelemetryErrorEvent,
 } from "../../sharedInterfaces/webview";
+import { WebviewRpc } from "./rpc";
 import { VscodeWebviewContext } from "./vscodeWebviewProvider";
 
 /**
@@ -78,15 +79,19 @@ export function deepClone<T>(obj: T): T {
 export function getCoreRPCs<TState, TReducers>(
     webviewContext: VscodeWebviewContext<TState, TReducers>,
 ): CoreRPCs {
+    return getCoreRPCs2(webviewContext.extensionRpc);
+}
+
+export function getCoreRPCs2<TReducers>(extensionRpc: WebviewRpc<TReducers>): CoreRPCs {
     return {
         log(message: string, level?: LoggerLevel) {
-            webviewContext.extensionRpc.log(message, level);
+            extensionRpc.log(message, level);
         },
         sendActionEvent(event: WebviewTelemetryActionEvent) {
-            webviewContext.extensionRpc.sendActionEvent(event);
+            extensionRpc.sendActionEvent(event);
         },
         sendErrorEvent(event: WebviewTelemetryErrorEvent) {
-            webviewContext.extensionRpc.sendErrorEvent(event);
+            extensionRpc.sendErrorEvent(event);
         },
     };
 }

--- a/src/reactviews/common/vscodeWebviewProvider.tsx
+++ b/src/reactviews/common/vscodeWebviewProvider.tsx
@@ -23,6 +23,7 @@ import {
     StateChangeNotification,
 } from "../../sharedInterfaces/webview";
 import { getEOL } from "./utils";
+import { vsCodeApiInstance } from "./acquireVsCodeApi";
 
 /**
  * Context for vscode webview functionality like theming, state management, rpc and vscode api.
@@ -57,7 +58,7 @@ export interface VscodeWebviewContext<State, Reducers> {
     EOL: string;
 }
 
-const vscodeApiInstance = acquireVsCodeApi<unknown>();
+const vscodeApiInstance = vsCodeApiInstance.vscodeApiInstance;
 
 const VscodeWebviewContext = createContext<VscodeWebviewContext<unknown, unknown> | undefined>(
     undefined,

--- a/src/reactviews/common/vscodeWebviewProvider2.tsx
+++ b/src/reactviews/common/vscodeWebviewProvider2.tsx
@@ -1,0 +1,194 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as l10n from "@vscode/l10n";
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+import { FluentProvider } from "@fluentui/react-components";
+import { LocConstants } from "./locConstants";
+import { WebviewApi } from "vscode-webview";
+import { WebviewRpc } from "./rpc";
+import { webviewTheme } from "./theme";
+import {
+    ColorThemeChangeNotification,
+    ColorThemeKind,
+    GetEOLRequest,
+    GetLocalizationRequest,
+    GetStateRequest,
+    GetThemeRequest,
+    LoadStatsNotification,
+    StateChangeNotification,
+} from "../../sharedInterfaces/webview";
+import { getEOL } from "./utils";
+import { vsCodeApiInstance } from "./acquireVsCodeApi";
+
+/**
+ * Context for vscode webview functionality like theming, state management, rpc and vscode api.
+ * @template State interface that contains definitions for all state properties.
+ * @template Reducers interface that contains definitions for all reducers and their payloads.
+ */
+export interface VscodeWebviewContext2Props<State, Reducers> {
+    /**
+     * The vscode api instance.
+     */
+    vscodeApi: WebviewApi<unknown>;
+    /**
+     * Rpc to communicate with the extension.
+     */
+    extensionRpc: WebviewRpc<Reducers>;
+    /**
+     * Selector friendly state
+     * @returns
+     */
+    getSnapshot: () => State;
+    subscribe: (listener: () => void) => () => void;
+    /**
+     * Theme of the webview.
+     */
+    themeKind: ColorThemeKind;
+    /**
+     * Localization status. The value is true when the localization file content is received from the extension.
+     * This is used to force a re-render of the component when the localization file content is received.
+     */
+    localization: boolean;
+    /**
+     * OS specific end of line character.
+     */
+    EOL: string;
+}
+
+const vscodeApiInstance = vsCodeApiInstance.vscodeApiInstance;
+
+export const VscodeWebviewContext2 = createContext<
+    VscodeWebviewContext2Props<unknown, unknown> | undefined
+>(undefined);
+
+interface VscodeWebviewProvider2Props {
+    children: React.ReactNode;
+}
+
+/**
+ * Provider for essential vscode webview functionality like
+ * theming, state management, rpc and vscode api.
+ * @param param0 child components
+ */
+export function VscodeWebviewProvider2<State, Reducers>({ children }: VscodeWebviewProvider2Props) {
+    const vscodeApi = vscodeApiInstance;
+    const extensionRpc = WebviewRpc.getInstance<Reducers>(vscodeApi);
+
+    const [theme, setTheme] = useState(ColorThemeKind.Light);
+    const [localization, setLocalization] = useState<boolean>(false);
+    const [EOL, setEOL] = useState<string>(getEOL());
+
+    const stateRef = useRef<State | undefined>(undefined);
+    const listenersRef = useRef(new Set<() => void>());
+    const [isInitialized, setIsInitialized] = useState(false);
+
+    const getSnapshot = useCallback(() => {
+        // Return a safe default while not initialized to prevent useSyncExternalStore from erroring
+        return stateRef.current ?? ({} as State);
+    }, []);
+
+    const subscribe = useCallback((listener: () => void) => {
+        listenersRef.current.add(listener);
+        return () => {
+            listenersRef.current.delete(listener);
+        };
+    }, []);
+
+    const emit = () => {
+        listenersRef.current.forEach((fn) => fn());
+    };
+
+    // Bootstrap - register notification handlers BEFORE fetching state
+    useEffect(() => {
+        // Register notification handlers first to prevent race conditions
+        extensionRpc.onNotification(ColorThemeChangeNotification.type, (params) => {
+            setTheme(params as ColorThemeKind);
+        });
+
+        extensionRpc.onNotification<State>(StateChangeNotification.type<State>(), (params) => {
+            stateRef.current = params;
+            emit();
+        });
+
+        async function bootstrap() {
+            try {
+                // Coordinate all initialization operations
+                const [theme, initialState, eol, fileContents] = await Promise.all([
+                    extensionRpc.sendRequest(GetThemeRequest.type),
+                    extensionRpc.sendRequest(GetStateRequest.type<State>()),
+                    extensionRpc.sendRequest(GetEOLRequest.type),
+                    extensionRpc.sendRequest(GetLocalizationRequest.type),
+                ]);
+
+                // Set state atomically
+                setTheme(theme);
+                stateRef.current = initialState;
+                setEOL(eol);
+
+                // Handle localization if available
+                if (fileContents) {
+                    await l10n.config({
+                        contents: fileContents,
+                    });
+                    // Brief delay to ensure l10n is properly initialized
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+                    LocConstants.createInstance();
+                }
+                setLocalization(true);
+
+                // Send load stats notification
+                await extensionRpc.sendNotification(LoadStatsNotification.type, {
+                    loadCompleteTimeStamp: Date.now(),
+                });
+
+                // Mark as initialized and emit state change
+                setIsInitialized(true);
+                emit();
+            } catch (error) {
+                console.error("Bootstrap failed:", error);
+                // Still mark as initialized to prevent infinite loading
+                setIsInitialized(true);
+            }
+        }
+
+        void bootstrap();
+    }, []);
+
+    return (
+        <VscodeWebviewContext2.Provider
+            value={{
+                vscodeApi: vscodeApi,
+                extensionRpc: extensionRpc,
+                getSnapshot,
+                subscribe,
+                themeKind: theme,
+                localization: localization,
+                EOL: EOL,
+            }}>
+            <FluentProvider
+                style={{
+                    height: "100%",
+                    width: "100%",
+                }}
+                theme={webviewTheme(theme)}>
+                {
+                    // don't render webview unless initialization is complete and state is available
+                    isInitialized && stateRef.current !== undefined && children
+                }
+            </FluentProvider>
+        </VscodeWebviewContext2.Provider>
+    );
+}
+
+export function useVscodeWebview2<State, Reducers>() {
+    const context = useContext(VscodeWebviewContext2);
+    if (!context) {
+        throw new Error("useVscodeWebview2 must be used within a VscodeWebviewProvider2");
+    }
+    return context as VscodeWebviewContext2Props<State, Reducers>;
+}


### PR DESCRIPTION
Introduce a slice-aware state provider for the webviews. Components subscribe to just a selected subset of state, avoiding unnecessary re-renders when unrelated state fields change.

I haven't change any existing webviews as the changes will be big and will take away from reviewing and understanding this component. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

