### PR TITLE
Adding contracts for result set streaming and consolidating execution plan code

### DIFF
--- a/src/controllers/queryNotificationHandler.ts
+++ b/src/controllers/queryNotificationHandler.ts
@@ -13,10 +13,14 @@ import {
     QueryExecuteCompleteNotification,
     QueryExecuteBatchStartNotification,
     QueryExecuteBatchCompleteNotification,
+    QueryExecuteResultSetAvailableNotification,
+    QueryExecuteResultSetUpdatedNotification,
     QueryExecuteResultSetCompleteNotification,
     QueryExecuteMessageNotification,
     QueryExecuteCompleteNotificationResult,
     QueryExecuteBatchNotificationParams,
+    QueryExecuteResultSetAvailableNotificationParams,
+    QueryExecuteResultSetUpdatedNotificationParams,
     QueryExecuteResultSetCompleteNotificationParams,
     QueryExecuteMessageParams,
 } from "../models/contracts/queryExecute";
@@ -60,6 +64,14 @@ export class QueryNotificationHandler {
             this.handleBatchCompleteNotification(),
         );
         client.onNotification(
+            QueryExecuteResultSetAvailableNotification.type,
+            this.handleResultSetAvailableNotification(),
+        );
+        client.onNotification(
+            QueryExecuteResultSetUpdatedNotification.type,
+            this.handleResultSetUpdatedNotification(),
+        );
+        client.onNotification(
             QueryExecuteResultSetCompleteNotification.type,
             this.handleResultSetCompleteNotification(),
         );
@@ -98,6 +110,18 @@ export class QueryNotificationHandler {
     public handleBatchCompleteNotification(): NotificationHandler<QueryExecuteBatchNotificationParams> {
         return this.makeHandler<QueryExecuteBatchNotificationParams>((r, e) =>
             r.handleBatchComplete(e),
+        );
+    }
+
+    public handleResultSetAvailableNotification(): NotificationHandler<QueryExecuteResultSetAvailableNotificationParams> {
+        return this.makeHandler<QueryExecuteResultSetAvailableNotificationParams>((r, e) =>
+            r.handleResultSetAvailable(e),
+        );
+    }
+
+    public handleResultSetUpdatedNotification(): NotificationHandler<QueryExecuteResultSetUpdatedNotificationParams> {
+        return this.makeHandler<QueryExecuteResultSetUpdatedNotificationParams>((r, e) =>
+            r.handleResultSetUpdated(e),
         );
     }
 

--- a/src/models/contracts/queryExecute.ts
+++ b/src/models/contracts/queryExecute.ts
@@ -55,7 +55,32 @@ export namespace QueryExecuteBatchCompleteNotification {
     );
 }
 
-// Query ResultSet Complete Notification -----------------------------------------------------------
+// ------------------------------- < Query ResultSet Available Notification > ------------------------------------
+export namespace QueryExecuteResultSetAvailableNotification {
+    export const type = new NotificationType<
+        QueryExecuteResultSetAvailableNotificationParams,
+        void
+    >("query/resultSetAvailable");
+}
+
+export class QueryExecuteResultSetAvailableNotificationParams {
+    resultSetSummary: ResultSetSummary;
+    ownerUri: string;
+}
+
+// ------------------------------- < Query ResultSet Updated Notification > ------------------------------------
+export namespace QueryExecuteResultSetUpdatedNotification {
+    export const type = new NotificationType<QueryExecuteResultSetUpdatedNotificationParams, void>(
+        "query/resultSetUpdated",
+    );
+}
+
+export class QueryExecuteResultSetUpdatedNotificationParams {
+    resultSetSummary: ResultSetSummary;
+    ownerUri: string;
+}
+
+// ------------------------------- < Query ResultSet Complete Notification > ------------------------------------
 export namespace QueryExecuteResultSetCompleteNotification {
     export const type = new NotificationType<QueryExecuteResultSetCompleteNotificationParams, void>(
         "query/resultSetComplete",

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -187,6 +187,7 @@ export class ResultSetSubset {
 
 export class ResultSetSummary {
     id: number;
+    batchId: number;
     rowCount: number;
     columnInfo: vscodeMssql.IDbColumn[];
 }

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -360,7 +360,7 @@ export class SqlOutputContentProvider {
                     defaultLocation: isOpenQueryResultsInTabByDefaultEnabled() ? "tab" : "pane",
                 });
             });
-            const resultSetListener = queryRunner.onResultSet(
+            const resultSetListener = queryRunner.onResultSetComplete(
                 async (resultSet: ResultSetSummary) => {
                     const resultWebviewState =
                         this._queryResultWebviewController.getQueryResultState(queryRunner.uri);
@@ -440,10 +440,15 @@ export class SqlOutputContentProvider {
                 if (hasError) {
                     tabState = QueryResultPaneTabs.Messages;
                 } else {
-                    tabState =
-                        Object.keys(resultWebviewState.resultSetSummaries).length > 0
-                            ? QueryResultPaneTabs.Results
-                            : QueryResultPaneTabs.Messages;
+                    if (resultWebviewState.isExecutionPlan) {
+                        tabState = QueryResultPaneTabs.ExecutionPlan;
+                    } else {
+                        if (Object.keys(resultWebviewState.resultSetSummaries)?.length > 0) {
+                            tabState = QueryResultPaneTabs.Results;
+                        } else {
+                            tabState = QueryResultPaneTabs.Messages;
+                        }
+                    }
                 }
                 resultWebviewState.tabStates.resultPaneTab = tabState;
                 this.updateWebviewState(queryRunner.uri, resultWebviewState);

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -74,14 +74,12 @@ export class SqlOutputContentProvider {
             this,
         );
 
-        if (!isOpenQueryResultsInTabByDefaultEnabled()) {
-            this._context.subscriptions.push(
-                vscode.window.registerWebviewViewProvider(
-                    "queryResult",
-                    this._queryResultWebviewController,
-                ),
-            );
-        }
+        this._context.subscriptions.push(
+            vscode.window.registerWebviewViewProvider(
+                "queryResult",
+                this._queryResultWebviewController,
+            ),
+        );
 
         /**
          * Command to copy all messages to clipboard for the active query result

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -358,7 +358,7 @@ export class SqlOutputContentProvider {
                     defaultLocation: isOpenQueryResultsInTabByDefaultEnabled() ? "tab" : "pane",
                 });
             });
-            const resultSetListener = queryRunner.onResultSetComplete(
+            const resultSetCompleteListener = queryRunner.onResultSetComplete(
                 async (resultSet: ResultSetSummary) => {
                     const resultWebviewState =
                         this._queryResultWebviewController.getQueryResultState(queryRunner.uri);
@@ -487,7 +487,7 @@ export class SqlOutputContentProvider {
             const queryRunnerState = new QueryRunnerState(queryRunner);
             queryRunnerState.listeners.push(
                 startListener,
-                resultSetListener,
+                resultSetCompleteListener,
                 batchStartListener,
                 onMessageListener,
                 onCompleteListener,

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -198,11 +198,6 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         this.onRequest(qr.GetWebviewLocationRequest.type, async () => {
             return qr.QueryResultWebviewLocation.Panel;
         });
-        this.onRequest(qr.ShowFilterDisabledMessageRequest.type, async () => {
-            this.vscodeWrapper.showInformationMessage(
-                LocalizedConstants.inMemoryDataProcessingThresholdExceeded,
-            );
-        });
         registerCommonRequestHandlers(this, this._correlationId);
     }
 
@@ -327,7 +322,6 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             this._queryResultWebviewPanelControllerMap
                 .get(uri)
                 .updateState(this.getQueryResultState(uri));
-            this._queryResultWebviewPanelControllerMap.get(uri).revealToForeground();
         }
     }
 

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -7,9 +7,7 @@ import VscodeWrapper from "../controllers/vscodeWrapper";
 import * as Constants from "../constants/constants";
 import * as vscode from "vscode";
 import { TelemetryViews, TelemetryActions } from "../sharedInterfaces/telemetry";
-import { ApiStatus } from "../sharedInterfaces/webview";
 import {
-    createExecutionPlanGraphs,
     saveExecutionPlan,
     showPlanXml,
     showQuery,
@@ -21,6 +19,7 @@ import { QueryResultWebviewPanelController } from "./queryResultWebviewPanelCont
 import { QueryResultWebviewController } from "./queryResultWebViewController";
 import store, { SubKeys } from "./singletonStore";
 import { JsonFormattingEditProvider } from "../utils/jsonFormatter";
+import * as LocalizedConstants from "../constants/locConstants";
 
 export function getNewResultPaneViewColumn(
     uri: string,
@@ -75,34 +74,6 @@ export function registerCommonRequestHandlers(
                 message.rowStart,
                 message.numberOfRows,
             );
-        let currentState = webviewViewController.getQueryResultState(message.uri);
-        if (
-            currentState.isExecutionPlan &&
-            currentState.resultSetSummaries[message.batchId] &&
-            // check if the current result set is the result set that contains the xml plan
-            currentState.resultSetSummaries[message.batchId][message.resultId].columnInfo[0]
-                .columnName === Constants.showPlanXmlColumnName
-        ) {
-            currentState.executionPlanState.xmlPlans[`${message.batchId},${message.resultId}`] =
-                result.rows[0][0].displayValue;
-        }
-        // if we are on the last result set and still don't have any xml plans
-        // then we should not show the query plan. for example, this happens
-        // if user runs actual plan with all print statements
-        else if (
-            // check that we're on the last batch
-            message.batchId === recordLength(currentState.resultSetSummaries) - 1 &&
-            // check that we're on the last result within the batch
-            message.resultId ===
-                recordLength(currentState.resultSetSummaries[message.batchId]) - 1 &&
-            // check that there's we have no xml plans
-            (!currentState.executionPlanState?.xmlPlans ||
-                !recordLength(currentState.executionPlanState.xmlPlans))
-        ) {
-            currentState.isExecutionPlan = false;
-            currentState.actualPlanEnabled = false;
-        }
-        webviewViewController.setQueryResultState(message.uri, currentState);
         return result;
     });
 
@@ -328,38 +299,6 @@ export function registerCommonRequestHandlers(
         }
         return state;
     });
-    webviewController.registerReducer("getExecutionPlan", async (state, payload) => {
-        // because this is an overridden call, this makes sure it is being
-        // called properly
-        if (!("uri" in payload)) return state;
-
-        const currentResultState = webviewViewController.getQueryResultState(payload.uri);
-        // Ensure execution plan state exists and execution plan graphs have not loaded
-        if (
-            currentResultState.executionPlanState &&
-            currentResultState.executionPlanState.executionPlanGraphs.length === 0 &&
-            // Check for non-empty XML plans and result summaries
-            recordLength(currentResultState.executionPlanState.xmlPlans) &&
-            recordLength(currentResultState.resultSetSummaries) &&
-            // Verify XML plans match expected number of result sets
-            recordLength(currentResultState.executionPlanState.xmlPlans) ===
-                webviewViewController.getNumExecutionPlanResultSets(
-                    currentResultState.resultSetSummaries,
-                    currentResultState.actualPlanEnabled,
-                )
-        ) {
-            state = (await createExecutionPlanGraphs(
-                state,
-                webviewViewController.getExecutionPlanService(),
-                Object.values(currentResultState.executionPlanState.xmlPlans),
-                "QueryResults",
-            )) as qr.QueryResultWebviewState;
-            state.executionPlanState.loadState = ApiStatus.Loaded;
-            state.tabStates.resultPaneTab = qr.QueryResultPaneTabs.ExecutionPlan;
-        }
-
-        return state;
-    });
     webviewController.registerReducer("openFileThroughLink", async (state, payload) => {
         // TO DO: add formatting? ADS doesn't do this, but it may be nice...
         const newDoc = await vscode.workspace.openTextDocument({
@@ -395,6 +334,11 @@ export function registerCommonRequestHandlers(
     webviewController.registerReducer("updateTotalCost", async (state, payload) => {
         return (await updateTotalCost(state, payload)) as qr.QueryResultWebviewState;
     });
+    webviewController.onRequest(qr.ShowFilterDisabledMessageRequest.type, async () => {
+        this.vscodeWrapper.showInformationMessage(
+            LocalizedConstants.inMemoryDataProcessingThresholdExceeded,
+        );
+    });
 }
 
 export function recordLength(record: any): number {
@@ -414,4 +358,21 @@ export function messageToString(message: qr.IMessage): string {
  */
 export function isOpenQueryResultsInTabByDefaultEnabled(): boolean {
     return vscode.workspace.getConfiguration().get(Constants.configOpenQueryResultsInTabByDefault);
+}
+
+/**
+ * Counts the number of result sets in the given summaries.
+ * @param resultSetSummaries The result set summaries to count.
+ * @returns The number of result sets.
+ */
+export function countResultSets(
+    resultSetSummaries: Record<number, Record<number, qr.ResultSetSummary>>,
+): number {
+    let count = 0;
+    for (const batchId in resultSetSummaries) {
+        if (Object.prototype.hasOwnProperty.call(resultSetSummaries, batchId)) {
+            count += Object.keys(resultSetSummaries[batchId]).length;
+        }
+    }
+    return count;
 }


### PR DESCRIPTION
## Description

This PR introduces streaming contracts for result sets while retrofitting the existing non-streaming architecture.

It also removes an unnecessary execution plan roundtrip: previously, execution plan XML was loaded into the webview, which then had to request the plan graphs. With this change, the extension now detects execution plan graph XML directly in the result set and generates the execution plan graphs itself, eliminating the extra request. 


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

