### PR TITLE
Add chat slash commands for copilot

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1764,6 +1764,10 @@
   "No active connection for database change": "No active connection for database change",
   "Connection Details": "Connection Details",
   "Authentication": "Authentication",
+  "Server Version": "Server Version",
+  "Server Edition": "Server Edition",
+  "Cloud": "Cloud",
+  "User": "User",
   "No connection information found": "No connection information found",
   "No active connection": "No active connection",
   "Opening schema designer...": "Opening schema designer...",
@@ -1791,7 +1795,7 @@
     ]
   },
   "Unknown error": "Unknown error",
-  "No active database connection. Please connect first using `/connect`.": "No active database connection. Please connect first using `/connect`.",
+  "No active database connection in the current editor. Please establish a connection to continue.": "No active database connection in the current editor. Please establish a connection to continue.",
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
   "Cancel failed: {0}/{0} is the error message": {
     "message": "Cancel failed: {0}",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1756,6 +1756,37 @@
       "{0} is the connection ID"
     ]
   },
+  "Connected successfully": "Connected successfully",
+  "Failed to connect": "Failed to connect",
+  "Disconnected successfully": "Disconnected successfully",
+  "Database changed successfully": "Database changed successfully",
+  "Failed to change database": "Failed to change database",
+  "No active connection for database change": "No active connection for database change",
+  "Connection Details": "Connection Details",
+  "Authentication": "Authentication",
+  "No connection information found": "No connection information found",
+  "No active connection": "No active connection",
+  "🔍 Opening schema designer...": "🔍 Opening schema designer...",
+  "No connection credentials found": "No connection credentials found",
+  "No active connection for schema view": "No active connection for schema view",
+  "📋 **Available Servers**": "📋 **Available Servers**",
+  "No saved connection profiles found.": "No saved connection profiles found.",
+  "Use `/connect` to create a new connection.": "Use `/connect` to create a new connection.",
+  "Unnamed Profile": "Unnamed Profile",
+  "Found {0} saved connection profile(s)./{0} is the number of connection profiles": {
+    "message": "Found {0} saved connection profile(s).",
+    "comment": [
+      "{0} is the number of connection profiles"
+    ]
+  },
+  "Error retrieving server list: {0}/{0} is the error message": {
+    "message": "Error retrieving server list: {0}",
+    "comment": [
+      "{0} is the error message"
+    ]
+  },
+  "Unknown error": "Unknown error",
+  "No active database connection. Please connect first using `/connect`.": "No active database connection. Please connect first using `/connect`.",
   "$(plug)  Connect to MSSQL": "$(plug)  Connect to MSSQL",
   "Cancel failed: {0}/{0} is the error message": {
     "message": "Cancel failed: {0}",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1766,12 +1766,17 @@
   "Authentication": "Authentication",
   "No connection information found": "No connection information found",
   "No active connection": "No active connection",
-  "🔍 Opening schema designer...": "🔍 Opening schema designer...",
+  "Opening schema designer...": "Opening schema designer...",
   "No connection credentials found": "No connection credentials found",
   "No active connection for schema view": "No active connection for schema view",
-  "📋 **Available Servers**": "📋 **Available Servers**",
+  "Available Servers": "Available Servers",
   "No saved connection profiles found.": "No saved connection profiles found.",
-  "Use `/connect` to create a new connection.": "Use `/connect` to create a new connection.",
+  "Use {0} to create a new connection./{0} is the connect command": {
+    "message": "Use {0} to create a new connection.",
+    "comment": [
+      "{0} is the connect command"
+    ]
+  },
   "Unnamed Profile": "Unnamed Profile",
   "Found {0} saved connection profile(s)./{0} is the number of connection profiles": {
     "message": "Found {0} saved connection profile(s).",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -237,6 +237,9 @@
     <trans-unit id="++CODE++a27adfa57c8938761efd3fc482ea8e81fc898b286f29d04c783c9d3b60b22824">
       <source xml:lang="en">Auto Arrange will automatically reposition all diagram elements based on optimal layout algorithms. Any custom positioning you&apos;ve created will be lost. Do you want to proceed with auto-arranging your schema diagram?</source>
     </trans-unit>
+    <trans-unit id="++CODE++87cdec8b1acc8c61a853ce73e9707a8a0c55e57922ff53e108262128e97553f2">
+      <source xml:lang="en">Available Servers</source>
+    </trans-unit>
     <trans-unit id="++CODE++92eb0b1fb89f1725b3c1fe652164720d7b2d17222e81bd5057f02f645fb24e67">
       <source xml:lang="en">Average: {0}  Count: {1}  Distinct Count: {2}  Max: {3}  Min: {4}  Null Count: {5}  Sum: {6}</source>
       <note>{0} is the average, {1} is the count, {2} is the distinct count, {3} is the max, {4} is the min, {5} is the null count, {6} is the sum</note>
@@ -1863,6 +1866,9 @@
     <trans-unit id="++CODE++3a8e07b84d53ba502ae8ee669003537bdbbe321d6c8c6fb6cbd63019cb3d400e">
       <source xml:lang="en">Opening Publish Script. This may take a while...</source>
     </trans-unit>
+    <trans-unit id="++CODE++fe0d6bd1aef549a43c5fca4a838882918bd3a85e9641cb5150f31df976e18e38">
+      <source xml:lang="en">Opening schema designer...</source>
+    </trans-unit>
     <trans-unit id="++CODE++291101a07fe980e93b900ae85c9eb824f9e7e93d0d754be7440b9386b615cad7">
       <source xml:lang="en">Operator</source>
     </trans-unit>
@@ -2734,8 +2740,9 @@
     <trans-unit id="++CODE++eeefe579e45c25e1a551b536d8eecc680562bce4d0aa58ffee1ad7df8cc84e63">
       <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source>
     </trans-unit>
-    <trans-unit id="++CODE++faaa8fa849491a397892a490650506fc6fe07a43fc6c74ea13dbb7259613eb06">
-      <source xml:lang="en">Use `/connect` to create a new connection.</source>
+    <trans-unit id="++CODE++6fa7eeedfe2d3774f7d0d8fbb044c15710f171f58174bf7435ab1757e92d0c27">
+      <source xml:lang="en">Use {0} to create a new connection.</source>
+      <note>{0} is the connect command</note>
     </trans-unit>
     <trans-unit id="++CODE++b82e11da3bc16786000d6e008e038f4d0272163a6476e0ca3c4b29d958051f9c">
       <source xml:lang="en">User name</source>
@@ -2985,12 +2992,6 @@
     </trans-unit>
     <trans-unit id="++CODE++4d765d766973242c68c5a2d3b20c7164beb22948ceaf7095ce44f901cc2f4052">
       <source xml:lang="en">❌ Deny Access (Current)</source>
-    </trans-unit>
-    <trans-unit id="++CODE++3c3af6db38a2839f23aa8a28419cb64299d7219eb7798929277c541a687d007c">
-      <source xml:lang="en">📋 **Available Servers**</source>
-    </trans-unit>
-    <trans-unit id="++CODE++d0ab501a2d8249e17d81150cb5b25991fec72f89346e8d813a5e8713bf6f729f">
-      <source xml:lang="en">🔍 Opening schema designer...</source>
     </trans-unit>
   </body></file>
   <file original="package" source-language="en" datatype="plaintext"><body>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -505,6 +505,9 @@
     <trans-unit id="++CODE++548e8cc0e8c2423c61f30c6e8b75a1a40c995e3be119df6272b280ab6c15a011">
       <source xml:lang="en">Close the current connection</source>
     </trans-unit>
+    <trans-unit id="++CODE++b977b950c1ae31e5aeb9ef778cc20a66fc034eb81e738e0206104b677962c465">
+      <source xml:lang="en">Cloud</source>
+    </trans-unit>
     <trans-unit id="++CODE++be6eb1fc3b05bf9dceebad2eac7841d1b2f40bda9aa2da34df8ca22af02bc3ed">
       <source xml:lang="en">Collapse</source>
     </trans-unit>
@@ -1716,8 +1719,8 @@
     <trans-unit id="++CODE++796911143ea8bb8e1ff88271e2618eb63b05d9e04cdf6e9363533b0715ab3574">
       <source xml:lang="en">No active connection for schema view</source>
     </trans-unit>
-    <trans-unit id="++CODE++f1311636cfce6dd7e5b8971f59cacbd1d06aac1951d5f85eaaf164453f559686">
-      <source xml:lang="en">No active database connection. Please connect first using `/connect`.</source>
+    <trans-unit id="++CODE++d932a05eba0200bedb4b5449ce9e6487525ba3ecfd164e137388fd0833b4121b">
+      <source xml:lang="en">No active database connection in the current editor. Please establish a connection to continue.</source>
     </trans-unit>
     <trans-unit id="++CODE++37d715d202ea8a671a72107c5949755a1cfc925eb3b51f4b2ea823d7a54f2aa7">
       <source xml:lang="en">No changes detected</source>
@@ -2330,6 +2333,12 @@
       <source xml:lang="en">Server - {0}</source>
       <note>{0} is the server name</note>
     </trans-unit>
+    <trans-unit id="++CODE++6b0054dcd0116896729545198c9cdfe9b8f97008d91d39084e5c8808a6784c58">
+      <source xml:lang="en">Server Edition</source>
+    </trans-unit>
+    <trans-unit id="++CODE++86c1cd65696eadbc588fd4fe04d8b03ca948befc5a89467c621edf47f885118c">
+      <source xml:lang="en">Server Version</source>
+    </trans-unit>
     <trans-unit id="++CODE++1c53883708ab16a3743793905feb38c8e77c295d846ff276491831e1de69b6e1">
       <source xml:lang="en">Server connection in progress. Do you want to cancel?</source>
     </trans-unit>
@@ -2743,6 +2752,9 @@
     <trans-unit id="++CODE++6fa7eeedfe2d3774f7d0d8fbb044c15710f171f58174bf7435ab1757e92d0c27">
       <source xml:lang="en">Use {0} to create a new connection.</source>
       <note>{0} is the connect command</note>
+    </trans-unit>
+    <trans-unit id="++CODE++b512d97e7cbf97c273e4db073bbb547aa65a84589227f8f3d9e4a72b9372a24d">
+      <source xml:lang="en">User</source>
     </trans-unit>
     <trans-unit id="++CODE++b82e11da3bc16786000d6e008e038f4d0272163a6476e0ca3c4b29d958051f9c">
       <source xml:lang="en">User name</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -205,6 +205,9 @@
     <trans-unit id="++CODE++f0762c4f3bfcd695e32e7fcd087dc2a60bc26cda108b4fc0a643445b397168c7">
       <source xml:lang="en">Are you sure?</source>
     </trans-unit>
+    <trans-unit id="++CODE++66880d2d8216260d201917a72eb245440ef18ba9b54c070ee39aa4c343ae126f">
+      <source xml:lang="en">Authentication</source>
+    </trans-unit>
     <trans-unit id="++CODE++eccf8ea40318babf1bd28fa823e0fa905383eed481da5fccb9f54ea4a6152943">
       <source xml:lang="en">Authentication Library has changed, please reload Visual Studio Code.</source>
     </trans-unit>
@@ -603,6 +606,9 @@
       <source xml:lang="en">Connect using profile {0}?</source>
       <note>{0} is the profile ID</note>
     </trans-unit>
+    <trans-unit id="++CODE++28d29898bc769fd6df013da142af60f451953946e641fc2a2bee0e49b235a623">
+      <source xml:lang="en">Connected successfully</source>
+    </trans-unit>
     <trans-unit id="++CODE++b6c3dc8ba33b3a93b9060f81da8fa7d496f07487cec7a12353257242b2ea9e24">
       <source xml:lang="en">Connected to server &quot;{0}&quot; on document &quot;{1}&quot;. Server information: {2}</source>
       <note>{0} is the server name
@@ -644,6 +650,9 @@
     </trans-unit>
     <trans-unit id="++CODE++5f04ae9ed6a865bb382c66ef4bd4e57df4ce19d4142b8c87ac40d65ae54d278f">
       <source xml:lang="en">Connecting...</source>
+    </trans-unit>
+    <trans-unit id="++CODE++880cac6e9612c7672ce73c666f54c5f789e7b1ed1b9f0b7f1431fe84a2e59bce">
+      <source xml:lang="en">Connection Details</source>
     </trans-unit>
     <trans-unit id="++CODE++dba530f818587a0d79d7bb8f59e07d372d10691f49c560e3e4c3d42d105fe9e7">
       <source xml:lang="en">Connection Dialog</source>
@@ -792,6 +801,9 @@
     <trans-unit id="++CODE++667dd91d86c6b574073536489e39f0c5ab034846a63d946e8ef9f7bedeb1f4fb">
       <source xml:lang="en">Database Project</source>
     </trans-unit>
+    <trans-unit id="++CODE++ec9c37392a809590dbb62879bd1b261c3675552b33d4d8936d539925d774f6a6">
+      <source xml:lang="en">Database changed successfully</source>
+    </trans-unit>
     <trans-unit id="++CODE++e97a0773fb7b656c174155270bd9ded70bc82caa0fc5d65b3ba24871577a5b08">
       <source xml:lang="en">Database name</source>
     </trans-unit>
@@ -850,6 +862,9 @@
     <trans-unit id="++CODE++2458834a3d92abf750b8161a959ff2bb0405a29bd8b3b77015d065249bd02b7f">
       <source xml:lang="en">Disconnected on document &quot;{0}&quot;</source>
       <note>{0} is the document name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++459c45733e24412e32c08ebea6b6819b4a29ca99ec1b99e5c8036d0165df44b7">
+      <source xml:lang="en">Disconnected successfully</source>
     </trans-unit>
     <trans-unit id="++CODE++810e6bf829af848a6ab728e3b8f94dde597f95f47f11b160ca7eaa9f0d21395b">
       <source xml:lang="en">Disconnecting from connection &apos;{0}&apos;</source>
@@ -1019,6 +1034,10 @@
     <trans-unit id="++CODE++619d1a6dc49f043552f7b8d14e6483de4a2caf1c8270d6168a642c8eccc3a752">
       <source xml:lang="en">Error occurred opening content in editor.</source>
     </trans-unit>
+    <trans-unit id="++CODE++7ce810c92d5881cd4638f73772ee57317b503d0f04dbc5cd2f281f77ac1d697d">
+      <source xml:lang="en">Error retrieving server list: {0}</source>
+      <note>{0} is the error message</note>
+    </trans-unit>
     <trans-unit id="++CODE++2982897442ab8ee74ad10f968e801f2979c59ecc19ae9d2041eeedec219fd8f1">
       <source xml:lang="en">Error running Docker commands. Please make sure Docker is running.</source>
     </trans-unit>
@@ -1085,6 +1104,12 @@
     <trans-unit id="++CODE++65b387854eab2ea5751dfeaf4b61e988e28642ef25dc8c09b8bd4e4ee99f6372">
       <source xml:lang="en">Failed to apply changes: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the publish changes operation</note>
+    </trans-unit>
+    <trans-unit id="++CODE++0f20f13b4e0c02dbfd1419272fdc0223aea4745a0704daf5f91876a21476bda2">
+      <source xml:lang="en">Failed to change database</source>
+    </trans-unit>
+    <trans-unit id="++CODE++46c9f3b7520fde539ec4452ba821c1b8ad43f18971284f033ab93d32f04c65df">
+      <source xml:lang="en">Failed to connect</source>
     </trans-unit>
     <trans-unit id="++CODE++6e543be4255a8c4362baca16d0850278f1d95a7df9cd38f4b94ecbda4abe57e5">
       <source xml:lang="en">Failed to connect to database: {0}</source>
@@ -1246,6 +1271,10 @@
     <trans-unit id="++CODE++463124bedefc986e5dc0c3e34607c881ba0337297037552decc1df70945e57e8">
       <source xml:lang="en">Found pending reconnect promise for uri {0}, waiting.</source>
       <note>{0} is the uri</note>
+    </trans-unit>
+    <trans-unit id="++CODE++fc70e7e548649aa12095a141703b67943b4437de990082c3646b3ab61884dcf0">
+      <source xml:lang="en">Found {0} saved connection profile(s).</source>
+      <note>{0} is the number of connection profiles</note>
     </trans-unit>
     <trans-unit id="++CODE++c910d474dcd724bff83ddedeb06bf1eceaf9fb3af7c76bb282be057f36e6dffa">
       <source xml:lang="en">General</source>
@@ -1675,12 +1704,30 @@
     <trans-unit id="++CODE++b363e5f44515909e667e5e4b24f9690b87a202de3c6b1f1f7b8b597205461ad6">
       <source xml:lang="en">No account selected</source>
     </trans-unit>
+    <trans-unit id="++CODE++9659b767df189a5839c87672cb77cb5c7e5dbe63f59c88712ad34358dda02676">
+      <source xml:lang="en">No active connection</source>
+    </trans-unit>
+    <trans-unit id="++CODE++fd8753767d0ca74647a1d3b877db12f2a65a06f4c81db6eadd086759df0a5ad1">
+      <source xml:lang="en">No active connection for database change</source>
+    </trans-unit>
+    <trans-unit id="++CODE++796911143ea8bb8e1ff88271e2618eb63b05d9e04cdf6e9363533b0715ab3574">
+      <source xml:lang="en">No active connection for schema view</source>
+    </trans-unit>
+    <trans-unit id="++CODE++f1311636cfce6dd7e5b8971f59cacbd1d06aac1951d5f85eaaf164453f559686">
+      <source xml:lang="en">No active database connection. Please connect first using `/connect`.</source>
+    </trans-unit>
     <trans-unit id="++CODE++37d715d202ea8a671a72107c5949755a1cfc925eb3b51f4b2ea823d7a54f2aa7">
       <source xml:lang="en">No changes detected</source>
+    </trans-unit>
+    <trans-unit id="++CODE++d359844ae129bd7d51eda9e3c61dcf5c4036be148cdf783fc11d6454e8ca372b">
+      <source xml:lang="en">No connection credentials found</source>
     </trans-unit>
     <trans-unit id="++CODE++bb6f0c310647145d31546d24967be9eb8ebae90f640642e9fbb5d7713e6e8550">
       <source xml:lang="en">No connection found for connectionId: {0}</source>
       <note>{0} is the connection ID</note>
+    </trans-unit>
+    <trans-unit id="++CODE++3820494b45e56abad074e97c277e6328476da0ec09dacdf18bc5d5d7a6984cb2">
+      <source xml:lang="en">No connection information found</source>
     </trans-unit>
     <trans-unit id="++CODE++e7877ea821bcdd1b117351c975bccabc10caea61e2e13fae7fe37e0179bd8470">
       <source xml:lang="en">No connection profile to remove.</source>
@@ -1707,6 +1754,9 @@
     </trans-unit>
     <trans-unit id="++CODE++ac4f3a6af42834b4d2a24a75250eee26cde1f70bb4bf0359acd6523cafd78d67">
       <source xml:lang="en">No results to display</source>
+    </trans-unit>
+    <trans-unit id="++CODE++e32e1aa390f5243f880caab46155befbe51dd11233564502e4699d1cd79e56ab">
+      <source xml:lang="en">No saved connection profiles found.</source>
     </trans-unit>
     <trans-unit id="++CODE++0affa67640b3025de7e70ca5091dd93bcd11bedecbd01aad309a6013841386af">
       <source xml:lang="en">No schema differences were found.</source>
@@ -2655,6 +2705,12 @@
     <trans-unit id="++CODE++a8283ade31856f71220db0e6f60a257c6889dc4dad0f275f66ad44b9ed9bf8d5">
       <source xml:lang="en">Undo</source>
     </trans-unit>
+    <trans-unit id="++CODE++27c2ccd962c2b8dccb52fe3688ab236f186f7a41fd57d810478712048e9ad3f8">
+      <source xml:lang="en">Unknown error</source>
+    </trans-unit>
+    <trans-unit id="++CODE++e4dd0ac78c7663f350454bad4258d3b6d38971181470082487d131decc61880b">
+      <source xml:lang="en">Unnamed Profile</source>
+    </trans-unit>
     <trans-unit id="++CODE++a41927d919e273a317907b7f6817ca593d800bc0eb3262ff288630d157bb9448">
       <source xml:lang="en">Unsupported architecture for Docker: {0}</source>
       <note>{0} is the architecture name of the machine</note>
@@ -2677,6 +2733,9 @@
     </trans-unit>
     <trans-unit id="++CODE++eeefe579e45c25e1a551b536d8eecc680562bce4d0aa58ffee1ad7df8cc84e63">
       <source xml:lang="en">Use T-SQL intellisense and syntax error checking on current document</source>
+    </trans-unit>
+    <trans-unit id="++CODE++faaa8fa849491a397892a490650506fc6fe07a43fc6c74ea13dbb7259613eb06">
+      <source xml:lang="en">Use `/connect` to create a new connection.</source>
     </trans-unit>
     <trans-unit id="++CODE++b82e11da3bc16786000d6e008e038f4d0272163a6476e0ca3c4b29d958051f9c">
       <source xml:lang="en">User name</source>
@@ -2926,6 +2985,12 @@
     </trans-unit>
     <trans-unit id="++CODE++4d765d766973242c68c5a2d3b20c7164beb22948ceaf7095ce44f901cc2f4052">
       <source xml:lang="en">❌ Deny Access (Current)</source>
+    </trans-unit>
+    <trans-unit id="++CODE++3c3af6db38a2839f23aa8a28419cb64299d7219eb7798929277c541a687d007c">
+      <source xml:lang="en">📋 **Available Servers**</source>
+    </trans-unit>
+    <trans-unit id="++CODE++d0ab501a2d8249e17d81150cb5b25991fec72f89346e8d813a5e8713bf6f729f">
+      <source xml:lang="en">🔍 Opening schema designer...</source>
     </trans-unit>
   </body></file>
   <file original="package" source-language="en" datatype="plaintext"><body>

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
                         "description": "Analyze query performance and suggest improvements (e.g., indexing, restructuring)."
                     },
                     {
-                        "name": "connectionDetails",
+                        "name": "getConnectionDetails",
                         "description": "Shows a complete breakdown of the active connection: server name, database, version, authentication type, and connection string."
                     },
                     {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
                     },
                     {
                         "name": "getConnectionDetails",
-                        "description": "Shows a complete breakdown of the active connection: server name, database, version, authentication type, and connection string."
+                        "description": "Shows a complete breakdown of the active connection: server name, database, version, authentication type."
                     },
                     {
                         "name": "changeDatabase",

--- a/package.json
+++ b/package.json
@@ -226,8 +226,21 @@
                 "id": "mssql.agent",
                 "name": "mssql",
                 "description": "Azure SQL Copilot agent",
-                "commands": [],
-                "isSticky": true
+                "isSticky": true,
+                "commands": [
+                    {
+                        "name": "runQuery",
+                        "description": "Execute a SQL query in the currently connected database and return results."
+                    },
+                    {
+                        "name": "explain",
+                        "description": "Provide natural language explanations for SQL/ORM code, queries, functions, or stored procedures."
+                    },
+                    {
+                        "name": "disconnect",
+                        "description": "Disconnect from the currently connected database."
+                    }
+                ]
             }
         ],
         "customEditors": [

--- a/package.json
+++ b/package.json
@@ -237,8 +237,64 @@
                         "description": "Provide natural language explanations for SQL/ORM code, queries, functions, or stored procedures."
                     },
                     {
+                        "name": "fix",
+                        "description": "Detect and correct syntax issues or missing constraints in SQL/ORM code.."
+                    },
+                    {
+                        "name": "optimize",
+                        "description": "Analyze query performance and suggest improvements (e.g., indexing, restructuring)."
+                    },
+                    {
+                        "name": "connectionDetails",
+                        "description": "Shows a complete breakdown of the active connection: server name, database, version, authentication type, and connection string."
+                    },
+                    {
+                        "name": "changeDatabase",
+                        "description": "Switch to a different database within the current server."
+                    },
+                    {
                         "name": "disconnect",
                         "description": "Disconnect from the currently connected database."
+                    },
+                    {
+                        "name": "connect",
+                        "description": "Connect to a database."
+                    },
+                    {
+                        "name": "showSchema",
+                        "description": "Visualize the structure of the current database schema, including tables, relationships, and keys."
+                    },
+                    {
+                        "name": "showDefinition",
+                        "description": "Display structure of a specific table, view, function, or stored procedure."
+                    },
+                    {
+                        "name": "listServers",
+                        "description": "List all available database servers in OE."
+                    },
+                    {
+                        "name": "listDatabases",
+                        "description": "List all databases on the current server."
+                    },
+                    {
+                        "name": "listSchemas",
+                        "description": "List all schemas in the current database."
+                    },
+                    {
+                        "name": "listTables",
+                        "description": "List all tables in the current database."
+                    },
+                    {
+                        "name": "listViews",
+                        "description": "List all views in the current database."
+                    },
+                    {
+                        "name": "listFunctions",
+                        "description": "List all functions in the current database."
+                    },
+                    {
+                        "name": "listProcedures",
+                        "description": "List all procedures in the current database."
                     }
                 ]
             }

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1492,6 +1492,51 @@ export class MssqlChatAgent {
             comment: ["{0} is the connection ID"],
         });
     };
+
+    // Chat Commands localization strings
+    public static connectedSuccessfully = l10n.t("Connected successfully");
+    public static failedToConnect = l10n.t("Failed to connect");
+    public static disconnectedSuccessfully = l10n.t("Disconnected successfully");
+    public static databaseChangedSuccessfully = l10n.t("Database changed successfully");
+    public static failedToChangeDatabase = l10n.t("Failed to change database");
+    public static noActiveConnectionForDatabaseChange = l10n.t(
+        "No active connection for database change",
+    );
+    public static connectionDetails = l10n.t("Connection Details");
+    public static serverLabel = l10n.t("Server");
+    public static databaseLabel = l10n.t("Database");
+    public static authentication = l10n.t("Authentication");
+    public static sqlLogin = l10n.t("SQL Login");
+    public static noConnectionInformationFound = l10n.t("No connection information found");
+    public static noActiveConnection = l10n.t("No active connection");
+    public static openingSchemaDesigner = l10n.t("🔍 Opening schema designer...");
+    public static noConnectionCredentialsFound = l10n.t("No connection credentials found");
+    public static noActiveConnectionForSchemaView = l10n.t("No active connection for schema view");
+    public static availableServers = l10n.t("📋 **Available Servers**");
+    public static noSavedConnectionProfilesFound = l10n.t("No saved connection profiles found.");
+    public static useConnectToCreateNewConnection = l10n.t(
+        "Use `/connect` to create a new connection.",
+    );
+    public static unnamedProfile = l10n.t("Unnamed Profile");
+    public static default = l10n.t("Default");
+    public static foundSavedConnectionProfiles = (count: number) => {
+        return l10n.t({
+            message: "Found {0} saved connection profile(s).",
+            args: [count],
+            comment: ["{0} is the number of connection profiles"],
+        });
+    };
+    public static errorRetrievingServerList = (errorMessage: string) => {
+        return l10n.t({
+            message: "Error retrieving server list: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message"],
+        });
+    };
+    public static unknownError = l10n.t("Unknown error");
+    public static noActiveDatabaseConnection = l10n.t(
+        "No active database connection. Please connect first using `/connect`.",
+    );
 }
 
 export class QueryEditor {

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1507,6 +1507,12 @@ export class MssqlChatAgent {
     public static databaseLabel = l10n.t("Database");
     public static authentication = l10n.t("Authentication");
     public static sqlLogin = l10n.t("SQL Login");
+    public static serverVersion = l10n.t("Server Version");
+    public static serverEdition = l10n.t("Server Edition");
+    public static cloud = l10n.t("Cloud");
+    public static yes = l10n.t("Yes");
+    public static no = l10n.t("No");
+    public static user = l10n.t("User");
     public static noConnectionInformationFound = l10n.t("No connection information found");
     public static noActiveConnection = l10n.t("No active connection");
     public static openingSchemaDesigner = l10n.t("Opening schema designer...");
@@ -1539,7 +1545,7 @@ export class MssqlChatAgent {
     };
     public static unknownError = l10n.t("Unknown error");
     public static noActiveDatabaseConnection = l10n.t(
-        "No active database connection. Please connect first using `/connect`.",
+        "No active database connection in the current editor. Please establish a connection to continue.",
     );
 }
 

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1509,14 +1509,18 @@ export class MssqlChatAgent {
     public static sqlLogin = l10n.t("SQL Login");
     public static noConnectionInformationFound = l10n.t("No connection information found");
     public static noActiveConnection = l10n.t("No active connection");
-    public static openingSchemaDesigner = l10n.t("🔍 Opening schema designer...");
+    public static openingSchemaDesigner = l10n.t("Opening schema designer...");
     public static noConnectionCredentialsFound = l10n.t("No connection credentials found");
     public static noActiveConnectionForSchemaView = l10n.t("No active connection for schema view");
-    public static availableServers = l10n.t("📋 **Available Servers**");
+    public static availableServers = l10n.t("Available Servers");
     public static noSavedConnectionProfilesFound = l10n.t("No saved connection profiles found.");
-    public static useConnectToCreateNewConnection = l10n.t(
-        "Use `/connect` to create a new connection.",
-    );
+    public static useConnectToCreateNewConnection = (connectCommand: string) => {
+        return l10n.t({
+            message: "Use {0} to create a new connection.",
+            args: [connectCommand],
+            comment: ["{0} is the connect command"],
+        });
+    };
     public static unnamedProfile = l10n.t("Unnamed Profile");
     public static default = l10n.t("Default");
     public static foundSavedConnectionProfiles = (count: number) => {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -842,6 +842,10 @@ export default class MainController implements vscode.Disposable {
         return this._initialized;
     }
 
+    public get context(): vscode.ExtensionContext {
+        return this._context;
+    }
+
     /**
      * Initializes the extension
      */
@@ -1725,7 +1729,7 @@ export default class MainController implements vscode.Disposable {
     /**
      * Choose a new database from the current server
      */
-    private async onChooseDatabase(): Promise<boolean> {
+    public async onChooseDatabase(): Promise<boolean> {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
             const success = await this._connectionMgr.onChooseDatabase();
             return success;

--- a/src/copilot/chatAgentRequestHandler.ts
+++ b/src/copilot/chatAgentRequestHandler.ts
@@ -27,6 +27,11 @@ import { MssqlChatAgent as loc } from "../constants/locConstants";
 import MainController from "../controllers/mainController";
 import { Logger } from "../models/logger";
 import { handleChatCommand, commandSkipsConnectionLabels } from "./chatCommands";
+import {
+    disconnectedLabelPrefix,
+    connectedLabelPrefix,
+    serverDatabaseLabelPrefix,
+} from "./chatConstants";
 
 export interface ISqlChatResult extends vscode.ChatResult {
     metadata: {
@@ -34,10 +39,6 @@ export interface ISqlChatResult extends vscode.ChatResult {
         correlationId: string;
     };
 }
-
-const DISCONNECTED_LABEL_PREFIX = "> ⚠️";
-const CONNECTED_LABEL_PREFIX = "> 🟢";
-const SERVER_DATABASE_LABEL_PREFIX = "> ➖";
 
 export const createSqlAgentRequestHandler = (
     copilotService: CopilotService,
@@ -308,7 +309,7 @@ export const createSqlAgentRequestHandler = (
 
                 // Show not connected message only if not handled by commands and command doesn't skip labels
                 if (!commandSkipsConnectionLabels(request.command)) {
-                    stream.markdown(`${DISCONNECTED_LABEL_PREFIX} ${loc.notConnected}\n\n`);
+                    stream.markdown(`${disconnectedLabelPrefix} ${loc.notConnected}\n\n`);
                 }
 
                 // Apply prompt template if this is a prompt substitute command
@@ -329,9 +330,9 @@ export const createSqlAgentRequestHandler = (
             }
 
             var connectionMessage =
-                `${CONNECTED_LABEL_PREFIX} ${loc.connectedTo}  \n` +
-                `${SERVER_DATABASE_LABEL_PREFIX} ${loc.server(connection.credentials.server)}  \n` +
-                `${SERVER_DATABASE_LABEL_PREFIX} ${loc.database(connection.credentials.database)}\n\n`;
+                `${connectedLabelPrefix} ${loc.connectedTo}  \n` +
+                `${serverDatabaseLabelPrefix} ${loc.server(connection.credentials.server)}  \n` +
+                `${serverDatabaseLabelPrefix} ${loc.database(connection.credentials.database)}\n\n`;
 
             // Handle chat commands
             const commandResult = await handleChatCommand(

--- a/src/copilot/chatCommands.ts
+++ b/src/copilot/chatCommands.ts
@@ -120,9 +120,18 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
         // TODO: Double check if this prompt template is optimal for optimize functionality
     },
     showSchema: {
-        type: CommandType.PromptSubstitute,
+        type: CommandType.Simple,
         requiresConnection: true,
-        promptTemplate: `${USE_TOOLS_PREFIX}show the database schema structure including tables, relationships, and keys. `,
+        handler: async (request, stream, controller, connectionUri) => {
+            if (connectionUri) {
+                // TODO: Implement schema designer opening
+                // - Call the schema designer command to visualize database structure
+                // - Should open the visual schema designer with tables, relationships, and keys
+                stream.markdown("🔍 Opening schema designer...\n\n");
+                // TODO: Call controller.schemaDesigner.open() or similar method
+            }
+            return true; // Command was handled
+        },
     },
     showDefinition: {
         type: CommandType.PromptSubstitute,

--- a/src/copilot/chatCommands.ts
+++ b/src/copilot/chatCommands.ts
@@ -1,0 +1,255 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import MainController from "../controllers/mainController";
+
+const DISCONNECTED_LABEL_PREFIX = "> ⚠️";
+const CONNECTED_LABEL_PREFIX = "> 🟢";
+const SERVER_DATABASE_LABEL_PREFIX = "> ➖";
+
+// Common prefix for prompt substitute commands to encourage tool usage
+const USE_TOOLS_PREFIX = "Use tools to ";
+
+export enum CommandType {
+    Simple = "simple",
+    PromptSubstitute = "prompt",
+}
+
+export interface CommandDefinition {
+    type: CommandType;
+    requiresConnection: boolean;
+    promptTemplate?: string;
+    handler?: (
+        request: vscode.ChatRequest,
+        stream: vscode.ChatResponseStream,
+        controller: MainController,
+        connectionUri: string | undefined,
+    ) => Promise<boolean>; // Returns true if command was handled, false to continue to language model
+}
+
+export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
+    // Simple command shortcuts - these are handled directly and don't go to language model
+    connect: {
+        type: CommandType.Simple,
+        requiresConnection: false,
+        handler: async (request, stream, controller, _connectionUri) => {
+            const res = await controller.onNewConnection();
+            if (res) {
+                stream.markdown(`${CONNECTED_LABEL_PREFIX} Connected successfully\n\n`);
+            } else {
+                stream.markdown(`${DISCONNECTED_LABEL_PREFIX} Failed to connect\n\n`);
+            }
+            return true; // Command was handled
+        },
+    },
+    disconnect: {
+        type: CommandType.Simple,
+        requiresConnection: true,
+        handler: async (request, stream, controller, connectionUri) => {
+            if (connectionUri) {
+                await controller.connectionManager.disconnect(connectionUri);
+                stream.markdown(`${DISCONNECTED_LABEL_PREFIX} Disconnected successfully\n\n`);
+            }
+            return true; // Command was handled
+        },
+    },
+    changeDatabase: {
+        type: CommandType.Simple,
+        requiresConnection: true,
+        handler: async (request, stream, controller, connectionUri) => {
+            if (connectionUri) {
+                // TODO: Implement database change logic
+                // - Parse database name from user input or show quick pick
+                // - Call connection manager to change database
+                // - Show success/failure message
+                stream.markdown(
+                    "🔄 Change Database command will open the database selection dialog.\n\n",
+                );
+            }
+            return true; // Command was handled
+        },
+    },
+    connectionDetails: {
+        type: CommandType.Simple,
+        requiresConnection: true,
+        handler: async (request, stream, controller, connectionUri) => {
+            if (connectionUri) {
+                const connection = controller.connectionManager.getConnectionInfo(connectionUri);
+                if (connection) {
+                    const details =
+                        `${CONNECTED_LABEL_PREFIX} **Connection Details**\n\n` +
+                        `${SERVER_DATABASE_LABEL_PREFIX} **Server:** ${connection.credentials.server}\n` +
+                        `${SERVER_DATABASE_LABEL_PREFIX} **Database:** ${connection.credentials.database}\n` +
+                        `${SERVER_DATABASE_LABEL_PREFIX} **Authentication:** ${connection.credentials.authenticationType || "SQL Login"}\n\n`;
+                    stream.markdown(details);
+                } else {
+                    stream.markdown(
+                        `${DISCONNECTED_LABEL_PREFIX} No connection information found\n\n`,
+                    );
+                }
+            }
+            return true; // Command was handled
+        },
+    },
+
+    // Prompt substitute commands - these modify the prompt and continue to language model
+    runQuery: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}run query: `,
+    },
+    explain: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}explain query: `,
+        // TODO: Double check if this prompt template is optimal for explain functionality
+    },
+    fix: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}fix this SQL code: `,
+        // TODO: Double check if this prompt template is optimal for fix functionality
+    },
+    optimize: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}optimize this SQL query for better performance: `,
+        // TODO: Double check if this prompt template is optimal for optimize functionality
+    },
+    showSchema: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}show the database schema structure including tables, relationships, and keys. `,
+    },
+    showDefinition: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}show the definition and structure of the specified database object: `,
+    },
+    listServers: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: false,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all available database servers and connection profiles. `,
+    },
+    listDatabases: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all databases available on the current server. `,
+    },
+    listSchemas: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all schemas in the current database. `,
+    },
+    listTables: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all tables in the current database. `,
+    },
+    listViews: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all views in the current database. `,
+    },
+    listFunctions: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all functions in the current database. `,
+    },
+    listProcedures: {
+        type: CommandType.PromptSubstitute,
+        requiresConnection: true,
+        promptTemplate: `${USE_TOOLS_PREFIX}list all stored procedures in the current database. `,
+    },
+};
+
+/**
+ * Checks if a command requires a database connection
+ */
+export function commandRequiresConnection(commandName: string): boolean {
+    const command = CHAT_COMMANDS[commandName];
+    return command?.requiresConnection ?? false;
+}
+
+/**
+ * Gets the command definition for a given command name
+ */
+export function getCommandDefinition(commandName: string): CommandDefinition | undefined {
+    return CHAT_COMMANDS[commandName];
+}
+
+/**
+ * Checks if a command is a simple command that should be handled directly
+ */
+export function isSimpleCommand(commandName: string): boolean {
+    const command = CHAT_COMMANDS[commandName];
+    return command?.type === CommandType.Simple;
+}
+
+/**
+ * Checks if a command is a prompt substitute command
+ */
+export function isPromptSubstituteCommand(commandName: string): boolean {
+    const command = CHAT_COMMANDS[commandName];
+    return command?.type === CommandType.PromptSubstitute;
+}
+
+/**
+ * Handles a chat command and returns whether the command was handled
+ * @param request The chat request
+ * @param stream The chat response stream
+ * @param controller The main controller
+ * @param connectionUri The current connection URI
+ * @returns Promise<{ handled: boolean, errorMessage?: string, promptToAdd?: string }>
+ */
+export async function handleChatCommand(
+    request: vscode.ChatRequest,
+    stream: vscode.ChatResponseStream,
+    controller: MainController,
+    connectionUri: string | undefined,
+): Promise<{ handled: boolean; errorMessage?: string; promptToAdd?: string }> {
+    const commandName = request.command;
+    if (!commandName) {
+        return { handled: false };
+    }
+
+    const commandDef = getCommandDefinition(commandName);
+    if (!commandDef) {
+        return { handled: false };
+    }
+
+    // Check connection requirements
+    if (commandDef.requiresConnection && !connectionUri) {
+        return {
+            handled: true,
+            errorMessage: `${DISCONNECTED_LABEL_PREFIX} No database connection. Please connect first using \`/connect\`.\n\n`,
+        };
+    }
+
+    // Special case: don't show "not connected" for connect command
+    if (commandName === "connect" && !connectionUri) {
+        // Allow connect command when not connected, don't show the disconnected message first
+    }
+
+    // TODO: For prompt substitute commands when not connected, we should return early
+    // instead of letting LLM continue with "Use tools to..." prompt, since tools won't work without connection
+
+    // Handle simple commands
+    if (commandDef.type === CommandType.Simple && commandDef.handler) {
+        await commandDef.handler(request, stream, controller, connectionUri);
+        return { handled: true };
+    }
+
+    // Handle prompt substitute commands
+    if (commandDef.type === CommandType.PromptSubstitute && commandDef.promptTemplate) {
+        return {
+            handled: false, // Don't handle completely, let it continue to language model
+            promptToAdd: commandDef.promptTemplate,
+        };
+    }
+
+    return { handled: false };
+}

--- a/src/copilot/chatCommands.ts
+++ b/src/copilot/chatCommands.ts
@@ -17,6 +17,8 @@ const SERVER_DATABASE_LABEL_PREFIX = "> ➖";
 // Common prefix for prompt substitute commands to encourage tool usage
 const USE_TOOLS_PREFIX = "Use tools to ";
 
+// TODO: Localize all user-facing strings in this file using locConstants
+
 export enum CommandType {
     Simple = "simple",
     PromptSubstitute = "prompt",

--- a/src/copilot/chatCommands.ts
+++ b/src/copilot/chatCommands.ts
@@ -30,7 +30,6 @@ export interface CommandDefinition {
     skipConnectionLabels?: boolean; // Skip showing generic connection status labels in chat handler
     promptTemplate?: string;
     handler?: (
-        request: vscode.ChatRequest,
         stream: vscode.ChatResponseStream,
         controller: MainController,
         connectionUri: string | undefined,
@@ -43,7 +42,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
         type: CommandType.Simple,
         requiresConnection: false,
         skipConnectionLabels: true, // Provides its own connection status
-        handler: async (request, stream, controller, _connectionUri) => {
+        handler: async (stream, controller, _connectionUri) => {
             const res = await controller.onNewConnection();
             if (res) {
                 stream.markdown(`${connectedLabelPrefix} ${loc.connectedSuccessfully}\n\n`);
@@ -57,7 +56,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
         type: CommandType.Simple,
         requiresConnection: true,
         skipConnectionLabels: true, // Provides its own connection status
-        handler: async (request, stream, controller, connectionUri) => {
+        handler: async (stream, controller, connectionUri) => {
             if (connectionUri) {
                 await controller.connectionManager.disconnect(connectionUri);
                 stream.markdown(`${disconnectedLabelPrefix} ${loc.disconnectedSuccessfully}\n\n`);
@@ -69,7 +68,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
         type: CommandType.Simple,
         requiresConnection: true,
         skipConnectionLabels: true, // Provides its own connection status
-        handler: async (request, stream, controller, connectionUri) => {
+        handler: async (stream, controller, connectionUri) => {
             if (connectionUri && isConnectionActive(controller, connectionUri)) {
                 const res = await controller.onChooseDatabase();
                 if (res) {
@@ -91,7 +90,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
         type: CommandType.Simple,
         requiresConnection: true,
         skipConnectionLabels: true, // Provides its own connection information
-        handler: async (request, stream, controller, connectionUri) => {
+        handler: async (stream, controller, connectionUri) => {
             if (connectionUri && isConnectionActive(controller, connectionUri)) {
                 const connection = controller.connectionManager.getConnectionInfo(connectionUri);
                 if (connection) {
@@ -162,7 +161,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
     showSchema: {
         type: CommandType.Simple,
         requiresConnection: true,
-        handler: async (request, stream, controller, connectionUri) => {
+        handler: async (stream, controller, connectionUri) => {
             if (connectionUri && isConnectionActive(controller, connectionUri)) {
                 stream.markdown(`🔍 ${loc.openingSchemaDesigner}\n\n`);
                 const connInfo = controller.connectionManager.getConnectionInfo(connectionUri);
@@ -200,7 +199,7 @@ export const CHAT_COMMANDS: Record<string, CommandDefinition> = {
     listServers: {
         type: CommandType.Simple,
         requiresConnection: false,
-        handler: async (request, stream, controller, _connectionUri) => {
+        handler: async (stream, controller, _connectionUri) => {
             try {
                 const profiles =
                     await controller.connectionManager.connectionStore.readAllConnections(false);
@@ -367,7 +366,7 @@ export async function handleChatCommand(
 
         // Handle simple commands
         if (commandDef.type === CommandType.Simple && commandDef.handler) {
-            await commandDef.handler(request, stream, controller, connectionUri);
+            await commandDef.handler(stream, controller, connectionUri);
             sendActionEvent(TelemetryViews.MssqlCopilot, TelemetryActions.ChatCommand, {
                 ...telemetryProperties,
                 success: "true",

--- a/src/copilot/chatConstants.ts
+++ b/src/copilot/chatConstants.ts
@@ -7,11 +7,14 @@
  * Chat UI formatting constants for consistent presentation across chat components
  */
 
-/** Prefix for messages indicating disconnected/error state */
+/** Prefix for messages indicating disconnected state */
 export const disconnectedLabelPrefix = "> ⚠️";
 
-/** Prefix for messages indicating connected/success state */
+/** Prefix for messages indicating connected state */
 export const connectedLabelPrefix = "> 🟢";
+
+/** Prefix for messages indicating general error state */
+export const errorLabelPrefix = "> ❌";
 
 /** Prefix for server/database information display */
 export const serverDatabaseLabelPrefix = "> ➖";

--- a/src/copilot/chatConstants.ts
+++ b/src/copilot/chatConstants.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Chat UI formatting constants for consistent presentation across chat components
+ */
+
+/** Prefix for messages indicating disconnected/error state */
+export const disconnectedLabelPrefix = "> ⚠️";
+
+/** Prefix for messages indicating connected/success state */
+export const connectedLabelPrefix = "> 🟢";
+
+/** Prefix for server/database information display */
+export const serverDatabaseLabelPrefix = "> ➖";

--- a/src/copilot/prompts.ts
+++ b/src/copilot/prompts.ts
@@ -7,20 +7,20 @@ import * as Constants from "../constants/constants";
 
 export const genericChatStart = `@${Constants.mssqlChatParticipantName} Hello!`;
 
-//TODO: figure out why EXPLAIN and EXPLAIN ANALYZE are not working
-export const analyzeQueryPerformancePrompt =
-    `@${Constants.mssqlChatParticipantName} Analyze the performance of this query.
+export const analyzeQueryPerformancePrompt = `@${Constants.mssqlChatParticipantName} Analyze the performance of this query.
 Provide a detailed analysis, including a summary of the execution plan,
 potential bottlenecks, and suggestions for optimization.
-Make sure to highlight any relevant statistics or metrics that can help in understanding the performance characteristics of the query.` +
-    // Run EXPLAIN and/or EXPLAIN ANALYZE on the query to get the execution plan and performance metrics.
-    `If the query is complex, break down the analysis into smaller parts for better clarity.
+Make sure to highlight any relevant statistics or metrics that can help in understanding the performance characteristics of the query.
+If the query is complex, break down the analysis into smaller parts for better clarity.
 Provide a summary of the key findings and recommendations at the end of the analysis.`;
 
-export const explainQueryPrompt = `@${Constants.mssqlChatParticipantName} Explain this query.
-Provide a detailed explanation of the query's purpose, business logic, structure, and functionality.
+// Shared prompt instructions to avoid duplication
+const EXPLAIN_QUERY_INSTRUCTIONS = `Provide a detailed explanation of the query's purpose, business logic, structure, and functionality.
 Make sure to clarify the role of each part of the query and how they contribute to the overall result.
-Provide examples or analogies if necessary to help me understand the query better.`;
+Provide examples or analogies if necessary to help understand the query better.`;
+
+export const explainQueryPrompt = `@${Constants.mssqlChatParticipantName} Explain this query.
+${EXPLAIN_QUERY_INSTRUCTIONS}`;
 
 export const explainQuerySelectionPrompt = `@${Constants.mssqlChatParticipantName} Explain the selected text of this query.
 Provide a detailed explanation of the query's purpose, business logic, structure, and functionality in the context of the query
@@ -39,3 +39,21 @@ Provide a revised version of the selected text that improves its performance, re
 Use the database context to ensure correctness. Think hard to find the absolute best version of the query.
 Make sure to explain the changes made and the reasons behind them.
 If applicable, include any relevant statistics or metrics that can help in understanding the performance characteristics of the revised query.`;
+
+// Common prefix for prompt substitute commands to encourage tool usage
+export const USE_TOOLS_PREFIX = "Use tools to ";
+
+// Prompt templates for chat commands
+export const CHAT_COMMAND_PROMPTS = {
+    runQuery: `${USE_TOOLS_PREFIX}run query: `,
+    explain: `${USE_TOOLS_PREFIX}explain this query. ${EXPLAIN_QUERY_INSTRUCTIONS}`,
+    fix: `${USE_TOOLS_PREFIX}fix this SQL query: `,
+    optimize: `${USE_TOOLS_PREFIX}optimize this SQL query for better performance: `,
+    showDefinition: `${USE_TOOLS_PREFIX}show the definition and structure of the specified database object: `,
+    listDatabases: `${USE_TOOLS_PREFIX}list all databases available on the current server. `,
+    listSchemas: `${USE_TOOLS_PREFIX}list all schemas in the current database. `,
+    listTables: `${USE_TOOLS_PREFIX}list all tables in the current database. `,
+    listViews: `${USE_TOOLS_PREFIX}list all views in the current database. `,
+    listFunctions: `${USE_TOOLS_PREFIX}list all functions in the current database. `,
+    listProcedures: `${USE_TOOLS_PREFIX}list all stored procedures in the current database. `,
+} as const;

--- a/src/sharedInterfaces/telemetry.ts
+++ b/src/sharedInterfaces/telemetry.ts
@@ -133,6 +133,7 @@ export enum TelemetryActions {
     PublishSession = "PublishSession",
     GetDefinition = "GetDefinition",
     LookupPassword = "LookupPassword",
+    ChatCommand = "ChatCommand",
 }
 
 /**

--- a/test/unit/chatCommands.test.ts
+++ b/test/unit/chatCommands.test.ts
@@ -1,0 +1,366 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import * as TypeMoq from "typemoq";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import {
+    handleChatCommand,
+    CHAT_COMMANDS,
+    commandRequiresConnection,
+    commandSkipsConnectionLabels,
+    isSimpleCommand,
+    isPromptSubstituteCommand,
+    getCommandDefinition,
+} from "../../src/copilot/chatCommands";
+import MainController from "../../src/controllers/mainController";
+import ConnectionManager, { ConnectionInfo } from "../../src/controllers/connectionManager";
+import * as telemetry from "../../src/telemetry/telemetry";
+
+suite("Chat Commands Tests", () => {
+    let mockMainController: TypeMoq.IMock<MainController>;
+    let mockConnectionManager: TypeMoq.IMock<ConnectionManager>;
+    let mockConnectionInfo: TypeMoq.IMock<ConnectionInfo>;
+    let mockChatStream: TypeMoq.IMock<vscode.ChatResponseStream>;
+    let mockChatRequest: TypeMoq.IMock<vscode.ChatRequest>;
+    let sandbox: sinon.SinonSandbox;
+
+    const sampleConnectionUri = "file:///path/to/sample.sql";
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+
+        // Stub telemetry functions
+        sandbox.stub(telemetry, "sendActionEvent");
+        sandbox.stub(telemetry, "sendErrorEvent");
+
+        // Mock ConnectionInfo with minimal required properties
+        mockConnectionInfo = TypeMoq.Mock.ofType<ConnectionInfo>();
+        mockConnectionInfo
+            .setup((x) => x.credentials)
+            .returns(
+                () =>
+                    ({
+                        server: "localhost",
+                        database: "testdb",
+                        authenticationType: "Integrated",
+                        user: "testuser",
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    }) as any,
+            );
+
+        // Mock ConnectionManager
+        mockConnectionManager = TypeMoq.Mock.ofType<ConnectionManager>();
+        mockConnectionManager
+            .setup((x) => x.getConnectionInfo(TypeMoq.It.isAny()))
+            .returns(() => mockConnectionInfo.object);
+        mockConnectionManager
+            .setup((x) => x.getServerInfo(TypeMoq.It.isAny()))
+            .returns(
+                () =>
+                    ({
+                        serverVersion: "15.0.2000.5",
+                        serverEdition: "Standard Edition",
+                        isCloud: false,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    }) as any,
+            );
+        mockConnectionManager
+            .setup((x) => x.disconnect(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(true));
+
+        // Mock MainController
+        mockMainController = TypeMoq.Mock.ofType<MainController>();
+        mockMainController
+            .setup((x) => x.connectionManager)
+            .returns(() => mockConnectionManager.object);
+        mockMainController.setup((x) => x.onNewConnection()).returns(() => Promise.resolve(true));
+        mockMainController.setup((x) => x.onChooseDatabase()).returns(() => Promise.resolve(true));
+
+        // Mock ChatResponseStream
+        mockChatStream = TypeMoq.Mock.ofType<vscode.ChatResponseStream>();
+        mockChatStream.setup((x) => x.markdown(TypeMoq.It.isAny())).returns(() => undefined);
+
+        // Mock ChatRequest
+        mockChatRequest = TypeMoq.Mock.ofType<vscode.ChatRequest>();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    suite("Command Definition Tests", () => {
+        test("commandRequiresConnection returns correct values", () => {
+            expect(commandRequiresConnection("connect")).to.be.false;
+            expect(commandRequiresConnection("disconnect")).to.be.true;
+            expect(commandRequiresConnection("getConnectionDetails")).to.be.true;
+            expect(commandRequiresConnection("listServers")).to.be.false;
+            expect(commandRequiresConnection("nonexistent")).to.be.false;
+        });
+
+        test("commandSkipsConnectionLabels returns correct values", () => {
+            expect(commandSkipsConnectionLabels("connect")).to.be.true;
+            expect(commandSkipsConnectionLabels("disconnect")).to.be.true;
+            expect(commandSkipsConnectionLabels("getConnectionDetails")).to.be.true;
+            expect(commandSkipsConnectionLabels("runQuery")).to.be.false;
+            expect(commandSkipsConnectionLabels("nonexistent")).to.be.false;
+        });
+
+        test("isSimpleCommand returns correct values", () => {
+            expect(isSimpleCommand("connect")).to.be.true;
+            expect(isSimpleCommand("disconnect")).to.be.true;
+            expect(isSimpleCommand("getConnectionDetails")).to.be.true;
+            expect(isSimpleCommand("runQuery")).to.be.false;
+            expect(isSimpleCommand("explain")).to.be.false;
+        });
+
+        test("isPromptSubstituteCommand returns correct values", () => {
+            expect(isPromptSubstituteCommand("connect")).to.be.false;
+            expect(isPromptSubstituteCommand("disconnect")).to.be.false;
+            expect(isPromptSubstituteCommand("runQuery")).to.be.true;
+            expect(isPromptSubstituteCommand("explain")).to.be.true;
+            expect(isPromptSubstituteCommand("fix")).to.be.true;
+        });
+
+        test("getCommandDefinition returns correct command definitions", () => {
+            const connectDef = getCommandDefinition("connect");
+            expect(connectDef).to.not.be.undefined;
+            expect(connectDef?.type).to.equal("simple");
+            expect(connectDef?.requiresConnection).to.be.false;
+            expect(connectDef?.skipConnectionLabels).to.be.true;
+
+            const runQueryDef = getCommandDefinition("runQuery");
+            expect(runQueryDef).to.not.be.undefined;
+            expect(runQueryDef?.type).to.equal("prompt");
+            expect(runQueryDef?.requiresConnection).to.be.true;
+
+            const nonexistentDef = getCommandDefinition("nonexistent");
+            expect(nonexistentDef).to.be.undefined;
+        });
+    });
+
+    suite("Command Handler Tests", () => {
+        test("handleChatCommand returns handled=false for unknown command", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "unknownCommand");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.false;
+            expect(result.errorMessage).to.be.undefined;
+        });
+
+        test("handleChatCommand returns handled=false for undefined command", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => undefined);
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.false;
+        });
+
+        test("handleChatCommand returns error for connection-required command without connection", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "disconnect");
+            mockConnectionManager
+                .setup((x) => x.getConnectionInfo(TypeMoq.It.isAny()))
+                .returns(() => undefined); // No connection
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                undefined,
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.contain("No active database connection");
+        });
+
+        test("connect command executes successfully", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "connect");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                undefined, // Connect doesn't need existing connection
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.be.undefined;
+            mockMainController.verify((x) => x.onNewConnection(), TypeMoq.Times.once());
+            mockChatStream.verify((x) => x.markdown(TypeMoq.It.isAny()), TypeMoq.Times.once());
+        });
+
+        test("disconnect command executes successfully with connection", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "disconnect");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.be.undefined;
+            mockConnectionManager.verify(
+                (x) => x.disconnect(TypeMoq.It.isAny()),
+                TypeMoq.Times.once(),
+            );
+        });
+
+        test("getConnectionDetails command shows connection information", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "getConnectionDetails");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.be.undefined;
+            // isConnectionActive calls getConnectionInfo once, handler calls it again
+            mockConnectionManager.verify(
+                (x) => x.getConnectionInfo(TypeMoq.It.isAny()),
+                TypeMoq.Times.atLeastOnce(),
+            );
+            mockConnectionManager.verify(
+                (x) => x.getServerInfo(TypeMoq.It.isAny()),
+                TypeMoq.Times.once(),
+            );
+            mockChatStream.verify((x) => x.markdown(TypeMoq.It.isAny()), TypeMoq.Times.once());
+        });
+
+        test("changeDatabase command executes successfully", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "changeDatabase");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.be.undefined;
+            mockMainController.verify((x) => x.onChooseDatabase(), TypeMoq.Times.once());
+        });
+
+        test("listServers command executes successfully", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "listServers");
+            const mockConnectionStore = {
+                readAllConnections: () =>
+                    Promise.resolve([
+                        {
+                            profileName: "Test Profile",
+                            server: "localhost",
+                            database: "testdb",
+                            authenticationType: "Integrated",
+                        },
+                    ]),
+            };
+            mockConnectionManager
+                .setup((x) => x.connectionStore)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .returns(() => mockConnectionStore as any);
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                undefined, // listServers doesn't need connection
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.be.undefined;
+            mockChatStream.verify(
+                (x) => x.markdown(TypeMoq.It.isAny()),
+                TypeMoq.Times.atLeastOnce(),
+            );
+        });
+
+        test("prompt substitute command returns promptToAdd", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "runQuery");
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                sampleConnectionUri,
+            );
+
+            expect(result.handled).to.be.false; // Prompt substitute commands don't handle completely
+            expect(result.promptToAdd).to.not.be.undefined;
+            expect(result.promptToAdd).to.contain("query"); // Should contain template text
+        });
+
+        test("command with exception returns error message", async () => {
+            mockChatRequest.setup((x) => x.command).returns(() => "listServers");
+            // Mock the connection store to throw an error
+            const mockConnectionStore = {
+                readAllConnections: () => Promise.reject(new Error("Database error")),
+            };
+            mockConnectionManager
+                .setup((x) => x.connectionStore)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .returns(() => mockConnectionStore as any);
+
+            const result = await handleChatCommand(
+                mockChatRequest.object,
+                mockChatStream.object,
+                mockMainController.object,
+                undefined,
+            );
+
+            expect(result.handled).to.be.true;
+            expect(result.errorMessage).to.not.be.undefined;
+            // Just check that an error message exists
+        });
+    });
+
+    suite("CHAT_COMMANDS Configuration", () => {
+        test("All simple commands have handlers", () => {
+            Object.entries(CHAT_COMMANDS).forEach(([name, def]) => {
+                if (def.type === "simple") {
+                    expect(def.handler, `Simple command ${name} should have a handler`).to.not.be
+                        .undefined;
+                }
+            });
+        });
+
+        test("All prompt substitute commands have prompt templates", () => {
+            Object.entries(CHAT_COMMANDS).forEach(([name, def]) => {
+                if (def.type === "prompt") {
+                    expect(
+                        def.promptTemplate,
+                        `Prompt substitute command ${name} should have a template`,
+                    ).to.not.be.undefined;
+                }
+            });
+        });
+
+        test("Commands that skip connection labels are properly configured", () => {
+            const skipLabelsCommands = Object.entries(CHAT_COMMANDS)
+                .filter(([, def]) => def.skipConnectionLabels)
+                .map(([name]) => name);
+
+            expect(skipLabelsCommands).to.include("connect");
+            expect(skipLabelsCommands).to.include("disconnect");
+            expect(skipLabelsCommands).to.include("getConnectionDetails");
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR implements a set of slash commands for the Copilot chat interface, enabling users to perform common database operations directly through chat. A transcript using the new commands can be found at the end (A space is added between @ and mssql to avoid spamming the user).

### Commands Implemented

**Simple Commands (direct execution):**
- `/connect` - Connect to a database server
- `/disconnect` - Disconnect from current server
- `/changeDatabase` - Switch to a different database
- `/getConnectionDetails` - Display current connection information
- `/showSchema` - Open the schema designer
- `/listServers` - List all saved connection profiles

**Prompt Substitute Commands (LLM-assisted):**
- `/runQuery` - Execute SQL queries 
- `/explain` - Get explanations for SQL code
- `/fix` - Fix SQL syntax and logic issues
- `/optimize` - Optimize SQL query performance
- `/listDatabases`, `/listSchemas`, `/listTables`, `/listViews`, `/listFunctions`, `/listProcedures` - List database objects

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
## Transcript
<details>
<summary>Chat transcript with the new commands</summary>
caohai: @ mssql /changeDatabase 

mssql: > ⚠️ No active database connection in the current editor. Please establish a connection to continue.



caohai: @ mssql /disconnect 

mssql: > ⚠️ No active database connection in the current editor. Please establish a connection to continue.



caohai: @ mssql /changeDatabase 

mssql: > ⚠️ No active database connection in the current editor. Please establish a connection to continue.



caohai: @ mssql /fix 

mssql: > ⚠️ No active database connection in the current editor. Please establish a connection to continue.



caohai: @ mssql /connect 

mssql: > 🟢 Connected successfully



caohai: @ mssql /connectionDetails 

mssql: > 🟢 **Connection Details**

> ➖ **Server:** (local)
> ➖ **Database:** master
> ➖ **Authentication:** Integrated



caohai: @ mssql /changeDatabase 

mssql: > 🟢 Database changed successfully



caohai: @ mssql /getConnectionDetails 

mssql: > 🟢 **Connection Details**  
> ➖ **Server:** (local)  
> ➖ **Database:** master  
> ➖ **Authentication:** Integrated  
> ➖ **Server Version:** 16.0.1145.1  
> ➖ **Server Edition:** Developer Edition (64-bit)  
> ➖ **Cloud:** No  



caohai: @ mssql /explain select 1;

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The query provided is:

```sql
SELECT 1;
```

### Explanation of the Query

1. **Purpose**:
   - This query simply selects the constant value `1`. It does not retrieve data from any table or perform any operations on a database. It is often used as a placeholder or to test database connectivity, query execution, or syntax.

2. **Business Logic**:
   - There is no business logic involved in this query since it does not interact with any database objects or perform any calculations. It is purely a technical query.

3. **Structure**:
   - **`SELECT`**: This is the SQL keyword used to retrieve data. In this case, it is retrieving a constant value.
   - **`1`**: This is the constant value being selected. It is not associated with any table or column.

4. **Functionality**:
   - When executed, the query will return a single row with a single column containing the value `1`.

### Example or Analogy
Think of this query as asking a calculator to display the number `1`. It does not involve any computation or input; it simply outputs the number you specify.

### Use Cases
- **Testing**: To verify that a database connection is working or that a query can execute without errors.
- **Placeholders**: Used in more complex queries or scripts where a simple query is needed temporarily.
- **Performance Testing**: To measure the overhead of executing a query without involving tables or data.

### Output
When you run this query, the result will look like this:

| (No Column Name) |
|-------------------|
| 1                 |

This is because no column alias is provided, so the column name defaults to `(No Column Name)` in most SQL Server tools.

caohai: @ mssql /fix select top 1 from sys.objects;

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The SQL query `SELECT TOP 1 FROM sys.objects;` contains a syntax error. Specifically, the query is missing the column(s) to select after the `SELECT` keyword.

### Corrected Query
To fix the query, you need to specify at least one column to retrieve. For example:

```sql
SELECT TOP 1 * 
FROM sys.objects;
```

### Explanation
- **`SELECT TOP 1`**: Retrieves only the first row from the result set.
- **`*`**: Selects all columns from the `sys.objects` table. Alternatively, you can specify specific column names instead of `*`.
- **`FROM sys.objects`**: Indicates the table from which to retrieve the data.

This corrected query will return the first row from the `sys.objects` system table.

caohai: @ mssql /optimize select * from sys.objects;

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The query `SELECT * FROM sys.objects;` was validated successfully for syntax and binding, meaning it is correctly written and references valid objects in the database. However, it was not executed, so no results were returned.

### Optimization Suggestions
To improve the performance of this query:
1. **Avoid `SELECT *`**:
   - Instead of selecting all columns, specify only the columns you need. For example:
     ```sql
     SELECT name, object_id, type
     FROM sys.objects;
     ```

2. **Filter Rows**:
   - Use a `WHERE` clause to limit the rows returned. For example, to retrieve only user tables:
     ```sql
     SELECT name, object_id, type
     FROM sys.objects
     WHERE type = 'U';
     ```

3. **Limit Results**:
   - If you only need a subset of rows, use `TOP` to limit the number of rows:
     ```sql
     SELECT TOP 100 name, object_id, type
     FROM sys.objects;
     ```

These changes reduce the amount of data retrieved, improving query performance. Let me know if you'd like further assistance!

caohai: @ mssql /listServers 

mssql: 📋 **Available Servers**

> ➖ **(local)**
> ➖ Server: (local)
> ➖ Database: Default
> ➖ Authentication: Integrated

> ➖ **docker-server**
> ➖ Server: localhost,1433
> ➖ Database: Default
> ➖ Authentication: SqlLogin

> ➖ **docker-TestDB-3**
> ➖ Server: localhost,1433
> ➖ Database: TestDB
> ➖ Authentication: SqlLogin

> ➖ **docker-TestDB-no-saved-pwd**
> ➖ Server: localhost,1433
> ➖ Database: TestDB
> ➖ Authentication: SqlLogin

> ➖ **hc-test-azure-synapse**
> ➖ Server: hc-test-synapse-ws.sql.azuresynapse.net
> ➖ Database: hcsynpase
> ➖ Authentication: AzureMFA

> ➖ **local-AdventureWorks**
> ➖ Server: localhost
> ➖ Database: AdventureWorks2022
> ➖ Authentication: Integrated

> ➖ **local-sql-server**
> ➖ Server: localhost
> ➖ Database: Default
> ➖ Authentication: Integrated

> ➖ **Unnamed Profile**
> ➖ Server: localhost
> ➖ Database: Default
> ➖ Authentication: Integrated

> ➖ **sql_server_container**
> ➖ Server: localhost,1434
> ➖ Database: Default
> ➖ Authentication: SqlLogin

> ➖ **test**
> ➖ Server: localhost,1433
> ➖ Database: Default
> ➖ Authentication: Integrated

> ➖ **test profile**
> ➖ Server: hacao-test-test.database.windows.net
> ➖ Database: Default
> ➖ Authentication: AzureMFA

Found 11 saved connection profile(s).



caohai: @ mssql /listDatabases 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current server contains the following databases:

1. **master**
2. **tempdb**
3. **model**
4. **msdb**
5. **AdventureWorksDW2022**
6. **AdventureWorks2022**

Let me know if you need further details about any of these databases!

caohai: @ mssql /listTables 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current database contains numerous tables across various schemas. Here is a summary of the tables grouped by their schema:

### **Schemas and Tables**
1. **Sales**
   - SalesTaxRate
   - PersonCreditCard
   - SalesTerritory
   - SalesTerritoryHistory
   - ShoppingCartItem
   - SpecialOffer
   - SpecialOfferProduct
   - Store
   - CountryRegionCurrency
   - CreditCard
   - Currency
   - CurrencyRate
   - Customer
   - SalesOrderDetail
   - SalesOrderHeader
   - SalesOrderHeaderSalesReason
   - SalesPerson
   - SalesPersonQuotaHistory
   - SalesReason

2. **Person**
   - PersonPhone
   - PhoneNumberType
   - Address
   - AddressType
   - StateProvince
   - BusinessEntity
   - BusinessEntityAddress
   - BusinessEntityContact
   - ContactType
   - CountryRegion
   - EmailAddress
   - Password
   - Person

3. **Production**
   - Product
   - ScrapReason
   - ProductCategory
   - ProductCostHistory
   - ProductDescription
   - ProductDocument
   - ProductInventory
   - ProductListPriceHistory
   - ProductModel
   - ProductModelIllustration
   - ProductModelProductDescriptionCulture
   - BillOfMaterials
   - ProductPhoto
   - ProductProductPhoto
   - TransactionHistory
   - TransactionHistoryArchive
   - ProductSubcategory
   - ProductVendor
   - UnitMeasure
   - WorkOrder
   - WorkOrderRouting
   - Culture
   - Document
   - Illustration
   - Location

4. **Purchasing**
   - ShipMethod
   - Vendor
   - PurchaseOrderDetail
   - PurchaseOrderHeader

5. **HumanResources**
   - Shift
   - Department
   - Employee
   - EmployeeDepartmentHistory
   - EmployeePayHistory
   - JobCandidate

6. **dbo**
   - DatabaseLog
   - ErrorLog
   - AWBuildVersion

---

If you need details about a specific table or schema, let me know!

caohai: @ mssql /listViews 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current database contains the following views:

### **Views by Schema**
#### **Person**
- vAdditionalContactInfo
- vStateProvinceCountryRegion

#### **HumanResources**
- vEmployee
- vEmployeeDepartment
- vEmployeeDepartmentHistory
- vJobCandidate
- vJobCandidateEmployment
- vJobCandidateEducation

#### **Sales**
- vIndividualCustomer
- vPersonDemographics
- vSalesPerson
- vSalesPersonSalesByFiscalYears
- vStoreWithDemographics
- vStoreWithContacts
- vStoreWithAddresses

#### **Production**
- vProductAndDescription
- vProductModelCatalogDescription
- vProductModelInstructions

#### **Purchasing**
- vVendorWithContacts
- vVendorWithAddresses

Let me know if you need details about any specific view!

caohai: @ mssql /listSchemas 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current database contains the following schemas:

1. **db_accessadmin**
2. **db_backupoperator**
3. **db_datareader**
4. **db_datawriter**
5. **db_ddladmin**
6. **db_denydatareader**
7. **db_denydatawriter**
8. **db_owner**
9. **db_securityadmin**
10. **dbo**
11. **guest**
12. **HumanResources**
13. **INFORMATION_SCHEMA**
14. **Person**
15. **Production**
16. **Purchasing**
17. **Sales**
18. **sys**

Let me know if you need further details about any of these schemas!

caohai: @ mssql /listProcedures 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current database contains the following stored procedures:

### **dbo Schema**
1. `uspGetBillOfMaterials`
2. `uspGetEmployeeManagers`
3. `uspGetManagerEmployees`
4. `uspGetWhereUsedProductID`
5. `uspPrintError`
6. `uspLogError`
7. `uspSearchCandidateResumes`

### **HumanResources Schema**
1. `uspUpdateEmployeeHireInfo`
2. `uspUpdateEmployeeLogin`
3. `uspUpdateEmployeePersonalInfo`

Let me know if you need details about any specific stored procedure!

caohai: @ mssql /listFunctions 

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The current database contains the following functions:

### **Scalar Functions** (Return a single value)
1. **dbo.ufnGetProductDealerPrice**
2. **dbo.ufnGetProductListPrice**
3. **dbo.ufnGetProductStandardCost**
4. **dbo.ufnGetStock**
5. **dbo.ufnGetDocumentStatusText**
6. **dbo.ufnGetPurchaseOrderStatusText**
7. **dbo.ufnGetSalesOrderStatusText**
8. **dbo.ufnLeadingZeros**
9. **dbo.ufnGetAccountingStartDate**
10. **dbo.ufnGetAccountingEndDate**

### **Table-Valued Functions** (Return a table)
1. **dbo.ufnGetContactInformation**

Let me know if you need details about any specific function!

caohai: @ mssql /showDefinition Person table

mssql: > 🟢 Connected to:  
> ➖ Server - (local)  
> ➖ Database - AdventureWorks2022

The **Person** table in the **AdventureWorks2022** database has the following structure and details:

### **Table Definition**
- **Schema**: Person
- **Type**: User Table
- **Created On**: May 8, 2023

### **Columns**
| Column Name            | Data Type         | Length | Nullable | Description                                                                 |
|------------------------|-------------------|--------|----------|-----------------------------------------------------------------------------|
| **BusinessEntityID**   | int               | 4      | No       | Primary key, uniquely identifies each person.                              |
| **PersonType**         | nchar(4)         | 4      | No       | Type of person (e.g., GC, SP, EM).                                         |
| **NameStyle**          | bit               | 1      | No       | Indicates if the name is in a Western-style format.                        |
| **Title**              | nvarchar(16)      | 16     | Yes      | Title of the person (e.g., Mr., Ms.).                                      |
| **FirstName**          | nvarchar(100)     | 100    | No       | First name of the person.                                                  |
| **MiddleName**         | nvarchar(100)     | 100    | Yes      | Middle name of the person.                                                 |
| **LastName**           | nvarchar(100)     | 100    | No       | Last name of the person.                                                   |
| **Suffix**             | nvarchar(20)      | 20     | Yes      | Suffix (e.g., Jr., Sr.).                                                   |
| **EmailPromotion**     | int               | 4      | No       | Indicates if the person is opted into email promotions.                    |
| **AdditionalContactInfo** | xml            | -1     | Yes      | Additional contact information in XML format.                              |
| **Demographics**       | xml               | -1     | Yes      | Demographic information in XML format.                                     |
| **rowguid**            | uniqueidentifier  | 16     | No       | Globally unique identifier for the row.                                    |
| **ModifiedDate**       | datetime          | 8      | No       | Date and time the row was last modified.                                   |

### **Indexes**
- **Primary Key**: `PK_Person_BusinessEntityID` (Clustered, on `BusinessEntityID`)
- **Unique Index**: `AK_Person_rowguid` (Non-clustered, on `rowguid`)
- **Additional Index**: `IX_Person_LastName_FirstName_MiddleName` (Non-clustered, on `LastName`, `FirstName`, `MiddleName`)

### **Constraints**
- **Check Constraints**:
  - `CK_Person_EmailPromotion`: Ensures `EmailPromotion` is between 0 and 2.
  - `CK_Person_PersonType`: Ensures `PersonType` is one of the valid types (e.g., GC, SP, EM).
- **Default Constraints**:
  - `DF_Person_EmailPromotion`: Default value for `EmailPromotion` is 0.
  - `DF_Person_ModifiedDate`: Default value for `ModifiedDate` is the current date.
  - `DF_Person_NameStyle`: Default value for `NameStyle` is 0.
  - `DF_Person_rowguid`: Default value for `rowguid` is a new GUID.

### **Relationships**
- **Foreign Keys**:
  - References `BusinessEntity` table via `BusinessEntityID`.
- **Referenced By**:
  - Tables such as `Employee`, `EmailAddress`, `Password`, `PersonPhone`, and `Customer`.

Let me know if you need further details or assistance with this table!

caohai: @ mssql /showSchema 

mssql: 🔍 Opening schema designer...



caohai: @ mssql /disconnect 

mssql: > ⚠️ Disconnected successfully

</details>
