### PR TITLE
Use generated GUID for fake password in test

### DIFF
--- a/test/unit/localContainersHelpers.test.ts
+++ b/test/unit/localContainersHelpers.test.ts
@@ -13,6 +13,7 @@ import * as lc from "../../src/sharedInterfaces/localContainers";
 import { DeploymentWebviewController } from "../../src/deployment/deploymentWebviewController";
 import MainController from "../../src/controllers/mainController";
 import { stubTelemetry } from "./utils";
+import { generateUUID } from "../e2e/baseFixtures";
 
 suite("localContainers logic", () => {
     let sandbox: sinon.SinonSandbox;
@@ -118,7 +119,7 @@ suite("localContainers logic", () => {
             formState: {
                 containerName: "goodName",
                 port: 1433,
-                password: "password123!",
+                password: generateUUID(),
                 acceptEula: true,
             } as any,
             formErrors: [] as string[],


### PR DESCRIPTION
## Description

CredScan was failing due to this hardcoded password.  Replacing with a generated GUID.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

