### PR TITLE
Adding Schema compare run comparison command to hookup SchemaCompare UI for sqlproj update proj usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ],
     "activationEvents": [
         "onUri",
+        "onCommand:mssql.schemaCompare.runComparison",
         "onCommand:mssql.loadCompletionExtension"
     ],
     "main": "./dist/extension",
@@ -901,6 +902,11 @@
             {
                 "command": "mssql.schemaCompareOpenFromCommandPalette",
                 "title": "%mssql.schemaCompare%",
+                "category": "MS SQL"
+            },
+            {
+                "command": "mssql.schemaCompare.runComparison",
+                "title": "Run Schema Comparison",
                 "category": "MS SQL"
             },
             {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -50,6 +50,7 @@ export const cmdCommandPaletteQueryHistory = "mssql.commandPaletteQueryHistory";
 export const cmdNewQuery = "mssql.newQuery";
 export const cmdSchemaCompare = "mssql.schemaCompare";
 export const cmdSchemaCompareOpenFromCommandPalette = "mssql.schemaCompareOpenFromCommandPalette";
+export const cmdSchemaCompareRunComparison = "mssql.schemaCompare.runComparison";
 export const cmdManageConnectionProfiles = "mssql.manageProfiles";
 export const cmdClearPooledConnections = "mssql.clearPooledConnections";
 export const cmdRebuildIntelliSenseCache = "mssql.rebuildIntelliSenseCache";


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
This pull request introduces a new command to immediately run a schema comparison in the MSSQL extension, improves command registration, and adds a corresponding unit test to ensure correct behavior. The changes are primarily focused on enhancing the extension's schema compare functionality and making it callable programmatically (such as from Azure Data Studio).

**Schema Compare Feature Additions:**

* Added a new command `mssql.schemaCompare.runComparison` to `package.json` activation events and command palette, enabling users and external tools to trigger a schema comparison directly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R907-R911)
* Registered the new command in `mainController.ts`, which invokes the `onSchemaCompareRunComparison` method to launch the schema compare UI and immediately start the comparison. [[1]](diffhunk://#diff-6551749c251883d4354dde8db43c093919871c9f70d05488ad28d1d99926f6e3R53) [[2]](diffhunk://#diff-226c7e3c205fb1d29e63f899a152924e487bf890bb934ecf2542a739504d2a08R1520-R1532)
* Implemented the `onSchemaCompareRunComparison` method in `mainController.ts`, which initializes the schema compare webview and runs the comparison with provided source and target endpoints.

**Testing Improvements:**

* Added a unit test in `mainController.test.ts` to verify that executing the new command correctly calls the handler and passes through the source and target parameters as expected. [[1]](diffhunk://#diff-a8df059fd593e193a83a0b67902dd68a41b1cefaaf2dd214456ed2a88e8e4bd9R20) [[2]](diffhunk://#diff-a8df059fd593e193a83a0b67902dd68a41b1cefaaf2dd214456ed2a88e8e4bd9R418-R445)
*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

