### PR TITLE
Properly disposing closed files. 

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -250,8 +250,8 @@ export default class MainController implements vscode.Disposable {
                 await UserSurvey.getInstance().launchSurvey("nps", getStandardNPSQuestions());
             });
             this.registerCommand(Constants.cmdCancelQuery);
-            this._event.on(Constants.cmdCancelQuery, () => {
-                this.onCancelQuery();
+            this._event.on(Constants.cmdCancelQuery, async () => {
+                await this.onCancelQuery();
             });
             this.registerCommand(Constants.cmdShowGettingStarted);
             this._event.on(Constants.cmdShowGettingStarted, async () => {
@@ -1985,13 +1985,13 @@ export default class MainController implements vscode.Disposable {
     /**
      * Handles the command to cancel queries
      */
-    private onCancelQuery(): void {
+    private async onCancelQuery(): Promise<void> {
         if (!this.canRunCommand() || !this.validateTextDocumentHasFocus()) {
             return;
         }
         try {
             let uri = this._vscodeWrapper.activeTextEditorUri;
-            this._outputContentProvider.cancelQuery(uri);
+            await this._outputContentProvider.cancelQuery(uri);
         } catch (err) {
             console.warn(`Unexpected error cancelling query : ${getErrorMessage(err)}`);
         }
@@ -2032,7 +2032,7 @@ export default class MainController implements vscode.Disposable {
             let fileUri = this._vscodeWrapper.activeTextEditorUri;
             let queryRunner = this._outputContentProvider.getQueryRunner(fileUri);
             if (queryRunner && queryRunner.isExecutingQuery) {
-                this._outputContentProvider.cancelQuery(fileUri);
+                await this._outputContentProvider.cancelQuery(fileUri);
             }
             const success = await this._connectionMgr.onDisconnect();
             if (success) {
@@ -2681,8 +2681,8 @@ export default class MainController implements vscode.Disposable {
             await this.updateUri(closedDocumentUri, this._lastOpenedUri);
         } else {
             // Pass along the close event to the other handlers for a normal closed file
+            await this._outputContentProvider.onDidCloseTextDocument(doc);
             await this._connectionMgr.onDidCloseTextDocument(doc);
-            this._outputContentProvider.onDidCloseTextDocument(doc);
         }
 
         // Reset special case timers and events

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -325,13 +325,13 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         }
     }
 
-    public removePanel(uri: string): void {
+    public async removePanel(uri: string): Promise<void> {
         if (this._queryResultWebviewPanelControllerMap.has(uri)) {
             this._queryResultWebviewPanelControllerMap.delete(uri);
             /**
              * Remove the corresponding query runner on panel closed
              */
-            this._sqlOutputContentProvider.cleanupRunner(uri);
+            await this._sqlOutputContentProvider.cleanupRunner(uri);
         }
     }
 

--- a/src/queryResult/queryResultWebviewPanelController.ts
+++ b/src/queryResult/queryResultWebviewPanelController.ts
@@ -74,7 +74,7 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
 
     public override dispose(): void {
         super.dispose();
-        this._queryResultWebviewViewController.removePanel(this._uri);
+        void this._queryResultWebviewViewController.removePanel(this._uri);
     }
 
     public revealToForeground() {

--- a/test/unit/sqlOutputContentProvider.test.ts
+++ b/test/unit/sqlOutputContentProvider.test.ts
@@ -303,7 +303,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         done();
     });
 
-    test("onDidCloseTextDocument properly mark the uri for deletion", (done) => {
+    test("onDidCloseTextDocument properly mark the uri for deletion", async () => {
         let title = "Test_Title";
         let uri = testUri;
         let querySelection: ISelectionData = {
@@ -327,13 +327,12 @@ suite("SqlOutputProvider Tests using mocks", () => {
             },
             languageId: "sql",
         };
-        mockContentProvider.object.onDidCloseTextDocument(doc);
+        await mockContentProvider.object.onDidCloseTextDocument(doc);
 
         // This URI should now be flagged for deletion later on
         console.log(mockMap.get(uri));
         assert.equal(mockMap.get(uri).flaggedForDeletion, true);
         mockMap.clear();
-        done();
     });
 
     test("isRunningQuery should return the correct state for the query", (done) => {
@@ -376,7 +375,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
 
         // Setup the function to call base and run it
         void mockContentProvider.object.runQuery(statusView.object, uri, querySelection, title);
-        mockContentProvider.object.cancelQuery(resultUri);
+        void mockContentProvider.object.cancelQuery(resultUri);
 
         // Ensure all side effects occured as intended
         assert.equal(mockMap.has(resultUri), true);
@@ -403,7 +402,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
 
         // Setup the function to call base and run it
         void mockContentProvider.object.runQuery(statusView.object, uri, querySelection, title);
-        mockContentProvider.object.cancelQuery(uri);
+        void mockContentProvider.object.cancelQuery(uri);
 
         // Ensure all side effects occured as intended
         assert.equal(mockMap.has(testUri), true);
@@ -442,7 +441,7 @@ suite("SqlOutputProvider Tests using mocks", () => {
         vscodeWrapper
             .setup((v) => v.showInformationMessage(TypeMoq.It.isAnyString()))
             .returns(() => Promise.resolve("error"));
-        contentProvider.cancelQuery("test_input");
+        void contentProvider.cancelQuery("test_input");
         vscodeWrapper.verify(
             (v) => v.showInformationMessage(TypeMoq.It.isAnyString()),
             TypeMoq.Times.once(),


### PR DESCRIPTION
## Description

Making sure we cancel any ongoing query execution and disconnect the file when a file is closed. Without this fix, a new file is not able to be connected to the server if a query execution is stuck. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

