### PR TITLE
Adds group to schema compare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -672,7 +672,8 @@
                 },
                 {
                     "command": "mssql.schemaCompare",
-                    "when": "view == dataworkspace.views.main && config.mssql.enableRichExperiences && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/"
+                    "when": "view == dataworkspace.views.main && config.mssql.enableRichExperiences && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/",
+                    "group": "1_dbProjectsFirst@4"
                 },
                 {
                     "command": "mssql.openQueryHistory",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR repositions the schema compare context menu option to appear below the publish command in the context menu that appears for Database project nodes.

Before:
<img width="405" height="563" alt="image" src="https://github.com/user-attachments/assets/295dfb6d-a707-4847-b5d7-087d50a6e1fd" />

After:
<img width="345" height="592" alt="image" src="https://github.com/user-attachments/assets/05d8625f-9e77-4f9b-9d3c-863b8eddeb9b" />


*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

