### PR TITLE
Improving copy last active connection code.

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -102,6 +102,11 @@ export interface IReconnectAction {
     (profile: IConnectionProfile | undefined): Promise<void>;
 }
 
+export interface ConnectionSuccessfulEvent {
+    connection: ConnectionInfo;
+    fileUri: string;
+}
+
 // ConnectionManager class is the main controller for connection management
 export default class ConnectionManager {
     private _statusView: StatusView;
@@ -123,6 +128,11 @@ export default class ConnectionManager {
         new vscode.EventEmitter<void>();
     public readonly onConnectionsChanged: vscode.Event<void> =
         this._onConnectionsChangedEmitter.event;
+
+    private _onSuccessfulConnectionEmitter: vscode.EventEmitter<ConnectionSuccessfulEvent> =
+        new vscode.EventEmitter<ConnectionSuccessfulEvent>();
+    public readonly onSuccessfulConnection: vscode.Event<ConnectionSuccessfulEvent> =
+        this._onSuccessfulConnectionEmitter.event;
 
     public initialized: Deferred<void> = new Deferred<void>();
 
@@ -666,6 +676,11 @@ export default class ConnectionManager {
             fileUri,
             LocalizedConstants.updatingIntelliSenseStatus,
         );
+
+        this._onSuccessfulConnectionEmitter.fire({
+            connection,
+            fileUri,
+        });
 
         this._vscodeWrapper.logToOutputChannel(
             LocalizedConstants.msgConnectedServerInfo(

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1587,11 +1587,7 @@ export default class ConnectionManager {
      * @param keepOldConnected Whether to keep the old file connected after copying the connection info.  Defaults to false.
      * @returns
      */
-    public async copyConnectionToFile(
-        oldFileUri: string,
-        newFileUri: string,
-        keepOldConnected: boolean = false,
-    ): Promise<void> {
+    public async copyConnectionToFile(oldFileUri: string, newFileUri: string): Promise<void> {
         // Is the new file connected or the old file not connected?
         if (!this.isConnected(oldFileUri) || this.isConnected(newFileUri)) {
             return;
@@ -1599,10 +1595,7 @@ export default class ConnectionManager {
 
         // Connect the saved uri and disconnect the untitled uri on successful connection
         let creds: IConnectionInfo = this._connections[oldFileUri].credentials;
-        let result = await this.connect(newFileUri, creds);
-        if (result && !keepOldConnected) {
-            await this.disconnect(oldFileUri);
-        }
+        await this.connect(newFileUri, creds);
     }
 
     public async refreshAzureAccountToken(uri: string): Promise<void> {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2570,7 +2570,7 @@ export default class MainController implements vscode.Disposable {
         const currentDocUri = vscode.window.activeTextEditor
             ? vscode.window.activeTextEditor.document.uri.toString(true)
             : undefined;
-        const newEditor = await this._sqlDocumentService.newQuery(content, true);
+        const newEditor = await this._sqlDocumentService.newQuery(content);
         const newDocUri = newEditor.document.uri.toString(true);
 
         // Case 1: User right-clicked on an OE node and selected "New Query"

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -68,11 +68,13 @@ export default class SqlDocumentService implements vscode.Disposable {
             }),
         );
 
-        this._disposables.push(
-            this._connectionMgr.onSuccessfulConnection((params) =>
-                this.onSuccessfulConnection(params),
-            ),
-        );
+        if (this._connectionMgr) {
+            this._disposables.push(
+                this._connectionMgr.onSuccessfulConnection((params) =>
+                    this.onSuccessfulConnection(params),
+                ),
+            );
+        }
     }
 
     dispose() {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -100,5 +100,5 @@ export async function listAllIterator<T>(iterator: PagedAsyncIterableIterator<T>
  * @returns A unique string key for the URI.
  */
 export function getUriKey(uri: vscode.Uri): string {
-    return uri.toString(true);
+    return uri?.toString(true);
 }

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -92,10 +92,8 @@ suite("MainController Tests", function () {
             selection: undefined,
         } as any;
         mockSqlDocumentService
-            .setup((x) => x.newQuery(undefined, true))
-            .returns(() => {
-                return Promise.resolve(editor);
-            });
+            .setup((x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(editor));
         connectionManager
             .setup((x) => x.onNewConnection())
             .returns(() => {
@@ -103,7 +101,10 @@ suite("MainController Tests", function () {
             });
 
         await mainController.onNewQuery(undefined, undefined);
-        mockSqlDocumentService.verify((x) => x.newQuery(undefined, true), TypeMoq.Times.once());
+        mockSqlDocumentService.verify(
+            (x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
+            TypeMoq.Times.once(),
+        );
         connectionManager.verify((x) => x.onNewConnection(), TypeMoq.Times.atLeastOnce());
     });
 
@@ -113,7 +114,7 @@ suite("MainController Tests", function () {
 
         // Make newQuery reject
         mockSqlDocumentService
-            .setup((x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isValue(true)))
+            .setup((x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.reject(new Error("boom")));
 
         connectionManager.setup((x) => x.onNewConnection()).returns(() => Promise.resolve() as any);
@@ -121,9 +122,9 @@ suite("MainController Tests", function () {
         // Act + assert reject
         await assert.rejects(() => mainController.onNewQuery(undefined, undefined), /boom/);
 
-        // Verify exactly how prod calls it (2 args, second is true)
+        // Verify prod calls newQuery once
         mockSqlDocumentService.verify(
-            (x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isValue(true)),
+            (x) => x.newQuery(TypeMoq.It.isAny(), TypeMoq.It.isAny()),
             TypeMoq.Times.once(),
         );
 

--- a/test/unit/sqlDocumentService.test.ts
+++ b/test/unit/sqlDocumentService.test.ts
@@ -245,7 +245,7 @@ suite("SqlDocumentService Tests", () => {
         });
 
         // Capture connect calls
-        const connectStub = connectionManager.connect as any;
+        const connectStub = connectionManager.connect;
 
         // Activate script1 to set last active connection info
         await sqlDocumentService.onDidChangeActiveTextEditor(editor1);
@@ -260,8 +260,6 @@ suite("SqlDocumentService Tests", () => {
         // Open a non-sql file -> should not connect
         await sqlDocumentService.onDidOpenTextDocument(textFile);
         expect(connectStub).to.not.have.been.called;
-
-        // Re-open script1 (already connected) -> may connect again or be a no-op; don't assert
     });
 
     function setupConnectionManagerMocks(


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Fixes edge cases when opening a new query after all previous SQL editors were closed. Previously, the extension attempted to copy the connection from the last active editor to the new one, which failed if the last editor was already closed. The logic has been updated to instead store the last active connection directly. When a new editor is created, it is now initialized using this stored connection.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

