### PR TITLE
Fixing toolbar icons for query editor. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
                 },
                 {
                     "command": "mssql.revealQueryResult",
-                    "when": "editorLangId == sql && !isInDiffEditor && view.queryResult.visible == false",
+                    "when": "editorLangId == sql && resource in mssql.connections && !isInDiffEditor && view.queryResult.visible == false",
                     "group": "navigation@2"
                 },
                 {
@@ -385,22 +385,22 @@
                 },
                 {
                     "command": "mssql.changeDatabase",
-                    "when": "editorLangId == sql && !isInDiffEditor && resourcePath not in mssql.runningQueries",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries",
                     "group": "navigation@4"
                 },
                 {
                     "command": "mssql.showEstimatedPlan",
-                    "when": "editorLangId == sql && !isInDiffEditor && resourcePath not in mssql.runningQueries",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries",
                     "group": "navigation@4"
                 },
                 {
                     "command": "mssql.enableActualPlan",
-                    "when": "editorLangId == sql && !isInDiffEditor && (resource not in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && (resource not in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
                     "group": "navigation@5"
                 },
                 {
                     "command": "mssql.disableActualPlan",
-                    "when": "editorLangId == sql && !isInDiffEditor && (resource in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && (resource in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
                     "group": "navigation@5"
                 }
             ],
@@ -818,16 +818,13 @@
                 "command": "mssql.revealQueryResult",
                 "title": "%mssql.revealQueryResult%",
                 "category": "MS SQL",
-                "icon": "media/revealQueryResult.svg"
+                "icon": "$(table)"
             },
             {
                 "command": "mssql.connect",
                 "title": "%mssql.connect%",
                 "category": "MS SQL",
-                "icon": {
-                    "dark": "media/connect_dark.svg",
-                    "light": "media/connect_light.svg"
-                }
+                "icon": "$(plug)"
             },
             {
                 "command": "mssql.disconnect",
@@ -857,10 +854,7 @@
                 "command": "mssql.changeDatabase",
                 "title": "%mssql.changeDatabase%",
                 "category": "MS SQL",
-                "icon": {
-                    "dark": "media/changeConnection_dark.svg",
-                    "light": "media/changeConnection_light.svg"
-                }
+                "icon": "$(database)"
             },
             {
                 "command": "mssql.manageProfiles",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
Hiding icons that are not actionable when the query is disconnected. 
Fixes: https://github.com/microsoft/vscode-mssql/issues/18010

| Feature | ✅ New | ❌ Old |
|---|---|---|
| Toolbar (Disconnected) | ![New](https://github.com/user-attachments/assets/3810c311-d675-4a72-898d-8912eebcd96e) | ![Old](https://github.com/user-attachments/assets/2d5e6427-a51c-4517-be09-8c6d08ff1093) |
| Toolbar (Connected) | ![New](https://github.com/user-attachments/assets/ceac1a81-c6e6-4088-b967-ff3682329ed1) | ![Old](https://github.com/user-attachments/assets/06a67b9e-40b0-4c97-ab09-07469ffb924d) |
| Connect Icon | ![New](https://github.com/user-attachments/assets/8b860fa4-f84b-4c9d-bffe-a9e5630563f2) | ![Old](https://github.com/user-attachments/assets/013515cb-615c-443c-bb68-cce080d27fd0) |
| Change Database Icon | ![New](https://github.com/user-attachments/assets/a1618e93-3aba-451f-89a3-2048cfd4be99) | ![Old](https://github.com/user-attachments/assets/2a822eb0-43cd-4eef-a380-a506a1b82173) |
| Reveal Result Pane Icon | ![New](https://github.com/user-attachments/assets/a9035421-d5ef-425e-ace1-0e8b3091093a) | ![Old](https://github.com/user-attachments/assets/41ae1bd0-a7fd-48e2-8b31-cf018f2af3d9) |




## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

