### PR TITLE
Adding null checks in sqlDocumentService to make sure oe service is initialized properly

### DIFF
--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -38,16 +38,17 @@ export default class SqlDocumentService implements vscode.Disposable {
     private _connectionMgr: ConnectionManager | undefined;
     private _outputContentProvider: SqlOutputContentProvider | undefined;
     private _statusview: StatusView | undefined;
-    private _objectExplorerService: ObjectExplorerService | undefined;
 
     constructor(private _mainController: MainController) {
         // In unit tests mocks may provide an undefined main controller; guard initialization.
         this._connectionMgr = this._mainController?.connectionManager;
         this._outputContentProvider = this._mainController?.outputContentProvider;
         this._statusview = this._mainController?.statusview;
-        this._objectExplorerService =
-            this._mainController?.objectEpxplorerProvider?.objectExplorerService;
         this.setupListeners();
+    }
+
+    public get objectExplorerService(): ObjectExplorerService | undefined {
+        return this._mainController?.objectEpxplorerProvider?.objectExplorerService;
     }
 
     private setupListeners(): void {
@@ -289,7 +290,7 @@ export default class SqlDocumentService implements vscode.Disposable {
         // Establish connection if needed
         if (
             connectionConfig?.shouldConnect &&
-            connectionConfig.connectionInfo &&
+            connectionConfig?.connectionInfo &&
             this._connectionMgr
         ) {
             const connectionPromise = new Deferred<boolean>();
@@ -305,7 +306,7 @@ export default class SqlDocumentService implements vscode.Disposable {
                 /**
                  * Skip creating an Object Explorer session if one already exists for the connection.
                  */
-                if (!this._objectExplorerService.hasSession(connectionConfig.connectionInfo)) {
+                if (!this.objectExplorerService?.hasSession(connectionConfig.connectionInfo)) {
                     await this._mainController.createObjectExplorerSession(
                         connectionConfig.connectionInfo,
                     );


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Sometimes the OE service isn’t initialized if the tree hasn’t been activated. This PR updates the logic to ensure we don’t attempt to create a new OE session when it’s initialized. It also changes the OE service reference into a getter, so if the OE is initialized later, the getter will always return the latest OE service instance.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

