### PR TITLE
Fix bunch of bugs in designers. 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -218,6 +218,8 @@
   "Back to preview": "Back to preview",
   "Copy": "Copy",
   "You must review and accept the terms to proceed": "You must review and accept the terms to proceed",
+  "Publish Changes": "Publish Changes",
+  "Open Publish Script": "Open Publish Script",
   "Create new firewall rule for {0}/{0} is the server name that the firewall rule will be created for": {
     "message": "Create new firewall rule for {0}",
     "comment": [
@@ -480,7 +482,6 @@
       "{0} is the number of selected tables"
     ]
   },
-  "Publish Changes": "Publish Changes",
   "Edit Table": "Edit Table",
   "Open in Editor": "Open in Editor",
   "Changed Tables": "Changed Tables",
@@ -636,7 +637,6 @@
       "{0} is the number of errors"
     ]
   },
-  "Open Publish Script": "Open Publish Script",
   "On Update": "On Update",
   "On Delete": "On Delete",
   "Cascade": "Cascade",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -204,6 +204,9 @@
       "{0} is the object type"
     ]
   },
+  "Expand properties pane": "Expand properties pane",
+  "Restore properties pane": "Restore properties pane",
+  "Close properties pane": "Close properties pane",
   "Table name": "Table name",
   "Remove {0}/{0} is the object type": {
     "message": "Remove {0}",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -539,6 +539,9 @@
     <trans-unit id="++CODE++4c7dd73e4af7d97c296dc01ab37edd119e5ef22592cb6a302bd9dc9a55264873">
       <source xml:lang="en">Close Find</source>
     </trans-unit>
+    <trans-unit id="++CODE++3bd5ea966485fd0a628d3dc7d499e2551a0381dcb8b4237bfdbb08aaf6b88468">
+      <source xml:lang="en">Close properties pane</source>
+    </trans-unit>
     <trans-unit id="++CODE++548e8cc0e8c2423c61f30c6e8b75a1a40c995e3be119df6272b280ab6c15a011">
       <source xml:lang="en">Close the current connection</source>
     </trans-unit>
@@ -1241,6 +1244,9 @@
     </trans-unit>
     <trans-unit id="++CODE++48ad32aba89e3b0bbab4397b56bd23794212fe69606e0b644ff3b543035a048d">
       <source xml:lang="en">Expand Workspace Explorer</source>
+    </trans-unit>
+    <trans-unit id="++CODE++d9c008a5e0915c79e82398085c2cd4b029fe53d96880ed8b874bf0bf0d52fb5b">
+      <source xml:lang="en">Expand properties pane</source>
     </trans-unit>
     <trans-unit id="++CODE++c39d646f10769b078ae82be4da7a0079ca91182b241e749be4276e08c215c654">
       <source xml:lang="en">Explorer</source>
@@ -2422,6 +2428,9 @@
     </trans-unit>
     <trans-unit id="++CODE++f225a9c1cec3aeb23174520a7be45fd29e7f9de8fecba6757bb7cd215235979e">
       <source xml:lang="en">Restore panel size</source>
+    </trans-unit>
+    <trans-unit id="++CODE++26b4293018ea72418733109f2e245387d9dfcfe7d4083c0c1f29eb1155c98365">
+      <source xml:lang="en">Restore properties pane</source>
     </trans-unit>
     <trans-unit id="++CODE++5d7e64a2598658aaaf1674a1b6222a0f6ab5bb588831a51d0936879cbf88670c">
       <source xml:lang="en">Result Set {0}</source>

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -305,7 +305,7 @@ export default class SqlDocumentService implements vscode.Disposable {
                 /**
                  * Skip creating an Object Explorer session if one already exists for the connection.
                  */
-                if (!this._objectExplorerService.hasSession(connectionConfig.connectionInfo)) {
+                if (!this._objectExplorerService?.hasSession(connectionConfig.connectionInfo)) {
                     await this._mainController.createObjectExplorerSession(
                         connectionConfig.connectionInfo,
                     );

--- a/src/reactviews/common/designerDefinitionPane.tsx
+++ b/src/reactviews/common/designerDefinitionPane.tsx
@@ -5,7 +5,6 @@
 
 import {
     Button,
-    Text,
     Toolbar,
     makeStyles,
     Tab,
@@ -99,7 +98,7 @@ const MAXIMUMPANEL_SIZE = 100;
 export interface DesignerIssue {
     description: string;
     severity: "error" | "warning" | "information";
-    propertyPath?: string[];
+    propertyPath?: (string | number)[];
 }
 
 export enum DesignerDefinitionTabs {
@@ -123,176 +122,193 @@ export const DesignerDefinitionPane = forwardRef<
         copyToClipboard: (script: string) => void;
         issues?: DesignerIssue[];
         onIssueClick?: (issue: DesignerIssue) => void;
+        activeTab?: DesignerDefinitionTabs;
+        setActiveTab?: (tab: DesignerDefinitionTabs) => void;
     }
->(({ script, themeKind, openInEditor, copyToClipboard, issues, onIssueClick }, ref) => {
-    const classes = useStyles();
-    const panelRef = useRef<ImperativePanelHandle>(null);
-    const [expandCollapseButtonLabel, setExpandCollapseButtonLabel] = useState<string>(
-        locConstants.tableDesigner.maximizePanelSize,
-    );
-    const [expandCollapseButtonIcon, setExpandCollapseButtonIcon] = useState<ReactElement>(
-        <FluentIcons.ChevronUp12Filled />,
-    );
-    const [activeTab, setActiveTab] = useState<DesignerDefinitionTabs>(
-        DesignerDefinitionTabs.Script,
-    );
-
-    useImperativeHandle(
+>(
+    (
+        {
+            script,
+            themeKind,
+            openInEditor,
+            copyToClipboard,
+            issues,
+            onIssueClick,
+            activeTab,
+            setActiveTab,
+        },
         ref,
-        () => ({
-            openPanel: (size: number = DEFAULTPANEL_SIZE) => {
-                if (panelRef.current?.isCollapsed()) {
-                    panelRef.current.expand(size);
-                }
-            },
-            closePanel: () => {
-                if (panelRef.current && !panelRef.current.isCollapsed()) {
-                    panelRef.current.collapse();
-                }
-            },
-            togglePanel: (size: number = DEFAULTPANEL_SIZE) => {
-                if (panelRef.current?.isCollapsed()) {
-                    panelRef.current.expand(size);
-                } else {
-                    panelRef?.current?.collapse();
-                }
-            },
-            isCollapsed: () => {
-                return panelRef.current?.isCollapsed() ?? true;
-            },
-        }),
-        [],
-    );
+    ) => {
+        const classes = useStyles();
+        const panelRef = useRef<ImperativePanelHandle>(null);
+        const [expandCollapseButtonLabel, setExpandCollapseButtonLabel] = useState<string>(
+            locConstants.tableDesigner.maximizePanelSize,
+        );
+        const [expandCollapseButtonIcon, setExpandCollapseButtonIcon] = useState<ReactElement>(
+            <FluentIcons.ChevronUp12Filled />,
+        );
 
-    return (
-        <Panel
-            collapsible
-            minSize={MINIMUMPANEL_SIZE}
-            ref={panelRef}
-            onResize={(size) => {
-                if (size === MAXIMUMPANEL_SIZE) {
-                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronDown12Filled />);
-                } else {
-                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronUp12Filled />);
-                }
-            }}>
-            <div className={classes.header}>
-                <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-                    <TabList
-                        size="small"
-                        selectedValue={activeTab}
-                        onTabSelect={(_event, data) => {
-                            setActiveTab(data.value as DesignerDefinitionTabs);
-                        }}>
-                        <Tab
-                            value={DesignerDefinitionTabs.Script}
-                            key={DesignerDefinitionTabs.Script}>
-                            {locConstants.schemaDesigner.definition}
-                        </Tab>
-                        {issues && issues.length > 0 && (
+        useImperativeHandle(
+            ref,
+            () => ({
+                openPanel: (size: number = DEFAULTPANEL_SIZE) => {
+                    if (panelRef.current?.isCollapsed()) {
+                        panelRef.current.expand(size);
+                    }
+                },
+                closePanel: () => {
+                    if (panelRef.current && !panelRef.current.isCollapsed()) {
+                        panelRef.current.collapse();
+                    }
+                },
+                togglePanel: (size: number = DEFAULTPANEL_SIZE) => {
+                    if (panelRef.current?.isCollapsed()) {
+                        panelRef.current.expand(size);
+                    } else {
+                        panelRef?.current?.collapse();
+                    }
+                },
+                isCollapsed: () => {
+                    return panelRef.current?.isCollapsed() ?? true;
+                },
+            }),
+            [],
+        );
+
+        return (
+            <Panel
+                collapsible
+                minSize={MINIMUMPANEL_SIZE}
+                ref={panelRef}
+                onResize={(size) => {
+                    if (size === MAXIMUMPANEL_SIZE) {
+                        setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
+                        setExpandCollapseButtonIcon(<FluentIcons.ChevronDown12Filled />);
+                    } else {
+                        setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
+                        setExpandCollapseButtonIcon(<FluentIcons.ChevronUp12Filled />);
+                    }
+                }}>
+                <div className={classes.header}>
+                    <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                        <TabList
+                            size="small"
+                            selectedValue={activeTab}
+                            onTabSelect={(_event, data) => {
+                                if (!setActiveTab) {
+                                    return;
+                                }
+                                setActiveTab(data.value as DesignerDefinitionTabs);
+                            }}>
                             <Tab
-                                value={DesignerDefinitionTabs.Issues}
-                                key={DesignerDefinitionTabs.Issues}>
-                                {locConstants.tableDesigner.issuesTabHeader(issues.length)}
+                                value={DesignerDefinitionTabs.Script}
+                                key={DesignerDefinitionTabs.Script}>
+                                {locConstants.schemaDesigner.definition}
                             </Tab>
+                            {issues && issues.length > 0 && (
+                                <Tab
+                                    value={DesignerDefinitionTabs.Issues}
+                                    key={DesignerDefinitionTabs.Issues}>
+                                    {locConstants.tableDesigner.issuesTabHeader(issues.length)}
+                                </Tab>
+                            )}
+                        </TabList>
+                    </div>
+                    <Toolbar style={{ gap: "3px" }}>
+                        {(activeTab === DesignerDefinitionTabs.Script ||
+                            activeTab === undefined) && (
+                            <>
+                                <Button
+                                    size="small"
+                                    appearance="subtle"
+                                    title={locConstants.schemaDesigner.openInEditor}
+                                    icon={<FluentIcons.Open12Regular />}
+                                    onClick={() => openInEditor(script)}>
+                                    {locConstants.schemaDesigner.openInEditor}
+                                </Button>
+                                <Button
+                                    size="small"
+                                    appearance="subtle"
+                                    title={locConstants.schemaDesigner.copy}
+                                    icon={<FluentIcons.Copy16Regular />}
+                                    onClick={() => copyToClipboard(script)}
+                                />
+                            </>
                         )}
-                    </TabList>
-                </div>
-                <Toolbar style={{ gap: "3px" }}>
-                    {activeTab === DesignerDefinitionTabs.Script && (
-                        <>
-                            <Button
-                                size="small"
-                                appearance="subtle"
-                                title={locConstants.schemaDesigner.openInEditor}
-                                icon={<FluentIcons.Open12Regular />}
-                                onClick={() => openInEditor(script)}>
-                                {locConstants.schemaDesigner.openInEditor}
-                            </Button>
-                            <Button
-                                size="small"
-                                appearance="subtle"
-                                title={locConstants.schemaDesigner.copy}
-                                icon={<FluentIcons.Copy16Regular />}
-                                onClick={() => copyToClipboard(script)}
-                            />
-                        </>
-                    )}
 
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        onClick={() => {
-                            if (panelRef.current?.getSize() === MAXIMUMPANEL_SIZE) {
-                                panelRef.current?.resize(DEFAULTPANEL_SIZE);
-                            } else {
-                                panelRef.current?.resize(MAXIMUMPANEL_SIZE);
-                            }
-                        }}
-                        title={expandCollapseButtonLabel}
-                        icon={expandCollapseButtonIcon}
-                    />
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        title={locConstants.schemaDesigner.close}
-                        icon={<FluentIcons.Dismiss12Regular />}
-                        onClick={() => {
-                            if (panelRef.current) {
-                                panelRef.current.collapse();
-                            }
-                        }}
-                    />
-                </Toolbar>
-            </div>
-
-            <div className={classes.tabContent}>
-                {(!issues ||
-                    issues.length === 0 ||
-                    activeTab === DesignerDefinitionTabs.Script) && (
-                    <div className={classes.designerDefinitionPaneScript}>
-                        <Editor
-                            height={"100%"}
-                            width={"100%"}
-                            language="sql"
-                            theme={resolveVscodeThemeType(themeKind)}
-                            value={script}
-                            options={{
-                                readOnly: true,
+                        <Button
+                            size="small"
+                            appearance="subtle"
+                            onClick={() => {
+                                if (panelRef.current?.getSize() === MAXIMUMPANEL_SIZE) {
+                                    panelRef.current?.resize(DEFAULTPANEL_SIZE);
+                                } else {
+                                    panelRef.current?.resize(MAXIMUMPANEL_SIZE);
+                                }
+                            }}
+                            title={expandCollapseButtonLabel}
+                            icon={expandCollapseButtonIcon}
+                        />
+                        <Button
+                            size="small"
+                            appearance="subtle"
+                            title={locConstants.schemaDesigner.close}
+                            icon={<FluentIcons.Dismiss12Regular />}
+                            onClick={() => {
+                                if (panelRef.current) {
+                                    panelRef.current.collapse();
+                                }
                             }}
                         />
-                    </div>
-                )}
-                {activeTab === DesignerDefinitionTabs.Issues && issues && issues.length > 0 && (
-                    <div className={classes.issuesContainer}>
-                        <List navigationMode="items">
-                            {issues.map((item, index) => (
-                                <ListItem
-                                    key={`issue-${index}`}
-                                    onAction={() => onIssueClick?.(item)}>
-                                    <div className={classes.issuesRows}>
-                                        {item.severity === "error" && (
-                                            <ErrorCircleRegular
-                                                fontSize={20}
-                                                color="var(--vscode-errorForeground)"
-                                            />
-                                        )}
-                                        {item.severity === "warning" && (
-                                            <WarningRegular fontSize={20} color="yellow" />
-                                        )}
-                                        {item.severity === "information" && (
-                                            <InfoRegular fontSize={20} color="blue" />
-                                        )}
-                                        {item.description}
-                                    </div>
-                                </ListItem>
-                            ))}
-                        </List>
-                    </div>
-                )}
-            </div>
-        </Panel>
-    );
-});
+                    </Toolbar>
+                </div>
+
+                <div className={classes.tabContent}>
+                    {(!issues ||
+                        issues.length === 0 ||
+                        activeTab === DesignerDefinitionTabs.Script) && (
+                        <div className={classes.designerDefinitionPaneScript}>
+                            <Editor
+                                height={"100%"}
+                                width={"100%"}
+                                language="sql"
+                                theme={resolveVscodeThemeType(themeKind)}
+                                value={script}
+                                options={{
+                                    readOnly: true,
+                                }}
+                            />
+                        </div>
+                    )}
+                    {activeTab === DesignerDefinitionTabs.Issues && issues && issues.length > 0 && (
+                        <div className={classes.issuesContainer}>
+                            <List navigationMode="items">
+                                {issues.map((item, index) => (
+                                    <ListItem
+                                        key={`issue-${index}`}
+                                        onAction={() => onIssueClick?.(item)}>
+                                        <div className={classes.issuesRows}>
+                                            {item.severity === "error" && (
+                                                <ErrorCircleRegular
+                                                    fontSize={20}
+                                                    color="var(--vscode-errorForeground)"
+                                                />
+                                            )}
+                                            {item.severity === "warning" && (
+                                                <WarningRegular fontSize={20} color="yellow" />
+                                            )}
+                                            {item.severity === "information" && (
+                                                <InfoRegular fontSize={20} color="blue" />
+                                            )}
+                                            {item.description}
+                                        </div>
+                                    </ListItem>
+                                ))}
+                            </List>
+                        </div>
+                    )}
+                </div>
+            </Panel>
+        );
+    },
+);

--- a/src/reactviews/common/designerDefinitionPane.tsx
+++ b/src/reactviews/common/designerDefinitionPane.tsx
@@ -215,8 +215,7 @@ export const DesignerDefinitionPane = forwardRef<
                         </TabList>
                     </div>
                     <Toolbar style={{ gap: "3px" }}>
-                        {(activeTab === DesignerDefinitionTabs.Script ||
-                            activeTab === undefined) && (
+                        {activeTab === DesignerDefinitionTabs.Script && (
                             <>
                                 <Button
                                     size="small"

--- a/src/reactviews/common/designerDefinitionPane.tsx
+++ b/src/reactviews/common/designerDefinitionPane.tsx
@@ -91,7 +91,7 @@ const useStyles = makeStyles({
     },
 });
 
-const DEFAULTPANEL_SIZE = 40;
+const DEFAULTPANEL_SIZE = 25;
 const MINIMUMPANEL_SIZE = 10;
 const MAXIMUMPANEL_SIZE = 100;
 

--- a/src/reactviews/common/designerDefinitionPane.tsx
+++ b/src/reactviews/common/designerDefinitionPane.tsx
@@ -1,0 +1,298 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    Button,
+    Text,
+    Toolbar,
+    makeStyles,
+    Tab,
+    TabList,
+    shorthands,
+    List,
+    ListItem,
+} from "@fluentui/react-components";
+import { Editor } from "@monaco-editor/react";
+import { ImperativePanelHandle, Panel } from "react-resizable-panels";
+import { resolveVscodeThemeType } from "./utils";
+import { ColorThemeKind } from "../../sharedInterfaces/webview";
+import * as FluentIcons from "@fluentui/react-icons";
+import { ErrorCircleRegular, InfoRegular, WarningRegular } from "@fluentui/react-icons";
+import { locConstants } from "./locConstants";
+import { useRef, useState, forwardRef, useImperativeHandle, ReactElement } from "react";
+
+const useStyles = makeStyles({
+    resizeHandle: {
+        position: "absolute",
+        top: "0",
+        right: "0",
+        width: "100%",
+        height: "10px",
+        cursor: "ns-resize",
+        zIndex: 1,
+        boxShadow: "0px -1px 1px  var(--vscode-editorWidget-border)",
+    },
+    resizePaneContainer: {
+        width: "100%",
+        position: "relative",
+    },
+    header: {
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+    },
+    ribbon: {
+        width: "100%",
+        display: "flex",
+        flexDirection: "row",
+        "> *": {
+            marginRight: "10px",
+        },
+        padding: "5px 0px",
+    },
+    designerDefinitionPaneTabs: {
+        flex: 1,
+    },
+    tabContent: {
+        ...shorthands.flex(1),
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        ...shorthands.overflow("auto"),
+    },
+    designerDefinitionPaneScript: {
+        width: "100%",
+        height: "100%",
+        position: "relative",
+    },
+    issuesContainer: {
+        width: "100%",
+        height: "calc( 100% - 10px )", // Subtracting 10px to account for padding and hiding double scrollbars
+        flexDirection: "column",
+        "> *": {
+            marginBottom: "10px",
+        },
+        backgroundColor: "var(--vscode-editor-background)",
+        padding: "5px",
+        overflow: "hidden auto",
+    },
+    issuesRows: {
+        display: "flex",
+        lineHeight: "20px",
+        padding: "5px",
+        "> *": {
+            marginRight: "10px",
+        },
+        ":hover": {
+            backgroundColor: "var(--vscode-editor-selectionHighlightBackground)",
+        },
+        width: "100%",
+    },
+});
+
+const DEFAULTPANEL_SIZE = 40;
+const MINIMUMPANEL_SIZE = 10;
+const MAXIMUMPANEL_SIZE = 100;
+
+export interface DesignerIssue {
+    description: string;
+    severity: "error" | "warning" | "information";
+    propertyPath?: string[];
+}
+
+export enum DesignerDefinitionTabs {
+    Script = "script",
+    Issues = "issues",
+}
+
+export interface DesignerDefinitionPaneRef {
+    openPanel: (size?: number) => void;
+    closePanel: () => void;
+    togglePanel: (size?: number) => void;
+    isCollapsed: () => boolean;
+}
+
+export const DesignerDefinitionPane = forwardRef<
+    DesignerDefinitionPaneRef,
+    {
+        script: string;
+        themeKind: ColorThemeKind;
+        openInEditor: (script: string) => void;
+        copyToClipboard: (script: string) => void;
+        issues?: DesignerIssue[];
+        onIssueClick?: (issue: DesignerIssue) => void;
+    }
+>(({ script, themeKind, openInEditor, copyToClipboard, issues, onIssueClick }, ref) => {
+    const classes = useStyles();
+    const panelRef = useRef<ImperativePanelHandle>(null);
+    const [expandCollapseButtonLabel, setExpandCollapseButtonLabel] = useState<string>(
+        locConstants.tableDesigner.maximizePanelSize,
+    );
+    const [expandCollapseButtonIcon, setExpandCollapseButtonIcon] = useState<ReactElement>(
+        <FluentIcons.ChevronUp12Filled />,
+    );
+    const [activeTab, setActiveTab] = useState<DesignerDefinitionTabs>(
+        DesignerDefinitionTabs.Script,
+    );
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            openPanel: (size: number = DEFAULTPANEL_SIZE) => {
+                if (panelRef.current?.isCollapsed()) {
+                    panelRef.current.expand(size);
+                }
+            },
+            closePanel: () => {
+                if (panelRef.current && !panelRef.current.isCollapsed()) {
+                    panelRef.current.collapse();
+                }
+            },
+            togglePanel: (size: number = DEFAULTPANEL_SIZE) => {
+                if (panelRef.current?.isCollapsed()) {
+                    panelRef.current.expand(size);
+                } else {
+                    panelRef?.current?.collapse();
+                }
+            },
+            isCollapsed: () => {
+                return panelRef.current?.isCollapsed() ?? true;
+            },
+        }),
+        [],
+    );
+
+    return (
+        <Panel
+            collapsible
+            minSize={MINIMUMPANEL_SIZE}
+            ref={panelRef}
+            onResize={(size) => {
+                if (size === MAXIMUMPANEL_SIZE) {
+                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
+                    setExpandCollapseButtonIcon(<FluentIcons.ChevronDown12Filled />);
+                } else {
+                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
+                    setExpandCollapseButtonIcon(<FluentIcons.ChevronUp12Filled />);
+                }
+            }}>
+            <div className={classes.header}>
+                <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                    <TabList
+                        size="small"
+                        selectedValue={activeTab}
+                        onTabSelect={(_event, data) => {
+                            setActiveTab(data.value as DesignerDefinitionTabs);
+                        }}>
+                        <Tab
+                            value={DesignerDefinitionTabs.Script}
+                            key={DesignerDefinitionTabs.Script}>
+                            {locConstants.schemaDesigner.definition}
+                        </Tab>
+                        {issues && issues.length > 0 && (
+                            <Tab
+                                value={DesignerDefinitionTabs.Issues}
+                                key={DesignerDefinitionTabs.Issues}>
+                                {locConstants.tableDesigner.issuesTabHeader(issues.length)}
+                            </Tab>
+                        )}
+                    </TabList>
+                </div>
+                <Toolbar style={{ gap: "3px" }}>
+                    {activeTab === DesignerDefinitionTabs.Script && (
+                        <>
+                            <Button
+                                size="small"
+                                appearance="subtle"
+                                title={locConstants.schemaDesigner.openInEditor}
+                                icon={<FluentIcons.Open12Regular />}
+                                onClick={() => openInEditor(script)}>
+                                {locConstants.schemaDesigner.openInEditor}
+                            </Button>
+                            <Button
+                                size="small"
+                                appearance="subtle"
+                                title={locConstants.schemaDesigner.copy}
+                                icon={<FluentIcons.Copy16Regular />}
+                                onClick={() => copyToClipboard(script)}
+                            />
+                        </>
+                    )}
+
+                    <Button
+                        size="small"
+                        appearance="subtle"
+                        onClick={() => {
+                            if (panelRef.current?.getSize() === MAXIMUMPANEL_SIZE) {
+                                panelRef.current?.resize(DEFAULTPANEL_SIZE);
+                            } else {
+                                panelRef.current?.resize(MAXIMUMPANEL_SIZE);
+                            }
+                        }}
+                        title={expandCollapseButtonLabel}
+                        icon={expandCollapseButtonIcon}
+                    />
+                    <Button
+                        size="small"
+                        appearance="subtle"
+                        title={locConstants.schemaDesigner.close}
+                        icon={<FluentIcons.Dismiss12Regular />}
+                        onClick={() => {
+                            if (panelRef.current) {
+                                panelRef.current.collapse();
+                            }
+                        }}
+                    />
+                </Toolbar>
+            </div>
+
+            <div className={classes.tabContent}>
+                {(!issues ||
+                    issues.length === 0 ||
+                    activeTab === DesignerDefinitionTabs.Script) && (
+                    <div className={classes.designerDefinitionPaneScript}>
+                        <Editor
+                            height={"100%"}
+                            width={"100%"}
+                            language="sql"
+                            theme={resolveVscodeThemeType(themeKind)}
+                            value={script}
+                            options={{
+                                readOnly: true,
+                            }}
+                        />
+                    </div>
+                )}
+                {activeTab === DesignerDefinitionTabs.Issues && issues && issues.length > 0 && (
+                    <div className={classes.issuesContainer}>
+                        <List navigationMode="items">
+                            {issues.map((item, index) => (
+                                <ListItem
+                                    key={`issue-${index}`}
+                                    onAction={() => onIssueClick?.(item)}>
+                                    <div className={classes.issuesRows}>
+                                        {item.severity === "error" && (
+                                            <ErrorCircleRegular
+                                                fontSize={20}
+                                                color="var(--vscode-errorForeground)"
+                                            />
+                                        )}
+                                        {item.severity === "warning" && (
+                                            <WarningRegular fontSize={20} color="yellow" />
+                                        )}
+                                        {item.severity === "information" && (
+                                            <InfoRegular fontSize={20} color="blue" />
+                                        )}
+                                        {item.description}
+                                    </div>
+                                </ListItem>
+                            ))}
+                        </List>
+                    </div>
+                )}
+            </div>
+        </Panel>
+    );
+});

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -178,6 +178,15 @@ export class LocConstants {
         };
     }
 
+    public get publishDialog() {
+        return {
+            publishChanges: l10n.t("Publish Changes"),
+            publish: l10n.t("Publish"),
+            openPublishScript: l10n.t("Open Publish Script"),
+            confirmationText: l10n.t("I have read the summary and understand the potential risks."),
+        };
+    }
+
     public get firewallRules() {
         return {
             createNewFirewallRuleFor: (serverName: string) =>

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -161,6 +161,9 @@ export class LocConstants {
                     args: [objectType],
                     comment: ["{0} is the object type"],
                 }),
+            expandPropertiesPane: l10n.t("Expand properties pane"),
+            restorePropertiesPane: l10n.t("Restore properties pane"),
+            closePropertiesPane: l10n.t("Close properties pane"),
             tableName: l10n.t("Table name"),
             remove: (objectType: string) =>
                 l10n.t({

--- a/src/reactviews/common/styles.ts
+++ b/src/reactviews/common/styles.ts
@@ -12,3 +12,89 @@ export const useAccordionStyles = makeStyles({
         margin: "10px",
     },
 });
+
+export const useMarkdownStyles = makeStyles({
+    markdownPage: {
+        backgroundColor: "var(--vscode-editorWidget-background)",
+        border: "1px solid var(--vscode-panel-border)",
+        borderRadius: "8px",
+        padding: "24px 32px",
+        margin: "16px",
+        boxShadow: "0 2px 8px rgba(0, 0, 0, 0.1)",
+        fontFamily: "var(--vscode-editor-font-family)",
+        fontSize: "14px",
+        lineHeight: "1.6",
+        color: "var(--vscode-editor-foreground)",
+        "& h1, & h2, & h3, & h4, & h5, & h6": {
+            color: "var(--vscode-textPreformat-foreground)",
+            borderBottom: "1px solid var(--vscode-panel-border)",
+            paddingBottom: "8px",
+            marginTop: "24px",
+            marginBottom: "16px",
+        },
+        "& h1": {
+            fontSize: "24px",
+            fontWeight: "600",
+        },
+        "& h2": {
+            fontSize: "20px",
+            fontWeight: "600",
+        },
+        "& h3": {
+            fontSize: "16px",
+            fontWeight: "600",
+        },
+        "& p": {
+            marginBottom: "16px",
+        },
+        "& ul, & ol": {
+            marginBottom: "16px",
+            paddingLeft: "24px",
+        },
+        "& li": {
+            marginBottom: "8px",
+        },
+        "& code": {
+            backgroundColor: "var(--vscode-textBlockQuote-background)",
+            border: "1px solid var(--vscode-panel-border)",
+            borderRadius: "4px",
+            padding: "2px 6px",
+            fontSize: "13px",
+            fontFamily: "var(--vscode-editor-font-family)",
+        },
+        "& pre": {
+            backgroundColor: "var(--vscode-textBlockQuote-background)",
+            border: "1px solid var(--vscode-panel-border)",
+            borderRadius: "6px",
+            padding: "16px",
+            marginBottom: "16px",
+            overflow: "auto",
+            "& code": {
+                backgroundColor: "transparent",
+                border: "none",
+                padding: "0",
+            },
+        },
+        "& blockquote": {
+            borderLeft: "4px solid var(--vscode-textBlockQuote-border)",
+            paddingLeft: "16px",
+            marginLeft: "0",
+            fontStyle: "italic",
+            color: "var(--vscode-descriptionForeground)",
+        },
+        "& table": {
+            width: "100%",
+            borderCollapse: "collapse",
+            marginBottom: "16px",
+            "& th, & td": {
+                border: "1px solid var(--vscode-panel-border)",
+                padding: "8px 12px",
+                textAlign: "left",
+            },
+            "& th": {
+                backgroundColor: "var(--vscode-editor-background)",
+                fontWeight: "600",
+            },
+        },
+    },
+});

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerDefinitionsPanel.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerDefinitionsPanel.tsx
@@ -3,54 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, makeStyles, Text, Toolbar } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
 import { SchemaDesignerContext } from "./schemaDesignerStateProvider";
 import { useContext, useEffect, useRef, useState } from "react";
-import { locConstants } from "../../common/locConstants";
-import Editor from "@monaco-editor/react";
-import { resolveVscodeThemeType } from "../../common/utils";
 import eventBus from "./schemaDesignerEvents";
-import { Panel, ImperativePanelHandle } from "react-resizable-panels";
-
-const useStyles = makeStyles({
-    resizeHandle: {
-        position: "absolute",
-        top: "0",
-        right: "0",
-        width: "100%",
-        height: "10px",
-        cursor: "ns-resize",
-        zIndex: 1,
-        boxShadow: "0px -1px 1px  var(--vscode-editorWidget-border)",
-    },
-    resizePaneContainer: {
-        width: "100%",
-        position: "relative",
-    },
-    header: {
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-    },
-});
-
-const DEFAULTPANEL_SIZE = 40;
-const MINIMUMPANEL_SIZE = 10;
-const MAXIMUMPANEL_SIZE = 100;
+import {
+    DesignerDefinitionPane,
+    DesignerDefinitionPaneRef,
+} from "../../common/designerDefinitionPane";
 
 export const SchemaDesignerDefinitionsPanel = () => {
     const context = useContext(SchemaDesignerContext);
-    const classes = useStyles();
     const [code, setCode] = useState<string>("");
-    const panelRef = useRef<ImperativePanelHandle>(null);
-    const [currentPanelSize, setCurrentPanelSize] = useState<number>(0);
-    const [expandCollapseButtonLabel, setExpandCollapseButtonLabel] = useState<string>(
-        locConstants.tableDesigner.maximizePanelSize,
-    );
-    const [expandCollapseButtonIcon, setExpandCollapseButtonIcon] = useState<JSX.Element>(
-        <FluentIcons.ChevronUp12Filled />,
-    );
+    const definitionPaneRef = useRef<DesignerDefinitionPaneRef>(null);
 
     useEffect(() => {
         eventBus.on("getScript", () => {
@@ -64,92 +28,24 @@ export const SchemaDesignerDefinitionsPanel = () => {
                 const script = await context.getDefinition();
                 setCode(script);
             }, 0);
-            if (!panelRef.current) {
+            if (!definitionPaneRef.current) {
                 return;
             }
-            if (panelRef.current.isCollapsed()) {
-                panelRef.current.expand(25);
+            if (definitionPaneRef.current.isCollapsed()) {
+                definitionPaneRef.current.openPanel(25);
             } else {
-                panelRef.current.collapse();
+                definitionPaneRef.current.closePanel();
             }
         });
     }, []);
 
-    useEffect(() => {}, [currentPanelSize]);
-
     return (
-        <Panel
-            collapsible
-            minSize={MINIMUMPANEL_SIZE}
-            ref={panelRef}
-            onResize={(size) => {
-                setCurrentPanelSize(size);
-
-                if (size === MAXIMUMPANEL_SIZE) {
-                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronDown12Filled />);
-                } else {
-                    setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronUp12Filled />);
-                }
-            }}>
-            <div className={classes.header}>
-                <Text weight="medium" style={{ marginLeft: "10px" }}>
-                    {locConstants.schemaDesigner.definition}
-                </Text>
-                <Toolbar style={{ gap: "3px" }}>
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        title={locConstants.schemaDesigner.openInEditor}
-                        icon={<FluentIcons.Open12Regular />}
-                        onClick={() => context.openInEditor(code)}>
-                        {locConstants.schemaDesigner.openInEditor}
-                    </Button>
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        title={locConstants.schemaDesigner.copy}
-                        icon={<FluentIcons.Copy16Regular />}
-                        onClick={() => context.copyToClipboard(code)}
-                    />
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        onClick={() => {
-                            if (panelRef.current?.getSize() === MAXIMUMPANEL_SIZE) {
-                                panelRef.current?.resize(DEFAULTPANEL_SIZE);
-                            } else {
-                                panelRef.current?.resize(MAXIMUMPANEL_SIZE);
-                            }
-                        }}
-                        title={expandCollapseButtonLabel}
-                        icon={expandCollapseButtonIcon}
-                    />
-                    <Button
-                        size="small"
-                        appearance="subtle"
-                        title={locConstants.schemaDesigner.close}
-                        icon={<FluentIcons.Dismiss12Regular />}
-                        onClick={() => {
-                            if (panelRef.current) {
-                                panelRef.current.collapse();
-                            }
-                        }}
-                    />
-                </Toolbar>
-            </div>
-            <Editor
-                key={code}
-                height={"100%"}
-                width={"100%"}
-                language="sql"
-                theme={resolveVscodeThemeType(context?.themeKind)}
-                value={code}
-                options={{
-                    readOnly: true,
-                }}
-            />
-        </Panel>
+        <DesignerDefinitionPane
+            ref={definitionPaneRef}
+            script={code}
+            themeKind={context?.themeKind}
+            openInEditor={context?.openInEditor}
+            copyToClipboard={context?.copyToClipboard}
+        />
     );
 };

--- a/src/reactviews/pages/SchemaDesigner/schemaDesignerDefinitionsPanel.tsx
+++ b/src/reactviews/pages/SchemaDesigner/schemaDesignerDefinitionsPanel.tsx
@@ -9,6 +9,7 @@ import eventBus from "./schemaDesignerEvents";
 import {
     DesignerDefinitionPane,
     DesignerDefinitionPaneRef,
+    DesignerDefinitionTabs,
 } from "../../common/designerDefinitionPane";
 
 export const SchemaDesignerDefinitionsPanel = () => {
@@ -46,6 +47,7 @@ export const SchemaDesignerDefinitionsPanel = () => {
             themeKind={context?.themeKind}
             openInEditor={context?.openInEditor}
             copyToClipboard={context?.copyToClipboard}
+            activeTab={DesignerDefinitionTabs.Script}
         />
     );
 };

--- a/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -53,6 +53,10 @@ const useStyles = makeStyles({
         fontWeight: "bold",
         marginRight: "5px",
     },
+    surface: {
+        width: "800px",
+        maxWidth: "800px",
+    },
 });
 
 export function PublishChangesDialogButton() {
@@ -385,7 +389,7 @@ export function PublishChangesDialogButton() {
                                     });
                                 }
                             }}>
-                            {locConstants.schemaDesigner.publish}
+                            {locConstants.publishDialog.publish}
                         </Button>
                         <Button
                             appearance="secondary"
@@ -393,7 +397,7 @@ export function PublishChangesDialogButton() {
                             onClick={() => {
                                 context.openInEditorWithConnection();
                             }}>
-                            {locConstants.schemaDesigner.openPublishScript}
+                            {locConstants.publishDialog.openPublishScript}
                         </Button>
                     </>
                 )}
@@ -438,13 +442,9 @@ export function PublishChangesDialogButton() {
     return (
         <Dialog open={open} onOpenChange={(_e, data) => setOpen(data.open)}>
             {triggerButton()}
-            <DialogSurface
-                style={{
-                    width: "100%",
-                    maxWidth: "800px",
-                }}>
+            <DialogSurface className={classes.surface}>
                 <DialogBody>
-                    <DialogTitle>{locConstants.schemaDesigner.publishChanges}</DialogTitle>
+                    <DialogTitle>{locConstants.publishDialog.publishChanges}</DialogTitle>
                     <DialogContent>{dialogContent()}</DialogContent>
                     <DialogActions>{footerButtons()}</DialogActions>
                 </DialogBody>

--- a/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -23,6 +23,7 @@ import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
 import { useContext, useState } from "react";
 import Markdown from "react-markdown";
 import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
+import { useMarkdownStyles } from "../../../common/styles";
 
 enum PublishDialogStages {
     NotStarted = "notStarted",
@@ -61,6 +62,7 @@ const useStyles = makeStyles({
 
 export function PublishChangesDialogButton() {
     const classes = useStyles();
+    const markdownClasses = useMarkdownStyles();
     const context = useContext(SchemaDesignerContext);
     const [open, setOpen] = useState(false);
     const [publishButtonDisabled, setPublishButtonDisabled] = useState(false);
@@ -260,7 +262,9 @@ export function PublishChangesDialogButton() {
                             maxHeight: "100%",
                             overflow: "auto",
                         }}>
-                        <Markdown>{state?.report?.dacReport?.report ?? ""}</Markdown>
+                        <div className={markdownClasses.markdownPage}>
+                            <Markdown>{state?.report?.dacReport?.report ?? ""}</Markdown>
+                        </div>
                     </div>
 
                     <Checkbox

--- a/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -85,7 +85,7 @@ export function PublishChangesDialogButton() {
             <Button
                 size="small"
                 appearance="subtle"
-                icon={<FluentIcons.DatabaseArrowUp16Filled />}
+                icon={<FluentIcons.DatabaseArrowUp16Regular />}
                 title={locConstants.schemaDesigner.publishChanges}
                 disabled={publishButtonDisabled}
                 onClick={async () => {

--- a/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
+++ b/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
@@ -33,6 +33,7 @@ import { LoadState } from "../../../sharedInterfaces/tableDesigner";
 import Markdown from "react-markdown";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { locConstants } from "../../common/locConstants";
+import { useMarkdownStyles } from "../../common/styles";
 
 const useStyles = makeStyles({
     dialogSurface: {
@@ -47,14 +48,11 @@ const useStyles = makeStyles({
     dialogFooterButtons: {
         marginTop: "10px",
     },
-    confirmationRow: {
-        marginTop: "8px",
-        marginBottom: "8px",
-    },
 });
 
 export const DesignerChangesPreviewButton = () => {
     const designerContext = useContext(TableDesignerContext);
+    const markdownClasses = useMarkdownStyles();
     const classes = useStyles();
     if (!designerContext) {
         return null;
@@ -214,9 +212,13 @@ export const DesignerChangesPreviewButton = () => {
                             flexDirection: "column",
                             overflow: "hidden",
                         }}>
-                        <Markdown>{state?.generatePreviewReportResult?.report}</Markdown>
+                        <div className={markdownClasses.markdownPage}>
+                            <Markdown>{state?.generatePreviewReportResult?.report}</Markdown>
+                        </div>
                         <Checkbox
-                            className={classes.confirmationRow}
+                            style={{
+                                margin: "5px",
+                            }}
                             label={locConstants.publishDialog.confirmationText}
                             required
                             checked={isConfirmationChecked}
@@ -310,7 +312,7 @@ export const DesignerChangesPreviewButton = () => {
                         designerContext.generatePreviewReport();
                     }}
                     disabled={(state?.issues?.length ?? 0) > 0}>
-                    {locConstants.tableDesigner.publish}
+                    {locConstants.publishDialog.publishChanges}
                 </Button>
             </DialogTrigger>
             <DialogSurface className={classes.dialogSurface}>

--- a/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
+++ b/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
@@ -11,7 +11,12 @@ import {
     Spinner,
     makeStyles,
 } from "@fluentui/react-components";
-import { CopyRegular, DatabaseArrowUp16Regular, ErrorCircleRegular } from "@fluentui/react-icons";
+import {
+    CopyRegular,
+    DatabaseArrowUp16Regular,
+    ErrorCircleRegular,
+    CheckmarkCircleFilled,
+} from "@fluentui/react-icons";
 import {
     Dialog,
     DialogActions,
@@ -25,25 +30,14 @@ import { useContext, useState } from "react";
 
 import { Button } from "@fluentui/react-button";
 import { LoadState } from "../../../sharedInterfaces/tableDesigner";
-import ReactMarkdown from "react-markdown";
+import Markdown from "react-markdown";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { locConstants } from "../../common/locConstants";
 
 const useStyles = makeStyles({
-    dialogContent: {
-        height: "300px",
-        overflow: "auto",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        width: "100%",
-        flexDirection: "column",
-    },
-    openScript: {
-        width: "150px",
-    },
-    updateDatabase: {
-        width: "150px",
+    dialogSurface: {
+        width: "800px",
+        maxWidth: "800px",
     },
     errorIcon: {
         fontSize: "100px",
@@ -53,16 +47,9 @@ const useStyles = makeStyles({
     dialogFooterButtons: {
         marginTop: "10px",
     },
-    markdownContainer: {
-        width: "calc(100% - 40px)",
-        height: "calc(100% - 80px)",
-        alignItems: "center",
-        justifyContent: "center",
-        border: "1px solid #e0e0e0",
-        overflow: "auto",
-        padding: "10px 5px 5px 10px",
-        margin: "5px",
-        backgroundColor: "var(--vscode-editor-background)",
+    confirmationRow: {
+        marginTop: "8px",
+        marginBottom: "8px",
     },
 });
 
@@ -100,7 +87,7 @@ export const DesignerChangesPreviewButton = () => {
 
     const publishingLoadingDialogContents = () => (
         <>
-            <DialogContent className={classes.dialogContent}>
+            <DialogContent>
                 <Spinner
                     label={locConstants.tableDesigner.publishingChanges}
                     labelPosition="below"
@@ -153,31 +140,35 @@ export const DesignerChangesPreviewButton = () => {
 
     const publishingSuccessDialogContents = () => (
         <>
-            <DialogContent className={classes.dialogContent}>
+            <DialogContent>
+                <CheckmarkCircleFilled style={{ width: "50px", height: "50px", marginBottom: 8 }} />
                 <div>{locConstants.tableDesigner.changesPublishedSuccessfully}</div>
             </DialogContent>
             <DialogActions>
-                <Button size="medium" appearance="primary" onClick={designerContext.closeDesigner}>
-                    {locConstants.tableDesigner.closeDesigner}
-                </Button>
                 <DialogTrigger action="close">
                     <Button
                         size="medium"
                         appearance="secondary"
                         onClick={() => {
                             setIsConfirmationChecked(false);
-                            designerContext.continueEditing;
+                            designerContext.continueEditing();
                         }}>
                         {locConstants.tableDesigner.continueEditing}
                     </Button>
                 </DialogTrigger>
+                <Button
+                    size="medium"
+                    appearance="secondary"
+                    onClick={designerContext.closeDesigner}>
+                    {locConstants.common.close}
+                </Button>
             </DialogActions>
         </>
     );
 
     const previewLoadingDialogContents = () => (
         <>
-            <DialogContent className={classes.dialogContent}>
+            <DialogContent>
                 <Spinner
                     label={locConstants.tableDesigner.loadingPreviewReport}
                     labelPosition="below"
@@ -188,7 +179,7 @@ export const DesignerChangesPreviewButton = () => {
 
     const previewLoadingErrorDialogContents = () => (
         <>
-            <DialogContent className={classes.dialogContent}>
+            <DialogContent>
                 <ErrorCircleRegular className={classes.errorIcon} />
                 <div>
                     {designerContext.state.generatePreviewReportResult?.schemaValidationError ??
@@ -216,65 +207,70 @@ export const DesignerChangesPreviewButton = () => {
         return (
             <>
                 <DialogContent>
-                    <div className={classes.markdownContainer}>
-                        <ReactMarkdown>{state?.generatePreviewReportResult?.report}</ReactMarkdown>
+                    <div
+                        style={{
+                            width: "100%",
+                            display: "flex",
+                            flexDirection: "column",
+                            overflow: "hidden",
+                        }}>
+                        <Markdown>{state?.generatePreviewReportResult?.report}</Markdown>
+                        <Checkbox
+                            className={classes.confirmationRow}
+                            label={locConstants.publishDialog.confirmationText}
+                            required
+                            checked={isConfirmationChecked}
+                            onChange={(_event, data) => {
+                                setIsConfirmationChecked(data.checked as boolean);
+                            }}
+                            // Setting initial focus on the checkbox when it is rendered.
+                            autoFocus
+                            /**
+                             * The focus outline is not visible on the checkbox when it is focused programmatically.
+                             * This is a workaround to make the focus outline visible on the checkbox when it is focused programmatically.
+                             * This is most likely a bug in the browser.
+                             */
+                            onFocus={(event) => {
+                                if (event.target.parentElement) {
+                                    event.target.parentElement.style.outlineStyle = "solid";
+                                    event.target.parentElement.style.outlineColor =
+                                        "var(--vscode-focusBorder)";
+                                }
+                            }}
+                            onBlur={(event) => {
+                                if (event.target.parentElement) {
+                                    event.target.parentElement.style.outline = "none";
+                                    event.target.parentElement.style.outlineColor = "";
+                                }
+                            }}
+                        />
                     </div>
-                    <Checkbox
-                        label={locConstants.tableDesigner.designerPreviewConfirmation}
-                        required
-                        checked={isConfirmationChecked}
-                        onChange={(_event, data) => {
-                            setIsConfirmationChecked(data.checked as boolean);
-                        }}
-                        // Setting initial focus on the checkbox when it is rendered.
-                        autoFocus
-                        /**
-                         * The focus outline is not visible on the checkbox when it is focused programmatically.
-                         * This is a workaround to make the focus outline visible on the checkbox when it is focused programmatically.
-                         * This is most likely a bug in the browser.
-                         */
-                        onFocus={(event) => {
-                            if (event.target.parentElement) {
-                                event.target.parentElement.style.outlineStyle = "solid";
-                                event.target.parentElement.style.outlineColor =
-                                    "var(--vscode-focusBorder)";
-                            }
-                        }}
-                        onBlur={(event) => {
-                            if (event.target.parentElement) {
-                                event.target.parentElement.style.outline = "none";
-                                event.target.parentElement.style.outlineColor = "";
-                            }
-                        }}
-                    />
                 </DialogContent>
                 <DialogActions>
-                    {getDialogCloseButton()}
-                    <DialogTrigger action="close">
-                        <Button
-                            icon={generateScriptIcon()}
-                            iconPosition="after"
-                            className={classes.openScript}
-                            disabled={state.apiState?.previewState !== LoadState.Loaded}
-                            appearance="secondary"
-                            onClick={designerContext.generateScript}>
-                            {locConstants.tableDesigner.generateScript}
-                        </Button>
-                    </DialogTrigger>
                     <Button
-                        className={classes.updateDatabase}
                         disabled={!isConfirmationChecked}
                         title={
                             !isConfirmationChecked
                                 ? locConstants.tableDesigner.youMustReviewAndAccept
-                                : locConstants.tableDesigner.updateDatabase
+                                : locConstants.publishDialog.publish
                         }
                         appearance="primary"
                         onClick={() => {
                             designerContext.publishChanges();
                         }}>
-                        {locConstants.tableDesigner.updateDatabase}
+                        {locConstants.publishDialog.publish}
                     </Button>
+                    <DialogTrigger action="close">
+                        <Button
+                            icon={generateScriptIcon()}
+                            iconPosition="after"
+                            disabled={state.apiState?.previewState !== LoadState.Loaded}
+                            appearance="secondary"
+                            onClick={designerContext.generateScript}>
+                            {locConstants.publishDialog.openPublishScript}
+                        </Button>
+                    </DialogTrigger>
+                    {getDialogCloseButton()}
                 </DialogActions>
             </>
         );
@@ -317,9 +313,9 @@ export const DesignerChangesPreviewButton = () => {
                     {locConstants.tableDesigner.publish}
                 </Button>
             </DialogTrigger>
-            <DialogSurface>
+            <DialogSurface className={classes.dialogSurface}>
                 <DialogBody>
-                    <DialogTitle>{locConstants.tableDesigner.previewDatabaseUpdates}</DialogTitle>
+                    <DialogTitle>{locConstants.publishDialog.publishChanges}</DialogTitle>
                     {getDialogContent()}
                 </DialogBody>
             </DialogSurface>

--- a/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
+++ b/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
@@ -11,7 +11,7 @@ import {
     Spinner,
     makeStyles,
 } from "@fluentui/react-components";
-import { CopyRegular, DatabaseArrowDownRegular, ErrorCircleRegular } from "@fluentui/react-icons";
+import { CopyRegular, DatabaseArrowUp16Regular, ErrorCircleRegular } from "@fluentui/react-icons";
 import {
     Dialog,
     DialogActions,
@@ -27,7 +27,6 @@ import { Button } from "@fluentui/react-button";
 import { LoadState } from "../../../sharedInterfaces/tableDesigner";
 import ReactMarkdown from "react-markdown";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
-import { ToolbarButton } from "@fluentui/react-toolbar";
 import { locConstants } from "../../common/locConstants";
 
 const useStyles = makeStyles({
@@ -305,16 +304,18 @@ export const DesignerChangesPreviewButton = () => {
     return (
         <Dialog inertTrapFocus>
             <DialogTrigger disableButtonEnhancement>
-                <ToolbarButton
+                <Button
+                    size="small"
+                    appearance="subtle"
                     aria-label={locConstants.tableDesigner.publish}
                     title={locConstants.tableDesigner.publish}
-                    icon={<DatabaseArrowDownRegular />}
+                    icon={<DatabaseArrowUp16Regular />}
                     onClick={() => {
                         designerContext.generatePreviewReport();
                     }}
                     disabled={(state?.issues?.length ?? 0) > 0}>
                     {locConstants.tableDesigner.publish}
-                </ToolbarButton>
+                </Button>
             </DialogTrigger>
             <DialogSurface>
                 <DialogBody>

--- a/src/reactviews/pages/TableDesigner/designerMainPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerMainPane.tsx
@@ -4,14 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Tab, TabList } from "@fluentui/react-tabs";
-import {
-    CounterBadge,
-    Field,
-    Input,
-    Text,
-    makeStyles,
-    shorthands,
-} from "@fluentui/react-components";
+import { CounterBadge, Field, Input, Text, makeStyles } from "@fluentui/react-components";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { useContext, useEffect, useState } from "react";
 import {
@@ -31,35 +24,23 @@ const useStyles = makeStyles({
         height: "100%",
         display: "flex",
         flexDirection: "column",
+        overflow: "auto",
+        flex: 1,
+        paddingTop: "10px",
+        paddingLeft: "10px",
+        paddingRight: "5px",
+        gap: "10px",
     },
     title: {
-        ...shorthands.margin("10px", "5px", "5px", "5px"),
-        gap: "10px",
         width: "400px",
         maxWidth: "100%",
         padding: "10px",
-        "> *": {
-            marginBottom: "10px",
-        },
-    },
-    separator: {
-        ...shorthands.margin("0px", "-20px", "0px", "0px"),
-        ...shorthands.padding("0px"),
-        fontSize: "5px",
-    },
-    form: {
-        height: "100%",
-        maxWidth: "100%",
-        overflow: "hidden",
     },
     tabButtonContainer: {
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
-        "> *": {
-            marginRight: "5px",
-        },
     },
 });
 
@@ -170,68 +151,51 @@ export const DesignerMainPane = () => {
 
     return (
         <div className={classes.root}>
-            <div className={classes.title}>
-                <Field label={locConstants.tableDesigner.tableName} orientation="horizontal">
-                    <Input
-                        size="medium"
-                        value={tableName}
-                        onChange={(_event, data) => {
-                            setTableName(data.value);
-                        }}
-                        autoFocus // initial focus
-                        onBlur={(_event) => {
-                            context.processTableEdit({
-                                source: "TabsView",
-                                type: DesignerEditType.Update,
-                                path: ["name"],
-                                value: tableName,
-                            });
-                        }}
-                    />
-                </Field>
-                <Field label={locConstants.tableDesigner.schema} orientation="horizontal">
-                    <SearchableDropdown
-                        size="medium"
-                        options={getSortedSchemaValues().map((option) => ({
-                            value: option,
-                        }))}
-                        onSelect={(option) => {
-                            context.processTableEdit({
-                                source: "TabsView",
-                                type: DesignerEditType.Update,
-                                path: ["schema"],
-                                value: option.value,
-                            });
-                        }}
-                        selectedOption={{
-                            value: schema,
-                        }}
-                    />
-                    {/* <Dropdown
-                        size="medium"
-                        value={schema}
-                        onOptionSelect={(_event, data) => {
-                            if (!data.optionValue) {
-                                return;
-                            }
-                            setSchema(data?.optionValue);
-                            context.processTableEdit({
-                                source: "TabsView",
-                                type: DesignerEditType.Update,
-                                path: ["schema"],
-                                value: data.optionValue,
-                            });
-                        }}
-                    >
-                        {
-                            // Sort schema values alphabetically
-                            getSortedSchemaValues().map((option) => {
-                                return <Option>{option}</Option>;
-                            })
-                        }
-                    </Dropdown> */}
-                </Field>
-            </div>
+            <Field
+                size="small"
+                label={locConstants.tableDesigner.tableName}
+                orientation="horizontal"
+                style={{ width: "300px" }}>
+                <Input
+                    size="small"
+                    value={tableName}
+                    onChange={(_event, data) => {
+                        setTableName(data.value);
+                    }}
+                    autoFocus // initial focus
+                    onBlur={(_event) => {
+                        context.processTableEdit({
+                            source: "TabsView",
+                            type: DesignerEditType.Update,
+                            path: ["name"],
+                            value: tableName,
+                        });
+                    }}
+                />
+            </Field>
+            <Field
+                size="small"
+                label={locConstants.tableDesigner.schema}
+                orientation="horizontal"
+                style={{ width: "300px" }}>
+                <SearchableDropdown
+                    size="small"
+                    options={getSortedSchemaValues().map((option) => ({
+                        value: option,
+                    }))}
+                    onSelect={(option) => {
+                        context.processTableEdit({
+                            source: "TabsView",
+                            type: DesignerEditType.Update,
+                            path: ["schema"],
+                            value: option.value,
+                        });
+                    }}
+                    selectedOption={{
+                        value: schema,
+                    }}
+                />
+            </Field>
             <TabList
                 size="small"
                 selectedValue={state.tabStates?.mainPaneTab}
@@ -258,7 +222,11 @@ export const DesignerMainPane = () => {
                     );
                 })}
             </TabList>
-            <div className={classes.form}>
+            <div
+                style={{
+                    flex: 1,
+                    width: "100%",
+                }}>
                 {state.view?.tabs.map((tab) => {
                     return (
                         <div

--- a/src/reactviews/pages/TableDesigner/designerMainPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerMainPane.tsx
@@ -22,13 +22,17 @@ const useStyles = makeStyles({
     root: {
         width: "100%",
         height: "100%",
+        paddingTop: "10px",
+        paddingLeft: "10px",
+        paddingRight: "10px",
+        boxSizing: "border-box",
+        overflow: "auto",
+    },
+    content: {
         display: "flex",
         flexDirection: "column",
         overflow: "auto",
         flex: 1,
-        paddingTop: "10px",
-        paddingLeft: "10px",
-        paddingRight: "5px",
         gap: "10px",
     },
     title: {
@@ -151,82 +155,80 @@ export const DesignerMainPane = () => {
 
     return (
         <div className={classes.root}>
-            <Field
-                size="small"
-                label={locConstants.tableDesigner.tableName}
-                orientation="horizontal"
-                style={{ width: "300px" }}>
-                <Input
+            <div className={classes.content}>
+                <Field
                     size="small"
-                    value={tableName}
-                    onChange={(_event, data) => {
-                        setTableName(data.value);
-                    }}
-                    autoFocus // initial focus
-                    onBlur={(_event) => {
-                        context.processTableEdit({
-                            source: "TabsView",
-                            type: DesignerEditType.Update,
-                            path: ["name"],
-                            value: tableName,
-                        });
-                    }}
-                />
-            </Field>
-            <Field
-                size="small"
-                label={locConstants.tableDesigner.schema}
-                orientation="horizontal"
-                style={{ width: "300px" }}>
-                <SearchableDropdown
+                    label={locConstants.tableDesigner.tableName}
+                    orientation="horizontal"
+                    style={{ width: "300px" }}>
+                    <Input
+                        size="small"
+                        value={tableName}
+                        onChange={(_event, data) => {
+                            setTableName(data.value);
+                        }}
+                        autoFocus // initial focus
+                        onBlur={(_event) => {
+                            context.processTableEdit({
+                                source: "TabsView",
+                                type: DesignerEditType.Update,
+                                path: ["name"],
+                                value: tableName,
+                            });
+                        }}
+                    />
+                </Field>
+                <Field
                     size="small"
-                    options={getSortedSchemaValues().map((option) => ({
-                        value: option,
-                    }))}
-                    onSelect={(option) => {
-                        context.processTableEdit({
-                            source: "TabsView",
-                            type: DesignerEditType.Update,
-                            path: ["schema"],
-                            value: option.value,
-                        });
-                    }}
-                    selectedOption={{
-                        value: schema,
-                    }}
-                />
-            </Field>
-            <TabList
-                size="small"
-                selectedValue={state.tabStates?.mainPaneTab}
-                onTabSelect={(_event, data) => {
-                    context.setTab(data.value as DesignerMainPaneTabs);
-                    context.setPropertiesComponents(undefined);
-                }}>
-                {state.view?.tabs.map((tab) => {
-                    const ariaLabel = getTabAriaLabel(tab.id);
-                    return (
-                        <Tab title={ariaLabel} value={tab.id} key={tab.id}>
-                            <div className={classes.tabButtonContainer}>
-                                <Text>{tab.title}</Text>
-                                {getCurrentTabIssuesCount(tab.id) > 0 && (
-                                    <CounterBadge
-                                        color="important"
-                                        size="small"
-                                        title={getTableIssuesCountLabel(tab.id)}
-                                        count={getCurrentTabIssuesCount(tab.id)}
-                                    />
-                                )}
-                            </div>
-                        </Tab>
-                    );
-                })}
-            </TabList>
-            <div
-                style={{
-                    flex: 1,
-                    width: "100%",
-                }}>
+                    label={locConstants.tableDesigner.schema}
+                    orientation="horizontal"
+                    style={{ width: "300px" }}>
+                    <SearchableDropdown
+                        size="small"
+                        options={getSortedSchemaValues().map((option) => ({
+                            value: option,
+                        }))}
+                        onSelect={(option) => {
+                            context.processTableEdit({
+                                source: "TabsView",
+                                type: DesignerEditType.Update,
+                                path: ["schema"],
+                                value: option.value,
+                            });
+                        }}
+                        selectedOption={{
+                            value: schema,
+                        }}
+                    />
+                </Field>
+                <TabList
+                    size="small"
+                    selectedValue={state.tabStates?.mainPaneTab}
+                    onTabSelect={(_event, data) => {
+                        context.setTab(data.value as DesignerMainPaneTabs);
+                        context.setPropertiesComponents(undefined);
+                    }}>
+                    {state.view?.tabs.map((tab) => {
+                        const ariaLabel = getTabAriaLabel(tab.id);
+                        return (
+                            <Tab title={ariaLabel} value={tab.id} key={tab.id}>
+                                <div className={classes.tabButtonContainer}>
+                                    <Text>{tab.title}</Text>
+                                    {getCurrentTabIssuesCount(tab.id) > 0 && (
+                                        <CounterBadge
+                                            color="important"
+                                            size="small"
+                                            title={getTableIssuesCountLabel(tab.id)}
+                                            count={getCurrentTabIssuesCount(tab.id)}
+                                            style={{ marginLeft: "6px" }}
+                                        />
+                                    )}
+                                </div>
+                            </Tab>
+                        );
+                    })}
+                </TabList>
+
                 {state.view?.tabs.map((tab) => {
                     return (
                         <div

--- a/src/reactviews/pages/TableDesigner/designerMainPaneTab.tsx
+++ b/src/reactviews/pages/TableDesigner/designerMainPaneTab.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { makeStyles, shorthands } from "@fluentui/react-components";
+import { makeStyles } from "@fluentui/react-components";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { useContext } from "react";
 import {
@@ -25,12 +25,9 @@ const useStyles = makeStyles({
     root: {
         width: "100%",
         height: "100%",
-        overflowX: "auto",
         display: "flex",
         flexDirection: "column",
-        paddingTop: "10px",
-        paddingLeft: "10px",
-        ...shorthands.gap("10px"),
+        gap: "10px",
     },
 });
 

--- a/src/reactviews/pages/TableDesigner/designerPageRibbon.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPageRibbon.tsx
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Toolbar } from "@fluentui/react-toolbar";
-import { Divider, makeStyles, shorthands } from "@fluentui/react-components";
+import { Button, Divider, makeStyles, shorthands } from "@fluentui/react-components";
 import { useContext } from "react";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { DesignerChangesPreviewButton } from "./designerChangesPreviewButton";
+import * as FluentIcons from "@fluentui/react-icons";
+import { locConstants } from "../../common/locConstants";
 
 const useStyles = makeStyles({
     separator: {
@@ -26,8 +28,21 @@ export const DesignerPageRibbon = () => {
 
     return (
         <div>
-            <Toolbar size="small">
+            <Toolbar
+                size="small"
+                style={{
+                    paddingTop: "5px",
+                    paddingBottom: "5px",
+                }}>
                 <DesignerChangesPreviewButton />
+                <Button
+                    size="small"
+                    appearance="subtle"
+                    icon={<FluentIcons.Code16Filled />}
+                    title={locConstants.schemaDesigner.definition}
+                    onClick={() => designerContext.toggleDefinitionPane()}>
+                    {locConstants.schemaDesigner.definition}
+                </Button>
             </Toolbar>
             <Divider className={classes.separator} />
         </div>

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -26,7 +26,11 @@ import {
     DropDownProperties,
     InputBoxProperties,
 } from "../../../sharedInterfaces/tableDesigner";
-import { ChevronRightFilled, ChevronLeftFilled, DismissRegular } from "@fluentui/react-icons";
+import {
+    ChevronRight16Regular,
+    ChevronLeft16Regular,
+    Dismiss16Regular,
+} from "@fluentui/react-icons";
 import { locConstants } from "../../common/locConstants";
 import { useAccordionStyles } from "../../common/styles";
 
@@ -265,9 +269,9 @@ export const DesignerPropertiesPane = () => {
                     }
                     icon={
                         context.propertiesPaneResizeInfo.isMaximized ? (
-                            <ChevronRightFilled />
+                            <ChevronRight16Regular />
                         ) : (
-                            <ChevronLeftFilled />
+                            <ChevronLeft16Regular />
                         )
                     }
                     style={{
@@ -291,7 +295,7 @@ export const DesignerPropertiesPane = () => {
                         context.setPropertiesComponents(undefined);
                     }}
                     title={locConstants.common.close}
-                    icon={<DismissRegular />}
+                    icon={<Dismiss16Regular />}
                 />
             </div>
             <div className={classes.stack}>

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -55,6 +55,7 @@ const useStyles = makeStyles({
         "> *": {
             marginBottom: "10px",
         },
+        ...shorthands.flex(1),
         overflowY: "auto",
         backgroundColor: "var(--vscode-editor-background)",
     },

--- a/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
+++ b/src/reactviews/pages/TableDesigner/designerPropertiesPane.tsx
@@ -40,13 +40,14 @@ const useStyles = makeStyles({
     },
     title: {
         display: "flex",
-        height: "30px",
-        paddingTop: "10px",
-        paddingBottom: "10px",
-        "> *": {
-            marginRight: "10px",
-        },
-        lineHeight: "30px",
+        alignItems: "center",
+        gap: "8px",
+        padding: "6px 8px",
+        borderBottom: "1px solid var(--vscode-editorWidget-border)",
+        backgroundColor: "var(--vscode-editorWidget-background)",
+        boxShadow: "0 1px 0 var(--vscode-editorWidget-border), 0 2px 6px rgba(0, 0, 0, 0.2)",
+        position: "relative",
+        zIndex: 1,
     },
     stack: {
         marginBottom: "10px",
@@ -246,7 +247,7 @@ export const DesignerPropertiesPane = () => {
         <div className={classes.root}>
             <div className={classes.title}>
                 <Button
-                    appearance="transparent"
+                    appearance="subtle"
                     onClick={() => {
                         if (context.propertiesPaneResizeInfo.isMaximized) {
                             context.propertiesPaneResizeInfo.setCurrentWidth(
@@ -259,8 +260,8 @@ export const DesignerPropertiesPane = () => {
                     }}
                     title={
                         context.propertiesPaneResizeInfo.isMaximized
-                            ? locConstants.tableDesigner.restorePanelSize
-                            : locConstants.tableDesigner.maximizePanelSize
+                            ? locConstants.tableDesigner.restorePropertiesPane
+                            : locConstants.tableDesigner.expandPropertiesPane
                     }
                     icon={
                         context.propertiesPaneResizeInfo.isMaximized ? (
@@ -274,7 +275,7 @@ export const DesignerPropertiesPane = () => {
                     }}
                 />
                 <Text
-                    size={500}
+                    size={400}
                     weight="semibold"
                     style={{
                         flex: 1,
@@ -285,15 +286,11 @@ export const DesignerPropertiesPane = () => {
                     )}
                 </Text>
                 <Button
-                    appearance="transparent"
+                    appearance="subtle"
                     onClick={() => {
                         context.setPropertiesComponents(undefined);
                     }}
-                    title={
-                        context.propertiesPaneResizeInfo.isMaximized
-                            ? locConstants.tableDesigner.restorePanelSize
-                            : locConstants.tableDesigner.maximizePanelSize
-                    }
+                    title={locConstants.common.close}
                     icon={<DismissRegular />}
                 />
             </div>

--- a/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -46,13 +46,7 @@ const useStyles = fluentui.makeStyles({
     },
 });
 
-export const DesignerTable = ({
-    component,
-    model,
-    componentPath,
-    UiArea,
-    loadPropertiesTabData = true,
-}: DesignerTableProps) => {
+export const DesignerTable = ({ component, model, componentPath, UiArea }: DesignerTableProps) => {
     const tableProps = component.componentProperties as designer.DesignerTableProperties;
     const context = useContext(TableDesignerContext);
     if (!context) {

--- a/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -435,6 +435,17 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                                     }}
                                     onFocus={(_event) => {
                                         setFocusedRowId(index);
+                                        // If properties pane is already open, update its content to show this row's properties
+                                        if (
+                                            context.state.propertiesPaneData &&
+                                            UiArea !== "PropertiesView"
+                                        ) {
+                                            context?.setPropertiesComponents({
+                                                componentPath: [...componentPath, index],
+                                                component: component,
+                                                model: model,
+                                            });
+                                        }
                                     }}
                                     key={componentPath.join(".") + index}>
                                     {columnsDef.map((column, columnIndex) => {

--- a/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -13,6 +13,7 @@ import {
     ArrowSortUpFilled,
     DeleteRegular,
     ReorderRegular,
+    SettingsRegular,
 } from "@fluentui/react-icons";
 import { useContext, useState } from "react";
 
@@ -72,6 +73,14 @@ export const DesignerTable = ({
                 renderHeaderCell: () => <>{colProps?.componentProperties.title ?? column}</>,
             });
         });
+    if (UiArea !== "PropertiesView") {
+        columnsDef.push(
+            fluentui.createTableColumn({
+                columnId: "properties",
+                renderHeaderCell: () => <></>,
+            }),
+        );
+    }
     if (tableProps.canMoveRows) {
         columnsDef.unshift(
             fluentui.createTableColumn({
@@ -118,6 +127,13 @@ export const DesignerTable = ({
                 defaultWidth: colProps?.componentProperties.width ?? 70,
             };
         });
+        if (UiArea !== "PropertiesView") {
+            result["properties"] = {
+                minWidth: 24,
+                idealWidth: 24,
+                defaultWidth: 24,
+            };
+        }
         if (tableProps.canMoveRows) {
             result["dragHandle"] = {
                 minWidth: 15,
@@ -236,6 +252,25 @@ export const DesignerTable = ({
                             });
                         }}
                         title={locConstants.tableDesigner.remove(tableProps.objectTypeDisplayName!)}
+                    />
+                );
+            case "properties":
+                return (
+                    <fluentui.Button
+                        appearance="subtle"
+                        size="small"
+                        icon={<SettingsRegular />}
+                        title={locConstants.tableDesigner.propertiesPaneTitle(
+                            tableProps.objectTypeDisplayName ?? "",
+                        )}
+                        onClick={() => {
+                            context?.setPropertiesComponents({
+                                componentPath: [...componentPath, row.rowId],
+                                component: component,
+                                model: model,
+                            });
+                            setFocusedRowId(rowIndex);
+                        }}
                     />
                 );
             default: {
@@ -404,20 +439,8 @@ export const DesignerTable = ({
                                         borderRight: border,
                                         marginTop: rowError ? "5px" : "",
                                     }}
-                                    onFocus={(event) => {
-                                        if (
-                                            !loadPropertiesTabData ||
-                                            tableProps.showItemDetailInPropertiesView === false
-                                        ) {
-                                            return;
-                                        }
-                                        context?.setPropertiesComponents({
-                                            componentPath: [...componentPath, row.rowId],
-                                            component: component,
-                                            model: model,
-                                        });
+                                    onFocus={(_event) => {
                                         setFocusedRowId(index);
-                                        event.preventDefault();
                                     }}
                                     key={componentPath.join(".") + index}>
                                     {columnsDef.map((column, columnIndex) => {

--- a/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
+++ b/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
@@ -129,51 +129,53 @@ export const TableDesigner = () => {
                         <div className={classes.mainPaneContainer}>
                             <DesignerMainPane />
                         </div>
-                        <Divider
-                            style={{
-                                width: "5px",
-                                height: "100%",
-                                flex: 0,
-                            }}
-                            vertical
-                        />
                         {context.state.propertiesPaneData && (
-                            <ResizableBox
-                                width={
-                                    context.propertiesPaneResizeInfo.isMaximized
-                                        ? 9999999
-                                        : context.propertiesPaneResizeInfo.currentWidth
-                                }
-                                onResizeStart={(_e, _div) => {
-                                    context.propertiesPaneResizeInfo.setIsMaximized(false);
-                                }}
-                                onResizeStop={(_e, div) => {
-                                    const parentContainerWidth =
-                                        div.node!.parentElement!.parentElement!.offsetWidth!;
-
-                                    const currentDivWidth = div.size.width;
-                                    if (currentDivWidth >= parentContainerWidth - 50) {
-                                        context.propertiesPaneResizeInfo.setIsMaximized(true);
-                                        context.propertiesPaneResizeInfo.setCurrentWidth(
-                                            parentContainerWidth,
-                                        );
-                                    } else {
-                                        context.propertiesPaneResizeInfo.setCurrentWidth(
-                                            div.size.width,
-                                        );
-                                        context.propertiesPaneResizeInfo.setOriginalWidth(
-                                            div.size.width,
-                                        );
+                            <>
+                                <Divider
+                                    style={{
+                                        width: "5px",
+                                        height: "100%",
+                                        flex: 0,
+                                    }}
+                                    vertical
+                                />
+                                <ResizableBox
+                                    width={
+                                        context.propertiesPaneResizeInfo.isMaximized
+                                            ? 9999999
+                                            : context.propertiesPaneResizeInfo.currentWidth
                                     }
-                                }}
-                                height={Infinity}
-                                maxConstraints={[Infinity, Infinity]}
-                                minConstraints={[10, Infinity]}
-                                resizeHandles={["w"]}
-                                handle={<div className={classes.propertiesPaneHandle} />}
-                                className={classes.propertiesPaneContainer}>
-                                <DesignerPropertiesPane />
-                            </ResizableBox>
+                                    onResizeStart={(_e, _div) => {
+                                        context.propertiesPaneResizeInfo.setIsMaximized(false);
+                                    }}
+                                    onResizeStop={(_e, div) => {
+                                        const parentContainerWidth =
+                                            div.node!.parentElement!.parentElement!.offsetWidth!;
+
+                                        const currentDivWidth = div.size.width;
+                                        if (currentDivWidth >= parentContainerWidth - 50) {
+                                            context.propertiesPaneResizeInfo.setIsMaximized(true);
+                                            context.propertiesPaneResizeInfo.setCurrentWidth(
+                                                parentContainerWidth,
+                                            );
+                                        } else {
+                                            context.propertiesPaneResizeInfo.setCurrentWidth(
+                                                div.size.width,
+                                            );
+                                            context.propertiesPaneResizeInfo.setOriginalWidth(
+                                                div.size.width,
+                                            );
+                                        }
+                                    }}
+                                    height={Infinity}
+                                    maxConstraints={[Infinity, Infinity]}
+                                    minConstraints={[10, Infinity]}
+                                    resizeHandles={["w"]}
+                                    handle={<div className={classes.propertiesPaneHandle} />}
+                                    className={classes.propertiesPaneContainer}>
+                                    <DesignerPropertiesPane />
+                                </ResizableBox>
+                            </>
                         )}
                     </div>
                     <ResizableBox

--- a/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
+++ b/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
@@ -14,6 +14,7 @@ import { DesignerMainPane } from "./designerMainPane";
 import { DesignerPropertiesPane } from "./designerPropertiesPane";
 import { DesignerResultPane } from "./designerResultPane";
 import { locConstants } from "../../common/locConstants";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 const useStyles = makeStyles({
     root: {
@@ -93,6 +94,10 @@ const useStyles = makeStyles({
         width: "300px",
         ...shorthands.overflow("hidden"),
     },
+    resizeHandle: {
+        height: "2px",
+        backgroundColor: "var(--vscode-editorWidget-border)",
+    },
 });
 
 export const TableDesigner = () => {
@@ -124,92 +129,73 @@ export const TableDesigner = () => {
             )}
             {tableDesignerState.apiState?.initializeState === designer.LoadState.Loaded && (
                 <div className={classes.mainContent}>
-                    <DesignerPageRibbon />
-                    <div className={classes.editor}>
-                        <div className={classes.mainPaneContainer}>
-                            <DesignerMainPane />
-                        </div>
-                        {context.state.propertiesPaneData && (
-                            <>
-                                <Divider
-                                    style={{
-                                        width: "5px",
-                                        height: "100%",
-                                        flex: 0,
-                                    }}
-                                    vertical
-                                />
-                                <ResizableBox
-                                    width={
-                                        context.propertiesPaneResizeInfo.isMaximized
-                                            ? 9999999
-                                            : context.propertiesPaneResizeInfo.currentWidth
-                                    }
-                                    onResizeStart={(_e, _div) => {
-                                        context.propertiesPaneResizeInfo.setIsMaximized(false);
-                                    }}
-                                    onResizeStop={(_e, div) => {
-                                        const parentContainerWidth =
-                                            div.node!.parentElement!.parentElement!.offsetWidth!;
+                    <PanelGroup direction="vertical">
+                        <Panel defaultSize={75}>
+                            <DesignerPageRibbon />
+                            <div className={classes.editor}>
+                                <div className={classes.mainPaneContainer}>
+                                    <DesignerMainPane />
+                                </div>
+                                {context.state.propertiesPaneData && (
+                                    <>
+                                        <Divider
+                                            style={{
+                                                width: "5px",
+                                                height: "100%",
+                                                flex: 0,
+                                            }}
+                                            vertical
+                                        />
+                                        <ResizableBox
+                                            width={
+                                                context.propertiesPaneResizeInfo.isMaximized
+                                                    ? 9999999
+                                                    : context.propertiesPaneResizeInfo.currentWidth
+                                            }
+                                            onResizeStart={(_e, _div) => {
+                                                context.propertiesPaneResizeInfo.setIsMaximized(
+                                                    false,
+                                                );
+                                            }}
+                                            onResizeStop={(_e, div) => {
+                                                const parentContainerWidth =
+                                                    div.node!.parentElement!.parentElement!
+                                                        .offsetWidth!;
 
-                                        const currentDivWidth = div.size.width;
-                                        if (currentDivWidth >= parentContainerWidth - 50) {
-                                            context.propertiesPaneResizeInfo.setIsMaximized(true);
-                                            context.propertiesPaneResizeInfo.setCurrentWidth(
-                                                parentContainerWidth,
-                                            );
-                                        } else {
-                                            context.propertiesPaneResizeInfo.setCurrentWidth(
-                                                div.size.width,
-                                            );
-                                            context.propertiesPaneResizeInfo.setOriginalWidth(
-                                                div.size.width,
-                                            );
-                                        }
-                                    }}
-                                    height={Infinity}
-                                    maxConstraints={[Infinity, Infinity]}
-                                    minConstraints={[10, Infinity]}
-                                    resizeHandles={["w"]}
-                                    handle={<div className={classes.propertiesPaneHandle} />}
-                                    className={classes.propertiesPaneContainer}>
-                                    <DesignerPropertiesPane />
-                                </ResizableBox>
-                            </>
-                        )}
-                    </div>
-                    <ResizableBox
-                        width={Infinity}
-                        height={
-                            context.resultPaneResizeInfo.isMaximized
-                                ? 9999999
-                                : context.resultPaneResizeInfo.currentHeight
-                        }
-                        maxConstraints={[Infinity, Infinity]}
-                        minConstraints={[Infinity, 10]}
-                        resizeHandles={["n"]}
-                        handle={<div className={classes.resultPaneHandle} />}
-                        className={classes.resultPaneContainer}
-                        onResizeStart={(_e, _div) => {
-                            context.resultPaneResizeInfo.setIsMaximized(false);
-                        }}
-                        onResizeStop={(_e, div) => {
-                            const parentContainerHeight =
-                                div.node!.parentElement!.parentElement!.offsetHeight!;
-
-                            const currentDivHeight = div.size.height;
-                            if (currentDivHeight >= parentContainerHeight - 50) {
-                                context.resultPaneResizeInfo.setIsMaximized(true);
-                                context.resultPaneResizeInfo.setCurrentHeight(
-                                    parentContainerHeight,
-                                );
-                            } else {
-                                context.resultPaneResizeInfo.setCurrentHeight(div.size.height);
-                                context.resultPaneResizeInfo.setOriginalHeight(div.size.height);
-                            }
-                        }}>
+                                                const currentDivWidth = div.size.width;
+                                                if (currentDivWidth >= parentContainerWidth - 50) {
+                                                    context.propertiesPaneResizeInfo.setIsMaximized(
+                                                        true,
+                                                    );
+                                                    context.propertiesPaneResizeInfo.setCurrentWidth(
+                                                        parentContainerWidth,
+                                                    );
+                                                } else {
+                                                    context.propertiesPaneResizeInfo.setCurrentWidth(
+                                                        div.size.width,
+                                                    );
+                                                    context.propertiesPaneResizeInfo.setOriginalWidth(
+                                                        div.size.width,
+                                                    );
+                                                }
+                                            }}
+                                            height={Infinity}
+                                            maxConstraints={[Infinity, Infinity]}
+                                            minConstraints={[10, Infinity]}
+                                            resizeHandles={["w"]}
+                                            handle={
+                                                <div className={classes.propertiesPaneHandle} />
+                                            }
+                                            className={classes.propertiesPaneContainer}>
+                                            <DesignerPropertiesPane />
+                                        </ResizableBox>
+                                    </>
+                                )}
+                            </div>
+                        </Panel>
+                        <PanelResizeHandle className={classes.resizeHandle} />
                         <DesignerResultPane />
-                    </ResizableBox>
+                    </PanelGroup>
                 </div>
             )}
         </div>

--- a/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
+++ b/src/reactviews/pages/TableDesigner/tableDesignerPage.tsx
@@ -94,11 +94,6 @@ const useStyles = makeStyles({
         width: "100%",
         position: "relative",
     },
-    mainPaneContainer: {
-        ...shorthands.flex(1),
-        height: "100%",
-        ...shorthands.overflow("hidden"),
-    },
     propertiesPaneContainer: {
         position: "relative",
         height: "100%",
@@ -171,23 +166,16 @@ export const TableDesigner = () => {
                             <div className={classes.topPanelContent}>
                                 <DesignerPageRibbon />
                                 <div className={classes.editor} ref={editorRef}>
-                                    {!context.state.propertiesPaneData && (
-                                        <div className={classes.mainPaneContainer}>
+                                    <PanelGroup direction="horizontal">
+                                        <Panel defaultSize={100} minSize={10} collapsible>
                                             <DesignerMainPane />
-                                        </div>
-                                    )}
-                                    {context.state.propertiesPaneData && (
-                                        <PanelGroup direction="horizontal">
-                                            <Panel defaultSize={80} minSize={10} collapsible>
-                                                <div className={classes.mainPaneContainer}>
-                                                    <DesignerMainPane />
-                                                </div>
-                                            </Panel>
-                                            <PanelResizeHandle
-                                                className={classes.verticalResizeHandle}
-                                            />
+                                        </Panel>
+                                        <PanelResizeHandle
+                                            className={classes.verticalResizeHandle}
+                                        />
+                                        {context.state.propertiesPaneData && (
                                             <Panel
-                                                defaultSize={20}
+                                                defaultSize={0}
                                                 minSize={10}
                                                 collapsible
                                                 ref={propertiesPanelRef}
@@ -214,8 +202,8 @@ export const TableDesigner = () => {
                                                     <DesignerPropertiesPane />
                                                 </div>
                                             </Panel>
-                                        </PanelGroup>
-                                    )}
+                                        )}
+                                    </PanelGroup>
                                 </div>
                             </div>
                         </Panel>

--- a/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -314,6 +314,7 @@ export class SchemaDesignerWebviewController extends ReactWebviewPanelController
         });
 
         this.onNotification(SchemaDesigner.CloseSchemaDesignerNotification.type, () => {
+            // Close the schema designer panel
             this.panel.dispose();
         });
     }

--- a/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -250,6 +250,7 @@ export class SchemaDesignerWebviewController extends ReactWebviewPanelController
 
         this.onNotification(SchemaDesigner.CopyToClipboardNotification.type, async (params) => {
             await vscode.env.clipboard.writeText(params.text);
+            await vscode.window.showInformationMessage(LocConstants.scriptCopiedToClipboard);
         });
 
         this.onNotification(SchemaDesigner.OpenInEditorNotification.type, async () => {
@@ -313,7 +314,6 @@ export class SchemaDesignerWebviewController extends ReactWebviewPanelController
         });
 
         this.onNotification(SchemaDesigner.CloseSchemaDesignerNotification.type, () => {
-            // Close the schema designer panel
             this.panel.dispose();
         });
     }

--- a/src/sharedInterfaces/tableDesigner.ts
+++ b/src/sharedInterfaces/tableDesigner.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { NotificationType } from "vscode-jsonrpc/browser";
+
 /**
  * Definition for the table designer service.
  */
@@ -736,11 +738,6 @@ export interface TableDesignerReducers {
     generatePreviewReport: {
         table: TableInfo;
     };
-    initializeTableDesigner: {
-        table: TableInfo;
-    };
-    scriptAsCreate: {};
-    copyScriptAsCreateToClipboard: {};
     setTab: {
         tabId: DesignerMainPaneTabs;
     };
@@ -750,9 +747,43 @@ export interface TableDesignerReducers {
     setResultTab: {
         tabId: DesignerResultPaneTabs;
     };
-    closeDesigner: {};
     continueEditing: {};
-    copyPublishErrorToClipboard: {};
 }
 
 export type DesignerUIArea = "PropertiesView" | "ScriptView" | "TopContentView" | "TabsView";
+
+export interface ScriptAsCreateParams {
+    script: string;
+}
+
+export interface CopyScriptAsCreateToClipboardParams {
+    script: string;
+}
+
+export interface CopyPublishErrorToClipboardParams {
+    error: string;
+}
+
+export namespace ScriptAsCreateNotification {
+    export const type = new NotificationType<ScriptAsCreateParams>("scriptAsCreate");
+}
+
+export namespace CopyScriptAsCreateToClipboardNotification {
+    export const type = new NotificationType<CopyScriptAsCreateToClipboardParams>(
+        "copyScriptAsCreateToClipboard",
+    );
+}
+
+export namespace CloseDesignerNotification {
+    export const type = new NotificationType<void>("closeDesigner");
+}
+
+export namespace CopyPublishErrorToClipboardNotification {
+    export const type = new NotificationType<CopyPublishErrorToClipboardParams>(
+        "copyPublishErrorToClipboard",
+    );
+}
+
+export namespace InitializeTableDesignerNotification {
+    export const type = new NotificationType<void>("initializeTableDesigner");
+}

--- a/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/src/tableDesigner/tableDesignerWebviewController.ts
@@ -419,27 +419,24 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
             return state;
         });
 
-        this.registerReducer("initializeTableDesigner", async (state) => {
+        this.onNotification(designer.InitializeTableDesignerNotification.type, async () => {
             await this.initialize();
-            return state;
         });
 
-        this.registerReducer("scriptAsCreate", async (state) => {
+        this.onNotification(designer.ScriptAsCreateNotification.type, async (params) => {
             await this._sqlDocumentService.newQuery({
-                content: (state.model["script"] as designer.InputBoxProperties).value ?? "",
+                content: params.script,
                 connectionStrategy: ConnectionStrategy.DoNotConnect,
             });
-
-            return state;
         });
 
-        this.registerReducer("copyScriptAsCreateToClipboard", async (state) => {
-            await vscode.env.clipboard.writeText(
-                (state.model["script"] as designer.InputBoxProperties).value ?? "",
-            );
-            await vscode.window.showInformationMessage(scriptCopiedToClipboard);
-            return state;
-        });
+        this.onNotification(
+            designer.CopyScriptAsCreateToClipboardNotification.type,
+            async (params) => {
+                await vscode.env.clipboard.writeText(params.script);
+                await vscode.window.showInformationMessage(scriptCopiedToClipboard);
+            },
+        );
 
         this.registerReducer("setTab", async (state, payload) => {
             state.tabStates.mainPaneTab = payload.tabId;
@@ -456,12 +453,11 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
             return state;
         });
 
-        this.registerReducer("closeDesigner", async (state) => {
+        this.onNotification(designer.CloseDesignerNotification.type, async () => {
             sendActionEvent(TelemetryViews.TableDesigner, TelemetryActions.Close, {
                 correlationId: this._correlationId,
             });
             this.panel.dispose();
-            return state;
         });
 
         this.registerReducer("continueEditing", async (state) => {
@@ -471,10 +467,13 @@ export class TableDesignerWebviewController extends ReactWebviewPanelController<
             });
             return state;
         });
-        this.registerReducer("copyPublishErrorToClipboard", async (state) => {
-            await vscode.env.clipboard.writeText(state.publishingError ?? "");
-            void vscode.window.showInformationMessage(copied);
-            return state;
-        });
+
+        this.onNotification(
+            designer.CopyPublishErrorToClipboardNotification.type,
+            async (params) => {
+                await vscode.env.clipboard.writeText(params.error);
+                void vscode.window.showInformationMessage(copied);
+            },
+        );
     }
 }

--- a/test/unit/tableDesigner.test.ts
+++ b/test/unit/tableDesigner.test.ts
@@ -445,42 +445,6 @@ suite("TableDesignerWebviewController tests", () => {
         );
     });
 
-    test("should call initialize in initializeTableDesigner reducer", async () => {
-        const initializeSpy = sinon.spy(controller as any, "initialize");
-
-        const callState = (controller as any)._state;
-
-        await controller["_reducerHandlers"].get("initializeTableDesigner")(
-            callState,
-            mockTableChangeInfo,
-        );
-
-        assert.ok(initializeSpy.calledOnce, "private initialize should be called once");
-
-        (initializeSpy as sinon.SinonSpy).restore();
-    });
-
-    test("should call newQuery with script content in scriptAsCreate reducer", async () => {
-        const mockScript = "CREATE TABLE example (...);";
-
-        const state = {
-            model: {
-                script: {
-                    value: mockScript,
-                },
-            },
-        };
-
-        await controller["_reducerHandlers"].get("scriptAsCreate")(state, mockPayload);
-
-        sinon.assert.calledOnceWithExactly(newQueryStub, {
-            content: mockScript,
-            connectionStrategy: ConnectionStrategy.DoNotConnect,
-        });
-
-        newQueryStub.restore();
-    });
-
     test("should set mainPaneTab in setTab reducer", async () => {
         const state = { tabStates: { mainPaneTab: "" } };
         const tabId = "properties";
@@ -524,53 +488,6 @@ suite("TableDesignerWebviewController tests", () => {
         );
     });
 
-    test("should copy script to clipboard in copyScriptAsCreateToClipboard reducer", async () => {
-        const infoStub = sinon.stub(vscode.window, "showInformationMessage").resolves();
-        const writeTextStub = sinon.stub().resolves();
-        const mockEnvClipboard = {
-            ...vscode.env.clipboard,
-            writeText: writeTextStub,
-        };
-
-        sandbox.replaceGetter(vscode.env, "clipboard", () => mockEnvClipboard);
-
-        // Setup state
-        const state = {
-            model: {
-                script: {
-                    value: "Test value",
-                },
-            },
-        };
-
-        await controller["_reducerHandlers"].get("copyScriptAsCreateToClipboard")(
-            state,
-            mockPayload,
-        );
-
-        assert.ok(writeTextStub.calledOnce, "Clipboard writeText should be called once");
-
-        assert.deepStrictEqual(
-            writeTextStub.firstCall.args,
-            ["Test value"],
-            "writeStub should be called with correct arguments",
-        );
-
-        infoStub.restore();
-    });
-
-    test("should dispose panel and send telemetry in closeDesigner reducer", async () => {
-        const disposeStub = sinon.stub(controller.panel, "dispose");
-
-        const state = (controller as any)._state;
-
-        await controller["_reducerHandlers"].get("closeDesigner")(state, mockPayload);
-
-        assert.ok(disposeStub.calledOnce, "panel.dispose should be called");
-
-        disposeStub.restore();
-    });
-
     test("should set publishState and send telemetry in continueEditing reducer", async () => {
         const state = (controller as any)._state;
 
@@ -581,35 +498,5 @@ suite("TableDesignerWebviewController tests", () => {
             td.LoadState.NotStarted,
             "publishState should be set to NotStarted",
         );
-    });
-
-    test("should copy publishing error to clipboard in copyPublishErrorToClipboard reducer", async () => {
-        const writeTextStub = sinon.stub().resolves();
-        const showInfoStub = sinon.stub().resolves();
-
-        const mockEnvClipboard = {
-            ...vscode.env.clipboard,
-            writeText: writeTextStub,
-        };
-
-        // Replace clipboard and window with stubs
-        sandbox.replaceGetter(vscode.env, "clipboard", () => mockEnvClipboard);
-        sandbox.replace(vscode.window, "showInformationMessage", showInfoStub);
-
-        // Setup state
-        const state = {
-            publishingError: "Something went wrong",
-        };
-
-        await controller["_reducerHandlers"].get("copyPublishErrorToClipboard")(state, mockPayload);
-
-        assert.ok(writeTextStub.calledOnce, "Clipboard writeText should be called once");
-        assert.strictEqual(
-            writeTextStub.firstCall.args[0],
-            "Something went wrong",
-            "writeText should be called with the publishing error",
-        );
-
-        assert.ok(showInfoStub.calledOnce, "showInformationMessage should be called once");
     });
 });


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

## Schema Designer

### 1. Publish Icon Update
Changes the schema designer publish icon to be a regular icon for better readability.

| Before | After |
|--------|-------|
| <img width="143" height="41" alt="image" src="https://github.com/user-attachments/assets/243eaae1-8fdb-4a81-afef-142c30e5446a" /> | <img width="141" height="39" alt="image" src="https://github.com/user-attachments/assets/bf957263-61d0-42fe-9add-99d546cdb57f" /> |

---

### 2. Markdown Display Improvements
Improves the schema designer Markdown display with better formatting for readability.

| Before | After |
|--------|-------|
| <img width="799" height="728" alt="image" src="https://github.com/user-attachments/assets/f1c4a8de-4093-43fd-8387-675d76003772" /> | <img width="799" height="733" alt="image" src="https://github.com/user-attachments/assets/9dfc59eb-5a9a-4a13-87ab-7c8dbc5f33d7" /> |

---

### 3. Definition Pane Styling
The definition pane is now a generic component, adopting schema designer styling.  
There are no visual changes, but the component is reusable.

| Before | After |
|--------|-------|
| <img width="1336" height="905" alt="image" src="https://github.com/user-attachments/assets/e21a8777-acc6-4051-b590-4fc5c4e9bcf7" /> | <img width="1337" height="908" alt="image" src="https://github.com/user-attachments/assets/a9652ccc-892e-4b45-8c66-f80d0c18e76e" /> |

### 4. Showing information message when script is copied.
Just nice visual feedback that the definition script is copied. Table designer already had this feedback.

<img width="469" height="71" alt="image" src="https://github.com/user-attachments/assets/bc333d4e-5bef-4e93-ae07-24fe2e4f5d7d" />


## Table Designer:
### 1. Public Icon and Label Update
Updates the public icon and label to match schema designer.  
Fixes #19268  

| Before | After |
|--------|-------|
| <img width="103" height="41" alt="image" src="https://github.com/user-attachments/assets/af7b860b-525a-417f-be3e-1ebff302710e" /> | <img width="134" height="36" alt="image" src="https://github.com/user-attachments/assets/69dedf5a-d901-4786-8fa5-6b995ecd9e08" /> |

---

### 2. Script Update: Create → Definition
Updates “Script as Create” to “Script as Definition” for consistency with schema designer.  
Adds toggles to the **View Definition** button at the top.  
Fixes #19267 and #19266  

| Before | After |
|--------|-------|
| <img width="1160" height="249" alt="image" src="https://github.com/user-attachments/assets/db77fd2b-bf40-4d77-9478-ba28c3933a2b" /> | <img width="1168" height="215" alt="image" src="https://github.com/user-attachments/assets/b6ec7bd8-4433-4a66-a3aa-4a5f0b7654d4" /> |

---

### 3. Toolbar Definition Button
Adds a new **Definition** button in the toolbar.

| New Toolbar Button |
|--------------------|
| <img width="273" height="36" alt="image" src="https://github.com/user-attachments/assets/9e180d94-690e-43c3-9e75-4ad9b637a171" /> |

---

### 4. Publish Dialog Update
Enhances the publish dialog with improved styling and layout.

| Before | After |
|--------|-------|
| <img width="602" height="480" alt="image" src="https://github.com/user-attachments/assets/fe7bc119-7ced-4c75-b07b-47219ba88478" /> | <img width="809" height="683" alt="image" src="https://github.com/user-attachments/assets/618a3a61-5ea3-4975-8de5-7e1ea1e2e805" /> |

---

### 5. Properties Pane Styling and Gear Icon
Updates the styling of the properties pane.  
Adds a **gear icon** to toggle the properties pane instead of auto-showing on row focus.  
Fixes #19264  

| Gear Icon for Properties Pane |
|-------------------------------|
| <img width="631" height="608" alt="image" src="https://github.com/user-attachments/assets/4edc8889-063c-4aa3-bcf5-7e07f658375a" /> |


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

