### PR TITLE
Allowing users to quickly change connections 

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3429,6 +3429,9 @@
     <trans-unit id="mssql.cancelQuery">
       <source xml:lang="en">Cancel Query</source>
     </trans-unit>
+    <trans-unit id="mssql.changeConnection">
+      <source xml:lang="en">Change Connection</source>
+    </trans-unit>
     <trans-unit id="mssql.changeDatabase">
       <source xml:lang="en">Change Database</source>
     </trans-unit>

--- a/package.json
+++ b/package.json
@@ -384,24 +384,29 @@
                     "group": "navigation@3"
                 },
                 {
-                    "command": "mssql.changeDatabase",
+                    "command": "mssql.changeConnection",
                     "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries",
                     "group": "navigation@4"
+                },
+                {
+                    "command": "mssql.changeDatabase",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries",
+                    "group": "navigation@5"
                 },
                 {
                     "command": "mssql.showEstimatedPlan",
                     "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries",
-                    "group": "navigation@4"
+                    "group": "navigation@10"
                 },
                 {
                     "command": "mssql.enableActualPlan",
                     "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && (resource not in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
-                    "group": "navigation@5"
+                    "group": "navigation@11"
                 },
                 {
                     "command": "mssql.disableActualPlan",
                     "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && (resource in mssql.executionPlan.urisWithActualPlanEnabled) && (resourcePath not in mssql.runningQueries)",
-                    "group": "navigation@5"
+                    "group": "navigation@12"
                 }
             ],
             "editor/context": [
@@ -844,6 +849,15 @@
                 "command": "mssql.filterNodeWithExistingFilters",
                 "title": "%mssql.filterNode%",
                 "icon": "$(filter-filled)"
+            },
+            {
+                "command": "mssql.changeConnection",
+                "title": "%mssql.changeConnection%",
+                "category": "MS SQL",
+                "icon": {
+                    "dark": "media/changeConnection_dark.svg",
+                    "light": "media/changeConnection_light.svg"
+                }
             },
             {
                 "command": "mssql.changeDatabase",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
     "mssql.cancelQuery": "Cancel Query",
     "mssql.revealQueryResult": "Reveal Query Result",
     "mssql.copyAll": "Copy All",
+    "mssql.changeConnection": "Change Connection",
     "mssql.changeDatabase": "Change Database",
     "mssql.addObjectExplorerLegacy": "Add Connection (Legacy)",
     "mssql.addObjectExplorer": "Add Connection",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -34,6 +34,7 @@ export const cmdrevealQueryResult = "mssql.revealQueryResult";
 export const cmdCopyAll = "mssql.copyAll";
 export const cmdConnect = "mssql.connect";
 export const cmdDisconnect = "mssql.disconnect";
+export const cmdChangeConnection = "mssql.changeConnection";
 export const cmdChangeDatabase = "mssql.changeDatabase";
 export const cmdChooseDatabase = "mssql.chooseDatabase";
 export const cmdChooseLanguageFlavor = "mssql.chooseLanguageFlavor";

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -204,6 +204,10 @@ export default class MainController implements vscode.Disposable {
             this._event.on(Constants.cmdConnect, () => {
                 void this.runAndLogErrors(this.onNewConnection());
             });
+            this.registerCommand(Constants.cmdChangeConnection);
+            this._event.on(Constants.cmdChangeConnection, () => {
+                void this.runAndLogErrors(this.onNewConnection());
+            });
             this.registerCommand(Constants.cmdDisconnect);
             this._event.on(Constants.cmdDisconnect, () => {
                 void this.runAndLogErrors(this.onDisconnect());

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -204,6 +204,7 @@ export default class SqlDocumentService implements vscode.Disposable {
         if (activeConnection) {
             this._lastActiveConnectionInfo = Utils.deepClone(activeConnection);
         }
+        this._statusview?.onDidChangeActiveTextEditor(editor, activeConnection !== undefined);
     }
 
     /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -113,19 +113,3 @@ export function getEditorEOL(): string {
         ? os.EOL
         : vscode.workspace.getConfiguration("files").get<string>("eol");
 }
-
-/**
- * Trims the given display string to the specified maximum length, adding an ellipsis if trimmed.
- * @param displayString long display string
- * @param maxLength maximum length of the string, 0 for empty string, negative or undefined for no limit
- * @returns trimmed display string
- */
-export function trimDisplayString(displayString: string, maxLength: number): string {
-    let result = displayString;
-    if (maxLength === 0) {
-        result = "";
-    } else if (maxLength > 0 && result.length > maxLength) {
-        result = result.slice(0, maxLength) + " \u2026"; // add ellipsis
-    }
-    return result;
-}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -113,3 +113,19 @@ export function getEditorEOL(): string {
         ? os.EOL
         : vscode.workspace.getConfiguration("files").get<string>("eol");
 }
+
+/**
+ * Trims the given display string to the specified maximum length, adding an ellipsis if trimmed.
+ * @param displayString long display string
+ * @param maxLength maximum length of the string, 0 for empty string, negative or undefined for no limit
+ * @returns trimmed display string
+ */
+export function trimDisplayString(displayString: string, maxLength: number): string {
+    let result = displayString;
+    if (maxLength === 0) {
+        result = "";
+    } else if (maxLength > 0 && result.length > maxLength) {
+        result = result.slice(0, maxLength) + " \u2026"; // add ellipsis
+    }
+    return result;
+}

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -44,7 +44,6 @@ class FileStatusBar {
 export default class StatusView implements vscode.Disposable {
     private _statusBars: { [fileUri: string]: FileStatusBar };
     private _lastShownStatusBar: FileStatusBar;
-    private _onDidChangeActiveTextEditorEvent: vscode.Disposable;
     private _onDidCloseTextDocumentEvent: vscode.Disposable;
     private _connectionStore: ConnectionStore;
 

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -13,7 +13,7 @@ import * as ConnectionContracts from "../models/contracts/connection";
 import * as Utils from "../models/utils";
 import { ConnectionStore } from "../models/connectionStore";
 import { IConnectionProfile } from "../models/interfaces";
-import { getUriKey, trimDisplayString } from "../utils/utils";
+import { getUriKey } from "../utils/utils";
 
 // Status bar element for each file in the editor
 class FileStatusBar {
@@ -198,6 +198,26 @@ export default class StatusView implements vscode.Disposable {
         this.showStatusBarItem(fileUri, bar.statusConnection);
     }
 
+    /**
+     * Trims the given display string to the specified maximum length, adding an ellipsis if trimmed.
+     * Since status bar has limited space, this helps to avoid a status bar item occupying too much space.
+     * @param displayString long display string
+     * @param maxLength maximum length of the string, 0 for empty string, negative or undefined for no limit
+     * @returns trimmed display string
+     */
+    private trimDisplayString(displayString: string, maxLength: number): string {
+        let result = displayString;
+        if (maxLength === undefined || maxLength < 0) {
+            return result;
+        }
+        if (maxLength === 0) {
+            result = "";
+        } else if (maxLength > 0 && result.length > maxLength) {
+            result = result.slice(0, maxLength) + " \u2026"; // add ellipsis
+        }
+        return result;
+    }
+
     public async connectSuccess(
         fileUri: string,
         connCreds: IConnectionInfo,
@@ -208,13 +228,13 @@ export default class StatusView implements vscode.Disposable {
         const statusBarConnectionInfoMaxLength: number = vscode.workspace
             .getConfiguration(Constants.extensionConfigSectionName)
             .get(Constants.configStatusBarConnectionInfoMaxLength);
-        bar.statusConnection.text = trimDisplayString(
+        bar.statusConnection.text = this.trimDisplayString(
             `$(check) ${ConnInfo.generateServerDisplayName(connCreds)}`,
             statusBarConnectionInfoMaxLength,
         );
         bar.statusConnection.tooltip = ConnInfo.getTooltip(connCreds, serverInfo);
 
-        bar.statusChangeDatabase.text = trimDisplayString(
+        bar.statusChangeDatabase.text = this.trimDisplayString(
             ConnInfo.generateDatabaseDisplayName(connCreds, true),
             statusBarConnectionInfoMaxLength,
         );

--- a/src/views/statusView.ts
+++ b/src/views/statusView.ts
@@ -63,6 +63,7 @@ export default class StatusView implements vscode.Disposable {
             if (this._statusBars.hasOwnProperty(bar)) {
                 this._statusBars[bar].statusLanguageFlavor.dispose();
                 this._statusBars[bar].statusConnection.dispose();
+                this._statusBars[bar].statusChangeDatabase.dispose();
                 this._statusBars[bar].statusQuery.dispose();
                 this._statusBars[bar].statusLanguageService.dispose();
                 this._statusBars[bar].sqlCmdMode.dispose();
@@ -73,7 +74,6 @@ export default class StatusView implements vscode.Disposable {
                 delete this._statusBars[bar];
             }
         }
-        this._onDidChangeActiveTextEditorEvent.dispose();
         this._onDidCloseTextDocumentEvent.dispose();
     }
 

--- a/test/unit/statusView.test.ts
+++ b/test/unit/statusView.test.ts
@@ -15,110 +15,105 @@ import { ConnectionStore } from "../../src/models/connectionStore";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 
 suite("Status View Tests", () => {
-    test("updateStatusMessage should not immediately update status message for definition request", (done) => {
-        return new Promise((resolve, reject) => {
-            let statusView = new StatusView();
-            let newStatus = LocalizedConstants.definitionRequestedStatus;
-            let currentStatus = "";
-            let getCurrentStatus = () => {
-                return currentStatus;
-            };
-            let actualStatusMessage = "";
-            let expectedStatusMessage = LocalizedConstants.gettingDefinitionMessage;
-            let updateMessage = (message) => {
-                actualStatusMessage = message;
-            };
-            statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
-            assert.equal(actualStatusMessage, "");
+    test("updateStatusMessage should not immediately update status message for definition request", async () => {
+        let statusView = new StatusView();
+        let newStatus = LocalizedConstants.definitionRequestedStatus;
+        let currentStatus = "";
+        let getCurrentStatus = () => {
+            return currentStatus;
+        };
+        let actualStatusMessage = "";
+        let expectedStatusMessage = LocalizedConstants.gettingDefinitionMessage;
+        let updateMessage = (message: string) => {
+            actualStatusMessage = message;
+        };
+        statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
+        assert.equal(actualStatusMessage, "");
+
+        await new Promise((resolve) => {
             setTimeout(() => {
                 assert.equal(actualStatusMessage, expectedStatusMessage);
+                resolve(undefined);
             }, 600);
-            statusView.dispose();
-            done();
         });
+
+        statusView.dispose();
     });
 
-    test("updateStatusMessage should not update status message for definition request if already completed", (done) => {
-        return new Promise((resolve, reject) => {
-            let statusView = new StatusView();
-            let newStatus = LocalizedConstants.definitionRequestedStatus;
-            let currentStatus = LocalizedConstants.definitionRequestCompletedStatus;
-            let getCurrentStatus = () => {
-                return currentStatus;
-            };
-            let actualStatusMessage = "";
-            let expectedStatusMessage = "";
-            let updateMessage = (message) => {
-                actualStatusMessage = message;
-            };
-            statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
-            assert.equal(actualStatusMessage, "");
+    test("updateStatusMessage should not update status message for definition request if already completed", async () => {
+        let statusView = new StatusView();
+        let newStatus = LocalizedConstants.definitionRequestedStatus;
+        let currentStatus = LocalizedConstants.definitionRequestCompletedStatus;
+        let getCurrentStatus = () => {
+            return currentStatus;
+        };
+        let actualStatusMessage = "";
+        let expectedStatusMessage = "";
+        let updateMessage = (message: string) => {
+            actualStatusMessage = message;
+        };
+        statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
+        assert.equal(actualStatusMessage, "");
+
+        await new Promise((resolve) => {
             setTimeout(() => {
                 assert.equal(actualStatusMessage, expectedStatusMessage);
+                resolve(undefined);
             }, 600);
-            statusView.dispose();
-            done();
         });
+
+        statusView.dispose();
     });
 
-    test("updateStatusMessage should update status message for definition request completed", (done) => {
-        return new Promise((resolve, reject) => {
-            let statusView = new StatusView();
-            let newStatus = LocalizedConstants.definitionRequestCompletedStatus;
-            let currentStatus = LocalizedConstants.definitionRequestCompletedStatus;
-            let getCurrentStatus = () => {
-                return currentStatus;
-            };
-            let actualStatusMessage = "";
-            let expectedStatusMessage = "";
-            let updateMessage = (message) => {
-                actualStatusMessage = message;
-            };
-            statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
-            assert.equal(actualStatusMessage, expectedStatusMessage);
-            statusView.dispose();
-            done();
-        });
+    test("updateStatusMessage should update status message for definition request completed", () => {
+        let statusView = new StatusView();
+        let newStatus = LocalizedConstants.definitionRequestCompletedStatus;
+        let currentStatus = LocalizedConstants.definitionRequestCompletedStatus;
+        let getCurrentStatus = () => {
+            return currentStatus;
+        };
+        let actualStatusMessage = "";
+        let expectedStatusMessage = "";
+        let updateMessage = (message: string) => {
+            actualStatusMessage = message;
+        };
+        statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
+        assert.equal(actualStatusMessage, expectedStatusMessage);
+        statusView.dispose();
     });
 
-    test("updateStatusMessage should update status message for updating intelliSense", (done) => {
-        return new Promise((resolve, reject) => {
-            let statusView = new StatusView();
-            let newStatus = LocalizedConstants.updatingIntelliSenseStatus;
-            let currentStatus = "";
-            let getCurrentStatus = () => {
-                return currentStatus;
-            };
-            let actualStatusMessage = "";
-            let expectedStatusMessage = LocalizedConstants.updatingIntelliSenseLabel;
-            let updateMessage = (message) => {
-                actualStatusMessage = message;
-            };
-            statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
-            assert.equal(actualStatusMessage, expectedStatusMessage);
-            statusView.dispose();
-            done();
-        });
+    test("updateStatusMessage should update status message for updating intelliSense", () => {
+        let statusView = new StatusView();
+        let newStatus = LocalizedConstants.updatingIntelliSenseStatus;
+        let currentStatus = "";
+        let getCurrentStatus = () => {
+            return currentStatus;
+        };
+        let actualStatusMessage = "";
+        let expectedStatusMessage = LocalizedConstants.updatingIntelliSenseLabel;
+        let updateMessage = (message: string) => {
+            actualStatusMessage = message;
+        };
+        statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
+        assert.equal(actualStatusMessage, expectedStatusMessage);
+        statusView.dispose();
     });
 
-    test("updateStatusMessage should update status message for intelliSense updated status", (done) => {
-        return new Promise((resolve, reject) => {
-            let statusView = new StatusView();
-            let newStatus = LocalizedConstants.intelliSenseUpdatedStatus;
-            let currentStatus = "";
-            let getCurrentStatus = () => {
-                return currentStatus;
-            };
-            let actualStatusMessage = "";
-            let expectedStatusMessage = "";
-            let updateMessage = (message) => {
-                actualStatusMessage = message;
-            };
-            statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
-            assert.equal(actualStatusMessage, expectedStatusMessage);
-            statusView.dispose();
-            done();
-        });
+    test("updateStatusMessage should update status message for intelliSense updated status", () => {
+        let statusView = new StatusView();
+        let newStatus = LocalizedConstants.intelliSenseUpdatedStatus;
+        let currentStatus = "";
+        let getCurrentStatus = () => {
+            return currentStatus;
+        };
+        let actualStatusMessage = "";
+        let expectedStatusMessage = "";
+        let updateMessage = (message: string) => {
+            actualStatusMessage = message;
+        };
+        statusView.updateStatusMessage(newStatus, getCurrentStatus, updateMessage);
+        assert.equal(actualStatusMessage, expectedStatusMessage);
+        statusView.dispose();
     });
 
     suite("Colorization tests", () => {


### PR DESCRIPTION
## Description
Fixes #18867

1. Added a **change connection** icon in the status bar.   Matches ADS change connection icon
<img width="279" height="75" alt="image" src="https://github.com/user-attachments/assets/d83ddcbb-43d9-4334-8422-ba4cc0f31265" />

2. Split the status bar into two buttons: one for changing the connection and another for changing the database.  

| Before | Now |
|--------|-----|
| <img width="222" height="163" alt="image" src="https://github.com/user-attachments/assets/c3f3d69f-bc4d-4bc8-ad3d-3797dbed3cd7" />| <img width="250" height="150" alt="image" src="https://github.com/user-attachments/assets/3a8dd8c8-7862-4203-86e1-e6ce1d8b3b66" /> <img width="139" height="64" alt="image" src="https://github.com/user-attachments/assets/31c885fe-e117-4e3c-b13d-1f5c0a6c8c64" /> |




## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

