### PR TITLE
Fixing context values for connections and running queries. 

### DIFF
--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1085,12 +1085,13 @@ export default class ConnectionManager {
          * contexts.
          * https://github.com/microsoft/vscode/blob/bb5a3c607b14787009f8e9fadb720beee596133c/src/vs/workbench/common/contextkeys.ts#L261C1-L262C1
          */
-        const connectionContext = [];
-        Object.keys(this._connections).forEach((key) => {
-            const Uri = vscode.Uri.parse(key);
-            connectionContext.push(Uri.toString());
-        });
-        vscode.commands.executeCommand("setContext", "mssql.connections", connectionContext);
+        vscode.commands.executeCommand(
+            "setContext",
+            "mssql.connections",
+            Object.keys(this._connections).map((key) => {
+                return vscode.Uri.parse(key).toString();
+            }),
+        );
     }
 
     /**

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -1084,6 +1084,7 @@ export default class ConnectionManager {
          * This is done to match the behavior of how vscode core handles resource URIs in
          * contexts.
          * https://github.com/microsoft/vscode/blob/bb5a3c607b14787009f8e9fadb720beee596133c/src/vs/workbench/common/contextkeys.ts#L261C1-L262C1
+         * TODO: aaskhan find the underlying issue that causes the mismatch in encoding and fix it.
          */
         vscode.commands.executeCommand(
             "setContext",

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -654,7 +654,7 @@ export default class ConnectionManager {
                 }
                 await self.handleConnectionErrors(fileUri, connection, result);
             }
-            if (!result.errorMessage || result.errorNumber !== 0) {
+            if (!result.errorMessage) {
                 await self.tryAddMruConnection(connection);
             }
         };
@@ -785,12 +785,6 @@ export default class ConnectionManager {
                 result.errorMessage ? result.errorMessage : result.messages,
             ),
         );
-        /**
-         * Making sure to clean up the connection if it exists since the connection failed
-         * and firing the onConnectionsChanged event so UI elements like codelens can update.
-         */
-        delete this._connections[fileUri];
-        this._onConnectionsChangedEmitter.fire();
         sendErrorEvent(
             TelemetryViews.ConnectionPrompt,
             TelemetryActions.CreateConnectionResult,
@@ -1205,6 +1199,11 @@ export default class ConnectionManager {
                     return false;
                 }
             }
+
+            // Clean up failed connection and fire event to update UI elements like codelens
+            delete this._connections[fileUri];
+            this._onConnectionsChangedEmitter.fire();
+            return false;
         } else {
             return true;
         }

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -311,8 +311,8 @@ export default class QueryRunner {
         this._isExecuting = true;
         this._totalElapsedMilliseconds = 0;
         this._statusView.executingQuery(this.uri);
-        QueryRunner._runningQueries.push(vscode.Uri.parse(this._ownerUri).path);
-        this.updateRunningQueries();
+
+        this.addRunningQuery(this._ownerUri);
 
         this._notificationHandler.registerRunner(this, this._ownerUri);
 
@@ -336,16 +336,6 @@ export default class QueryRunner {
             onError(error);
             throw error;
         }
-    }
-
-    /**
-     * Remove uri from runningQueries
-     */
-    private removeRunningQuery(): void {
-        QueryRunner._runningQueries = QueryRunner._runningQueries.filter(
-            (fileName) => fileName !== vscode.Uri.parse(this._ownerUri).path,
-        );
-        this.updateRunningQueries();
     }
 
     // handle the result of the notification
@@ -1679,6 +1669,31 @@ export default class QueryRunner {
 
         // Return as string
         return value;
+    }
+
+    /**
+     * Vscode core expects uri.fsPath for resourcePath context value.
+     * https://github.com/microsoft/vscode/blob/bb5a3c607b14787009f8e9fadb720beee596133c/src/vs/workbench/common/contextkeys.ts#L275
+     */
+
+    /**
+     * Add query to running queries list
+     * @param ownerUri The owner URI of the query
+     */
+    private addRunningQuery(ownerUri: string): void {
+        const key = vscode.Uri.parse(ownerUri).fsPath;
+        QueryRunner._runningQueries.push(key);
+        this.updateRunningQueries();
+    }
+
+    /**
+     * Remove current query from running queries list
+     */
+    private removeRunningQuery(): void {
+        QueryRunner._runningQueries = QueryRunner._runningQueries.filter(
+            (fileName) => fileName !== vscode.Uri.parse(this._ownerUri).fsPath,
+        );
+        this.updateRunningQueries();
     }
 
     private updateRunningQueries() {

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -312,7 +312,7 @@ export default class QueryRunner {
         this._totalElapsedMilliseconds = 0;
         this._statusView.executingQuery(this.uri);
 
-        this.addRunningQuery(this._ownerUri);
+        QueryRunner.addRunningQuery(this._ownerUri);
 
         this._notificationHandler.registerRunner(this, this._ownerUri);
 
@@ -1680,10 +1680,10 @@ export default class QueryRunner {
      * Add query to running queries list
      * @param ownerUri The owner URI of the query
      */
-    private addRunningQuery(ownerUri: string): void {
+    private static addRunningQuery(ownerUri: string): void {
         const key = vscode.Uri.parse(ownerUri).fsPath;
         QueryRunner._runningQueries.push(key);
-        this.updateRunningQueries();
+        QueryRunner.updateRunningQueries();
     }
 
     /**
@@ -1693,10 +1693,10 @@ export default class QueryRunner {
         QueryRunner._runningQueries = QueryRunner._runningQueries.filter(
             (fileName) => fileName !== vscode.Uri.parse(this._ownerUri).fsPath,
         );
-        this.updateRunningQueries();
+        QueryRunner.updateRunningQueries();
     }
 
-    private updateRunningQueries() {
+    private static updateRunningQueries() {
         vscode.commands.executeCommand(
             "setContext",
             "mssql.runningQueries",


### PR DESCRIPTION
## Description
This fixes the context variable to match the vscode's expected values.  This fixes the issues where we are not updating toolbar icons properly when the files are connected or the query is running. 

For example,  the query has started executing (as seen in the status bar) but it doesn't reflect in toolbar. 

<img width="1332" height="1108" alt="image" src="https://github.com/user-attachments/assets/5d046073-92e3-4537-9281-195cbe6a818b" />


1. In mssql.connection, we store the resource using uri.toString(true) whereas vscode expects uri.toString().
https://github.com/microsoft/vscode/blob/bb5a3c607b14787009f8e9fadb720beee596133c/src/vs/workbench/…
1. In mssql.runningQueries, we store the resourcePath using uri.path where as vscode expects uri.fsPath. 
https://github.com/microsoft/vscode/blob/bb5a3c607b14787009f8e9fadb720beee596133c/src/vs/workbench/…


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

