### PR TITLE
Fix webview panel creation. 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -456,6 +456,7 @@
     ]
   },
   "Loading text view...": "Loading text view...",
+  "Please wait while the results are being loaded...": "Please wait while the results are being loaded...",
   "No results for the active editor": "No results for the active editor",
   "Run a query in the current editor, or switch to an editor that has results.": "Run a query in the current editor, or switch to an editor that has results.",
   "Add new column": "Add new column",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -456,7 +456,7 @@
     ]
   },
   "Loading text view...": "Loading text view...",
-  "Please wait while the results are being loaded...": "Please wait while the results are being loaded...",
+  "Loading results...": "Loading results...",
   "No results for the active editor": "No results for the active editor",
   "Run a query in the current editor, or switch to an editor that has results.": "Run a query in the current editor, or switch to an editor that has results.",
   "Add new column": "Add new column",

--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -459,6 +459,7 @@
   "Loading results...": "Loading results...",
   "No results for the active editor": "No results for the active editor",
   "Run a query in the current editor, or switch to an editor that has results.": "Run a query in the current editor, or switch to an editor that has results.",
+  "Failed to start query.": "Failed to start query.",
   "Add new column": "Add new column",
   "Table": "Table",
   "Save": "Save",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2265,6 +2265,9 @@
     <trans-unit id="++CODE++2e0422920bb9bd61c1c7edf3554564e5ca37f4f0bc5d5a96b0402fb3a4c00155">
       <source xml:lang="en">Please select a workspace where you have sufficient permissions (Contributor or higher)</source>
     </trans-unit>
+    <trans-unit id="++CODE++d89a0118be9cdeac31865e642e6a790922feb0117bffe1c6accb6459d7509d09">
+      <source xml:lang="en">Please wait while the results are being loaded...</source>
+    </trans-unit>
     <trans-unit id="++CODE++72e9a59f5a1d6289dbacb35df897d6c007c55a27e77018455c37e7b372668475">
       <source xml:lang="en">Port</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1843,6 +1843,9 @@
     <trans-unit id="++CODE++934bbb16d95b8f72c6353bba1afc96aee3975ae50aaca4b3abe9389f292b4987">
       <source xml:lang="en">Loading local containers...</source>
     </trans-unit>
+    <trans-unit id="++CODE++b00da16333ce9b6f0088556c62cd8766f0a1f02a823e3dca0cd8fd040136e297">
+      <source xml:lang="en">Loading results...</source>
+    </trans-unit>
     <trans-unit id="++CODE++6fdb41249bacbb3684e7217e3b3d938e36b39e8d0f4300681cba1968b3301495">
       <source xml:lang="en">Loading tenants...</source>
     </trans-unit>
@@ -2264,9 +2267,6 @@
     </trans-unit>
     <trans-unit id="++CODE++2e0422920bb9bd61c1c7edf3554564e5ca37f4f0bc5d5a96b0402fb3a4c00155">
       <source xml:lang="en">Please select a workspace where you have sufficient permissions (Contributor or higher)</source>
-    </trans-unit>
-    <trans-unit id="++CODE++d89a0118be9cdeac31865e642e6a790922feb0117bffe1c6accb6459d7509d09">
-      <source xml:lang="en">Please wait while the results are being loaded...</source>
     </trans-unit>
     <trans-unit id="++CODE++72e9a59f5a1d6289dbacb35df897d6c007c55a27e77018455c37e7b372668475">
       <source xml:lang="en">Port</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1366,6 +1366,9 @@
     <trans-unit id="++CODE++cc941d13be3079b6fc2c4cf73df1e3583aca4d5f0df87203767037625e8d37aa">
       <source xml:lang="en">Failed to start SQL Server container. Please check the error message for more details, and then try again.</source>
     </trans-unit>
+    <trans-unit id="++CODE++08e3cce193c1731c751f4e68352687632cb9edb3e01e8bc9200742d0bd5f7b2c">
+      <source xml:lang="en">Failed to start query.</source>
+    </trans-unit>
     <trans-unit id="++CODE++8d966abf7ce439608c05903323ea676d64af27e6119ddcc6edebd6db2cd5c479">
       <source xml:lang="en">Failed to start {0}.</source>
       <note>Failed to start {0}.</note>

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -92,6 +92,9 @@ export default class QueryRunner {
     private _uriToQueryStringMap = new Map<string, string>();
     private static _runningQueries = [];
 
+    private _startFailedEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    public onStartFailed: vscode.Event<string> = this._startFailedEmitter.event;
+
     private _startEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     public onStart: vscode.Event<string> = this._startEmitter.event;
 
@@ -333,6 +336,7 @@ export default class QueryRunner {
             // Show error message here to ensure test expectation is met
             let errorMsg = error instanceof Error ? error.message : String(error);
             this._vscodeWrapper.showErrorMessage("Execution failed: " + errorMsg);
+            this._startFailedEmitter.fire(this.uri);
             onError(error);
             throw error;
         }

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -291,7 +291,6 @@ export default class QueryRunner {
             if (promise) {
                 this._uriToQueryPromiseMap.set(this._ownerUri, promise);
             }
-            throw new Error("Query execution failed");
             await this._client
                 .sendRequest(QueryExecuteRequest.type, queryDetails)
                 .then(onSuccess, onError);

--- a/src/controllers/reactWebviewBaseController.ts
+++ b/src/controllers/reactWebviewBaseController.ts
@@ -47,6 +47,8 @@ import {
     RequestType,
 } from "vscode-jsonrpc/node";
 import { MessageReader } from "vscode-languageclient";
+import { Deferred } from "../protocol";
+
 class WebviewControllerMessageReader extends AbstractMessageReader implements MessageReader {
     private _onData: Emitter<Message>;
     private _disposables: vscode.Disposable[] = [];
@@ -126,6 +128,11 @@ export abstract class ReactWebviewBaseController<State, Reducers> implements vsc
     private _isDisposed: boolean = false;
     private _onDisposed: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     public readonly onDisposed: vscode.Event<void> = this._onDisposed.event;
+
+    /**
+     * A one-time promise that resolves when the webview is ready to receive messages.
+     */
+    private _webviewReady: Deferred<void> = new Deferred<void>();
 
     private _state: State;
     private _isFirstLoad: boolean = true;
@@ -288,6 +295,12 @@ export abstract class ReactWebviewBaseController<State, Reducers> implements vsc
             const timeStamp = message.loadCompleteTimeStamp;
             const timeToLoad = timeStamp - this._loadStartTime;
             if (this._isFirstLoad) {
+                /**
+                 * This notification is sent from the webview when it has finished loading. We use
+                 * this to track when the webview is ready to receive messages.
+                 */
+                this._webviewReady.resolve();
+
                 console.log(
                     `Load stats for ${this._sourceFile}` + "\n" + `Total time: ${timeToLoad} ms`,
                 );
@@ -496,6 +509,21 @@ export abstract class ReactWebviewBaseController<State, Reducers> implements vsc
         this._onDisposed.fire();
         this._disposables.forEach((d) => d.dispose());
         this._isDisposed = true;
+    }
+
+    /**
+     * Returns a promise that resolves when the webview has finished its initial load
+     * and is ready to receive JSON-RPC requests/notifications. Use this before sending
+     * any messages that require the webview script side to be active.
+     * Typical usage:
+     * ```typescript
+     * await controller.whenWebviewReady();
+     * await controller.sendRequest(...); // safe to send requests now
+     * ```
+     * @returns
+     */
+    public whenWebviewReady(): Promise<void> {
+        return this._webviewReady.promise;
     }
 }
 

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -337,6 +337,10 @@ export class SqlOutputContentProvider {
                 executionPlanOptions?.includeActualExecutionPlanXml,
             this._actualPlanStatuses.includes(uri),
         );
+        if (isOpenQueryResultsInTabByDefaultEnabled()) {
+            await this._queryResultWebviewController.createPanelController(queryRunner.uri);
+            await new Promise<void>((resolve) => setTimeout(resolve, 300));
+        }
         if (queryRunner) {
             void queryCallback(queryRunner);
         }
@@ -371,9 +375,6 @@ export class SqlOutputContentProvider {
                 );
                 resultWebviewState.tabStates.resultPaneTab = QueryResultPaneTabs.Messages;
                 resultWebviewState.isExecutionPlan = false;
-                if (isOpenQueryResultsInTabByDefaultEnabled()) {
-                    await this._queryResultWebviewController.createPanelController(queryRunner.uri);
-                }
                 this.updateWebviewState(queryRunner.uri, resultWebviewState);
                 this.revealQueryResult(queryRunner.uri);
                 sendActionEvent(TelemetryViews.QueryResult, TelemetryActions.OpenQueryResult, {

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -368,12 +368,23 @@ export class SqlOutputContentProvider {
             // and map it to the results uri
             queryRunner = new QueryRunner(uri, title, statusView ? statusView : this._statusView);
 
+            const startFailedListener = queryRunner.onStartFailed(async (error) => {
+                this.updateWebviewState(queryRunner.uri, {
+                    initializationError: getErrorMessage(error),
+                    resultSetSummaries: {},
+                    executionPlanState: {},
+                    messages: [],
+                    fontSettings: { fontSize: 0, fontFamily: "" },
+                });
+            });
+
             const startListener = queryRunner.onStart(async (_panelUri) => {
                 const resultWebviewState = this._queryResultWebviewController.getQueryResultState(
                     queryRunner.uri,
                 );
                 resultWebviewState.tabStates.resultPaneTab = QueryResultPaneTabs.Messages;
                 resultWebviewState.isExecutionPlan = false;
+                resultWebviewState.initializationError = undefined;
                 this.updateWebviewState(queryRunner.uri, resultWebviewState);
                 this.revealQueryResult(queryRunner.uri);
                 sendActionEvent(TelemetryViews.QueryResult, TelemetryActions.OpenQueryResult, {
@@ -533,6 +544,7 @@ export class SqlOutputContentProvider {
 
             const queryRunnerState = new QueryRunnerState(queryRunner);
             queryRunnerState.listeners.push(
+                startFailedListener,
                 startListener,
                 resultSetAvailableListener,
                 resultSetUpdatedListener,

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -339,7 +339,6 @@ export class SqlOutputContentProvider {
         );
         if (isOpenQueryResultsInTabByDefaultEnabled()) {
             await this._queryResultWebviewController.createPanelController(queryRunner.uri);
-            await new Promise<void>((resolve) => setTimeout(resolve, 300));
         }
         if (queryRunner) {
             void queryCallback(queryRunner);

--- a/src/queryHistory/queryHistoryProvider.ts
+++ b/src/queryHistory/queryHistoryProvider.ts
@@ -194,6 +194,9 @@ export class QueryHistoryProvider implements vscode.TreeDataProvider<any> {
      * Creates the node label for a query history node
      */
     private createHistoryNodeLabel(ownerUri: string): string {
+        if (this.getQueryString(ownerUri) === undefined) {
+            return "";
+        }
         const queryString = Utils.limitStringSize(this.getQueryString(ownerUri)).trim();
         const connectionLabel = Utils.limitStringSize(this.getConnectionLabel(ownerUri)).trim();
         return `${queryString} : ${connectionLabel}`;

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -237,6 +237,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         controller.revealToForeground();
         this._queryResultWebviewPanelControllerMap.set(uri, controller);
         this.showSplashScreen();
+        await controller.whenWebviewReady();
     }
 
     public addQueryResultState(

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -215,6 +215,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             },
             autoSizeColumns: this.getAutoSizeColumnsConfig(),
             inMemoryDataProcessingThreshold: this.getInMemoryDataProcessingThresholdConfig(),
+            initializationError: undefined,
         };
     }
 

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -503,7 +503,7 @@ export class LocConstants {
                     comment: ["{0} is the index of the result set"],
                 }),
             loadingTextView: l10n.t("Loading text view..."),
-            loadingResultsMessage: l10n.t("Please wait while the results are being loaded..."),
+            loadingResultsMessage: l10n.t("Loading results..."),
             noResultsHeader: l10n.t("No results for the active editor"),
             noResultMessage: l10n.t(
                 "Run a query in the current editor, or switch to an editor that has results.",

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -503,6 +503,7 @@ export class LocConstants {
                     comment: ["{0} is the index of the result set"],
                 }),
             loadingTextView: l10n.t("Loading text view..."),
+            loadingResultsMessage: l10n.t("Please wait while the results are being loaded..."),
             noResultsHeader: l10n.t("No results for the active editor"),
             noResultMessage: l10n.t(
                 "Run a query in the current editor, or switch to an editor that has results.",

--- a/src/reactviews/common/locConstants.ts
+++ b/src/reactviews/common/locConstants.ts
@@ -508,6 +508,7 @@ export class LocConstants {
             noResultMessage: l10n.t(
                 "Run a query in the current editor, or switch to an editor that has results.",
             ),
+            failedToStartQuery: l10n.t("Failed to start query."),
         };
     }
 

--- a/src/reactviews/common/useVscodeSelector.ts
+++ b/src/reactviews/common/useVscodeSelector.ts
@@ -33,8 +33,8 @@ export function useVscodeSelector<State, Reducers, T>(
     const selected = snap ? selector(snap) : (undefined as T);
     const ref = useRef(selected);
 
-    // Only update ref if we have a valid selection and it's different
-    if (selected !== undefined && !equals(ref.current, selected)) {
+    // Update whenever the selected slice changes
+    if (!equals(ref.current as T, selected as T)) {
         ref.current = selected;
     }
 

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -15,6 +15,7 @@ import {
     makeStyles,
     shorthands,
     Text,
+    Spinner,
 } from "@fluentui/react-components";
 import {
     DataGridBody,
@@ -642,20 +643,33 @@ export const QueryResultPane = () => {
         <div className={classes.root}>
             <div className={classes.noResultsContainer}>
                 <div className={classes.noResultsScrollablePane}>
-                    <div className={classes.noResultsIcon} aria-hidden>
-                        <DatabaseSearch24Regular />
-                    </div>
-                    <Title3>{locConstants.queryResult.noResultsHeader}</Title3>
-                    <Text>{locConstants.queryResult.noResultMessage}</Text>
-                    <Link
-                        className={classes.hidePanelLink}
-                        onClick={async () => {
-                            await context.extensionRpc.sendRequest(ExecuteCommandRequest.type, {
-                                command: "workbench.action.closePanel",
-                            });
-                        }}>
-                        {locConstants.queryResult.clickHereToHideThisPanel}
-                    </Link>
+                    {webviewLocation === "document" ? (
+                        <Spinner
+                            label={locConstants.queryResult.loadingResultsMessage}
+                            labelPosition="below"
+                            size="large"
+                        />
+                    ) : (
+                        <>
+                            <div className={classes.noResultsIcon} aria-hidden>
+                                <DatabaseSearch24Regular />
+                            </div>
+                            <Title3>{locConstants.queryResult.noResultsHeader}</Title3>
+                            <Text>{locConstants.queryResult.noResultMessage}</Text>
+                            <Link
+                                className={classes.hidePanelLink}
+                                onClick={async () => {
+                                    await context.extensionRpc.sendRequest(
+                                        ExecuteCommandRequest.type,
+                                        {
+                                            command: "workbench.action.closePanel",
+                                        },
+                                    );
+                                }}>
+                                {locConstants.queryResult.clickHereToHideThisPanel}
+                            </Link>
+                        </>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -662,6 +662,7 @@ export const QueryResultPane = () => {
                             <ErrorCircle24Regular />
                         </div>
                         <Title3>{locConstants.queryResult.failedToStartQuery}</Title3>
+                        <Text className={classes.noResultMessage}>{initilizationError}</Text>
                     </div>
                 </div>
             </div>

--- a/src/reactviews/pages/QueryResult/queryResultPane.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultPane.tsx
@@ -25,7 +25,7 @@ import {
     RowRenderer,
 } from "@fluentui-contrib/react-data-grid-react-window";
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { DatabaseSearch24Regular, OpenRegular } from "@fluentui/react-icons";
+import { DatabaseSearch24Regular, ErrorCircle24Regular, OpenRegular } from "@fluentui/react-icons";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import ResultGrid, { ResultGridHandle } from "./resultGrid";
 import CommandBar from "./commandBar";
@@ -135,7 +135,18 @@ const useStyles = makeStyles({
         display: "grid",
         placeItems: "center",
         borderRadius: "14px",
+        // Use VS Code theme info color for background accent
+        // color-mix provides theme-aware translucent gradient
         background: "linear-gradient(135deg, rgba(0,120,212,.16), rgba(0,120,212,.06))",
+    },
+    resultErrorIcon: {
+        width: "56px",
+        height: "56px",
+        display: "grid",
+        placeItems: "center",
+        borderRadius: "14px",
+        // Use VS Code theme error color for background accent
+        background: "linear-gradient(135deg, rgba(255,0,0,.16), rgba(255,0,0,.06))",
     },
 });
 
@@ -157,6 +168,9 @@ export const QueryResultPane = () => {
     const resultSetSummaries = useQueryResultSelector<
         Record<number, Record<number, qr.ResultSetSummary>>
     >((s) => s.resultSetSummaries);
+    const initilizationError = useQueryResultSelector<string | undefined>(
+        (s) => s.initializationError,
+    );
     const messages = useQueryResultSelector<qr.IMessage[]>((s) => s.messages);
     const uri = useQueryResultSelector<string | undefined>((s) => s.uri);
     const fontSettings = useQueryResultSelector<qr.FontSettings>((s) => s.fontSettings);
@@ -639,41 +653,60 @@ export const QueryResultPane = () => {
         }, 10);
     }, [uri]);
 
-    return !uri || !hasResultsOrMessages(resultSetSummaries, messages) ? (
-        <div className={classes.root}>
-            <div className={classes.noResultsContainer}>
-                <div className={classes.noResultsScrollablePane}>
-                    {webviewLocation === "document" ? (
-                        <Spinner
-                            label={locConstants.queryResult.loadingResultsMessage}
-                            labelPosition="below"
-                            size="large"
-                        />
-                    ) : (
-                        <>
-                            <div className={classes.noResultsIcon} aria-hidden>
-                                <DatabaseSearch24Regular />
-                            </div>
-                            <Title3>{locConstants.queryResult.noResultsHeader}</Title3>
-                            <Text>{locConstants.queryResult.noResultMessage}</Text>
-                            <Link
-                                className={classes.hidePanelLink}
-                                onClick={async () => {
-                                    await context.extensionRpc.sendRequest(
-                                        ExecuteCommandRequest.type,
-                                        {
-                                            command: "workbench.action.closePanel",
-                                        },
-                                    );
-                                }}>
-                                {locConstants.queryResult.clickHereToHideThisPanel}
-                            </Link>
-                        </>
-                    )}
+    if (initilizationError) {
+        return (
+            <div className={classes.root}>
+                <div className={classes.noResultsContainer}>
+                    <div className={classes.noResultsScrollablePane}>
+                        <div className={classes.resultErrorIcon} aria-hidden>
+                            <ErrorCircle24Regular />
+                        </div>
+                        <Title3>{locConstants.queryResult.failedToStartQuery}</Title3>
+                    </div>
                 </div>
             </div>
-        </div>
-    ) : (
+        );
+    }
+
+    if (!uri || !hasResultsOrMessages(resultSetSummaries, messages)) {
+        return (
+            <div className={classes.root}>
+                <div className={classes.noResultsContainer}>
+                    <div className={classes.noResultsScrollablePane}>
+                        {webviewLocation === "document" ? (
+                            <Spinner
+                                label={locConstants.queryResult.loadingResultsMessage}
+                                labelPosition="below"
+                                size="large"
+                            />
+                        ) : (
+                            <>
+                                <div className={classes.noResultsIcon} aria-hidden>
+                                    <DatabaseSearch24Regular />
+                                </div>
+                                <Title3>{locConstants.queryResult.noResultsHeader}</Title3>
+                                <Text>{locConstants.queryResult.noResultMessage}</Text>
+                                <Link
+                                    className={classes.hidePanelLink}
+                                    onClick={async () => {
+                                        await context.extensionRpc.sendRequest(
+                                            ExecuteCommandRequest.type,
+                                            {
+                                                command: "workbench.action.closePanel",
+                                            },
+                                        );
+                                    }}>
+                                    {locConstants.queryResult.clickHereToHideThisPanel}
+                                </Link>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
         <div className={classes.root} ref={resultPaneParentRef}>
             <div className={classes.ribbon} ref={ribbonRef}>
                 <TabList

--- a/src/sharedInterfaces/queryResult.ts
+++ b/src/sharedInterfaces/queryResult.ts
@@ -66,6 +66,7 @@ export interface QueryResultWebviewState extends ExecutionPlanWebviewState {
     fontSettings: FontSettings;
     autoSizeColumns?: boolean;
     inMemoryDataProcessingThreshold?: number;
+    initializationError?: string;
 }
 
 export interface QueryResultReducers extends Omit<ExecutionPlanReducers, "getExecutionPlan"> {

--- a/test/unit/queryRunner.test.ts
+++ b/test/unit/queryRunner.test.ts
@@ -175,12 +175,6 @@ suite("Query Runner tests", () => {
 
             // ... The query runner should not be running a query
             assert.strictEqual(queryRunner.isExecutingQuery, false);
-
-            // ... An error message should have been shown
-            testVscodeWrapper.verify(
-                (x) => x.showErrorMessage(TypeMoq.It.isAnyString()),
-                TypeMoq.Times.once(),
-            );
         }
     });
 


### PR DESCRIPTION
## Description

1. Create the webview panel before starting the query execution. This makes sure that all  state updates are properly sent to the webview.
1. Awaiting properly before query panel creation  is created. This ensures that webview RPCs are set properly and all the react resources are loaded properly.
1. Adding a different splash screen for query result documents.It is a simple spinner with a “Loading results” message to indicate progress while results are being prepared.
1. Adding splash screen in case query fails to start.

<img width="536" height="688" alt="image" src="https://github.com/user-attachments/assets/f3994bf2-d052-4ff1-88a9-1e190522e81e" />


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

