### PR TITLE
Fixing new query command logic and consolidating code.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -216,13 +216,13 @@ jobs:
         continue-on-error: true
         run: |
           set +e  # Don't exit on errors
-          VS_CODE_VERSION=stable
-          SERVER_NAME=localhost
-          AUTHENTICATION_TYPE="SQL Login"
-          USER_NAME=sa
-          PASSWORD=${{ env.PASSWORD }}
-          SAVE_PASSWORD=No
-          PROFILE_NAME=test-server
+          export VS_CODE_VERSION=stable
+          export SERVER_NAME=localhost
+          export AUTHENTICATION_TYPE="SQL Login"
+          export USER_NAME=sa
+          export PASSWORD=${{ env.PASSWORD }}
+          export SAVE_PASSWORD=No
+          export PROFILE_NAME=test-server
           cd pr
           export BUILT_VSIX_PATH=$(find ./ -name "*.vsix" -exec realpath {} \; | head -n 1)
           DISPLAY=:10 yarn smoketest
@@ -251,13 +251,13 @@ jobs:
       - name: Run smoke tests for target branch # for calculating coverage comparison
         continue-on-error: true
         run: |
-          VS_CODE_VERSION=stable
-          SERVER_NAME=localhost
-          AUTHENTICATION_TYPE="SQL Login"
-          USER_NAME=sa
-          PASSWORD=${{ env.PASSWORD }}
-          SAVE_PASSWORD=No
-          PROFILE_NAME=test-server
+          export VS_CODE_VERSION=stable
+          export SERVER_NAME=localhost
+          export AUTHENTICATION_TYPE="SQL Login"
+          export USER_NAME=sa
+          export PASSWORD=${{ env.PASSWORD }}
+          export SAVE_PASSWORD=No
+          export PROFILE_NAME=test-server
           cd target
           export BUILT_VSIX_PATH=$(find ./ -name "*.vsix" | head -n 1)
           DISPLAY=:10 yarn smoketest

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -21,7 +21,6 @@ import { sendActionEvent } from "../telemetry/telemetry";
 import { TreeNodeInfo } from "../objectExplorer/nodes/treeNodeInfo";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
 import { IConnectionProfile } from "../models/interfaces";
-import { ObjectExplorerUtils } from "../objectExplorer/objectExplorerUtils";
 
 /**
  * Service for creating untitled documents for SQL query

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -17,6 +17,11 @@ import MainController from "./mainController";
 import * as vscodeMssql from "vscode-mssql";
 import { Deferred } from "../protocol";
 import { ObjectExplorerService } from "../objectExplorer/objectExplorerService";
+import { sendActionEvent } from "../telemetry/telemetry";
+import { TreeNodeInfo } from "../objectExplorer/nodes/treeNodeInfo";
+import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
+import { IConnectionProfile } from "../models/interfaces";
+import { ObjectExplorerUtils } from "../objectExplorer/objectExplorerUtils";
 
 /**
  * Service for creating untitled documents for SQL query
@@ -51,6 +56,10 @@ export default class SqlDocumentService implements vscode.Disposable {
         return this._mainController?.objectEpxplorerProvider?.objectExplorerService;
     }
 
+    public get objectExplorerTree(): vscode.TreeView<TreeNodeInfo> {
+        return this._mainController?.objectExplorerTree;
+    }
+
     private setupListeners(): void {
         this._disposables.push(
             vscode.workspace.onDidCloseTextDocument(async (doc) => {
@@ -76,6 +85,33 @@ export default class SqlDocumentService implements vscode.Disposable {
             }),
         );
 
+        this._disposables.push(
+            vscode.commands.registerCommand(Constants.cmdNewQuery, async (node?: TreeNodeInfo) => {
+                await this.handleNewQueryCommand(node);
+            }),
+        );
+
+        this._disposables.push(
+            vscode.commands.registerCommand(
+                Constants.cmdObjectExplorerNewQuery,
+                async (treeNodeInfo: TreeNodeInfo) => {
+                    const connectionCredentials = treeNodeInfo.connectionProfile;
+                    const databaseName = ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
+
+                    if (
+                        databaseName !== connectionCredentials.database &&
+                        databaseName !== LocalizedConstants.defaultDatabaseLabel
+                    ) {
+                        connectionCredentials.database = databaseName;
+                    } else if (databaseName === LocalizedConstants.defaultDatabaseLabel) {
+                        connectionCredentials.database = "";
+                    }
+                    treeNodeInfo.updateConnectionProfile(connectionCredentials);
+                    await this.handleNewQueryCommand(treeNodeInfo);
+                },
+            ),
+        );
+
         if (this._connectionMgr) {
             this._disposables.push(
                 this._connectionMgr.onSuccessfulConnection((params) =>
@@ -83,6 +119,68 @@ export default class SqlDocumentService implements vscode.Disposable {
                 ),
             );
         }
+    }
+
+    /**
+     * Opens a new query and creates new connection. Connection precedence is:
+     * 1. User right-clicked on an OE node and selected "New Query": use that node's connection profile
+     * 2. User triggered "New Query" from command palette and the active document has a connection: copy that to the new document
+     * 3. User triggered "New Query" from command palette while they have a connected OE node selected: use that node's connection profile
+     * 4. User triggered "New Query" from command palette and there's no reasonable context: prompt for connection to use
+     */
+    private async handleNewQueryCommand(node?: TreeNodeInfo, content?: string): Promise<boolean> {
+        if (!this._connectionMgr || !this._mainController) {
+            return false;
+        }
+
+        let connectionCreds: vscodeMssql.IConnectionInfo | undefined;
+        let connectionStrategy: ConnectionStrategy;
+        let nodeType: string | undefined;
+
+        if (node) {
+            // Case 1: User right-clicked on an OE node and selected "New Query"
+            connectionCreds = node.connectionProfile;
+            nodeType = node.nodeType;
+            connectionStrategy = ConnectionStrategy.CopyConnectionFromInfo;
+        } else if (this._lastActiveConnectionInfo) {
+            // Case 2: User triggered "New Query" from command palette and the active document has a connection
+            connectionCreds = undefined;
+            nodeType = "previousEditor";
+            connectionStrategy = ConnectionStrategy.CopyLastActive;
+        } else if (this.objectExplorerTree.selection?.length === 1) {
+            // Case 3: User triggered "New Query" from command palette while they have a connected OE node selected
+            connectionCreds = this.objectExplorerTree.selection[0].connectionProfile;
+            nodeType = this.objectExplorerTree.selection[0].nodeType;
+            connectionStrategy = ConnectionStrategy.CopyConnectionFromInfo;
+        } else {
+            connectionStrategy = ConnectionStrategy.PromptForConnection;
+        }
+
+        if (connectionCreds) {
+            await this._connectionMgr.handlePasswordBasedCredentials(connectionCreds);
+        }
+
+        await this.newQuery({
+            content,
+            connectionStrategy: connectionStrategy,
+            connectionInfo: connectionCreds,
+        });
+
+        await this._connectionMgr.connectionStore.removeRecentlyUsed(
+            connectionCreds as IConnectionProfile,
+        );
+
+        sendActionEvent(
+            TelemetryViews.CommandPalette,
+            TelemetryActions.NewQuery,
+            {
+                nodeType: nodeType,
+                isContainer: connectionCreds?.containerName ? "true" : "false",
+            },
+            undefined,
+            connectionCreds as IConnectionProfile,
+            this._connectionMgr.getServerInfo(connectionCreds),
+        );
     }
 
     dispose() {

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -272,8 +272,7 @@ export default class SqlDocumentService implements vscode.Disposable {
         }
 
         const activeDocumentUri = getUriKey(editor.document.uri);
-        const activeConnection =
-            await this._connectionMgr?.getConnectionInfoFromUri(activeDocumentUri);
+        const activeConnection = this._connectionMgr?.getConnectionInfoFromUri(activeDocumentUri);
 
         if (activeConnection) {
             this._lastActiveConnectionInfo = Utils.deepClone(activeConnection);

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -125,6 +125,7 @@ export default class SqlDocumentService implements vscode.Disposable {
             nodeType = this.objectExplorerTree.selection[0].nodeType;
             connectionStrategy = ConnectionStrategy.CopyConnectionFromInfo;
         } else {
+            // Case 4: User triggered "New Query" from command palette and there's no reasonable context
             connectionStrategy = ConnectionStrategy.PromptForConnection;
         }
 

--- a/src/controllers/sqlDocumentService.ts
+++ b/src/controllers/sqlDocumentService.ts
@@ -85,33 +85,6 @@ export default class SqlDocumentService implements vscode.Disposable {
             }),
         );
 
-        this._disposables.push(
-            vscode.commands.registerCommand(Constants.cmdNewQuery, async (node?: TreeNodeInfo) => {
-                await this.handleNewQueryCommand(node);
-            }),
-        );
-
-        this._disposables.push(
-            vscode.commands.registerCommand(
-                Constants.cmdObjectExplorerNewQuery,
-                async (treeNodeInfo: TreeNodeInfo) => {
-                    const connectionCredentials = treeNodeInfo.connectionProfile;
-                    const databaseName = ObjectExplorerUtils.getDatabaseName(treeNodeInfo);
-
-                    if (
-                        databaseName !== connectionCredentials.database &&
-                        databaseName !== LocalizedConstants.defaultDatabaseLabel
-                    ) {
-                        connectionCredentials.database = databaseName;
-                    } else if (databaseName === LocalizedConstants.defaultDatabaseLabel) {
-                        connectionCredentials.database = "";
-                    }
-                    treeNodeInfo.updateConnectionProfile(connectionCredentials);
-                    await this.handleNewQueryCommand(treeNodeInfo);
-                },
-            ),
-        );
-
         if (this._connectionMgr) {
             this._disposables.push(
                 this._connectionMgr.onSuccessfulConnection((params) =>
@@ -128,7 +101,7 @@ export default class SqlDocumentService implements vscode.Disposable {
      * 3. User triggered "New Query" from command palette while they have a connected OE node selected: use that node's connection profile
      * 4. User triggered "New Query" from command palette and there's no reasonable context: prompt for connection to use
      */
-    private async handleNewQueryCommand(node?: TreeNodeInfo, content?: string): Promise<boolean> {
+    public async handleNewQueryCommand(node?: TreeNodeInfo, content?: string): Promise<boolean> {
         if (!this._connectionMgr || !this._mainController) {
             return false;
         }

--- a/test/e2e/connection.spec.ts
+++ b/test/e2e/connection.spec.ts
@@ -52,7 +52,7 @@ test.describe("MSSQL Extension - Database Connection", async () => {
 
         await screenshot(vsCodePage, testInfo, "connected");
 
-        await openNewQueryEditor(vsCodePage, profileName, password);
+        await openNewQueryEditor(vsCodePage);
         await screenshot(vsCodePage, testInfo, "new query editor opened");
 
         await disconnect(vsCodePage);

--- a/test/e2e/connection.spec.ts
+++ b/test/e2e/connection.spec.ts
@@ -55,9 +55,11 @@ test.describe("MSSQL Extension - Database Connection", async () => {
         await openNewQueryEditor(vsCodePage);
         await screenshot(vsCodePage, testInfo, "new query editor opened");
 
+        // New editor should be connected to the last added connection
         await disconnect(vsCodePage);
         await screenshot(vsCodePage, testInfo, "disconnected");
 
+        // Verify that the Connect to MSSQL button is visible again after disconnecting
         const connectAgainButton = await vsCodePage.getByText("Connect to MSSQL");
         await expect(connectAgainButton).toBeVisible({ timeout: 10 * 1000 });
     });

--- a/test/e2e/connection.spec.ts
+++ b/test/e2e/connection.spec.ts
@@ -25,7 +25,7 @@ test.describe("MSSQL Extension - Database Connection", async () => {
     test.beforeAll(async () => {
         // Launch with new UI off
         const { electronApp, page } = await launchVsCodeWithMssqlExtension({
-            useNewUI: false,
+            useNewUI: true,
         });
         vsCodeApp = electronApp;
         vsCodePage = page;
@@ -58,8 +58,8 @@ test.describe("MSSQL Extension - Database Connection", async () => {
         await disconnect(vsCodePage);
         await screenshot(vsCodePage, testInfo, "disconnected");
 
-        const disconnectedStatus = await vsCodePage.getByText("Connect to MSSQL");
-        await expect(disconnectedStatus).toBeVisible({ timeout: 10 * 1000 });
+        const connectAgainButton = await vsCodePage.getByText("Connect to MSSQL");
+        await expect(connectAgainButton).toBeVisible({ timeout: 10 * 1000 });
     });
 
     test.afterEach(async ({}, testInfo) => {

--- a/test/e2e/queryExecution.spec.ts
+++ b/test/e2e/queryExecution.spec.ts
@@ -97,7 +97,7 @@ SELECT Name FROM TestTable;`;
     });
 
     test.afterAll(async () => {
-        await openNewQueryEditor(vsCodePage, profileName, password);
+        await openNewQueryEditor(vsCodePage);
         const dropTestDatabaseScript = `
 USE master
 ALTER DATABASE TestDB SET SINGLE_USER WITH ROLLBACK IMMEDIATE

--- a/test/e2e/queryExecution.spec.ts
+++ b/test/e2e/queryExecution.spec.ts
@@ -97,40 +97,16 @@ SELECT Name FROM TestTable;`;
     });
 
     test.afterAll(async () => {
-        try {
-            await openNewQueryEditor(vsCodePage);
-            const dropTestDatabaseScript = `
+        await openNewQueryEditor(vsCodePage);
+        const dropTestDatabaseScript = `
 USE master
-IF EXISTS (SELECT name FROM sys.databases WHERE name = 'TestDB')
-BEGIN
-    ALTER DATABASE TestDB SET SINGLE_USER WITH ROLLBACK IMMEDIATE
-    DROP DATABASE TestDB
-END`;
-            await enterTextIntoQueryEditor(vsCodePage, dropTestDatabaseScript);
-            await executeQuery(vsCodePage);
+ALTER DATABASE TestDB SET SINGLE_USER WITH ROLLBACK IMMEDIATE
+DROP DATABASE TestDB;`;
+        await enterTextIntoQueryEditor(vsCodePage, dropTestDatabaseScript);
+        await executeQuery(vsCodePage);
 
-            await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
-        } catch (error) {
-            console.warn("Database cleanup failed:", error);
-        }
+        await new Promise((resolve) => setTimeout(resolve, 10 * 1000));
 
-        try {
-            await Promise.race([
-                vsCodeApp.close(),
-                new Promise((_, reject) =>
-                    setTimeout(() => reject(new Error("VSCode close timeout")), 30000),
-                ),
-            ]);
-        } catch (error) {
-            console.warn("VSCode close failed or timed out:", error);
-            try {
-                const process = vsCodeApp.process();
-                if (process) {
-                    await process.kill();
-                }
-            } catch (killError) {
-                console.warn("Failed to kill VSCode process:", killError);
-            }
-        }
+        await vsCodeApp.close();
     });
 });

--- a/test/e2e/queryExecution.spec.ts
+++ b/test/e2e/queryExecution.spec.ts
@@ -65,7 +65,7 @@ test.describe("MSSQL Extension - Query Execution", async () => {
     });
 
     test("Create table, insert data, and execute query", async ({}, testInfo) => {
-        await openNewQueryEditor(vsCodePage, profileName, password);
+        await openNewQueryEditor(vsCodePage);
         await screenshot(vsCodePage, testInfo, "NewEditorOpened");
 
         const createTestDB = "CREATE DATABASE TestDB;";
@@ -75,7 +75,7 @@ test.describe("MSSQL Extension - Query Execution", async () => {
         await screenshot(vsCodePage, testInfo, "CreateDbExecuted");
 
         await screenshot(vsCodePage, testInfo, "NewEditorOpened2");
-        await openNewQueryEditor(vsCodePage, profileName, password);
+        await openNewQueryEditor(vsCodePage);
 
         const sqlScript = `
 USE TestDB;

--- a/test/e2e/queryExecution.spec.ts
+++ b/test/e2e/queryExecution.spec.ts
@@ -37,7 +37,7 @@ test.describe("MSSQL Extension - Query Execution", async () => {
     test.beforeAll(async () => {
         // Launch with new UI off
         const { electronApp, page } = await launchVsCodeWithMssqlExtension({
-            useNewUI: false,
+            useNewUI: true,
         });
         vsCodeApp = electronApp;
         vsCodePage = page;

--- a/test/e2e/utils/testHelpers.ts
+++ b/test/e2e/utils/testHelpers.ts
@@ -57,11 +57,7 @@ export async function addDatabaseConnection(
     await iframe.getByRole("button", { name: "Connect", exact: true }).click();
 }
 
-export async function openNewQueryEditor(
-    vsCodePage: Page,
-    profileName: string,
-    password: string,
-): Promise<void> {
+export async function openNewQueryEditor(vsCodePage: Page): Promise<void> {
     await vsCodePage.keyboard.press(`${getModifierKey()}+P`);
     await waitForCommandPaletteToBeVisible(vsCodePage);
     await vsCodePage.keyboard.type(">MS SQL: New Query");

--- a/test/e2e/utils/testHelpers.ts
+++ b/test/e2e/utils/testHelpers.ts
@@ -15,6 +15,7 @@ export async function addDatabaseConnection(
     savePassword: string,
     profileName: string,
 ): Promise<void> {
+    let iframe: FrameLocator;
     // Navigate to Sql Server Tab
     const sqlServerTabContainer = vsCodePage.locator('[role="tab"][aria-label^="SQL Server"]');
     const isSelected = await sqlServerTabContainer.getAttribute("aria-selected");
@@ -28,44 +29,32 @@ export async function addDatabaseConnection(
     await expect(addConnectionButton).toBeVisible({ timeout: 10000 });
     await addConnectionButton.click();
 
-    await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${serverName}`);
-    await vsCodePage.keyboard.press("Enter");
+    iframe = await getWebviewByTitle(vsCodePage, "Connection Dialog");
+
+    await iframe.getByRole("textbox", { name: "Server name" }).fill(serverName);
 
     if (databaseName) {
-        await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${databaseName}`);
+        await iframe.getByRole("textbox", { name: "Database name" }).fill(databaseName);
     }
-    await vsCodePage.keyboard.press("Enter");
-
-    await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${authType}`);
-    await vsCodePage.keyboard.press("Enter");
+    await iframe.getByRole("combobox", { name: "Authentication type" }).click();
+    // Then select an option from the dropdown list that appears
+    await iframe.getByRole("option", { name: authType }).click();
 
     if (authType === "SQL Login") {
-        await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${userName}`);
-        await vsCodePage.keyboard.press("Enter");
+        await iframe.getByRole("textbox", { name: "User name" }).fill(userName);
+        await iframe.getByRole("textbox", { name: "Password" }).fill(password);
 
-        await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${password}`);
-        await vsCodePage.keyboard.press("Enter");
-
-        await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${savePassword}`);
-        await vsCodePage.keyboard.press("Enter");
+        await iframe.getByRole("checkbox", { name: "Save Password" }).click();
     }
 
     if (profileName) {
-        await vsCodePage.fill('input[aria-controls="quickInput_list"]', `${profileName}`);
+        await iframe.getByRole("textbox", { name: "Profile name" }).fill(profileName);
     }
-    await vsCodePage.keyboard.press("Enter");
 
     await new Promise((resolve) => setTimeout(resolve, 1 * 1000));
 
-    const enableTrustServerCertificateButton = await vsCodePage.getByText(
-        "Enable Trust Server Certificate",
-    );
-    const isEnableTrustButtonVisible = await enableTrustServerCertificateButton.isVisible({
-        timeout: 3 * 1000,
-    });
-    if (isEnableTrustButtonVisible) {
-        await enableTrustServerCertificateButton.click();
-    }
+    await iframe.getByRole("checkbox", { name: "Trust server certificate" }).click();
+    await iframe.getByRole("button", { name: "Connect", exact: true }).click();
 }
 
 export async function openNewQueryEditor(
@@ -73,25 +62,15 @@ export async function openNewQueryEditor(
     profileName: string,
     password: string,
 ): Promise<void> {
-    await vsCodePage.keyboard.press("Control+P");
+    await vsCodePage.keyboard.press(`${getModifierKey()}+P`);
     await waitForCommandPaletteToBeVisible(vsCodePage);
     await vsCodePage.keyboard.type(">MS SQL: New Query");
     await waitForCommandPaletteToBeVisible(vsCodePage);
     await vsCodePage.keyboard.press("Enter");
-    await waitForCommandPaletteToBeVisible(vsCodePage);
-    await vsCodePage.keyboard.type(profileName);
-    await waitForCommandPaletteToBeVisible(vsCodePage);
-    await vsCodePage.keyboard.press("Enter");
-    await waitForCommandPaletteToBeVisible(vsCodePage);
-    await vsCodePage.keyboard.type(password);
-    await vsCodePage.keyboard.press("Enter");
-
-    await new Promise((resolve) => setTimeout(resolve, 1 * 1000));
-    await vsCodePage.keyboard.press("Escape");
 }
 
 export async function disconnect(vsCodePage: Page): Promise<void> {
-    await vsCodePage.keyboard.press("Control+P");
+    await vsCodePage.keyboard.press(`${getModifierKey()}+P`);
     await vsCodePage.keyboard.type(">MS SQL: Disconnect");
     // await new Promise(resolve => setTimeout(resolve, 1 * 1000));
     await vsCodePage.keyboard.press("Enter");
@@ -113,4 +92,12 @@ export async function waitForCommandPaletteToBeVisible(vsCodePage: Page): Promis
 
 export async function getWebviewByTitle(vsCodePage: Page, title: string): Promise<FrameLocator> {
     return vsCodePage.frameLocator(".webview").frameLocator(`[title='${title}']`);
+}
+
+export function isMac(): boolean {
+    return process.platform === "darwin";
+}
+
+export function getModifierKey(): string {
+    return isMac() ? "Meta" : "Control";
 }

--- a/test/unit/mainController.test.ts
+++ b/test/unit/mainController.test.ts
@@ -18,7 +18,6 @@ import * as Constants from "../../src/constants/constants";
 suite("MainController Tests", function () {
     let mainController: MainController;
     let connectionManager: TypeMoq.IMock<ConnectionManager>;
-    // Use the real SqlDocumentService instance from the controller
 
     setup(async () => {
         // Need to activate the extension to get the mainController

--- a/test/unit/sqlDocumentService.test.ts
+++ b/test/unit/sqlDocumentService.test.ts
@@ -13,6 +13,7 @@ import * as LocalizedConstants from "../../src/constants/locConstants";
 import MainController from "../../src/controllers/mainController";
 import ConnectionManager from "../../src/controllers/connectionManager";
 import SqlDocumentService, { ConnectionStrategy } from "../../src/controllers/sqlDocumentService";
+import * as Telemetry from "../../src/telemetry/telemetry";
 import SqlToolsServerClient from "../../src/languageservice/serviceclient";
 import { IConnectionInfo } from "vscode-mssql";
 
@@ -110,6 +111,7 @@ suite("SqlDocumentService Tests", () => {
         };
         connectionManager.getServerInfo.returns(undefined as any);
         connectionManager.handlePasswordBasedCredentials.resolves();
+        const sendActionStub = sandbox.stub(Telemetry, "sendActionEvent");
 
         const node: any = { connectionProfile: {}, nodeType: "Server" };
         await sqlDocumentService.handleNewQueryCommand(node, undefined);
@@ -117,8 +119,11 @@ suite("SqlDocumentService Tests", () => {
         expect(newQueryStub).to.have.been.calledOnce;
         expect((connectionManager as any).connectionStore.removeRecentlyUsed).to.have.been
             .calledOnce;
+        expect(connectionManager.handlePasswordBasedCredentials).to.have.been.calledOnce;
+        expect(sendActionStub).to.have.been.calledOnce;
 
         newQueryStub.restore();
+        sendActionStub.restore();
     });
 
     test("handleNewQueryCommand should not create a new connection if new query fails", async () => {
@@ -138,6 +143,73 @@ suite("SqlDocumentService Tests", () => {
         }
 
         expect(connectionManager.onNewConnection).to.not.have.been.called;
+    });
+
+    test("handleNewQueryCommand uses CopyLastActive when last active connection exists", async () => {
+        const editor: vscode.TextEditor = { document: { uri: "test_uri" } } as any;
+        const newQueryStub = sandbox.stub(sqlDocumentService, "newQuery").callsFake((opts: any) => {
+            expect(opts.connectionStrategy).to.equal(ConnectionStrategy.CopyLastActive);
+            expect(opts.connectionInfo).to.equal(undefined);
+            return Promise.resolve(editor);
+        });
+
+        // simulate last active connection
+        sqlDocumentService["_lastActiveConnectionInfo"] = { server: "localhost" } as any;
+        // remove OE selection influence
+        mainController.objectExplorerTree = { selection: [] } as any;
+        connectionManager.connectionStore = {
+            removeRecentlyUsed: sandbox.stub().resolves(),
+        } as any;
+
+        await sqlDocumentService.handleNewQueryCommand(undefined, "SELECT 1");
+
+        expect(newQueryStub).to.have.been.calledOnce;
+        newQueryStub.restore();
+    });
+
+    test("handleNewQueryCommand uses OE selection when exactly one node is selected", async () => {
+        const nodeConnection = { server: "oeServer" } as any;
+        mainController.objectExplorerTree = {
+            selection: [{ connectionProfile: nodeConnection, nodeType: "Database" }],
+        } as any;
+        connectionManager.handlePasswordBasedCredentials.resolves();
+        connectionManager.connectionStore = {
+            removeRecentlyUsed: sandbox.stub().resolves(),
+        } as any;
+
+        const editor: vscode.TextEditor = { document: { uri: "t" } } as any;
+        const newQueryStub = sandbox.stub(sqlDocumentService, "newQuery").callsFake((opts: any) => {
+            expect(opts.connectionStrategy).to.equal(ConnectionStrategy.CopyConnectionFromInfo);
+            expect(opts.connectionInfo).to.equal(nodeConnection);
+            return Promise.resolve(editor);
+        });
+
+        await sqlDocumentService.handleNewQueryCommand(undefined, undefined);
+        expect(connectionManager.handlePasswordBasedCredentials).to.have.been.calledOnceWith(
+            nodeConnection,
+        );
+        expect(newQueryStub).to.have.been.calledOnce;
+        newQueryStub.restore();
+    });
+
+    test("handleNewQueryCommand prompts for connection when no context", async () => {
+        // clear last active and OE selection
+        sqlDocumentService["_lastActiveConnectionInfo"] = undefined;
+        mainController.objectExplorerTree = { selection: [] } as any;
+        connectionManager.connectionStore = {
+            removeRecentlyUsed: sandbox.stub().resolves(),
+        } as any;
+
+        const editor: vscode.TextEditor = { document: { uri: "x" } } as any;
+        const newQueryStub = sandbox.stub(sqlDocumentService, "newQuery").callsFake((opts: any) => {
+            expect(opts.connectionStrategy).to.equal(ConnectionStrategy.PromptForConnection);
+            expect(opts.connectionInfo).to.equal(undefined);
+            return Promise.resolve(editor);
+        });
+
+        await sqlDocumentService.handleNewQueryCommand(undefined, undefined);
+        expect(newQueryStub).to.have.been.calledOnce;
+        newQueryStub.restore();
     });
 
     // Standard closed document event test


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

1. This moves all the new query creation logic into sqlDocumentService. 
2. Fix the 2nd case for newQueryCommand if there was no active editor but the lastActiveEditor still had a value.
3. Added tests to make sure that handle new command cases are adequately tested.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

