### PR TITLE
Cleaning up previous query run and  unnecessary callbacks in query execution code. 

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1486,6 +1486,12 @@
       "{0} is the average, {1} is the count, {2} is the distinct count, {3} is the max, {4} is the min, {5} is the null count, {6} is the sum"
     ]
   },
+  "An error occurred while retrieving rows: {0}/{0} is the error message": {
+    "message": "An error occurred while retrieving rows: {0}",
+    "comment": [
+      "{0} is the error message"
+    ]
+  },
   "{0} stopped successfully./{0} stopped successfully.": {
     "message": "{0} stopped successfully.",
     "comment": [

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -163,6 +163,10 @@
       <source xml:lang="en">An error occurred while removing Microsoft Entra account: {0}</source>
       <note>{0} is the error message</note>
     </trans-unit>
+    <trans-unit id="++CODE++381d558ea8ee3e00d772e070932d5a334e7743c399dda1ddd675e1962d6e32bc">
+      <source xml:lang="en">An error occurred while retrieving rows: {0}</source>
+      <note>{0} is the error message</note>
+    </trans-unit>
     <trans-unit id="++CODE++6bda942fdd68d287fb0f1659be0f2011ad842f9295aa230d763f3cec6db5b000">
       <source xml:lang="en">An error occurred while searching database objects</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -949,6 +949,12 @@ export class QueryResult {
                 "{0} is the average, {1} is the count, {2} is the distinct count, {3} is the max, {4} is the min, {5} is the null count, {6} is the sum",
             ],
         });
+    public static getRowsError = (error: string) =>
+        l10n.t({
+            message: "An error occurred while retrieving rows: {0}",
+            args: [error],
+            comment: ["{0} is the error message"],
+        });
 }
 
 export class LocalContainers {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2017,7 +2017,7 @@ export default class MainController implements vscode.Disposable {
             isSqlCmd = false;
             const editor = this._vscodeWrapper.activeTextEditor;
             const title = path.basename(editor.document.fileName);
-            this._outputContentProvider.createQueryRunner(this._statusview, uri, title);
+            await this._outputContentProvider.createQueryRunner(this._statusview, uri, title);
         }
         await this._outputContentProvider.toggleSqlCmd(this._vscodeWrapper.activeTextEditorUri);
         await this._connectionMgr.onChooseLanguageFlavor(true, !isSqlCmd);

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -561,7 +561,7 @@ export default class QueryRunner {
         } catch (error) {
             // TODO: Localize
             this._vscodeWrapper.showErrorMessage(
-                "Something went wrong getting more rows: " + error.message,
+                LocalizedConstants.QueryResult.getRowsError(getErrorMessage(error)),
             );
             void Promise.reject(error);
         }

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -231,6 +231,23 @@ export default class QueryRunner {
         return queryCancelResult;
     }
 
+    public async resetQueryRunner(): Promise<void> {
+        try {
+            let cancelParams: QueryCancelParams = { ownerUri: this._ownerUri };
+            await this._client.sendRequest(QueryCancelRequest.type, cancelParams);
+        } catch {
+            // Suppress any errors
+        }
+        this._isExecuting = false;
+        this._hasCompleted = true;
+        this.removeRunningQuery();
+        const promise = this._uriToQueryPromiseMap.get(this._ownerUri);
+        if (promise) {
+            promise.reject("Query cancelled");
+            this._uriToQueryPromiseMap.delete(this._ownerUri);
+        }
+    }
+
     // Pulls the query text from the current document/selection and initiates the query
     public async runStatement(line: number, column: number): Promise<void> {
         await this.doRunQuery(

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -51,7 +51,6 @@ import * as os from "os";
 import { Deferred } from "../protocol";
 import { sendActionEvent } from "../telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
-import { RequestType } from "vscode-languageclient";
 
 export interface IResultSet {
     columns: string[];

--- a/src/controllers/queryRunner.ts
+++ b/src/controllers/queryRunner.ts
@@ -80,7 +80,6 @@ export const editorEol =
  * and handles getting more rows from the service layer and disposing when the content is closed.
  */
 export default class QueryRunner {
-    // MEMBER VARIABLES ////////////////////////////////////////////////////
     private _batchSets: BatchSummary[] = [];
     private _batchSetMessages: { [batchId: number]: IResultMessage[] } = {};
     private _isExecuting: boolean;
@@ -212,6 +211,10 @@ export default class QueryRunner {
 
     // PUBLIC METHODS ======================================================
 
+    /**
+     * Cancels the currently running query.
+     * @returns A promise that resolves to the result of the cancel operation.
+     */
     public async cancel(): Promise<QueryCancelResult> {
         // Make the request to cancel the query
         let cancelParams: QueryCancelParams = { ownerUri: this._ownerUri };
@@ -231,6 +234,9 @@ export default class QueryRunner {
         return queryCancelResult;
     }
 
+    /**
+     * Resets the query runner to a clean state if we want to run another query on it.
+     */
     public async resetQueryRunner(): Promise<void> {
         try {
             let cancelParams: QueryCancelParams = { ownerUri: this._ownerUri };
@@ -248,7 +254,9 @@ export default class QueryRunner {
         }
     }
 
-    // Pulls the query text from the current document/selection and initiates the query
+    /**
+     * Runs a query against the database for the current statement based on the cursor position.
+     */
     public async runStatement(line: number, column: number): Promise<void> {
         await this.doRunQuery(
             <ISelectionData>{
@@ -1022,7 +1030,6 @@ export default class QueryRunner {
             rowIdToSelectionMap,
             batchId,
             resultId,
-            includeHeaders,
         );
 
         await this.writeStringToClipboard(jsonString);
@@ -1402,7 +1409,6 @@ export default class QueryRunner {
         rowIdToSelectionMap: Map<number, ISlickRange[]>,
         batchId: number,
         resultId: number,
-        includeHeaders: boolean,
     ): string {
         // Get column headers for property names
         let allRowIds = Array.from(rowIdToRowMap.keys()).sort((a, b) => a - b);

--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -258,6 +258,12 @@ export class SqlOutputContentProvider {
 
     // PUBLIC METHODS //////////////////////////////////////////////////////
 
+    public isRunningQuery(uri: string): boolean {
+        return !this._queryResultsMap.has(uri)
+            ? false
+            : this._queryResultsMap.get(uri).queryRunner.isExecutingQuery;
+    }
+
     /**
      * Runs a query against the database.
      * @param statusView The status view to use for showing query progress

--- a/test/unit/sqlOutputContentProvider.test.ts
+++ b/test/unit/sqlOutputContentProvider.test.ts
@@ -15,6 +15,7 @@ import { ISelectionData } from "../../src/models/interfaces";
 import SqlDocumentService from "../../src/controllers/sqlDocumentService";
 import { ExecutionPlanService } from "../../src/services/executionPlanService";
 import * as sinon from "sinon";
+import QueryRunner from "../../src/controllers/queryRunner";
 
 suite("SqlOutputProvider Tests using mocks", () => {
     const testUri = "Test_URI";
@@ -72,11 +73,66 @@ suite("SqlOutputProvider Tests using mocks", () => {
             } as vscode.Disposable;
         });
 
+        // // Mock vscode.workspace.openTextDocument to avoid file system access
+        // sandbox.stub(vscode.workspace, "openTextDocument").callsFake((uri) => {
+        //     return Promise.resolve({
+        //         uri: typeof uri === "string" ? vscode.Uri.parse(uri) : uri,
+        //         getText: () => "SELECT * FROM test_table",
+        //         languageId: "sql",
+        //         lineCount: 1,
+        //         lineAt: () => ({
+        //             text: "SELECT * FROM test_table",
+        //             range: new vscode.Range(0, 0, 0, 25)
+        //         }),
+        //         positionAt: () => new vscode.Position(0, 0),
+        //         offsetAt: () => 0,
+        //         validateRange: (range) => range,
+        //         validatePosition: (position) => position,
+        //         getWordRangeAtPosition: () => undefined,
+        //         save: () => Promise.resolve(true),
+        //         isDirty: false,
+        //         isUntitled: false,
+        //         isClosed: false,
+        //         eol: vscode.EndOfLine.LF,
+        //         fileName: typeof uri === "string" ? uri : uri.path,
+        //         version: 1
+        //     } as vscode.TextDocument);
+        // });
+
         statusView.setup((x) => x.cancelingQuery(TypeMoq.It.isAny()));
         statusView.setup((x) => x.executedQuery(TypeMoq.It.isAny()));
         context.setup((c) => c.extensionPath).returns(() => "test_uri");
         const subscriptions: vscode.Disposable[] = [];
         context.setup((c) => c.subscriptions).returns(() => subscriptions);
+
+        // // Mock parseUri method
+        // vscodeWrapper.setup((v) => v.parseUri(TypeMoq.It.isAnyString())).returns((uri) => vscode.Uri.parse(uri));
+
+        // // Mock openTextDocument method
+        // vscodeWrapper.setup((v) => v.openTextDocument(TypeMoq.It.isAny())).returns(() => {
+        //     return Promise.resolve({
+        //         uri: vscode.Uri.parse("test_uri"),
+        //         getText: () => "SELECT * FROM test_table",
+        //         languageId: "sql",
+        //         lineCount: 1,
+        //         lineAt: () => ({
+        //             text: "SELECT * FROM test_table",
+        //             range: new vscode.Range(0, 0, 0, 25)
+        //         }),
+        //         positionAt: () => new vscode.Position(0, 0),
+        //         offsetAt: () => 0,
+        //         validateRange: (range) => range,
+        //         validatePosition: (position) => position,
+        //         getWordRangeAtPosition: () => undefined,
+        //         save: () => Promise.resolve(true),
+        //         isDirty: false,
+        //         isUntitled: false,
+        //         isClosed: false,
+        //         eol: vscode.EndOfLine.LF,
+        //         fileName: "test_uri",
+        //         version: 1
+        //     } as vscode.TextDocument);
+        // });
         contentProvider = new SqlOutputContentProvider(
             context.object,
             statusView.object,
@@ -486,6 +542,13 @@ suite("SqlOutputProvider Tests using mocks", () => {
                 let config = stubs.createWorkspaceConfiguration(configResult);
                 return config;
             });
+
+        contentProvider.queryResultWebviewController.createPanelController = sandbox
+            .stub()
+            .resolves();
+
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
         let testQueryRunner = contentProvider.getQueryRunner("test_uri");
         assert.equal(testQueryRunner, undefined);
         await contentProvider.runQuery(statusView.object, "test_uri", undefined, "test_title");

--- a/test/unit/sqlOutputContentProvider.test.ts
+++ b/test/unit/sqlOutputContentProvider.test.ts
@@ -73,66 +73,12 @@ suite("SqlOutputProvider Tests using mocks", () => {
             } as vscode.Disposable;
         });
 
-        // // Mock vscode.workspace.openTextDocument to avoid file system access
-        // sandbox.stub(vscode.workspace, "openTextDocument").callsFake((uri) => {
-        //     return Promise.resolve({
-        //         uri: typeof uri === "string" ? vscode.Uri.parse(uri) : uri,
-        //         getText: () => "SELECT * FROM test_table",
-        //         languageId: "sql",
-        //         lineCount: 1,
-        //         lineAt: () => ({
-        //             text: "SELECT * FROM test_table",
-        //             range: new vscode.Range(0, 0, 0, 25)
-        //         }),
-        //         positionAt: () => new vscode.Position(0, 0),
-        //         offsetAt: () => 0,
-        //         validateRange: (range) => range,
-        //         validatePosition: (position) => position,
-        //         getWordRangeAtPosition: () => undefined,
-        //         save: () => Promise.resolve(true),
-        //         isDirty: false,
-        //         isUntitled: false,
-        //         isClosed: false,
-        //         eol: vscode.EndOfLine.LF,
-        //         fileName: typeof uri === "string" ? uri : uri.path,
-        //         version: 1
-        //     } as vscode.TextDocument);
-        // });
-
         statusView.setup((x) => x.cancelingQuery(TypeMoq.It.isAny()));
         statusView.setup((x) => x.executedQuery(TypeMoq.It.isAny()));
         context.setup((c) => c.extensionPath).returns(() => "test_uri");
         const subscriptions: vscode.Disposable[] = [];
         context.setup((c) => c.subscriptions).returns(() => subscriptions);
 
-        // // Mock parseUri method
-        // vscodeWrapper.setup((v) => v.parseUri(TypeMoq.It.isAnyString())).returns((uri) => vscode.Uri.parse(uri));
-
-        // // Mock openTextDocument method
-        // vscodeWrapper.setup((v) => v.openTextDocument(TypeMoq.It.isAny())).returns(() => {
-        //     return Promise.resolve({
-        //         uri: vscode.Uri.parse("test_uri"),
-        //         getText: () => "SELECT * FROM test_table",
-        //         languageId: "sql",
-        //         lineCount: 1,
-        //         lineAt: () => ({
-        //             text: "SELECT * FROM test_table",
-        //             range: new vscode.Range(0, 0, 0, 25)
-        //         }),
-        //         positionAt: () => new vscode.Position(0, 0),
-        //         offsetAt: () => 0,
-        //         validateRange: (range) => range,
-        //         validatePosition: (position) => position,
-        //         getWordRangeAtPosition: () => undefined,
-        //         save: () => Promise.resolve(true),
-        //         isDirty: false,
-        //         isUntitled: false,
-        //         isClosed: false,
-        //         eol: vscode.EndOfLine.LF,
-        //         fileName: "test_uri",
-        //         version: 1
-        //     } as vscode.TextDocument);
-        // });
         contentProvider = new SqlOutputContentProvider(
             context.object,
             statusView.object,


### PR DESCRIPTION
## Description

### Fix: Query Execution State Mismatch
There was an issue where the frontend stopped tracking a query run while the query was still executing in STS. In this state, attempting to run the query again from the frontend caused STS to throw the following error:


https://github.com/microsoft/sqltoolsservice/blob/c9283a1458269886a829c43af5a32fa0353b05e6/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs#L955-L959

To resolve this, the frontend now explicitly sends a **cancel request** before starting a new query run, even when the frontend believes no query is executing. This ensures STS does not have a stale running query.  
- The cancel request is safe: it will not error out if no query is running, as shown here: [QueryExecutionService.cs#L493-L501](https://github.com/microsoft/sqltoolsservice/blob/c9283a1458269886a829c43af5a32fa0353b05e6/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs#L493-L501).

### Cleanup
1. Removed unused code in `queryRunner`.
2. Removed unnecessary callbacks when starting query runs, to make it easier to debug and step through.



## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

