### PR TITLE
Fixing new panel location logic and auto panel switching. 

### DIFF
--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3441,6 +3441,9 @@
     <trans-unit id="mssql.openQueryResultsInTabByDefault.description">
       <source xml:lang="en">Automatically display query results in a new tab instead of the query pane. This option takes effect only if `mssql.enableRichExperiences` is enabled.</source>
     </trans-unit>
+    <trans-unit id="mssql.autoRevealResultsPanel">
+      <source xml:lang="en">Automatically reveal the results panel when switching to an editor with query results.</source>
+    </trans-unit>
     <trans-unit id="mssql.cancelQuery">
       <source xml:lang="en">Cancel Query</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3442,7 +3442,7 @@
       <source xml:lang="en">Automatically display query results in a new tab instead of the query pane. This option takes effect only if `mssql.enableRichExperiences` is enabled.</source>
     </trans-unit>
     <trans-unit id="mssql.autoRevealResultsPanel">
-      <source xml:lang="en">Automatically reveal the results panel when switching to an editor with query results.</source>
+      <source xml:lang="en">Automatically reveal the results panel when switching to an editor with query results. Only applies when &apos;Open Results in New Tab&apos; is enabled.</source>
     </trans-unit>
     <trans-unit id="mssql.cancelQuery">
       <source xml:lang="en">Cancel Query</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3442,7 +3442,7 @@
       <source xml:lang="en">Automatically display query results in a new tab instead of the query pane. This option takes effect only if `mssql.enableRichExperiences` is enabled.</source>
     </trans-unit>
     <trans-unit id="mssql.autoRevealResultsPanel">
-      <source xml:lang="en">Automatically reveal the results panel when switching to an editor with query results. Only applies when &apos;Open Results in New Tab&apos; is enabled.</source>
+      <source xml:lang="en">Automatically reveal the results panel when switching to an editor with query results. Only applies when &apos;Open Results in Tab&apos; is enabled.</source>
     </trans-unit>
     <trans-unit id="mssql.cancelQuery">
       <source xml:lang="en">Cancel Query</source>

--- a/package.json
+++ b/package.json
@@ -2028,6 +2028,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "%mssql.connectionManagement.rememberPasswordsUntilRestart%"
+                },
+                "mssql.autoRevealResultsPanel": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%mssql.autoRevealResultsPanel%",
+                    "scope": "window"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
                 },
                 {
                     "command": "mssql.revealQueryResult",
-                    "when": "editorLangId == sql && resource in mssql.connections && !isInDiffEditor && view.queryResult.visible == false",
+                    "when": "editorLangId == sql && resource in mssql.connections && !isInDiffEditor",
                     "group": "navigation@2"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -226,5 +226,6 @@
     "mssql.connectionSharing.clearAllConnectionSharingPermissions": "Clear All Connection Sharing Permissions",
     "mssql.statusBar.connectionInfoMaxLength.description": "The maximum number of characters to display for the connection info in the status bar. Set to -1 for no limit.",
     "mssql.schemaDesigner.enableExpandCollapseButtons": "Enable expand/collapse buttons in Schema Designer table nodes when tables have more than 10 columns",
-    "mssql.connectionManagement.rememberPasswordsUntilRestart": "Temporarily store passwords for connections with 'Saved Passwords' disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session."
+    "mssql.connectionManagement.rememberPasswordsUntilRestart": "Temporarily store passwords for connections with 'Saved Passwords' disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session.",
+    "mssql.autoRevealResultsPanel": "Automatically reveal the results panel when switching to an editor with query results."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -227,5 +227,5 @@
     "mssql.statusBar.connectionInfoMaxLength.description": "The maximum number of characters to display for the connection info in the status bar. Set to -1 for no limit.",
     "mssql.schemaDesigner.enableExpandCollapseButtons": "Enable expand/collapse buttons in Schema Designer table nodes when tables have more than 10 columns",
     "mssql.connectionManagement.rememberPasswordsUntilRestart": "Temporarily store passwords for connections with 'Saved Passwords' disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session.",
-    "mssql.autoRevealResultsPanel": "Automatically reveal the results panel when switching to an editor with query results."
+    "mssql.autoRevealResultsPanel": "Automatically reveal the results panel when switching to an editor with query results. Only applies when 'Open Results in New Tab' is enabled."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -227,5 +227,5 @@
     "mssql.statusBar.connectionInfoMaxLength.description": "The maximum number of characters to display for the connection info in the status bar. Set to -1 for no limit.",
     "mssql.schemaDesigner.enableExpandCollapseButtons": "Enable expand/collapse buttons in Schema Designer table nodes when tables have more than 10 columns",
     "mssql.connectionManagement.rememberPasswordsUntilRestart": "Temporarily store passwords for connections with 'Saved Passwords' disabled, until the extension is restarted. This prevents repeated password prompts when reusing connections within the same session.",
-    "mssql.autoRevealResultsPanel": "Automatically reveal the results panel when switching to an editor with query results. Only applies when 'Open Results in New Tab' is enabled."
+    "mssql.autoRevealResultsPanel": "Automatically reveal the results panel when switching to an editor with query results. Only applies when 'Open Results in Tab' is enabled."
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -242,6 +242,7 @@ export const configSchemaDesignerEnableExpandCollapseButtons =
     "mssql.schemaDesigner.enableExpandCollapseButtons";
 export const configSavePasswordsUntilRestart =
     "mssql.connectionManagement.rememberPasswordsUntilRestart";
+export const configAutoRevealResultsPanel = "mssql.autoRevealResultsPanel";
 
 // ToolsService Constants
 export const serviceInstallingTo = "Installing SQL tools service to";

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -62,13 +62,31 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         context.subscriptions.push(
             vscode.window.onDidChangeActiveTextEditor((editor) => {
                 const uri = editor?.document?.uri?.toString(true);
-                /**
-                 * Do not load query results in the webview view if a panel is already opened for the results
-                 */
-                if (uri && this._queryResultStateMap.has(uri) && !this.hasPanel(uri)) {
-                    this.state = this.getQueryResultState(uri);
+                if (this.hasPanel(uri)) {
+                    const editorViewColumn = editor?.viewColumn;
+                    const panelViewColumn =
+                        this._queryResultWebviewPanelControllerMap.get(uri).viewColumn;
+
+                    /**
+                     * If the results are shown in webview panel, and the active editor is not in the same
+                     * view column as the results, then reveal the panel to the foreground
+                     */
+                    if (editorViewColumn !== panelViewColumn && this.shouldAutoRevealResultsPanel) {
+                        this.revealPanel(uri);
+                    }
                 } else {
-                    this.showSplashScreen();
+                    if (uri && this._queryResultStateMap.has(uri)) {
+                        /**
+                         * If the results are shown in webview view, then update the state to show the
+                         * results for the active editor
+                         */
+                        this.state = this.getQueryResultState(uri);
+                    } else {
+                        /**
+                         * If there is no results for the active editor, then show the splash screen
+                         */
+                        this.showSplashScreen();
+                    }
                 }
             }),
         );
@@ -121,6 +139,10 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                 }
             }),
         );
+    }
+
+    private get shouldAutoRevealResultsPanel(): boolean {
+        return this.vscodeWrapper.getConfiguration().get(Constants.configAutoRevealResultsPanel);
     }
 
     private async initialize() {

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -61,8 +61,14 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
 
         context.subscriptions.push(
             vscode.window.onDidChangeActiveTextEditor((editor) => {
+                console.log(editor);
                 const uri = editor?.document?.uri?.toString(true);
-                if (this.hasPanel(uri)) {
+                const hasPanel = uri && this.hasPanel(uri);
+                const hasWebviewViewState = uri && this._queryResultStateMap.has(uri);
+
+                if (hasWebviewViewState && !hasPanel) {
+                    this.state = this.getQueryResultState(uri);
+                } else if (hasPanel) {
                     const editorViewColumn = editor?.viewColumn;
                     const panelViewColumn =
                         this._queryResultWebviewPanelControllerMap.get(uri).viewColumn;
@@ -71,22 +77,11 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
                      * If the results are shown in webview panel, and the active editor is not in the same
                      * view column as the results, then reveal the panel to the foreground
                      */
-                    if (editorViewColumn !== panelViewColumn && this.shouldAutoRevealResultsPanel) {
+                    if (this.shouldAutoRevealResultsPanel && editorViewColumn !== panelViewColumn) {
                         this.revealPanel(uri);
                     }
                 } else {
-                    if (uri && this._queryResultStateMap.has(uri)) {
-                        /**
-                         * If the results are shown in webview view, then update the state to show the
-                         * results for the active editor
-                         */
-                        this.state = this.getQueryResultState(uri);
-                    } else {
-                        /**
-                         * If there is no results for the active editor, then show the splash screen
-                         */
-                        this.showSplashScreen();
-                    }
+                    this.showSplashScreen();
                 }
             }),
         );

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -61,7 +61,6 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
 
         context.subscriptions.push(
             vscode.window.onDidChangeActiveTextEditor((editor) => {
-                console.log(editor);
                 const uri = editor?.document?.uri?.toString(true);
                 const hasPanel = uri && this.hasPanel(uri);
                 const hasWebviewViewState = uri && this._queryResultStateMap.has(uri);

--- a/src/queryResult/queryResultWebviewPanelController.ts
+++ b/src/queryResult/queryResultWebviewPanelController.ts
@@ -93,4 +93,8 @@ export class QueryResultWebviewPanelController extends ReactWebviewPanelControll
     public getQueryResultWebviewViewController(): QueryResultWebviewController {
         return this._queryResultWebviewViewController;
     }
+
+    public get viewColumn(): vscode.ViewColumn {
+        return this._viewColumn;
+    }
 }

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -21,6 +21,8 @@ import store, { SubKeys } from "./singletonStore";
 import { JsonFormattingEditProvider } from "../utils/jsonFormatter";
 import * as LocalizedConstants from "../constants/locConstants";
 
+export const MAX_VIEW_COLUMN = 9;
+
 export function getNewResultPaneViewColumn(
     uri: string,
     vscodeWrapper: VscodeWrapper,
@@ -28,31 +30,36 @@ export function getNewResultPaneViewColumn(
     // // Find configuration options
     let config = vscodeWrapper.getConfiguration(Constants.extensionConfigSectionName, uri);
     let splitPaneSelection = config[Constants.configSplitPaneSelection];
-    let viewColumn: vscode.ViewColumn;
 
     switch (splitPaneSelection) {
         case "current":
-            viewColumn = vscodeWrapper.activeTextEditor.viewColumn;
-            break;
+            return vscodeWrapper.activeTextEditor.viewColumn;
         case "end":
-            viewColumn = vscode.ViewColumn.Three;
-            break;
-        // default case where splitPaneSelection is next or anything else
+            const visibleEditors = vscode.window.visibleTextEditors;
+            const maxViewColumn = visibleEditors.reduce((max, editor) => {
+                return editor.viewColumn && editor.viewColumn > max ? editor.viewColumn : max;
+            }, 0);
+            return Math.min(maxViewColumn + 1, MAX_VIEW_COLUMN) as vscode.ViewColumn;
+        /**
+         * 'next' is the default case.
+         */
+        case "next":
         default:
-            // if there's an active text editor
-            if (vscodeWrapper.isEditingSqlFile) {
-                viewColumn = vscodeWrapper.activeTextEditor.viewColumn;
-                if (viewColumn === vscode.ViewColumn.One) {
-                    viewColumn = vscode.ViewColumn.Two;
-                } else {
-                    viewColumn = vscode.ViewColumn.Three;
-                }
-            } else {
-                // otherwise take default results column
-                viewColumn = vscode.ViewColumn.Two;
+            const currentEditor = vscode.window.visibleTextEditors.find((editor) => {
+                return (
+                    editor.document.uri.toString(true) === uri && editor.viewColumn !== undefined
+                );
+            });
+            if (!currentEditor) {
+                return vscode.ViewColumn.One;
             }
+
+            const newViewColumn = Math.min(
+                (currentEditor.viewColumn ?? 1) + 1,
+                MAX_VIEW_COLUMN,
+            ) as vscode.ViewColumn;
+            return newViewColumn;
     }
-    return viewColumn;
 }
 
 export function registerCommonRequestHandlers(


### PR DESCRIPTION
## Description
Fixes: #1480
1. Revealing the corresponding result panel when the active query editor is changed. This can be turned off in settings.
2. Refine where new results panels open based on user preference. It leads to more predictable result panel opening based on config's “Split Results To” is set to current/next/end

1. Current: Always open in current editor.
2. Next: Always open in next column. Max column is 9
3. End: Always open in the last visible column + 1. Max column is 9. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

