### PR TITLE
Making sure run Query runs the query when the OE isn't initalized. 

### DIFF
--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2129,7 +2129,11 @@ export default class MainController implements vscode.Disposable {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
             let credentials = await this._connectionMgr.onNewConnection();
             if (credentials) {
-                await this.createObjectExplorerSession(credentials);
+                try {
+                    await this.createObjectExplorerSession(credentials);
+                } catch (error) {
+                    this._connectionMgr.client.logger.error(error);
+                }
                 return true;
             }
         }


### PR DESCRIPTION
## Description

When OE is not initialized, the **Run Query** command fails on the first attempt because `checkIsReadyToExecuteQuery()` returns `false`.  

This PR updates the logic to absorb the OE initialization error, ensuring that `checkIsReadyToExecuteQuery()` can still validate readiness without blocking query execution on the first try.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

