### PR TITLE
Feature/Improvement: CTRL + Scroll to expand and contract query result columns

### DIFF
--- a/src/reactviews/pages/QueryResult/resultGrid.tsx
+++ b/src/reactviews/pages/QueryResult/resultGrid.tsx
@@ -83,7 +83,7 @@ const ResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props: ResultG
         selectedCols.forEach((colIdx) => {
             const col = columns[colIdx];
             if (col && col.width) {
-                col.width = Math.max(40, Math.min(col.width + delta, 800));
+                col.width = Math.max(40, col.width + delta);
                 changed = true;
             }
         });


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

This PR makes it easier to expand or contract one or more selected columns in the query results grid with two simple shortcuts: CTRL + Scroll up (to expand a column/columns) and CTRL + Scroll Down (to contract a column/columns). Full column selection is not required, a single selection in a column and anything in between will work. This also makes expanding a column that trails off the end of the query results WebView much easier to expand.

P.S. my [other PR](https://github.com/microsoft/vscode-mssql/pull/19961) needs review 

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

