### PR TITLE
[CodeCoverage] Enable CodeCov checks for mssql ext

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,11 +3,9 @@ coverage:
     project: #code coverage requirements for the entire project
       default:
         target: 50% #the required coverage value
-        informational: true #temporary until CodeCov is setup on the repo
     patch: # code coverage requirements for the changes in the commit
       default:
         target: 70% #the required coverage value
-        informational: true #temporary until CodeCov is setup on the repo
 comment: #Layout of the PR comment
   layout: "reach, diff, files"
   behavior: default


### PR DESCRIPTION
## Description

Currently, the CodeCov checks are set as informational i.e. it doesn't block checkins. Looks like the coverage reports are getting generated correctly, so enabling the checks with this PR. This will enable two checks.

- Patch coverage of the commit should be atleast 70%
- Overall coverage should not drop below 50%

As we improve the code coverage, we can bring up the overall coverage threshold.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
