### PR TITLE
Fix VS Code debug config for bundled extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/**/*.js", "${workspaceRoot}/out/src/**/*.js"],
             "rendererDebugOptions": {
                 "pauseForSourceMap": true,
                 "sourceMapRenames": true,
@@ -38,7 +38,7 @@
                 "--skip-welcome"
             ],
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/**/*.js", "${workspaceRoot}/out/src/**/*.js"],
             "env": {
                 // Uncomment this to use a specified version of STS, see
                 // https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable


### PR DESCRIPTION
## Description
Add the dist/**/*.js glob to both extension host launch configs so VS Code maps breakpoints to the bundled output. Without these changes, the breakpoints aren’t hit when I start debugging in VS Code.


## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md) 