### PR TITLE
Adding fixes for get rows out of bounds. 

### DIFF
--- a/src/reactviews/pages/QueryResult/table/asyncDataView.ts
+++ b/src/reactviews/pages/QueryResult/table/asyncDataView.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// import * as vscode from 'vscode';
 import { IDisposableDataProvider } from "./dataProvider";
+import { v4 as uuid } from "uuid";
 
 export interface IObservableCollection<T> {
     getLength(): number;
@@ -22,9 +22,9 @@ class DataWindow<T> {
     private _data: T[] | undefined;
     private _length: number = 0;
     private _offsetFromDataSource: number = -1;
-    private _currentRequestId: number = 0;
+    private _currentRequestId: string = uuid();
     private _debounceTimeout: NodeJS.Timeout | undefined;
-    private readonly _debounceDelay: number = 50; // ms to wait before sending request
+    private readonly _getRowsDebounceDelayMs: number = 50;
     private _lastPositionTime: number = 0;
     private _consecutivePositionCount: number = 0;
 
@@ -76,7 +76,7 @@ class DataWindow<T> {
         this._data = undefined;
 
         // Increment request ID to invalidate any pending requests
-        this._currentRequestId++;
+        this._currentRequestId = uuid();
         const currentRequestId = this._currentRequestId;
 
         if (length === 0) {
@@ -124,7 +124,7 @@ class DataWindow<T> {
             this._debounceTimeout = setTimeout(() => {
                 this._debounceTimeout = undefined;
                 executeLoad();
-            }, this._debounceDelay);
+            }, this._getRowsDebounceDelayMs);
         } else {
             // Otherwise, load immediately (scrollbar drag, single scroll, or first few scrolls)
             executeLoad();


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

While I was not able to repo this issue, I am adding more guardrails around the getRows code so it doesn't lead to negative row fetches. 

This also adds debouncing when scrolling through tables so that we don't spam sts with too many requests and also adding checks so that cell values don't keep fluctuating as we try to update from state results.

Fixes: #20283 

Before:

![Code_mWBpYpLpnj](https://github.com/user-attachments/assets/02dbe6c7-cca6-4046-9166-dd4c8edcfb41)


Fixed:

![Code_94vWT6pDYj](https://github.com/user-attachments/assets/6502a764-8db1-4910-ad52-aca7a0274459)


## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
