### PR TITLE
Removed unnecessary capacity permissions check when determining workspace permissions in Fabric Provisioning

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1242,7 +1242,6 @@
     "Search Workspaces": "Search Workspaces",
     "Workspace is required": "Workspace is required",
     "Insufficient Workspace Permissions": "Insufficient Workspace Permissions",
-    "Insufficient Capacity Permissions": "Insufficient Capacity Permissions",
     "Fabric is not supported in the current cloud ({0}).  Ensure setting '{1}' is configured correctly./{0} is the cloud name{1} is the setting name": {
         "message": "Fabric is not supported in the current cloud ({0}).  Ensure setting '{1}' is configured correctly.",
         "comment": ["{0} is the cloud name", "{1} is the setting name"]

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1728,9 +1728,6 @@
     <trans-unit id="++CODE++23175b00048139605147500e1f2eb6c43b4e938ee3dbcfebb00ae6b472284cdb">
       <source xml:lang="en">Instant Container Setup</source>
     </trans-unit>
-    <trans-unit id="++CODE++07fe70d13a25b3d4c4f7d4e64e1aaa9b9d80952a1478fb7e2da36209ccbf549f">
-      <source xml:lang="en">Insufficient Capacity Permissions</source>
-    </trans-unit>
     <trans-unit id="++CODE++207b04072a822fa8e76629bcd504bc8c19525b86f444ac77a6f3be1c88a502eb">
       <source xml:lang="en">Insufficient Workspace Permissions</source>
     </trans-unit>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -916,7 +916,6 @@ export class Fabric {
     public static searchWorkspaces = l10n.t("Search Workspaces");
     public static workspaceIsRequired = l10n.t("Workspace is required");
     public static insufficientWorkspacePermissions = l10n.t("Insufficient Workspace Permissions");
-    public static insufficientCapacityPermissions = l10n.t("Insufficient Capacity Permissions");
 
     public static fabricNotSupportedInCloud = (cloudName: string, settingName: string) => {
         return l10n.t({

--- a/src/sharedInterfaces/fabricProvisioning.ts
+++ b/src/sharedInterfaces/fabricProvisioning.ts
@@ -28,7 +28,6 @@ export class FabricProvisioningState
     workspacesWithPermissions: Record<string, IWorkspace> = {};
     workspacesWithoutPermissions: Record<string, IWorkspace> = {};
     isWorkspacesErrored: boolean = false;
-    capacityIds: string[] = [];
     userGroupIds: string[] = [];
     deploymentStartTime: string = "";
     workspaces: IWorkspace[] = [];

--- a/test/unit/fabricProvisioningHelpers.test.ts
+++ b/test/unit/fabricProvisioningHelpers.test.ts
@@ -245,7 +245,6 @@ suite("Fabric Provisioning logic", () => {
         const result = await fabricHelpers.reloadFabricComponents(deploymentController, "tenant1");
 
         // Check that sets and arrays were reset
-        assert.deepStrictEqual(Array.from(result.capacityIds), []);
         assert.deepStrictEqual(Array.from(result.userGroupIds), []);
         assert.deepStrictEqual(result.workspaces, []);
         assert.deepStrictEqual(result.databaseNamesInWorkspace, []);
@@ -288,11 +287,6 @@ suite("Fabric Provisioning logic", () => {
         assert.strictEqual(options[1].value, "ws2");
         assert.strictEqual(options[1].description, Fabric.insufficientWorkspacePermissions);
         assert.strictEqual(options[1].icon, "Warning20Regular");
-
-        // ws3 has no capacity permission
-        assert.strictEqual(options[2].value, "ws3");
-        assert.strictEqual(options[2].description, Fabric.insufficientCapacityPermissions);
-        assert.strictEqual(options[2].icon, "Warning20Regular");
     });
 
     test("getWorkspaces updates state with workspace options", async () => {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
Fixes https://github.com/microsoft/vscode-mssql/issues/20198

Previously, the code validated both capacity and workspace permissions to determine which workspaces were available for database provisioning. However, only workspace permissions are actually required, as outlined in the documentation below.
Doc: https://learn.microsoft.com/en-us/rest/api/fabric/sqldatabase/items/create-sql-database?tabs=HTTP 

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [X] New or updated **unit tests** added
-   [X] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [X] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
