### PR TITLE
Adding extra padding in result grid

### DIFF
--- a/src/reactviews/pages/QueryResult/table/table.ts
+++ b/src/reactviews/pages/QueryResult/table/table.ts
@@ -637,6 +637,10 @@ export class Table<T extends Slick.SlickData> implements IThemable {
             );
         }
 
+        content.push(
+            `.monaco-table .${this.idPrefix} .grid-cell-value-container { padding: 2px; }`,
+        );
+
         if (styles.tableHeaderForeground) {
             content.push(
                 `.monaco-table .${this.idPrefix} .slick-header .slick-header-column { color: ${styles.tableHeaderForeground}; }`,


### PR DESCRIPTION
## Description

Adding extra padding around the cells in the result grid to improve readability.

Before

<img width="409" height="183" alt="image" src="https://github.com/user-attachments/assets/147c2ec9-a26d-4a24-b880-99b8add3f24a" />

After

<img width="408" height="186" alt="image" src="https://github.com/user-attachments/assets/8846f5d7-4e98-41af-8fbb-6a2dc5637906" />


## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
