### PR TITLE
Show query  plan tab when query plan xml result is clicked

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -166,6 +166,10 @@ export const databaseString = "Database";
 export const localizedTexts = "localizedTexts";
 export const ipAddressRegex =
     /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/;
+export const xml = "xml";
+export const json = "json";
+export const queryPlanXmlStart = "<ShowPlanXML";
+
 /**
  * Azure Firewall rule name convention is specified here:
  * https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Firewall.Name/

--- a/src/queryResult/utils.ts
+++ b/src/queryResult/utils.ts
@@ -307,12 +307,22 @@ export function registerCommonRequestHandlers(
     });
     webviewController.registerReducer("openFileThroughLink", async (state, payload) => {
         // TO DO: add formatting? ADS doesn't do this, but it may be nice...
+
+        // If the content is an execution plan XML, open it in the execution plan tab
+        if (
+            payload.type === Constants.xml &&
+            payload.content.startsWith(Constants.queryPlanXmlStart)
+        ) {
+            state.tabStates.resultPaneTab = qr.QueryResultPaneTabs.ExecutionPlan;
+            return state;
+        }
+
         const newDoc = await vscode.workspace.openTextDocument({
             content: payload.content,
             language: payload.type,
         });
 
-        if (payload.type === "json") {
+        if (payload.type === Constants.json) {
             const formatter = new JsonFormattingEditProvider();
             const edits = await formatter.provideDocumentFormattingEdits(newDoc);
             const workspaceEdit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
Fixes https://github.com/microsoft/vscode-mssql/issues/18846

Previously, when a Query Plan XML was clicked in the result grid, it would open up a new XML document with the Query Plan XML. Now, it pulls up the Query Plan View in the Query Results Pane

![showPlanTabWhenQueryPlanXmlClicked](https://github.com/user-attachments/assets/fd781b7e-9611-4e94-8841-8b574249c062)

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [X] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
