### PR TITLE
Disabling auto reveal by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2028,7 +2028,7 @@
                 },
                 "mssql.autoRevealResultsPanel": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "%mssql.autoRevealResultsPanel%",
                     "scope": "window"
                 },


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Disabling auto reveal result grid panel. This will add back default behavior of our extension before I added this option.
https://github.com/microsoft/vscode-mssql/pull/20196

Switching to false as it can become a little annoying if you are trying to compare results in one webview with text from a different query editor. 


## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
