### PR TITLE
Throttling query result set updates to prevent spamming webview rpc. 

### DIFF
--- a/src/models/sqlOutputContentProvider.ts
+++ b/src/models/sqlOutputContentProvider.ts
@@ -354,7 +354,6 @@ export class SqlOutputContentProvider {
             executionPlanOptions?.includeEstimatedExecutionPlanXml ||
                 this._actualPlanStatuses.includes(uri) ||
                 executionPlanOptions?.includeActualExecutionPlanXml,
-            this._actualPlanStatuses.includes(uri),
         );
         if (isOpenQueryResultsInTabByDefaultEnabled()) {
             await this._queryResultWebviewController.createPanelController(queryRunner.uri);
@@ -453,7 +452,7 @@ export class SqlOutputContentProvider {
                         resultWebviewState.resultSetSummaries[batchId] = {};
                     }
                     resultWebviewState.resultSetSummaries[batchId][resultId] = resultSet;
-                    this.updateWebviewState(queryRunner.uri, resultWebviewState);
+                    this.scheduleThrottledUpdate(queryRunner.uri);
                 },
             );
 

--- a/src/queryResult/queryResultWebViewController.ts
+++ b/src/queryResult/queryResultWebViewController.ts
@@ -269,12 +269,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
         await controller.whenWebviewReady();
     }
 
-    public addQueryResultState(
-        uri: string,
-        title: string,
-        isExecutionPlan?: boolean,
-        actualPlanEnabled?: boolean,
-    ): void {
+    public addQueryResultState(uri: string, title: string, isExecutionPlan?: boolean): void {
         let currentState = {
             resultSetSummaries: {},
             messages: [],
@@ -285,7 +280,6 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             uri: uri,
             title: title,
             isExecutionPlan: isExecutionPlan,
-            actualPlanEnabled: actualPlanEnabled,
             ...(isExecutionPlan && {
                 executionPlanState: {
                     loadState: ApiStatus.Loading,
@@ -300,7 +294,7 @@ export class QueryResultWebviewController extends ReactWebviewViewController<
             },
             autoSizeColumns: this.getAutoSizeColumnsConfig(),
             inMemoryDataProcessingThreshold: getInMemoryGridDataProcessingThreshold(),
-        };
+        } as qr.QueryResultWebviewState;
         this._queryResultStateMap.set(uri, currentState);
     }
 


### PR DESCRIPTION
## Description

Doing this prevents spamming webview rpc when a large grid is streamed and we get a bunch of resultSet updates. This is the same logic we used in messages to prevent message spamming. 

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
