### PR TITLE
Forcing all grids to re-render when the grid is minimized. 

### DIFF
--- a/src/reactviews/pages/QueryResult/queryResultsGridView.tsx
+++ b/src/reactviews/pages/QueryResult/queryResultsGridView.tsx
@@ -156,6 +156,11 @@ export const QueryResultsGridView = () => {
 
                 const isMaximized = maximizedGridKey === gridKey;
                 const shouldHide = maximizedGridKey !== undefined && !isMaximized;
+                /**
+                 * When a grid is minimized, we unmount it to allow it to re-measure its dimensions
+                 * when it is restored. This ensures that the grid layout is correct based on the
+                 * available space and restores its column dimensions properly.
+                 */
                 if (shouldHide) {
                     return undefined;
                 }


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

So previously, when the grid was maximized and the Webviews was re-rendered, other grids could have flakiness in setting their column width.

This could lead to some grids to have all their columns set to minimum width
For example: 

<img width="844" height="407" alt="image" src="https://github.com/user-attachments/assets/698a4a24-0db7-4034-a30b-0e72c7e618d1" />


This PR forces grids to re-render when a grid is minimized, making them set their dimensions correctly. 

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
