### PR TITLE
v-bump STS to 5.0.20251103.1

### DIFF
--- a/src/configurations/config.ts
+++ b/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251029.3",
+        version: "5.0.20251103.1",
         downloadFileNames: {
             Windows_86: "win-x86-net8.0.zip",
             Windows_64: "win-x64-net8.0.zip",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR bumps the STS version used by the MSSQL extension.

<img width="1319" height="329" alt="image" src="https://github.com/user-attachments/assets/203ed53d-1f01-4dd9-9a3b-80943c69e5d7" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
