### PR TITLE
Update GHCP extension check to github.copilot-chat

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     IconUtils.initialize(context.extensionUri);
 
     // Check if GitHub Copilot is installed
-    const copilotExtension = vscode.extensions.getExtension("GitHub.copilot");
+    const copilotExtension = vscode.extensions.getExtension("github.copilot-chat");
     vscode.commands.executeCommand(
         "setContext",
         "mssql.copilot.isGHCInstalled",


### PR DESCRIPTION
## Description
This PR updates extension ID check from GitHub.copilot to github.copilot-chat

### Context:

Within the extension:
We check for Copilot extension presence to conditionally show/hide Copilot-related UI elements (context menu commands like "Explain Query", "Rewrite Query", and Object Explorer chat options). This prevents showing these features to users without Copilot installed.
https://github.com/microsoft/vscode-mssql/blob/895f8669e1b31bb18029489c58d22e075f4463ba/package.json#L644
GitHub Copilot:
The github.copilot extension is being deprecated by early 2026 and replaced with github.copilot-chat as the single unified extension.

### No compatibility concerns:
Currently when you install Copilot in Visual Studio Code, you get two extensions:
[GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) - Provides inline coding suggestions as you type.
[GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) - A companion extension that provides conversational AI assistance.

In reality we should've checked `github.copilot-chat` from the beginning but it didn't matter as these two extensions come in one bundle.

References:

VS Code blog: [https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone](https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone)

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
