### PR TITLE
Bump STS to bring in SimpleExecute fixes

### DIFF
--- a/src/configurations/config.ts
+++ b/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251104.2",
+        version: "5.0.20251107.1",
         downloadFileNames: {
             Windows_86: "win-x86-net8.0.zip",
             Windows_64: "win-x64-net8.0.zip",


### PR DESCRIPTION
## Description

This PR bumps STS to `5.0.20251107.1` to bring in a few `SimpleExecute` fixes, this is used by GHCP agent mode `runQueryTool`.

PR to STS: https://github.com/microsoft/sqltoolsservice/pull/2536

Changes since last STS version:
https://github.com/microsoft/sqltoolsservice/compare/5.0.20251104.2...5.0.20251107.1
<img width="851" height="374" alt="image" src="https://github.com/user-attachments/assets/3720cd09-8a81-4c20-864e-864c0810ea8a" />


## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
