### PR TITLE
Bumping STS to 5.0.20251110.1 to take SMO 180.10.0 (non-preview)

### DIFF
--- a/src/configurations/config.ts
+++ b/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251107.1",
+        version: "5.0.20251110.1",
         downloadFileNames: {
             Windows_86: "win-x86-net8.0.zip",
             Windows_64: "win-x64-net8.0.zip",


### PR DESCRIPTION
Bumping STS to take a SMO update.

SMO 180.10.0 brings:
* a "release" version (instead of `-preview`)
* JSON INDEX support

<img width="2131" height="554" alt="image" src="https://github.com/user-attachments/assets/e596e997-b42c-4718-8c9b-14afde12eba4" />
