### PR TITLE
Fix for reset adv options changes

### DIFF
--- a/src/reactviews/pages/PublishProject/components/advancedDeploymentOptionsDrawer.tsx
+++ b/src/reactviews/pages/PublishProject/components/advancedDeploymentOptionsDrawer.tsx
@@ -71,11 +71,14 @@ export const AdvancedDeploymentOptionsDrawer = ({
     const [localChanges, setLocalChanges] = useState<Array<{ optionName: string; value: boolean }>>(
         [],
     );
+    // Snapshot of localChanges when drawer opens (for cancel functionality)
+    const [localChangesSnapshot, setLocalChangesSnapshot] = useState(localChanges);
 
-    // Clear local changes when deploymentOptions change (e.g., from profile loading)
     useEffect(() => {
-        setLocalChanges([]);
-    }, [state.deploymentOptions]);
+        if (isAdvancedDrawerOpen) {
+            setLocalChangesSnapshot([...localChanges]);
+        }
+    }, [isAdvancedDrawerOpen]);
 
     const getCurrentValue = useCallback(
         (optionName: string, baseValue: boolean): boolean => {
@@ -185,6 +188,9 @@ export const AdvancedDeploymentOptionsDrawer = ({
 
     // Options reset handler, clears all local changes (reset to base deployment options)
     const handleReset = () => {
+        if (state.defaultDeploymentOptions) {
+            context?.updateDeploymentOptions(state.defaultDeploymentOptions);
+        }
         setLocalChanges([]);
     };
 
@@ -247,9 +253,9 @@ export const AdvancedDeploymentOptionsDrawer = ({
         }
     };
 
-    // Clear local changes and close drawer
+    // Cancel: restore snapshot from when drawer opened (discard current session changes)
     const handleCancel = () => {
-        setLocalChanges([]);
+        setLocalChanges(localChangesSnapshot);
         setIsAdvancedDrawerOpen(false);
     };
 

--- a/test/unit/publishProjectWebViewController.test.ts
+++ b/test/unit/publishProjectWebViewController.test.ts
@@ -669,6 +669,50 @@ suite("PublishProjectWebViewController Tests", () => {
             newState.deploymentOptions.booleanOptionsDictionary.allowDropBlockingAssemblies.value,
         ).to.be.true;
     });
+
+    test("deployment options reset restores default values", async () => {
+        const controller = createTestController();
+        await controller.initialized.promise;
+
+        const reducerHandlers = controller["_reducerHandlers"] as Map<string, Function>;
+        const updateDeploymentOptions = reducerHandlers.get("updateDeploymentOptions");
+
+        // Set up default deployment options
+        const defaultOptions = {
+            excludeObjectTypes: { value: [], description: "", displayName: "" },
+            booleanOptionsDictionary: {
+                ignoreTableOptions: {
+                    value: false,
+                    description: "Ignore table options",
+                    displayName: "Ignore Table Options",
+                },
+            },
+            objectTypesDictionary: {},
+        };
+
+        controller.state.defaultDeploymentOptions = defaultOptions;
+
+        // User makes changes
+        const modifiedOptions = structuredClone(defaultOptions);
+        modifiedOptions.booleanOptionsDictionary.ignoreTableOptions.value = true;
+
+        let state = await updateDeploymentOptions(controller.state, {
+            deploymentOptions: modifiedOptions,
+        });
+
+        // Verify change is applied
+        expect(state.deploymentOptions.booleanOptionsDictionary.ignoreTableOptions.value).to.be
+            .true;
+
+        // Reset should restore defaults
+        state = await updateDeploymentOptions(state, {
+            deploymentOptions: state.defaultDeploymentOptions,
+        });
+
+        // Verify reset to default value
+        expect(state.deploymentOptions.booleanOptionsDictionary.ignoreTableOptions.value).to.be
+            .false;
+    });
     //#endregion
 
     //#region Generate Script Tests


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

Issue: https://github.com/microsoft/vscode-mssql/issues/20520

## Description

This PR fixes the advanced options enable/disable reset button on drawer reopens. when local changes are made and user can reset them at anytime before the publish. We are preserving the changes, but the reset button is sets to disable on reopen, and fixed that in this pr.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
