### PR TITLE
[PORT] Publish Dialog - Publish project to a new local container

### DIFF
--- a/localization/l10n/bundle.l10n.json
+++ b/localization/l10n/bundle.l10n.json
@@ -1622,6 +1622,8 @@
     "Image tag": "Image tag",
     "Microsoft SQL Server License Agreement": "Microsoft SQL Server License Agreement",
     "Select Connection": "Select Connection",
+    "Checking Docker prerequisites...": "Checking Docker prerequisites...",
+    "Creating SQL Server container...": "Creating SQL Server container...",
     "Port must be a number between 1 and 65535": "Port must be a number between 1 and 65535",
     "Invalid SQL Server password for {0}. Password must be 8–128 characters long and meet the complexity requirements.  For more information see https://docs.microsoft.com/sql/relational-databases/security/password-policy": "Invalid SQL Server password for {0}. Password must be 8–128 characters long and meet the complexity requirements.  For more information see https://docs.microsoft.com/sql/relational-databases/security/password-policy",
     "{0} password doesn't match the confirmation password": "{0} password doesn't match the confirmation password",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -530,6 +530,9 @@
     <trans-unit id="++CODE++43034967e711bc54bfe87c71c74ca2a19a39ca0d6e18c5d495cd90634d25eea0">
       <source xml:lang="en">Checking Docker Engine Configuration</source>
     </trans-unit>
+    <trans-unit id="++CODE++75fa3318f66944d01336b10cbb1e3c08afc6e230d849ee6fff4f4dba7f19489c">
+      <source xml:lang="en">Checking Docker prerequisites...</source>
+    </trans-unit>
     <trans-unit id="++CODE++469663d6e6c1f487f123cf95220bce4d9ac1c98f2cd06e373ccb0baa14c343d4">
       <source xml:lang="en">Checking if Docker is installed</source>
     </trans-unit>
@@ -1020,6 +1023,9 @@
     <trans-unit id="++CODE++f25b28d86db44d028580bac2348b043db0eebc8a41f443aaaa5d22bfd2cb3fd2">
       <source xml:lang="en">Creating SQL Database for workspace {0}</source>
       <note>{0} is the workspace ID</note>
+    </trans-unit>
+    <trans-unit id="++CODE++13329d1a1f2527d959fddce415af48d6141533dbec36dd8d8e33fae7bce865df">
+      <source xml:lang="en">Creating SQL Server container...</source>
     </trans-unit>
     <trans-unit id="++CODE++9c37c64c878515cc2b5cd8ce05b7513d90d2134a1a2c36469aaa548d6fdfa6e9">
       <source xml:lang="en">Creating and starting your SQL Server container</source>

--- a/src/constants/locConstants.ts
+++ b/src/constants/locConstants.ts
@@ -1365,6 +1365,8 @@ export class PublishProject {
     public static SqlServerImageTag = l10n.t("Image tag");
     public static SqlServerLicenseAgreement = l10n.t("Microsoft SQL Server License Agreement");
     public static ServerConnectionPlaceholder = l10n.t("Select Connection");
+    public static CheckingDockerPrerequisites = l10n.t("Checking Docker prerequisites...");
+    public static CreatingSqlServerContainer = l10n.t("Creating SQL Server container...");
     // Validation messages
     public static InvalidPortMessage = l10n.t("Port must be a number between 1 and 65535");
     public static InvalidSQLPasswordMessage(name: string) {

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -2586,6 +2586,7 @@ export default class MainController implements vscode.Disposable {
             this._vscodeWrapper,
             this.connectionManager,
             projectFilePath,
+            this,
             this.sqlProjectsService,
             this.dacFxService,
             deploymentOptions.defaultDeploymentOptions,

--- a/src/reactviews/pages/PublishProject/components/sqlCmdVariablesSection.tsx
+++ b/src/reactviews/pages/PublishProject/components/sqlCmdVariablesSection.tsx
@@ -27,10 +27,9 @@ const useStyles = makeStyles({
     tableContainer: {
         width: "100%",
         maxWidth: "640px",
-        maxHeight: "425px",
+        maxHeight: "368px",
         overflowY: "auto",
         border: "1px solid var(--vscode-panel-border)",
-        position: "relative",
     },
     table: {
         width: "100%",
@@ -41,21 +40,7 @@ const useStyles = makeStyles({
         top: "0",
         backgroundColor: "var(--vscode-editor-background, var(--vscode-sideBar-background))",
         borderBottom: "2px solid var(--vscode-panel-border)",
-        zIndex: 2,
-    },
-    tableHeaderCell: {
-        borderRight: "1px solid var(--vscode-panel-border)",
-        padding: "4px 8px",
-        "&:last-child": {
-            borderRight: "none",
-        },
-    },
-    nameCell: {
-        width: "40%",
-        fontWeight: "600",
-    },
-    valueCell: {
-        width: "60%",
+        zIndex: 1,
     },
     tableCell: {
         borderRight: "1px solid var(--vscode-panel-border)",
@@ -68,14 +53,16 @@ const useStyles = makeStyles({
     valueHeaderContent: {
         display: "flex",
         alignItems: "center",
-        justifyContent: "space-between",
+        justifyContent: "center",
         width: "100%",
+        position: "relative",
     },
     revertButton: {
         minWidth: "20px",
         height: "20px",
         padding: "2px",
-        marginLeft: "8px",
+        position: "absolute",
+        right: "0",
     },
 });
 
@@ -176,15 +163,18 @@ export const SqlCmdVariablesSection: React.FC = () => {
             required={sqlCmdComponent.required}
             orientation="horizontal">
             <div className={styles.tableContainer}>
-                <Table className={styles.table} size="small" aria-label={loc.SqlCmdVariablesLabel}>
+                <Table
+                    className={styles.table}
+                    size="extra-small"
+                    aria-label={loc.SqlCmdVariablesLabel}>
                     <TableHeader className={styles.tableHeader}>
                         <TableRow>
-                            <TableHeaderCell
-                                className={`${styles.tableHeaderCell} ${styles.nameCell}`}>
-                                {loc.SqlCmdVariableNameColumn}
+                            <TableHeaderCell className={styles.tableCell}>
+                                <div style={{ textAlign: "center", width: "100%" }}>
+                                    {loc.SqlCmdVariableNameColumn}
+                                </div>
                             </TableHeaderCell>
-                            <TableHeaderCell
-                                className={`${styles.tableHeaderCell} ${styles.valueCell}`}>
+                            <TableHeaderCell className={styles.tableCell}>
                                 <div className={styles.valueHeaderContent}>
                                     <span>{loc.SqlCmdVariableValueColumn}</span>
                                     <Tooltip
@@ -207,12 +197,13 @@ export const SqlCmdVariablesSection: React.FC = () => {
                     <TableBody>
                         {variableEntries.map(([varName]) => (
                             <TableRow key={varName}>
-                                <TableCell className={`${styles.tableCell} ${styles.nameCell}`}>
+                                <TableCell className={styles.tableCell}>
                                     <TableCellLayout>{varName}</TableCellLayout>
                                 </TableCell>
-                                <TableCell className={`${styles.tableCell} ${styles.valueCell}`}>
+                                <TableCell className={styles.tableCell}>
                                     <Input
                                         size="small"
+                                        style={{ width: "100%" }}
                                         value={localValues[varName] || ""}
                                         onChange={(_, data) =>
                                             handleValueChange(varName, data.value)

--- a/src/reactviews/pages/PublishProject/publishProject.tsx
+++ b/src/reactviews/pages/PublishProject/publishProject.tsx
@@ -51,11 +51,13 @@ function PublishProjectDialog() {
         <form className={formStyles.formRoot} onSubmit={(e) => e.preventDefault()}>
             <div className={formStyles.formDiv} style={{ overflow: "auto" }}>
                 {formMessage && (
-                    <DialogMessage
-                        message={formMessage}
-                        onMessageButtonClicked={() => {}}
-                        onCloseMessage={context.closeMessage}
-                    />
+                    <div>
+                        <DialogMessage
+                            message={formMessage}
+                            onMessageButtonClicked={() => {}}
+                            onCloseMessage={context.closeMessage}
+                        />
+                    </div>
                 )}
                 <PublishTargetSection />
                 <PublishProfileField />


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

Issue: https://github.com/microsoft/vscode-mssql/issues/20520
Main PR: https://github.com/microsoft/vscode-mssql/pull/20508

## Description

This PR:
 
- Adds the back-end functionality of deploying project to a new local development container, which purely reuse the existing deployment UI helper methods.
- The process will validate three prerequisites and then create and start a new container, builds the project and deploy the latest built dacpac to the created container.
- Also, we display live updates to the user using vscode progress window notifications.
- Along with the container changes, have fixed some sqlcmd table styles(better UI) and publishProject.tsx dialogMessage ele that are causing the formmessage text to flow out of the container and overlaps with publish fields.(attahed the images below)
- Added end-to-end tests that validates the full project deployment to container flow and helper methods too.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
