### PR TITLE
Porting "Bumping STS to 5.0.20251110.1 to take SMO 180.10.0 (non-preview) (#20526)"

### DIFF
--- a/src/configurations/config.ts
+++ b/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251107.1",
+        version: "5.0.20251110.1",
         downloadFileNames: {
             Windows_86: "win-x86-net8.0.zip",
             Windows_64: "win-x64-net8.0.zip",


### PR DESCRIPTION
Original PR: #20526 
Bug: https://github.com/microsoft/vscode-mssql/issues/20450

<img width="445" height="351" alt="image" src="https://github.com/user-attachments/assets/7cd866fc-5ece-490e-abf1-7f71c2dcc0b7" />

The SMO bump moves from `180.9.0-preview` to `180.10.0`.  Aside from the fact that this goes from a preview version to a release version, the only change is that this brings in support for JSON INDEX.