### PR TITLE
chore: replace HTML strings with native DOM elements

### DIFF
--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
@@ -12,6 +12,8 @@ import React, {
     useMemo,
 } from "react";
 import {
+    createDomElement,
+    htmlEncode,
     SlickgridReactInstance,
     Column,
     GridOption,
@@ -175,19 +177,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                         const hasFailed = failedCellsRef.current.has(changeKey);
                         const displayValue = value ?? "";
                         const isNullValue = displayValue === "NULL";
-
-                        // Safely escape HTML entities (with null/undefined check)
-                        const escapedDisplayValue =
-                            displayValue && typeof displayValue === "string"
-                                ? displayValue
-                                      .replace(/&/g, "&amp;")
-                                      .replace(/</g, "&lt;")
-                                      .replace(/>/g, "&gt;")
-                                      .replace(/"/g, "&quot;")
-                                      .replace(/'/g, "&#039;")
-                                : String(displayValue || "");
-
-                        const escapedTooltip = escapedDisplayValue;
+                        const escapedTooltip = htmlEncode(displayValue);
 
                         // Build CSS classes based on cell state
                         const cellClasses = [];
@@ -201,19 +191,28 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                             cellClasses.push("table-cell-null");
                         }
 
-                        const classAttr =
-                            cellClasses.length > 0 ? ` class="${cellClasses.join(" ")}"` : "";
-
                         // Failed cells get error styling
                         if (hasFailed) {
-                            return `<div title="${escapedTooltip}"${classAttr}>${escapedDisplayValue}</div>`;
+                            return createDomElement("div", {
+                                className: cellClasses.join(" "),
+                                title: escapedTooltip,
+                                textContent: displayValue,
+                            });
                         }
                         // Modified cells get warning styling
                         if (isModified) {
-                            return `<div title="${escapedTooltip}"${classAttr}>${escapedDisplayValue}</div>`;
+                            return createDomElement("div", {
+                                className: cellClasses.join(" "),
+                                title: escapedTooltip,
+                                textContent: displayValue,
+                            });
                         }
                         // Normal cells
-                        return `<span title="${escapedTooltip}"${classAttr}>${escapedDisplayValue}</span>`;
+                        return createDomElement("span", {
+                            className: cellClasses.join(" "),
+                            title: escapedTooltip,
+                            textContent: displayValue,
+                        });
                     },
                 };
 


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

provide CSP safe code to the new Editor table (`TableDataGrid.tsx`) by replacing HTML strings with native DOM elements.

_Side note: I'm the maintainer of Slickgrid-React/Universal_

#### Why?
1. better perf: when defining a `formatter` in Slickgrid-React and providing HTML code as a string, SlickGrid needs to parse it, sanitize it (when a sanitizer is provided), and eventually convert it to native code by assigning it to `innerHTML`.... if however we're providing native DOM element from the start, then there's nothing to parse and can be used "as-is" by simply using `.appendChild()`
2. CSP (Content Security Policy) safe because, as mentioned above, providing native DOM elements can be used "as is" and is in terms CSP safe because it's already native. 

The number 2. above is the main reason to open this PR and this feature to provide native DOM element directly to the `formatter` was added about 2 years ago (it didn't exists in the old SlickGrid lib, that might be why you didn't know about it).

More info in the docs: https://ghiscoding.gitbook.io/slickgrid-react/developer-guides/csp-compliance

### Questions to maintainers
- is the cell value expected to be html encoded? 
   - because I removed encoding for the cell value but kept it for the tooltip text. 
   - I'm also using `textContent` which mean that html strings would be displayed "as is" (e.g. html string are displayed "as is" and as simple text), is that the expectation?  OR do you prefer to assign the text directly to the `innerHTML`? If so, we should probably sanitize it (I like to use [DOMPurify](https://github.com/cure53/DOMPurify), the tooltip should also be sanitized)

### Notes about the code change
An important note is that I use code that already exist in Slickgrid-React/Universal
- [`createDomElement`](https://github.com/ghiscoding/slickgrid-universal/blob/master/packages/utils/src/domUtils.ts#L20-L35) is a simple function to create DOM element and provide multiple properties in an object as the 2nd argument and all of that in 1 call. It's also fully typed with intellisense and used internally by SlickGrid which simplifies the internal code a lot... 
- [`htmlEncode`](https://github.com/ghiscoding/slickgrid-universal/blob/65152547866a9f9dc59bf74f91efdd24944b9764/packages/utils/src/domUtils.ts#L209-L219) which is nearly identical to your previous code implementation

Side note, I'm not personally using this extension, I'm just thinking of contributing to this project since it's using Slickgrid-React which I maintain. I also cannot test this extension myself since I don't have access to any SQL DB and I do see some test failures (mostly firewall though)... feel free to take over the PR and modify it as you want. Cheers

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
