### PR TITLE
Fix web view initialization problem (Blank grid cells in query editor).

### DIFF
--- a/extensions/mssql/src/reactviews/common/rpc.ts
+++ b/extensions/mssql/src/reactviews/common/rpc.ts
@@ -31,10 +31,13 @@ import {
     RequestType,
 } from "vscode-jsonrpc/browser";
 
-// Chromium throttles setTimeout(0) when a webview is hidden which in turn stalls
-// vscode-jsonrpc's internal queue. Replace the runtime's setImmediate shim with
-// a MessageChannel based microtask so responses resolve immediately regardless
-// of visibility.
+/**
+ * Chromium throttles setTimeout(0) when a webview is hidden which in turn stalls
+ * vscode-jsonrpc's internal queue. Replace the runtime's setImmediate shim with
+ * a MessageChannel based microtask so responses resolve immediately regardless
+ * of visibility.
+ * Upstream vscode-jsonrpc issue: https://github.com/microsoft/vscode-languageserver-node/issues/1692
+ */
 const fixSetImmediate = (() => {
     let patched = false;
     return () => {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

After switching to `vscode-jsonrpc`, I introduced a perf regression in webviews. The library uses the RAL (Runtime Abstraction Layer), which implements a timer object with `setImmediate` to resolve queued requests. Unlike Node—which provides a built-in [`setImmediate`](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate)—the browser fallback tries to mimic it using `setTimeout(0)`.

Chromium (since version 88) throttles timers in hidden webviews, turning every `setTimeout(0)` into a one-second delay. VS Code webviews appear to be hidden for a few milliseconds before becoming visible (needs more investigation). So if ~30 requests are queued during initialization, it can take ~30 seconds to resolve them, completely breaking the experience.


https://github.com/user-attachments/assets/fcd1a140-c8e0-486d-89cc-78dad041ce64



This fix overrides the library’s `setImmediate` implementation in RAL so requests resolve immediately. It’s definitely a workaround. An actual fix should come from the library. I’ve opened an issue here: https://github.com/microsoft/vscode-languageserver-node/issues/1692



## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
