### PR TITLE
chore: simplify SlickGrid formatter

### DIFF
--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
@@ -181,34 +181,23 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
 
                         // Build CSS classes based on cell state
                         const cellClasses = [];
+
+                        // Failed cells get error styling
                         if (hasFailed) {
                             cellClasses.push("table-cell-error");
-                        } else if (isModified) {
+                        }
+                        // Modified cells get warning styling
+                        else if (isModified) {
                             cellClasses.push("table-cell-modified");
                         }
 
+                        // NULL cells get different styling
                         if (isNullValue) {
                             cellClasses.push("table-cell-null");
                         }
 
-                        // Failed cells get error styling
-                        if (hasFailed) {
-                            return createDomElement("div", {
-                                className: cellClasses.join(" "),
-                                title: escapedTooltip,
-                                textContent: displayValue,
-                            });
-                        }
-                        // Modified cells get warning styling
-                        if (isModified) {
-                            return createDomElement("div", {
-                                className: cellClasses.join(" "),
-                                title: escapedTooltip,
-                                textContent: displayValue,
-                            });
-                        }
-                        // Normal cells
-                        return createDomElement("span", {
+                        const elmType = hasFailed || isModified ? "div" : "span";
+                        return createDomElement(elmType, {
                             className: cellClasses.join(" "),
                             title: escapedTooltip,
                             textContent: displayValue,


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

a simple follow-up PR to previous PR #20694, most specifically a follow-up to this [comment](https://github.com/microsoft/vscode-mssql/pull/20694#pullrequestreview-3507784272)

it merges 3 DOM elements into a single one since they all follow roughly the same logic.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

### Future Code Review Questions

@lewis-sanchez I see that you added the `editCommandHandler` which is typically used for Undo Edit, but in your case it looks like you provided your own way of dealing with Undo... so in that case the use of `editCommandHandler` is totally irrelevant because `editCommand.execute();` is already the default code execution within SlickGrid when no edit handler is provided (see [here](https://github.com/ghiscoding/slickgrid-universal/blob/ef23686a3b8d758ec354f14bd3eca2499f6e33b4/packages/common/src/core/slickGrid.ts#L7400-L7405)), which mean that you could remove this handler without affecting the code (unless you really want to use its Undo feature later on?)

https://github.com/microsoft/vscode-mssql/blob/55a828dfe3ad2d75dc1c3f52999d89e98cd84981/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx#L355-L357