### PR TITLE
[Port] Revert "Identify container connections through container id (#20675)"…

### DIFF
--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -159,6 +159,7 @@ export const outputContentTypeShowError = "showError";
 export const outputContentTypeShowWarning = "showWarning";
 export const outputServiceLocalhost = "http://localhost:";
 export const localhost = "localhost";
+export const localhostIP = "127.0.0.1";
 export const defaultContainerName = "sql_server_container";
 export const msgContentProviderSqlOutputHtml = "dist/html/sqlOutput.ejs";
 export const contentProviderMinFile = "dist/js/app.min.js";

--- a/extensions/mssql/src/deployment/dockerUtils.ts
+++ b/extensions/mssql/src/deployment/dockerUtils.ts
@@ -13,6 +13,8 @@ import {
     defaultPortNumber,
     docker,
     dockerDeploymentLoggerChannelName,
+    localhost,
+    localhostIP,
     Platform,
     windowsDockerDesktopExecutable,
     x64,
@@ -129,10 +131,6 @@ export const COMMANDS = {
         command: "docker",
         args: ["ps", "-a", "--format", "{{.Names}}"],
     }),
-    GET_CONTAINER_NAME_FROM_ID: (containerId: string): DockerCommand => ({
-        command: "docker",
-        args: ["ps", "-a", "--filter", `id=${containerId}`, "--format", "{{.Names}}"],
-    }),
     INSPECT: (id: string): DockerCommand => ({
         command: "docker",
         args: ["inspect", sanitizeContainerInput(id)],
@@ -153,11 +151,11 @@ export const COMMANDS = {
             "-e",
             "ACCEPT_EULA=Y",
             "-e",
-            `\'SA_PASSWORD=${password}\'`,
+            `SA_PASSWORD=${password}`,
             "-p",
-            `\'${port}:${defaultPortNumber}\'`,
+            `${port}:${defaultPortNumber}`,
             "--name",
-            `\'${sanitizeContainerInput(name)}\'`,
+            sanitizeContainerInput(name),
         ];
 
         if (hostname) {
@@ -918,14 +916,42 @@ async function getUsedPortsFromContainers(containerIds: string[]): Promise<Set<n
 }
 
 /**
- * Checks if a connection is a Docker container by inspecting the machine name.
- * In docker containers, the machine name corresponds to the container ID.
- * If it is a Docker container, returns the container name; otherwise, returns undefined.
+ * Finds a Docker container by checking if its exposed ports match the server name.
+ * It inspects each container to find a match with the server name.
  */
-export async function checkIfConnectionIsDockerContainer(machineName: string): Promise<string> {
+async function findContainerByPort(containerIds: string[], serverName: string): Promise<string> {
+    if (serverName === localhost || serverName === localhostIP) {
+        serverName += `,${defaultPortNumber}`;
+    }
+    for (const id of containerIds) {
+        try {
+            const inspect = await execDockerCommand(COMMANDS.INSPECT_CONTAINER(id));
+            const ports = inspect.match(/"HostPort":\s*"(\d+)"/g);
+
+            if (ports?.some((p) => serverName.includes(p.match(/\d+/)?.[0] || ""))) {
+                const nameMatch = inspect.match(/"Name"\s*:\s*"\/([^"]+)"/);
+                if (nameMatch) return nameMatch[1];
+            }
+        } catch {
+            // skip container if inspection fails
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Checks if a connection is a Docker container by inspecting the server name.
+ */
+export async function checkIfConnectionIsDockerContainer(serverName: string): Promise<string> {
+    if (!serverName.includes(localhost) && !serverName.includes(localhostIP)) return "";
+
     try {
-        const stdout = await execDockerCommand(COMMANDS.GET_CONTAINER_NAME_FROM_ID(machineName));
-        return stdout.trim();
+        const stdout = await execDockerCommand(COMMANDS.GET_CONTAINERS());
+        const containerIds = stdout.split("\n").filter(Boolean);
+        if (!containerIds.length) return undefined;
+
+        return await findContainerByPort(containerIds, serverName);
     } catch {
         return undefined;
     }

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -710,10 +710,13 @@ export class ObjectExplorerService {
             return undefined;
         }
 
-        if (!connectionProfile.containerName) {
-            const serverInfo = this._connectionManager.getServerInfo(connectionInfo);
-            const machineName = (serverInfo as any)["machineName"] ?? "";
-            const containerName = await checkIfConnectionIsDockerContainer(machineName);
+        // Check if connection is a Docker container
+        const serverName = connectionProfile.connectionString
+            ? connectionProfile.connectionString.match(/^Server=([^;]+)/)?.[1]
+            : connectionProfile.server;
+
+        if (serverName && !connectionProfile.containerName) {
+            const containerName = await checkIfConnectionIsDockerContainer(serverName);
             if (containerName) {
                 connectionProfile.containerName = containerName;
             }


### PR DESCRIPTION
… (#20723)

This reverts pr https://github.com/microsoft/vscode-mssql/pull/20675, which caused a regression in the OE.

Original pr: https://github.com/microsoft/vscode-mssql/pull/20723
# Pull Request Template – vscode-mssql

## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [X] New or updated **unit tests** added
-   [X] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [X] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
