### PR TITLE
Add configuration option to show batch start/completion messages (default enabled)

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1805,6 +1805,12 @@
                     "default": false,
                     "scope": "resource"
                 },
+                "mssql.showBatchMessages": {
+                    "type": "boolean",
+                    "description": "%mssql.showBatchMessages%",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "mssql.splitPaneSelection": {
                     "type": "string",
                     "description": "%mssql.splitPaneSelection%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -121,6 +121,7 @@
     "mssql.copyIncludeHeaders": "[Optional] Configuration options for copying results from the Results View",
     "mssql.copyRemoveNewLine": "[Optional] Configuration options for copying multi-line results from the Results View",
     "mssql.showBatchTime": "[Optional] Should execution time be shown for individual batches",
+    "mssql.showBatchMessages": "[Optional] Show batch start and completion messages including 'Started executing query at...' and 'Commands completed successfully' messages.",
     "mssql.splitPaneSelection": "[Optional] Configuration options for which column new result panes should open in",
     "mssql.preventAutoExecuteScript": "Prevent automatic execution of scripts (e.g., 'Select Top 1000'). When enabled, scripts will not be automatically executed upon generation.",
     "mssql.format.alignColumnDefinitionsInColumns": "Should column definitions be aligned?",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -223,6 +223,7 @@ export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";
 export const configSplitPaneSelection = "splitPaneSelection";
 export const configShowBatchTime = "showBatchTime";
+export const configShowBatchMessages = "showBatchMessages";
 export const configPreventAutoExecuteScript = "mssql.query.preventAutoExecuteScript";
 export enum extConfigResultKeys {
     Shortcuts = "shortcuts",

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -564,7 +564,7 @@ export default class QueryRunner {
             Constants.extensionConfigSectionName,
             this.uri,
         );
-        let showBatchMessages: boolean = extConfig.get(Constants.configShowBatchMessages) ?? true;
+        let showBatchMessages: boolean = extConfig.get(Constants.configShowBatchMessages);
 
         // Only show success messages if the configuration allows it
         let shouldShowMessage = message.isError || showBatchMessages;

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -487,35 +487,37 @@ export class SqlOutputContentProvider {
                     Constants.extensionConfigSectionName,
                     queryUri,
                 );
-                let showBatchMessages: boolean = extConfig.get(Constants.configShowBatchMessages) ?? true;
-                
-                if (showBatchMessages) {
-                    let time = new Date().toLocaleTimeString();
-                    if (batch.executionElapsed && batch.executionEnd) {
-                        time = new Date(batch.executionStart).toLocaleTimeString();
-                    }
+                let showBatchMessages: boolean = extConfig.get(Constants.configShowBatchMessages);
 
-                    // Build a message for the selection and send the message
-                    // from the webview
-                    let message: IMessage = {
-                        message: LocalizedConstants.runQueryBatchStartMessage,
-                        selection: batch.selection,
-                        isError: false,
-                        time: time,
-                        link: {
-                            text: LocalizedConstants.runQueryBatchStartLine(
-                                batch.selection.startLine + 1,
-                            ),
-                            uri: queryRunner.uri,
-                        },
-                    };
-
-                    const resultWebviewState = this._queryResultWebviewController.getQueryResultState(
-                        queryRunner.uri,
-                    );
-                    resultWebviewState.messages.push(message);
-                    this.scheduleThrottledUpdate(queryRunner.uri);
+                if (showBatchMessages === false) {
+                    return;
                 }
+
+                let time = new Date().toLocaleTimeString();
+                if (batch.executionElapsed && batch.executionEnd) {
+                    time = new Date(batch.executionStart).toLocaleTimeString();
+                }
+
+                // Build a message for the selection and send the message
+                // from the webview
+                let message: IMessage = {
+                    message: LocalizedConstants.runQueryBatchStartMessage,
+                    selection: batch.selection,
+                    isError: false,
+                    time: time,
+                    link: {
+                        text: LocalizedConstants.runQueryBatchStartLine(
+                            batch.selection.startLine + 1,
+                        ),
+                        uri: queryRunner.uri,
+                    },
+                };
+
+                const resultWebviewState = this._queryResultWebviewController.getQueryResultState(
+                    queryRunner.uri,
+                );
+                resultWebviewState.messages.push(message);
+                this.scheduleThrottledUpdate(queryRunner.uri);
             });
 
             const onMessageListener = queryRunner.onMessage(async (message) => {


### PR DESCRIPTION
This PR adds a new configuration option `mssql.showBatchMessages` that allows users to control the display of batch start and completion messages in the SQL output panel. 

**Problem**: When executing large SQL files (thousands of lines), the output panel becomes cluttered with "Started executing query at..." and "Commands completed successfully" messages, making it difficult to spot actual error messages. This differs from SQL Server Management Studio behavior, which doesn't show these verbose batch messages by default.

**Solution**: Added a configurable option that:
- Defaults to `true` (preserves current behavior for backward compatibility)
- When set to `false`, suppresses batch start/completion messages while preserving all error messages
- Allows users to achieve SSMS-like output behavior for cleaner error visibility