### PR TITLE
Removing ambiguous mssql.intelliSense.lowerCaseSuggestions setting and use Formatting options instead

### DIFF
--- a/extensions/mssql/README.md
+++ b/extensions/mssql/README.md
@@ -193,8 +193,7 @@ Configure the MSSQL extension using these settings. Set them in user preferences
   "mssql.intelliSense.enableIntelliSense": true,           // Enable IntelliSense for T-SQL code completion
   "mssql.intelliSense.enableErrorChecking": true,          // Enable real-time syntax and semantic error checking
   "mssql.intelliSense.enableSuggestions": true,            // Enable code suggestions and autocompletion
-  "mssql.intelliSense.enableQuickInfo": true,              // Show quick info tooltips on hover
-  "mssql.intelliSense.lowerCaseSuggestions": false         // Display suggestions in lowercase (false = match case)
+  "mssql.intelliSense.enableQuickInfo": true              // Show quick info tooltips on hover
 }
 
 // Query Execution

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1902,12 +1902,6 @@
                     "description": "%mssql.intelliSense.enableQuickInfo%",
                     "scope": "window"
                 },
-                "mssql.intelliSense.lowerCaseSuggestions": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%mssql.intelliSense.lowerCaseSuggestions%",
-                    "scope": "window"
-                },
                 "mssql.persistQueryResultTabs": {
                     "type": "boolean",
                     "default": false,

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -140,7 +140,6 @@
     "mssql.intelliSense.enableSuggestions": "Should IntelliSense suggestions be enabled",
     "mssql.intelliSense.enableQuickInfo": "Should IntelliSense quick info be enabled",
     "mssql.enableQueryHistoryFeature": "Should Query History feature be enabled",
-    "mssql.intelliSense.lowerCaseSuggestions": "Should IntelliSense suggestions be lowercase",
     "mssql.persistQueryResultTabs": "Should query result selections and scroll positions be saved when switching tabs (may impact performance)",
     "mssql.queryHistoryLimit": "Number of query history entries to show in the Query History view",
     "mssql.autoDisableNonTSqlLanguageService": "Should language service be auto-disabled when extension detects Non-MSSQL files",

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251205.1",
+        version: "5.0.20251210.3",
         downloadFileNames: {
             Windows_64: "win-x64-net8.0.zip",
             Windows_ARM64: "win-arm64-net8.0.zip",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4943,9 +4943,6 @@
     <trans-unit id="mssql.intelliSense.enableSuggestions">
       <source xml:lang="en">Should IntelliSense suggestions be enabled</source>
     </trans-unit>
-    <trans-unit id="mssql.intelliSense.lowerCaseSuggestions">
-      <source xml:lang="en">Should IntelliSense suggestions be lowercase</source>
-    </trans-unit>
     <trans-unit id="mssql.piiLogging">
       <source xml:lang="en">Should Personally Identifiable Information (PII) be logged in the Azure Logs output channel and the output channel log file.</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Users are confused by the two similar settings - Format.KeywordCasing and Intellisense.LowercaseSuggestions, as described in the referenced bug

https://github.com/microsoft/vscode-mssql/issues/19987?reload=1?reload=1

So to simplify settings, this PR removes mssql.intelliSense.lowerCaseSuggestions. The new version of STS will use Format.KeywordCasing to determine is Completions should be returned in Lowercase or Upper case.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
