### PR TITLE
[PORT] Fixing the open scmp/select publish profile with azure mfa failing to load the profile and databases

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1666,7 +1666,10 @@
     "DacFx service is not available. Profile loaded without deployment options. Publish and generate script operations cannot be performed.": "DacFx service is not available. Profile loaded without deployment options. Publish and generate script operations cannot be performed.",
     "Failed to list databases": "Failed to list databases",
     "Failed to fetch Docker container tags: {0}": "Failed to fetch Docker container tags: {0}",
-    "Profile loaded but connection failed. Please connect to the server manually.": "Profile loaded but connection failed. Please connect to the server manually.",
+    "Profile loaded, but the connection could not be automatically established. Please create a connection to {0} then try again./{0} is the server name": {
+        "message": "Profile loaded, but the connection could not be automatically established. Please create a connection to {0} then try again.",
+        "comment": ["{0} is the server name"]
+    },
     "Schema Compare": "Schema Compare",
     "Options have changed. Recompare to see the comparison?": "Options have changed. Recompare to see the comparison?",
     "Failed to generate script: '{0}'/{0} is the error message returned from the generate script operation": {
@@ -1680,6 +1683,10 @@
     "Schema Compare failed: '{0}'/{0} is the error message returned from the compare operation": {
         "message": "Schema Compare failed: '{0}'",
         "comment": ["{0} is the error message returned from the compare operation"]
+    },
+    "Connection failed: {0}/{0} is the error message from the connection attempt": {
+        "message": "Connection failed: {0}",
+        "comment": ["{0} is the error message from the connection attempt"]
     },
     "Loading Schema Designer Model...": "Loading Schema Designer Model...",
     "Schema Designer Model is ready. Changes can now be published.": "Schema Designer Model is ready. Changes can now be published.",

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1407,9 +1407,13 @@ export class PublishProject {
     public static FailedToFetchContainerTags = (errorMessage: string) => {
         return l10n.t("Failed to fetch Docker container tags: {0}", errorMessage);
     };
-    public static ProfileLoadedConnectionFailed = l10n.t(
-        "Profile loaded but connection failed. Please connect to the server manually.",
-    );
+    public static ProfileLoadedConnectionFailed = (serverName: string) =>
+        l10n.t({
+            message:
+                "Profile loaded, but the connection could not be automatically established. Please create a connection to {0} then try again.",
+            args: [serverName],
+            comment: ["{0} is the server name"],
+        });
 }
 
 export class SchemaCompare {
@@ -1496,6 +1500,12 @@ export class SchemaCompare {
             message: "Cannot include {0}. Excluded dependents exist",
             args: [diffEntryName],
             comment: ["{0} is the name of the entry"],
+        });
+    public static connectionFailed = (errorMessage: string) =>
+        l10n.t({
+            message: "Connection failed: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message from the connection attempt"],
         });
 }
 

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -796,6 +796,89 @@ suite("SchemaCompareWebViewController Tests", () => {
         openScmpStub.restore();
     });
 
+    test("openScmp reducer - with Azure MFA connection without accountId - populates accountId from saved profile", async () => {
+        // Setup Azure MFA endpoint info without accountId
+        const azureMfaTargetEndpointInfo = {
+            endpointType: 0,
+            packageFilePath: "",
+            serverDisplayName: "azure-server.database.windows.net (user@domain.com)",
+            serverName: "azure-server.database.windows.net",
+            databaseName: "testdb",
+            ownerUri: "",
+            connectionDetails: {
+                options: {
+                    server: "azure-server.database.windows.net",
+                    database: "testdb",
+                    authenticationType: "AzureMFA",
+                    accountId: undefined, // Missing accountId - this is what we're testing
+                    user: "user@domain.com",
+                    email: "user@domain.com",
+                },
+            },
+            connectionName: "",
+            projectFilePath: "",
+            targetScripts: [],
+            extractTarget: 5,
+            dataSchemaProvider: "",
+        };
+
+        const expectedResultMock = {
+            success: true,
+            errorMessage: "",
+            sourceEndpointInfo,
+            targetEndpointInfo: azureMfaTargetEndpointInfo,
+            originalTargetName: "testdb",
+            originalTargetServerName: "azure-server.database.windows.net",
+            originalConnectionString: "",
+            deploymentOptions,
+            excludedSourceElements: [],
+            excludedTargetElements: [],
+        };
+
+        const filePath = "c:\\test_azure.scmp";
+
+        const showOpenDialogForScmpStub = sandbox
+            .stub(scUtils, "showOpenDialogForScmp")
+            .resolves(filePath);
+
+        const openScmpStub = sandbox.stub(scUtils, "openScmp").resolves(expectedResultMock);
+
+        // Stub connectionManager methods
+        connectionManagerStub.getUriForScmpConnection.returns(undefined); // No existing connection
+        connectionManagerStub.connect.resolves(true);
+
+        // Configure the ensureAccountIdForAzureMfa stub to populate accountId
+        const ensureAccountIdStub =
+            connectionManagerStub.ensureAccountIdForAzureMfa as sinon.SinonStub;
+        ensureAccountIdStub.callsFake(async (connInfo) => {
+            // Simulate what the real method does - populate accountId from saved profile
+            connInfo.accountId = "test-account-id-12345";
+            return true;
+        });
+
+        const payload = {};
+
+        const actualResult = await controller["_reducerHandlers"].get("openScmp")(
+            mockInitialState,
+            payload,
+        );
+
+        expect(showOpenDialogForScmpStub).to.have.been.calledOnce;
+        expect(openScmpStub).to.have.been.calledOnce;
+
+        // Verify the helper was called to populate missing accountId
+        expect(ensureAccountIdStub).to.have.been.calledOnce;
+
+        // Verify connect was called with accountId populated
+        const connectCallArgs = connectionManagerStub.connect.firstCall.args;
+        expect(connectCallArgs[1].accountId).to.equal("test-account-id-12345");
+
+        expect(actualResult.schemaCompareOpenScmpResult).to.deep.equal(expectedResultMock);
+
+        openScmpStub.restore();
+        ensureAccountIdStub.restore();
+    });
+
     test("saveScmp reducer - when called - completes successfully", async () => {
         const expectedResultMock = {
             success: true,

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -868,6 +868,10 @@
     <trans-unit id="++CODE++8d137af9c64fba09bbb003aba93f0b029898fe19e7927cd696f4c3e2b69f538d">
       <source xml:lang="en">Connection error</source>
     </trans-unit>
+    <trans-unit id="++CODE++b6ab038b215e73e2ef60b1b4afc9ef7cd9d76c67a2e266eec2d806e53701ca2d">
+      <source xml:lang="en">Connection failed: {0}</source>
+      <note>{0} is the error message from the connection attempt</note>
+    </trans-unit>
     <trans-unit id="++CODE++fb6d70b252967b1a424bfa1f8be6c56eb3359e0a7f86d477837002be7af317f3">
       <source xml:lang="en">Connection is not active. Please establish a connection before performing this action.</source>
     </trans-unit>
@@ -2908,8 +2912,9 @@
     <trans-unit id="++CODE++8a0d6f1276ee19a91fb06f73344d1d60f2d1f1c8d7e0454c8bb31ea00c2b9a30">
       <source xml:lang="en">Profile created successfully</source>
     </trans-unit>
-    <trans-unit id="++CODE++21eda41850777c46deb17245aa52751b4406410fdcc51f6644fc38b317201e71">
-      <source xml:lang="en">Profile loaded but connection failed. Please connect to the server manually.</source>
+    <trans-unit id="++CODE++b0d070ae80a582b478d83f8d81282ede72d99e81778076328e1c877c5a463f16">
+      <source xml:lang="en">Profile loaded, but the connection could not be automatically established. Please create a connection to {0} then try again.</source>
+      <note>{0} is the server name</note>
     </trans-unit>
     <trans-unit id="++CODE++c7b24e72fefeade2fc1706604bb5c2ee848b055ed154428128c10d5020549a7a">
       <source xml:lang="en">Profile removed successfully</source>


### PR DESCRIPTION
Save scmp doesn't save accountID info because the accountID is not a valid SQL Server connection property. for the azure server and loading that scmp file fails to make the server connection due to the missing accountID info. This fix makes sures to get the matching profile from the available connections and get the accountID from there to connect to the server.

Added the same logic to SC and Publish profile.xml load scenario for azure mfa.
Place the `helper method in shared utils.
Added telemetry event in connection manager
Added error message to the SC UI

Issue: https://github.com/microsoft/vscode-mssql/issues/20432 
PR: https://github.com/microsoft/vscode-mssql/pull/20762