### PR TITLE
Sql Package telemetry events are failing to capture after the decoupling

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -401,23 +401,15 @@ function readJsonFromExtensionRoot(relativePath: string): any {
 
 export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
 	if (!packageJson) {
-		packageJson = readJsonFromExtensionRoot('package.ads.json');
+		packageJson = readJsonFromExtensionRoot('package.json');
 	}
 
-	const vscodePackageJson = readJsonFromExtensionRoot('package.json');
-	const azdataApi = getAzdataApi();
-
-	if (!packageJson || !azdataApi && !vscodePackageJson) {
+	if (!packageJson) {
 		return undefined;
 	}
 
-	// When the extension is compiled and packaged, the content of package.json get copied here in the extension.js. This happens before the
-	// package.vscode.json values replace the corresponding values in the package.json for the sql-database-projects-vscode extension
-	// so we need to read these values directly from the package.vscode.json to get the correct extension and publisher names
-	const extensionName = azdataApi ? packageJson.name : vscodePackageJson.name;
-
 	return {
-		name: extensionName,
+		name: packageJson.name,
 		version: packageJson.version,
 		aiKey: packageJson.aiKey
 	};


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Telemetry events are getting lost when properties are missing from package json file after we decouple sql proj extension from ADS. This fixes the issue to capture the correct key from the json. And also removed ADS related checks and conditions from the telemetry event.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
