### PR TITLE
Clean up stub used in tests for Edit Data

### DIFF
--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -132,16 +132,8 @@ suite("TableExplorerWebViewController - Reducers", () => {
         // Setup mock services
         mockVscodeWrapper = stubVscodeWrapper(sandbox);
         mockTableExplorerService = sandbox.createStubInstance(TableExplorerService);
-        mockTableExplorerService.initialize.resolves();
+        // Only define stubs that need specific return values
         mockTableExplorerService.subset.resolves(createMockSubsetResult());
-        mockTableExplorerService.commit.resolves({});
-        mockTableExplorerService.createRow.resolves();
-        mockTableExplorerService.deleteRow.resolves({});
-        mockTableExplorerService.updateCell.resolves();
-        mockTableExplorerService.revertCell.resolves();
-        mockTableExplorerService.revertRow.resolves();
-        mockTableExplorerService.generateScripts.resolves();
-        mockTableExplorerService.dispose.resolves({});
         mockTableExplorerService.serializeData.resolves({ succeeded: true, messages: "" });
         // Setup sqlToolsClient property for notification handling
         Object.defineProperty(mockTableExplorerService, "sqlToolsClient", {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Cleaning up stubs that don't return anything since createStubInstance provides a default stub.

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
