### PR TITLE
Fixing SqlProj test to properly validate cross-platform slashes on Windows and Unix

### DIFF
--- a/extensions/mssql/test/unit/utils.ts
+++ b/extensions/mssql/test/unit/utils.ts
@@ -185,6 +185,14 @@ export function stubWithProgress(
 }
 
 export function stubPathAsPlatform(sandbox: sinon.SinonSandbox, platform: path.PlatformPath): void {
+    if (
+        (process.platform === "win32" && platform === path.win32) ||
+        (process.platform !== "win32" && platform === path.posix)
+    ) {
+        // stubbing the path module to the same platform results in infinite recursion when calling the stubbed methods.
+        return;
+    }
+
     sandbox.stub(path, "dirname").callsFake(platform.dirname);
     sandbox.stub(path, "join").callsFake(platform.join);
     sandbox.stub(path, "basename").callsFake(platform.basename);


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/vscode-mssql/pull/20858 to check Windows slashes on Unix and Unix slashes on Windows.  Tests now validate behavior correctly for all platforms, regardless of which platform is executing the tests.

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
