### PR TITLE
Filter glob patterns from None items in project tree

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -400,6 +400,11 @@ export class Project implements ISqlProject {
 
 		if (result.scripts?.length > 0) { // empty array from SqlToolsService is deserialized as null
 			for (var path of result.scripts) {
+				// Skip glob patterns - they should be expanded by the backend
+				// MSBuild globs can include: *, **, ?, [abc], [a-z], [!abc]
+				if (path.includes('*') || path.includes('?') || path.includes('[')) {
+					continue;
+				}
 				noneItemEntries.push(this.createFileProjectEntry(path, EntryType.File));
 			}
 		}

--- a/extensions/sql-database-projects/test/baselines/openSdkStyleSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/test/baselines/openSdkStyleSqlProjectBaseline.xml
@@ -30,6 +30,13 @@
     <None Include="folder1\Script.PostDeployment2.sql" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="queries/**" />
+    <None Include="scripts/file?.sql" />
+    <None Include="Script[123].sql" />
+    <None Include="data[a-z].txt" />
+    <None Include="test[!_]*.sql" />
+  </ItemGroup>
+  <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(SystemDacpacsLocation)\SystemDacpacs\150\master.dacpac">
       <SuppressMissingDependenciesErrors>False</SuppressMissingDependenciesErrors>
       <DatabaseVariableLiteralValue>master</DatabaseVariableLiteralValue>

--- a/extensions/sql-database-projects/test/project.test.ts
+++ b/extensions/sql-database-projects/test/project.test.ts
@@ -1200,6 +1200,16 @@ projectSuite('Project: round trip updates', function (): void {
 		(project.isCrossPlatformCompatible).should.be.true('Project should be detected as cross-plat compatible');
 		(spy.notCalled).should.be.true('Prompt to update .sqlproj should not have been shown for cross-plat project.');
 	}
+
+	test('Should filter out glob patterns from None items', async function (): Promise<void> {
+		const projFilePath = await testUtils.createTestSqlProjFile(this.test, baselines.openSdkStyleSqlProjectBaseline);
+		const project: Project = await Project.openProject(projFilePath);
+
+		// Verify that glob patterns with *, ?, or [ are not included in noneDeployScripts
+		// Even if the backend returns patterns like "queries/**", "script?.sql", "Script[123].sql", "data[a-z].txt", or "test[!_]*.sql", they should be filtered out
+		const hasGlobPattern = project.noneDeployScripts.some(f => f.relativePath.includes('*') || f.relativePath.includes('?') || f.relativePath.includes('['));
+		should(hasGlobPattern).be.false('None items should not contain glob patterns with *, ?, or [');
+	});
 });
 
 async function testUpdateInRoundTrip(test: Mocha.Runnable | undefined, fileBeforeupdate: string): Promise<void> {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

# Issue: https://github.com/microsoft/vscode-mssql/issues/20388 

## Description

When users add <None Include="queries/**" /> to their .sqlproj files, the SqlToolsService backend returns both the glob pattern itself and the expanded file paths. This caused the literal pattern "queries/**" to appear as a clickable but non-existent file in the project tree.

Changes:
- Filter out paths containing glob wildcards (*, ?, [ )
- Add test case validating glob patterns are excluded from noneDeployScripts
- Update baseline to include examples of all MSBuild glob pattern types:
  * Recursive wildcard (**)
  * Single character wildcard (?)
  * Character set ([abc])
  * Character range ([a-z])
  * Negation ([!_])

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Before Fix:
<img width="1259" height="601" alt="image" src="https://github.com/user-attachments/assets/b8204592-516b-4fed-9232-cae230d574d5" />
<img width="804" height="621" alt="image" src="https://github.com/user-attachments/assets/e2cdeb9a-ad08-4328-b428-af87b8a980b3" />

After Fix:
<img width="1230" height="482" alt="image" src="https://github.com/user-attachments/assets/64b1ce72-21cb-4903-a74e-245bbd6d99c7" />

