### PR TITLE
Adjust min column width so filter input box is visible in Edit Data

### DIFF
--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
@@ -243,7 +243,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     sortable: true,
                     filterable: true,
                     resizable: true,
-                    minWidth: 98,
+                    minWidth: 180,
                     type: "string",
                     filter: {
                         model: FluentCompoundFilter,


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR fixes #20873 

This PR adjusts the min column width for data columns that appear in the Edit Data grid. Previously when a data row had a lot of columns the grid would appear like this with the input box being hidden:
<img width="608" height="188" alt="image" src="https://github.com/user-attachments/assets/41fc7fed-31de-4fc5-837d-cc8b01062488" />

With the changes in this PR the column width is adjusted so that it's always visible.
<img width="722" height="82" alt="image" src="https://github.com/user-attachments/assets/4e106606-a217-4a9d-a26a-067337af56a3" />



_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
