### PR TITLE
vBump STS version from 5.0.20251230.1 to 5.0.20260114.1

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20251230.1",
+        version: "5.0.20260114.1",
         downloadFileNames: {
             Windows_64: "win-x64-net8.0.zip",
             Windows_ARM64: "win-arm64-net8.0.zip",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR upgrades the STS version from 5.0.20251230.1 to the latest generated 5.0.20260114.1

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

<img width="684" height="251" alt="image" src="https://github.com/user-attachments/assets/4ab6e3ac-3bf6-4e9d-9ec2-4a08123b569f" />

