### PR TITLE
Fix Edit Data grid column header context menu styles

### DIFF
--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.css
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.css
@@ -293,13 +293,13 @@
     min-width: 180px !important;
 }
 
-#tableExplorerGrid .slick-header-menu .slick-menu-item {
+#tableExplorerGrid .slick-header-menu > div > li {
     background-color: transparent !important;
     color: var(--vscode-menu-foreground) !important;
-    padding: 4px 20px 4px 30px !important;
-    line-height: 22px !important;
+    padding: 2px 20px 2px 30px !important;
+    height: 34px !important;
     font-size: 13px !important;
-    border: none !important;
+    border: 1px solid transparent !important;
     cursor: pointer !important;
     position: relative !important;
     display: flex !important;


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/20874
Here's a screenshot of the before and after for the column header context menu. The divider is now clearly present in the context menu too.

Before:
<img width="274" height="288" alt="image" src="https://github.com/user-attachments/assets/ed5433b1-ba80-4429-9fcc-34720b3b261b" />

After:
<img width="208" height="229" alt="image" src="https://github.com/user-attachments/assets/c3572b25-1b04-4c63-ab72-6e3a364c0089" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [x] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
