### PR TITLE
Corrects capitalization of the dacpacdialog viewid

### DIFF
--- a/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
+++ b/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
@@ -35,7 +35,7 @@ export const DACPAC_EXTENSION = ".dacpac";
 export const BACPAC_EXTENSION = ".bacpac";
 
 // View ID constant for NPS survey
-const DACPAC_DIALOG_VIEW_ID = "dacpacDialog";
+const DACPAC_DIALOG_VIEW_ID = "DacpacDialog";
 
 /**
  * Controller for the DacpacDialog webview.


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

The capitalization of this viewid is not correct, since file paths on unix systems are capital sensitive, this caused dacpacdialog to not open.

Solves issue #20897.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [X] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
