### PR TITLE
Added isAdvancedoption as an optional prop in form items

### DIFF
--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -169,7 +169,6 @@ export interface ConnectionDialogFormItemSpec
         ConnectionDialogWebviewState,
         ConnectionDialogFormItemSpec
     > {
-    isAdvancedOption: boolean;
     optionCategory?: string;
     optionCategoryLabel?: string;
 }

--- a/extensions/mssql/src/sharedInterfaces/deployment.ts
+++ b/extensions/mssql/src/sharedInterfaces/deployment.ts
@@ -110,7 +110,6 @@ export enum DeploymentType {
 export interface DeploymentFormItemSpec
     extends FormItemSpec<DeploymentFormState, DeploymentWebviewState, DeploymentFormItemSpec> {
     componentWidth: string;
-    isAdvancedOption: boolean;
 }
 
 export type DeploymentTypeState = LocalContainersState | FabricProvisioningState;

--- a/extensions/mssql/src/sharedInterfaces/fabricProvisioning.ts
+++ b/extensions/mssql/src/sharedInterfaces/fabricProvisioning.ts
@@ -68,7 +68,6 @@ export interface FabricProvisioningFormItemSpec
         FabricProvisioningFormItemSpec
     > {
     componentWidth: string;
-    isAdvancedOption: boolean;
 }
 
 export interface FabricProvisioningContextProps

--- a/extensions/mssql/src/sharedInterfaces/form.ts
+++ b/extensions/mssql/src/sharedInterfaces/form.ts
@@ -84,6 +84,11 @@ export interface FormItemSpec<
      * Validation state and message for the form item
      */
     validation?: FormItemValidationState;
+
+    /**
+     * Whether the form item is an advanced option
+     */
+    isAdvancedOption?: boolean;
 }
 
 export interface FormItemValidationState {

--- a/extensions/mssql/src/sharedInterfaces/localContainers.ts
+++ b/extensions/mssql/src/sharedInterfaces/localContainers.ts
@@ -56,7 +56,6 @@ export interface LocalContainersFormItemSpec
         LocalContainersFormItemSpec
     > {
     componentWidth: string;
-    isAdvancedOption: boolean;
 }
 
 export interface LocalContainersContextProps


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Added isAdvancedoption as an optional prop in form items because it was being used by multiple forms.

## Code Changes Checklist

-   [X] New or updated **unit tests** added
-   [X] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [X] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
