### PR TITLE
[PORT] - Revert - Publish dialog GA changes (#20938)

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1753,6 +1753,7 @@
         "comment": ["{0} is the webview name"]
     },
     "General": "General",
+    "Publish Project (Preview)": "Publish Project (Preview)",
     "Publish Profile": "Publish Profile",
     "Load profile...": "Load profile...",
     "Save As": "Save As",

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1346,7 +1346,7 @@ export class TableDesigner {
 }
 
 export class PublishProject {
-    public static Title = l10n.t("Publish Project");
+    public static Title = l10n.t("Publish Project (Preview)");
     public static PublishProfileLabel = l10n.t("Publish Profile");
     public static PublishProfilePlaceholder = l10n.t("Load profile...");
     public static SelectPublishProfile = l10n.t("Select Profile");

--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -8,10 +8,10 @@ All notable changes to the SQL Database Projects extension will be documented in
 
 ## [1.5.6] - 2026-01-28
 
-- Releasing the Publish dialog as GA, replacing the previous quickpick-based publish flow with an enhanced dialog experience.
 - Added a new 'Target platform' selector when creating an Azure SQL database project.
+- Added an icon and 'Publish Project' header to the Publish (preview) dialog.
 - Resolved an issue where SQL project telemetry events were not being captured consistently.
-- Fixed a macOS issue where the new Publish dialog could not locate the DACPAC file.
+- Fixed a macOS issue where the new Publish (preview) dialog could not locate the DACPAC file.
 - Fixed a problem where selecting 'View changes in schema compare' from 'Update project from database' did not automatically launch Schema Compare.
 - Resolved a build failure that occurred when the Windows terminal default profile was set to Git Bash.
 

--- a/extensions/sql-database-projects/l10n/bundle.l10n.json
+++ b/extensions/sql-database-projects/l10n/bundle.l10n.json
@@ -374,5 +374,6 @@
   "Are you sure you want to move {0} to {1}?": "Are you sure you want to move {0} to {1}?",
   "Move": "Move",
   "Error when renaming file from {0} to {1}. Error: {2}": "Error when renaming file from {0} to {1}. Error: {2}",
-  "Unhandled node type for move": "Unhandled node type for move"
+  "Unhandled node type for move": "Unhandled node type for move",
+  "A tasks.json file already exists in your workspace. Adding SQL project build task to the existing file.": "A tasks.json file already exists in your workspace. Adding SQL project build task to the existing file."
 }

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -159,6 +159,11 @@
         "category": "%sqlDatabaseProjects.displayName%"
       },
       {
+        "command": "sqlDatabaseProjects.publish",
+        "title": "%sqlDatabaseProjects.publish%",
+        "category": "%sqlDatabaseProjects.displayName%"
+      },
+      {
         "command": "sqlDatabaseProjects.publishDialog",
         "title": "%sqlDatabaseProjects.publishDialog%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -314,6 +319,10 @@
           "when": "false"
         },
         {
+          "command": "sqlDatabaseProjects.publish",
+          "when": "false"
+        },
+        {
           "command": "sqlDatabaseProjects.publishDialog",
           "when": "false"
         },
@@ -396,8 +405,13 @@
           "group": "1_dbProjectsFirst@2"
         },
         {
+          "command": "sqlDatabaseProjects.publish",
+          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/ && (azdataAvailable || !(config.sqlDatabaseProjects.enablePreviewFeatures || config.mssql.enableExperimentalFeatures))",
+          "group": "1_dbProjectsFirst@3"
+        },
+        {
           "command": "sqlDatabaseProjects.publishDialog",
-          "when": "view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/",
+          "when": "!azdataAvailable && view == dataworkspace.views.main && viewItem =~ /^(databaseProject.itemType.project|databaseProject.itemType.legacyProject)$/ && (config.sqlDatabaseProjects.enablePreviewFeatures || config.mssql.enableExperimentalFeatures)",
           "group": "1_dbProjectsFirst@3"
         },
         {

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -9,7 +9,7 @@
 	"sqlDatabaseProjects.build": "Build",
 	"sqlDatabaseProjects.buildWithCodeAnalysis": "Build With Code Analysis",
 	"sqlDatabaseProjects.publish": "Publish",
-	"sqlDatabaseProjects.publishDialog": "Publish",
+	"sqlDatabaseProjects.publishDialog": "Publish (Preview)",
 	"sqlDatabaseProjects.createProjectFromDatabase": "Create Project From Database",
 	"sqlDatabaseProjects.updateProjectFromDatabase": "Update Project From Database",
 	"sqlDatabaseProjects.properties": "Properties",

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -709,3 +709,8 @@ export function errorRenamingFile(source: string, destination: string, error: st
 export const unhandledMoveNode = l10n.t("Unhandled node type for move");
 
 //#endregion
+
+//#region tasks.json
+export const updatingExistingTasksJson = l10n.t("A tasks.json file already exists in your workspace. Adding SQL project build task to the existing file.");
+export const sqlProjectBuildTaskLabel = 'sqlproj: Build';
+//#endregion

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -63,6 +63,7 @@ export default class MainController implements vscode.Disposable {
 
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.build', async (node: WorkspaceTreeItem) => { return this.projectsController.buildProject(node, false); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.buildWithCodeAnalysis', async (node: WorkspaceTreeItem) => { return this.projectsController.buildProject(node, true); }));
+		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.publish', async (node: WorkspaceTreeItem) => { return this.projectsController.publishProject(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.publishDialog', async (node: WorkspaceTreeItem) => { return this.projectsController.publishProject(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.schemaCompare', async (node: WorkspaceTreeItem) => { return this.projectsController.schemaCompare(node); }));
 		this.context.subscriptions.push(vscode.commands.registerCommand('sqlDatabaseProjects.schemaComparePublishProjectChanges', async (operationId: string, projectFilePath: string, folderStructure: mssql.ExtractTarget): Promise<mssql.SchemaComparePublishProjectResult> => { return await this.projectsController.schemaComparePublishProjectChanges(operationId, projectFilePath, folderStructure); }));

--- a/extensions/sql-database-projects/test/projectController.test.ts
+++ b/extensions/sql-database-projects/test/projectController.test.ts
@@ -216,9 +216,17 @@ suite('ProjectsController', function (): void {
 				}
 			});
 
-			test('Should create .vscode/tasks.json with isDefault=true when configureDefaultBuild is true', async function (): Promise<void> {
+			test('Should create .vscode/tasks.json at workspace level with isDefault=true when configureDefaultBuild is true', async function (): Promise<void> {
 				const projController = new ProjectsController(testContext.outputChannel);
 				const projFileDir = await testUtils.generateTestFolderPath(this.test);
+
+				// Mock workspace folder to return the project folder's parent as the workspace root
+				const workspaceFolder: vscode.WorkspaceFolder = {
+					uri: vscode.Uri.file(projFileDir),
+					name: 'test-workspace',
+					index: 0
+				};
+				sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder);
 
 				// Act: create a new project with configureDefaultBuild: true
 				const projFilePath = await projController.createNewProject({
@@ -231,13 +239,13 @@ suite('ProjectsController', function (): void {
 					sdkStyle: false
 				});
 
-				const project = await Project.openProject(projFilePath);
-				// Path to the expected tasks.json file
-				const tasksJsonPath = path.join(projFileDir, project.projectFileName, '.vscode', 'tasks.json');
+				await Project.openProject(projFilePath);
+				// Path to the expected tasks.json file - now at workspace level, not inside project folder
+				const tasksJsonPath = path.join(projFileDir, '.vscode', 'tasks.json');
 
-				// Assert: tasks.json exists
+				// Assert: tasks.json exists at workspace level
 				const exists = await utils.exists(tasksJsonPath);
-				should(exists).be.true('.vscode/tasks.json should be created when configureDefaultBuild is true');
+				should(exists).be.true('.vscode/tasks.json should be created at workspace level when configureDefaultBuild is true');
 
 				// If exists, check if isDefault is true in any build task
 				if (exists) {
@@ -249,6 +257,60 @@ suite('ProjectsController', function (): void {
 					should(task.group).not.be.undefined();
 					should(task.group.isDefault).equal('true', 'The build task should have isDefault: true');
 				}
+			});
+
+			test('Should merge SQL build task into existing tasks.json when it already exists at workspace level', async function (): Promise<void> {
+				const projController = new ProjectsController(testContext.outputChannel);
+				const projFileDir = await testUtils.generateTestFolderPath(this.test);
+
+				// Create existing tasks.json with a different task
+				const vscodeFolder = path.join(projFileDir, '.vscode');
+				await fs.mkdir(vscodeFolder, { recursive: true });
+				const existingTasksJson = {
+					version: '2.0.0',
+					tasks: [
+						{
+							label: 'Existing Task',
+							type: 'shell',
+							command: 'echo Hello'
+						}
+					]
+				};
+				await fs.writeFile(path.join(vscodeFolder, 'tasks.json'), JSON.stringify(existingTasksJson, null, '\t'));
+
+				// Mock workspace folder
+				const workspaceFolder: vscode.WorkspaceFolder = {
+					uri: vscode.Uri.file(projFileDir),
+					name: 'test-workspace',
+					index: 0
+				};
+				sinon.stub(vscode.workspace, 'getWorkspaceFolder').returns(workspaceFolder);
+
+				// Spy on showInformationMessage to verify notification
+				const showInfoSpy = sinon.spy(vscode.window, 'showInformationMessage');
+
+				// Act: create a new project with configureDefaultBuild: true
+				await projController.createNewProject({
+					newProjName: 'TestProjectWithTasks',
+					folderUri: vscode.Uri.file(projFileDir),
+					projectTypeId: constants.emptySqlDatabaseProjectTypeId,
+					configureDefaultBuild: true,
+					projectGuid: 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575',
+					targetPlatform: SqlTargetPlatform.sqlAzure,
+					sdkStyle: false
+				});
+
+				// Assert: tasks.json now has both tasks
+				const tasksJsonPath = path.join(vscodeFolder, 'tasks.json');
+				const tasksJsonContent = await fs.readFile(tasksJsonPath, 'utf-8');
+				const tasksJson = JSON.parse(tasksJsonContent);
+
+				should(tasksJson.tasks).be.Array().and.have.length(2);
+				should(tasksJson.tasks[0].label).equal('Existing Task', 'Existing task should be preserved');
+				should(tasksJson.tasks[1].label).equal('Build', 'SQL build task should be added');
+
+				// Assert: notification was shown
+				should(showInfoSpy.calledWith(constants.updatingExistingTasksJson)).be.true('Should show notification when updating existing tasks.json');
 			});
 
 			async function verifyFolderAdded(folderName: string, projController: ProjectsController, project: Project, node: BaseProjectTreeItem): Promise<void> {

--- a/localization/xliff/sql-database-projects.xlf
+++ b/localization/xliff/sql-database-projects.xlf
@@ -43,6 +43,9 @@
     <trans-unit id="++CODE++51c6f6f7088acc0dd08061a0d7a08e200653d1fbdc6f47315aa2e99eb3ca1920">
       <source xml:lang="en">A reference to this database already exists in this project</source>
     </trans-unit>
+    <trans-unit id="++CODE++69ed64de5ab064f36a1a9c3d7d36a5710581b8b6f0523bfbb919ee6f116b71c8">
+      <source xml:lang="en">A tasks.json file already exists in your workspace. Adding SQL project build task to the existing file.</source>
+    </trans-unit>
     <trans-unit id="++CODE++7078c833200717b99c1414ef7696aaf5d7af1c16d201435b2ce243dba8891e4b">
       <source xml:lang="en">A {0} script already exists. The new script will not be included in build.</source>
     </trans-unit>
@@ -1228,11 +1231,11 @@
     <trans-unit id="sqlDatabaseProjects.properties">
       <source xml:lang="en">Properties</source>
     </trans-unit>
-    <trans-unit id="sqlDatabaseProjects.publishDialog">
-      <source xml:lang="en">Publish</source>
-    </trans-unit>
     <trans-unit id="sqlDatabaseProjects.publish">
       <source xml:lang="en">Publish</source>
+    </trans-unit>
+    <trans-unit id="sqlDatabaseProjects.publishDialog">
+      <source xml:lang="en">Publish (Preview)</source>
     </trans-unit>
     <trans-unit id="sqlDatabaseProjects.rename">
       <source xml:lang="en">Rename</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3168,6 +3168,9 @@
     <trans-unit id="++CODE++42b341b8072aa3adcb1b6f83353574f79b03c073faeb2c64253cdb6248c011c1">
       <source xml:lang="en">Publish Project</source>
     </trans-unit>
+    <trans-unit id="++CODE++e800f91c86916c398645bf581043fd3d6a275d1199cb474019114e6f2195f8b1">
+      <source xml:lang="en">Publish Project (Preview)</source>
+    </trans-unit>
     <trans-unit id="++CODE++a2ca822b9abcd933ac2e91d9b212646bfa3bf125e734e4bf1e1d1d6b9235925f">
       <source xml:lang="en">Publish Settings File</source>
     </trans-unit>


### PR DESCRIPTION


# Pull Request Template – vscode-mssql

## Description

- Revert "Remove publish dialog preview flag and deprecate old flow, New Publish Dialog ready for GA (#20905)"

This reverts commit ddc6ebf253b0cb1cb32d06ce487a36a8c87e3c1e.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
