### PR TITLE
[Port] Identify whether a connection is a docker container in OE

### DIFF
--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -164,7 +164,6 @@ export const outputContentTypeShowError = "showError";
 export const outputContentTypeShowWarning = "showWarning";
 export const outputServiceLocalhost = "http://localhost:";
 export const localhost = "localhost";
-export const localhostIP = "127.0.0.1";
 export const defaultContainerName = "sql_server_container";
 export const msgContentProviderSqlOutputHtml = "dist/html/sqlOutput.ejs";
 export const contentProviderMinFile = "dist/js/app.min.js";

--- a/extensions/mssql/src/deployment/dockerUtils.ts
+++ b/extensions/mssql/src/deployment/dockerUtils.ts
@@ -13,8 +13,6 @@ import {
     defaultPortNumber,
     docker,
     dockerDeploymentLoggerChannelName,
-    localhost,
-    localhostIP,
     Platform,
     windowsDockerDesktopExecutable,
     x64,
@@ -131,6 +129,10 @@ export const COMMANDS = {
         command: "docker",
         args: ["ps", "-a", "--format", "{{.Names}}"],
     }),
+    GET_CONTAINER_NAME_FROM_ID: (containerId: string): DockerCommand => ({
+        command: "docker",
+        args: ["ps", "-a", "--filter", `id=${containerId}`, "--format", "{{.Names}}"],
+    }),
     INSPECT: (id: string): DockerCommand => ({
         command: "docker",
         args: ["inspect", sanitizeContainerInput(id)],
@@ -151,11 +153,11 @@ export const COMMANDS = {
             "-e",
             "ACCEPT_EULA=Y",
             "-e",
-            `SA_PASSWORD=${password}`,
+            `\'SA_PASSWORD=${password}\'`,
             "-p",
-            `${port}:${defaultPortNumber}`,
+            `\'${port}:${defaultPortNumber}\'`,
             "--name",
-            sanitizeContainerInput(name),
+            `\'${sanitizeContainerInput(name)}\'`,
         ];
 
         if (hostname) {
@@ -916,42 +918,17 @@ async function getUsedPortsFromContainers(containerIds: string[]): Promise<Set<n
 }
 
 /**
- * Finds a Docker container by checking if its exposed ports match the server name.
- * It inspects each container to find a match with the server name.
+ * Determines whether a connection is running inside a Docker container.
+ *
+ * Inspects the `machineName` from the connection's server info. For Docker connections,
+ * the machine name is set to the UUID corresponding to the container's ID.
+ *
+ * @param machineName The machine name hosting the connection, as reported in its server info.
  */
-async function findContainerByPort(containerIds: string[], serverName: string): Promise<string> {
-    if (serverName === localhost || serverName === localhostIP) {
-        serverName += `,${defaultPortNumber}`;
-    }
-    for (const id of containerIds) {
-        try {
-            const inspect = await execDockerCommand(COMMANDS.INSPECT_CONTAINER(id));
-            const ports = inspect.match(/"HostPort":\s*"(\d+)"/g);
-
-            if (ports?.some((p) => serverName.includes(p.match(/\d+/)?.[0] || ""))) {
-                const nameMatch = inspect.match(/"Name"\s*:\s*"\/([^"]+)"/);
-                if (nameMatch) return nameMatch[1];
-            }
-        } catch {
-            // skip container if inspection fails
-        }
-    }
-
-    return undefined;
-}
-
-/**
- * Checks if a connection is a Docker container by inspecting the server name.
- */
-export async function checkIfConnectionIsDockerContainer(serverName: string): Promise<string> {
-    if (!serverName.includes(localhost) && !serverName.includes(localhostIP)) return "";
-
+export async function checkIfConnectionIsDockerContainer(machineName: string): Promise<string> {
     try {
-        const stdout = await execDockerCommand(COMMANDS.GET_CONTAINERS());
-        const containerIds = stdout.split("\n").filter(Boolean);
-        if (!containerIds.length) return undefined;
-
-        return await findContainerByPort(containerIds, serverName);
+        const stdout = await execDockerCommand(COMMANDS.GET_CONTAINER_NAME_FROM_ID(machineName));
+        return stdout.trim();
     } catch {
         return undefined;
     }

--- a/extensions/mssql/test/unit/dockerUtilities.test.ts
+++ b/extensions/mssql/test/unit/dockerUtilities.test.ts
@@ -1079,9 +1079,9 @@ suite("Docker Utilities", () => {
             }),
         });
 
-        // 1. Non-localhost server: should return ""
+        // 1. Non-localhost server: should return undefined
         let result = await dockerUtils.checkIfConnectionIsDockerContainer("some.remote.host");
-        expect(result, "Should return empty string for non-localhost address").to.equal("");
+        expect(result, "Should return undefined for non-localhost address").to.equal(undefined);
 
         // 2. Docker command fails: should return undefined
         spawnStub.returns(createFailureProcess(new Error("spawn failed")) as any);
@@ -1092,18 +1092,16 @@ suite("Docker Utilities", () => {
         spawnStub.resetHistory();
         spawnStub.returns(createSuccessProcess("") as any); // simulate no containers
 
-        // 3. Docker command returns no containers: should return undefined
+        // 3. Docker command returns no containers: should return empty string
         result = await dockerUtils.checkIfConnectionIsDockerContainer("127.0.0.1");
-        expect(result, "Should return undefined when no containers exist").to.equal(undefined);
+        expect(result, "Should return empty string when no containers exist").to.equal("");
 
-        // 4. Containers exist and one matches the port: should return the container id
+        // 3. Containers exist and one matches the port: should return the container id
         spawnStub.resetHistory();
-        spawnStub.returns(
-            createSuccessProcess(`"HostPort": "1433", "Name": "/testContainer",\n`) as any,
-        ); // simulate container with port 1433
+        spawnStub.returns(createSuccessProcess(`dockercontainerid`) as any); // simulate container with port 1433
 
         result = await dockerUtils.checkIfConnectionIsDockerContainer("localhost, 1433");
-        expect(result, "Should return matched container ID").to.equal("testContainer");
+        expect(result, "Should return matched container ID").to.equal("dockercontainerid");
     });
 
     test("findAvailablePort: should find next available port", async () => {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description
Original PR: https://github.com/microsoft/vscode-mssql/pull/20728
Fixes https://github.com/microsoft/vscode-mssql/issues/20579
Fixes https://github.com/microsoft/vscode-mssql/issues/19606

Check whether a connection is a docker container by matching a connections' server info's machine name to the existing docker container ids.

Also fixes https://github.com/microsoft/vscode-mssql/issues/20536 by properly escaping container inputs on container creation

## Code Changes Checklist

-   [X] New or updated **unit tests** added
-   [X] All existing tests pass (`npm run test`)
-   [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [X] Telemetry/logging updated if relevant
-   [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
