### PR TITLE
Fixing copyright header snippet. 

### DIFF
--- a/.vscode/shared.code-snippets
+++ b/.vscode/shared.code-snippets
@@ -7,7 +7,7 @@
     // Example:
     "Copyright Header": {
         "scope": "javascript,javascriptreact,typescript,typescriptreact,css,rust",
-        "prefix": ["header", "stub", "copyright", "msft", "microsoft"],
+        "prefix": ["header", "stub", "copyright", "microsoft"],
         "body": [
             "/*---------------------------------------------------------------------------------------------",
             " *  Copyright (c) Microsoft Corporation. All rights reserved.",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Adding back Microsoft copyright snippet. 

<img width="562" height="59" alt="image" src="https://github.com/user-attachments/assets/c7460c3a-fa13-4d37-b7f4-590ea07f3c23" />


## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
