### PR TITLE
Port "Fixing copyright header snippet." (#20990)

### DIFF
--- a/.vscode/shared.code-snippets
+++ b/.vscode/shared.code-snippets
@@ -5,17 +5,17 @@
     // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
     // Placeholders with the same ids are connected.
     // Example:
-    "MSFT Copyright Header": {
-        "scope": "javascript,typescript,css,rust",
-        "prefix": ["header", "stub", "copyright"],
+    "Copyright Header": {
+        "scope": "javascript,javascriptreact,typescript,typescriptreact,css,rust",
+        "prefix": ["header", "stub", "copyright", "microsoft"],
         "body": [
             "/*---------------------------------------------------------------------------------------------",
             " *  Copyright (c) Microsoft Corporation. All rights reserved.",
             " *  Licensed under the MIT License. See License.txt in the project root for license information.",
             " *--------------------------------------------------------------------------------------------*/",
             "",
-            "$0",
+            "$0"
         ],
-        "description": "Insert Copyright Statement",
-    },
+        "description": "Insert Copyright Statement"
+    }
 }


### PR DESCRIPTION
Port of #20990 to release/1.40-test2

Original PR: https://github.com/microsoft/vscode-mssql/pull/20990