### PR TITLE
Add size calculation for Data Workspace in baseline artifacts

### DIFF
--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -66,6 +66,11 @@ jobs:
           sqlproj_vsix_size=$(stat -c%s "$sqlproj_vsix")
           sqlproj_vsix_size=$((sqlproj_vsix_size / 1024))
 
+          # Calculate Data Workspace sizes
+          dataworkspace_vsix=$(find ./extensions/data-workspace -name "*.vsix")
+          dataworkspace_vsix_size=$(stat -c%s "$dataworkspace_vsix")
+          dataworkspace_vsix_size=$((dataworkspace_vsix_size / 1024))
+
           # Create baseline metadata file
           cat > baseline-sizes.json <<EOF
           {
@@ -74,6 +79,9 @@ jobs:
             },
             "sql_database_projects": {
               "vsix_kb": $sqlproj_vsix_size
+            },
+            "data_workspace": {
+              "vsix_kb": $dataworkspace_vsix_size
             },
             "commit": "${{ github.sha }}",
             "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Description

This should fix this issue in size compare table for data workspace extension.
<img width="511" height="122" alt="image" src="https://github.com/user-attachments/assets/722ce612-09f8-4ab2-9f31-5aa798a1231c" />


## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
