### PR TITLE
Schema Designer tool: fix apply_edits edits schema items

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2875,7 +2875,11 @@
                                     "required": ["expectedVersion", "edits"],
                                     "properties": {
                                         "expectedVersion": { "type": "string", "minLength": 1 },
-                                        "edits": { "type": "array", "minItems": 1 }
+                                        "edits": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": { "$ref": "#/properties/payload/properties/edits/items" }
+                                        }
                                     }
                                 }
                             },

--- a/extensions/mssql/test/unit/schemaDesignerToolManifest.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerToolManifest.test.ts
@@ -111,6 +111,15 @@ suite("Schema Designer LM tool manifest schema", () => {
             applyEditsVariant.properties?.payload?.properties?.edits?.minItems,
             "apply_edits: payload.edits.minItems",
         ).to.equal(1);
+        expect(
+            applyEditsVariant.properties?.payload?.properties?.edits?.items,
+            "apply_edits: payload.edits.items",
+        ).to.exist;
+        expect(
+            applyEditsVariant.properties?.payload?.properties?.edits?.items?.$ref ??
+                applyEditsVariant.properties?.payload?.properties?.edits?.items?.oneOf,
+            "apply_edits: payload.edits.items should be a $ref or oneOf",
+        ).to.exist;
     });
 
     test("mssql_schema_designer get_table requires payload.table id OR (schema + name)", () => {


### PR DESCRIPTION

## Description

Fixes VS Code LM tool schema validation for mssql_schema_designer by ensuring apply_edits.payload.edits defines items and reuses the canonical edit item schema via $ref. This prevents validation error: tool parameters array type must have items.


## Code Changes Checklist

-   [x] New or updated **unit tests** added
-   [x] All existing tests pass (`npm run test`)
-   [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
