### PR TITLE
Making vscodewebviewProvider2 non blocking on non-essential requests. 

### DIFF
--- a/extensions/mssql/src/controllers/localizationCache.ts
+++ b/extensions/mssql/src/controllers/localizationCache.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+
+let localizationFileCache: string | undefined;
+let localizationFileReadPromise: Promise<string | undefined> | undefined;
+
+export function initializeWebviewLocalizationCache(): void {
+    void getLocalizationFileContentsCached();
+}
+
+export async function getLocalizationFileContentsCached(): Promise<string | undefined> {
+    if (localizationFileCache !== undefined) {
+        return localizationFileCache;
+    }
+
+    if (localizationFileReadPromise) {
+        return localizationFileReadPromise;
+    }
+
+    if (!vscode.l10n.uri) {
+        return undefined;
+    }
+
+    localizationFileReadPromise = (async () => {
+        try {
+            const file = await vscode.workspace.fs.readFile(vscode.l10n.uri);
+            const fileContents = Buffer.from(file).toString();
+            localizationFileCache = fileContents;
+            return fileContents;
+        } finally {
+            localizationFileReadPromise = undefined;
+        }
+    })();
+
+    return localizationFileReadPromise;
+}

--- a/extensions/mssql/src/extension.ts
+++ b/extensions/mssql/src/extension.ts
@@ -22,6 +22,7 @@ import { TelemetryActions, TelemetryViews } from "./sharedInterfaces/telemetry";
 import { ChatResultFeedbackKind } from "vscode";
 import { IconUtils } from "./utils/iconUtils";
 import { ChangelogWebviewController } from "./controllers/changelogWebviewController";
+import { initializeWebviewLocalizationCache } from "./controllers/localizationCache";
 
 /** exported for testing purposes only */
 export let controller: MainController = undefined;
@@ -30,6 +31,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
     let vscodeWrapper = new VscodeWrapper();
     controller = new MainController(context, undefined, vscodeWrapper);
     context.subscriptions.push(controller);
+    // Initialize loc cache for webviews early so that it's ready by the time any webview requests it.
+    initializeWebviewLocalizationCache();
 
     IconUtils.initialize(context.extensionUri);
 


### PR DESCRIPTION
## Description

1. Optimized VscodeWebviewProvider2 startup so the first render waits only for the initial state. Theme, keybindings, EOL, localization, and load-stats are now loaded in the background. A fallback path was also added to prevent infinite blank screens if state bootstrap fails.
2. Refactored localization loading into controllers/localizationCache.ts, initializing a single in-memory cache (initializeWebviewLocCache()) during extension activation. This avoids reading localization files on every webview creation. While item 1 already ensures webviews don’t block on localization, this is a perf win and reduces redundant I/O.

## Code Changes Checklist

-   [ ] New or updated **unit tests** added
-   [ ] All existing tests pass (`npm run test`)
-   [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
-   [ ] Telemetry/logging updated if relevant
-   [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
