### PR TITLE
Forcing unit test to launch compiled version of extension to fix mocks. 

### DIFF
--- a/extensions/mssql/extension.entry.js
+++ b/extensions/mssql/extension.entry.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+"use strict";
+
+const entryMode = process.env.MSSQL_EXTENSION_ENTRY;
+const extensionModulePath = entryMode === "out" ? "./out/src/extension" : "./dist/extension";
+
+module.exports = require(extensionModulePath);

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -39,7 +39,7 @@
         "onUri",
         "onCommand:mssql.loadCompletionExtension"
     ],
-    "main": "./dist/extension",
+    "main": "./extension.entry.js",
     "l10n": "./l10n",
     "extensionDependencies": [
         "vscode.sql"

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -147,7 +147,6 @@
         "dockerode": "^4.0.9",
         "error-ex": "^1.3.0",
         "figures": "^1.4.0",
-        "find-remove": "5.1.1",
         "fix-path": "^5.0.0",
         "has-proto": "^1.2.0",
         "jquery": "^3.4.1",

--- a/extensions/mssql/test/unit/runTest.ts
+++ b/extensions/mssql/test/unit/runTest.ts
@@ -55,6 +55,7 @@ async function main() {
                 TEST_PATTERN: testPattern ?? "",
                 // Some runners read MOCHA_GREP; set it too for convenience
                 MOCHA_GREP: testPattern ?? "",
+                MSSQL_EXTENSION_ENTRY: "out",
             },
         });
     } catch (err) {


### PR DESCRIPTION
## Description

Unit tests and extension runtime were executing from different build outputs, which prevented runtime mocks from working reliably.
Tests run from out/test and can only mock modules loaded from out/src, but the extension was being activated from dist/extension.

This PR aligns those runtimes so unit tests can mock extension behavior consistently, and removes the need to skip SQL Tools Service startup through unit test only environment flags.


### How we do it.

1. Added a stable extension entry shim that selects runtime target based on environment:
      - default: `dist/extension`
      - unit test mode: `out/src/extension`
2. Updated package main to point to the entry shim.
3. Updated unit test runner to set `MSSQL_EXTENSION_ENTRY=out`
4. Added activation-time mock for SqlToolsServiceClient.initialize in unit test utilities so tests that do not require the real service do not start it.


Remove find-remove as it was having problem with being compiled in typescript and esbuild with same time 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
