### PR TITLE
Adds result message support to simple query results

### DIFF
--- a/extensions/mssql/typings/vscode-mssql.d.ts
+++ b/extensions/mssql/typings/vscode-mssql.d.ts
@@ -2608,6 +2608,17 @@ declare module "vscode-mssql" {
          * Each row is an array of DbCellValue, representing the values of each column in that row.
          */
         rows: DbCellValue[][];
+        /**
+         * Messages generated during query execution (e.g. PRINT output, info messages).
+         */
+        messages?: ResultMessage[];
+    }
+
+    export interface ResultMessage {
+        batchId?: number;
+        isError: boolean;
+        time?: string;
+        message: string;
     }
 
     export interface IScriptingObject {


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

This PR adds a messages property to the `SimpleExecuteResult` object defined in the vscode-mssql types file. This is necessary to expose the messages property to a new extension that will be interacting with the MSSQL extension to run simple queries.

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
