### PR TITLE
Minor fixups for context menus

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -570,24 +570,49 @@
                     "group": "2_MSSQL_serverDbActions@2"
                 },
                 {
-                    "command": "mssql.renameDatabase",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/",
-                    "group": "2_MSSQL_serverDbActions@3"
-                },
-                {
-                    "command": "mssql.dropDatabase",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/",
-                    "group": "2_MSSQL_serverDbActions@4"
-                },
-                {
                     "command": "mssql.searchDatabase",
                     "when": "view == objectExplorer && viewItem =~ /\\btype=(Server|Database)\\b/",
-                    "group": "2_MSSQL_serverDbActions@5"
+                    "group": "2_MSSQL_serverDbActions@3"
                 },
                 {
                     "command": "mssql.dacpacDialog.launch",
                     "when": "view == objectExplorer && viewItem =~ /\\btype=(disconnectedServer|Server|Database)\\b/",
-                    "group": "2_MSSQL_serverDbActions@3"
+                    "group": "2_MSSQL_serverDbActions@4"
+                },
+                {
+                    "command": "mssql.renameDatabase",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/",
+                    "group": "2_MSSQL_serverDbActions@5"
+                },
+                {
+                    "command": "mssql.dropDatabase",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/",
+                    "group": "2_MSSQL_serverDbActions@6"
+                },
+                {
+                    "command": "mssql.backupDatabase",
+                    "when": "view == objectExplorer && viewItem =~ /\\b(type|subType)=(Database|DockerContainerDatabase)\\b/",
+                    "group": "2_MSSQL_serverDbActions@7"
+                },
+                {
+                    "command": "mssql.restoreDatabase",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Server)\\b/",
+                    "group": "2_MSSQL_serverDbActions@8"
+                },
+                {
+                    "command": "mssql.restoreDatabase",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/",
+                    "group": "2_MSSQL_serverDbActions@8"
+                },
+                {
+                    "command": "mssql.flatFileImport",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=Server\\b/",
+                    "group": "2_MSSQL_serverDbActions@9"
+                },
+                {
+                    "command": "mssql.flatFileImport",
+                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/",
+                    "group": "2_MSSQL_serverDbActions@9"
                 },
                 {
                     "command": "mssql.objectExplorerNewQuery",
@@ -766,31 +791,6 @@
                 {
                     "command": "mssql.startContainer",
                     "when": "view == objectExplorer && viewItem =~ /\\bsubType=(disconnectedDockerContainer|DockerContainerDatabase)\\b/"
-                },
-                {
-                    "command": "mssql.backupDatabase",
-                    "when": "view == objectExplorer && viewItem =~ /\\b(type|subType)=(Database|DockerContainerDatabase)\\b/",
-                    "group": "2_MSSQL_serverDbActions@6"
-                },
-                {
-                    "command": "mssql.flatFileImport",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=Server\\b/",
-                    "group": "2_MSSQL_serverDbActions@3"
-                },
-                {
-                    "command": "mssql.flatFileImport",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/",
-                    "group": "2_MSSQL_serverDbActions@6"
-                },
-                {
-                    "command": "mssql.restoreDatabase",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Server)\\b/",
-                    "group": "2_MSSQL_serverDbActions@3"
-                },
-                {
-                    "command": "mssql.restoreDatabase",
-                    "when": "view == objectExplorer && viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/",
-                    "group": "2_MSSQL_serverDbActions@6"
                 }
             ],
             "commandPalette": [

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -279,5 +279,5 @@
     "mssql.profiler.xelEditorDisplayName": "SQL Server Extended Events Log",
     "mssql.backupDatabase": "Backup Database (Preview)",
     "mssql.restoreDatabase": "Restore Database (Preview)",
-    "mssql.flatFileImport": "Import flat file (Preview)"
+    "mssql.flatFileImport": "Import Flat File (Preview)"
 }

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -6757,7 +6757,7 @@
       <source xml:lang="en">Import BACPAC</source>
     </trans-unit>
     <trans-unit id="mssql.flatFileImport">
-      <source xml:lang="en">Import flat file (Preview)</source>
+      <source xml:lang="en">Import Flat File (Preview)</source>
     </trans-unit>
     <trans-unit id="mssql.profiler.launchFromObjectExplorer">
       <source xml:lang="en">Launch Profiler (Preview)</source>


### PR DESCRIPTION
Further context menu reorganization will happen in the next release.  This is just a quick sanity fixup for 1.40

Addresses #21254

Before/After Server:
<img width="733" height="571" alt="image" src="https://github.com/user-attachments/assets/37f93d2f-d7df-465a-bb02-9e31e728874e" />


Before/After Database:
<img width="733" height="501" alt="image" src="https://github.com/user-attachments/assets/49919872-f5fe-48fa-9c6b-4b4dbd11f43c" />
