### PR TITLE
Open in tab fix for query editor. 

### DIFF
--- a/extensions/mssql/src/reactviews/common/keyboardUtils.ts
+++ b/extensions/mssql/src/reactviews/common/keyboardUtils.ts
@@ -116,6 +116,7 @@ const specialKeyMap: Record<string, KeyResolution> = {
 };
 
 const FUNCTION_KEY_REGEX = /^f([1-9]|1[0-2])$/;
+const WEBVIEW_ACTIONS = Object.values(WebviewAction) as WebviewAction[];
 
 /**
  * Normalizes the raw keyboard shortcut string into tokens.
@@ -236,16 +237,15 @@ function getDefaultConfig(): WebviewKeyBindingConfiguration {
  * @returns Parsed webview shortcuts
  */
 export function parseWebviewKeyboardShortcutConfig(
-    config: WebviewKeyBindingConfiguration,
+    config?: WebviewKeyBindingConfiguration,
 ): WebviewKeyBindings {
     const webviewKeyBinding = {} as WebviewKeyBindings;
-    config = { ...getDefaultConfig(), ...config };
-    Object.keys(config).forEach((key) => {
-        const keyType = key as WebviewAction;
-        webviewKeyBinding[keyType] = getShortcutInfo(
-            config[key as keyof WebviewKeyBindingConfiguration],
-        );
+    const mergedConfig = { ...getDefaultConfig(), ...(config ?? {}) };
+
+    WEBVIEW_ACTIONS.forEach((action) => {
+        webviewKeyBinding[action] = getShortcutInfo(mergedConfig[action]);
     });
+
     return webviewKeyBinding;
 }
 

--- a/extensions/mssql/src/sharedInterfaces/webview.ts
+++ b/extensions/mssql/src/sharedInterfaces/webview.ts
@@ -347,7 +347,7 @@ export enum WebviewAction {
 /**
  * Keyboard shortcut configuration for webview actions.
  */
-export type WebviewKeyBindingConfiguration = Record<WebviewAction, string>;
+export type WebviewKeyBindingConfiguration = Partial<Record<WebviewAction, string>>;
 
 /**
  * Representation of a key combination for a webview shortcut.


### PR DESCRIPTION
## Description

Issue: #21264 

1. isStateInitialized was being set too early in the state-change notification path, which allowed webviews to render before bootstrap had completed.
1. This PR hardens keybinding state initialization by always starting from safe defaults.
1. This PR renames isStateInitialized to isBootstrapComplete to reflect the actual readiness signal.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
