### PR TITLE
Swapping keymap aka.ms link for extension gallery launch

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1269,6 +1269,7 @@
     "No customized settings found": "No customized settings found",
     "No customized settings found in Azure Data Studio": "No customized settings found in Azure Data Studio",
     "Looking for Azure Data Studio key bindings, like F5 to execute queries?": "Looking for Azure Data Studio key bindings, like F5 to execute queries?",
+    "Download the keymap extension to automatically import key mappings from Azure Data Studio. These changes will show in your keyboard shortcut preferences.": "Download the keymap extension to automatically import key mappings from Azure Data Studio. These changes will show in your keyboard shortcut preferences.",
     "Install the MSSQL Database Management Keymap extension": "Install the MSSQL Database Management Keymap extension",
     "{0} connection group imported/{0} is the number of connection groups imported (singular)": {
         "message": "{0} connection group imported",

--- a/extensions/mssql/src/controllers/azureDataStudioMigrationWebviewController.ts
+++ b/extensions/mssql/src/controllers/azureDataStudioMigrationWebviewController.ts
@@ -51,7 +51,7 @@ const defaultState: AzureDataStudioMigrationWebviewState = {
 };
 
 const AZURE_DATA_STUDIO_MIGRATION_VIEW_ID = "azureDataStudioMigration";
-const KEYMAP_EXTENSION_LINK = "https://aka.ms/vscode-mssql-keymap";
+const KEYMAP_EXTENSION_ID = "ms-mssql.mssql-database-management-keymap";
 
 const EXCLUDED_SETTINGS = new Set<string>([
     // Exclude logging-related settings
@@ -424,7 +424,7 @@ export class AzureDataStudioMigrationWebviewController extends ReactWebviewPanel
         });
 
         this.onNotification(OpenKeymapLinkNotification.type, async () => {
-            await vscode.env.openExternal(vscode.Uri.parse(KEYMAP_EXTENSION_LINK));
+            await vscode.commands.executeCommand("extension.open", KEYMAP_EXTENSION_ID);
         });
     }
 

--- a/extensions/mssql/src/reactviews/common/locConstants.ts
+++ b/extensions/mssql/src/reactviews/common/locConstants.ts
@@ -1942,6 +1942,9 @@ export class LocConstants {
             keymapCallout: l10n.t(
                 "Looking for Azure Data Studio key bindings, like F5 to execute queries?",
             ),
+            keymapTooltip: l10n.t(
+                "Download the keymap extension to automatically import key mappings from Azure Data Studio. These changes will show in your keyboard shortcut preferences.",
+            ),
             keymapCalloutLink: l10n.t("Install the MSSQL Database Management Keymap extension"),
             importedConnectionGroups: (count: number) =>
                 count === 1

--- a/extensions/mssql/src/reactviews/pages/AzureDataStudioMigration/azureDataStudioMigrationPage.tsx
+++ b/extensions/mssql/src/reactviews/pages/AzureDataStudioMigration/azureDataStudioMigrationPage.tsx
@@ -513,15 +513,19 @@ export const AzureDataStudioMigrationPage = () => {
                                 </div>
                                 <Body1 className={classes.summaryText}>
                                     {LocMigration.keymapCallout}{" "}
-                                    <Link
-                                        onClick={() =>
-                                            void extensionRpc.sendNotification(
-                                                OpenKeymapLinkNotification.type,
-                                            )
-                                        }
-                                        inline>
-                                        {LocMigration.keymapCalloutLink}
-                                    </Link>
+                                    <Tooltip
+                                        content={LocMigration.keymapTooltip}
+                                        relationship="label">
+                                        <Link
+                                            onClick={() =>
+                                                void extensionRpc.sendNotification(
+                                                    OpenKeymapLinkNotification.type,
+                                                )
+                                            }
+                                            inline>
+                                            {LocMigration.keymapCalloutLink}
+                                        </Link>
+                                    </Tooltip>
                                 </Body1>
                             </>
                         )}

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1790,6 +1790,9 @@
     <trans-unit id="++CODE++831c69f02fd7c9c62450695c18f11c56b34ae3ababb1670737507a5cc01404b4">
       <source xml:lang="en">Don&apos;t show this again</source>
     </trans-unit>
+    <trans-unit id="++CODE++342f82d48698a8da781e445917d1fc3b3b2426d771d0a96b949f0b42b428ab6f">
+      <source xml:lang="en">Download the keymap extension to automatically import key mappings from Azure Data Studio. These changes will show in your keyboard shortcut preferences.</source>
+    </trans-unit>
     <trans-unit id="++CODE++ee63712617071ca7ce50c71160db6d021704d06fafc9307c6bc9a3ee11730cac">
       <source xml:lang="en">Downloading the Data API Builder container image</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Swaps the download link to launch to the keymap in the extension gallery directly

Addressing https://github.com/microsoft/vscode-mssql/issues/21231

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
