### PR TITLE
Added editable target database field for restore (#21278)

### DIFF
--- a/extensions/mssql/src/controllers/restoreDatabaseWebviewController.ts
+++ b/extensions/mssql/src/controllers/restoreDatabaseWebviewController.ts
@@ -435,11 +435,13 @@ export class RestoreDatabaseWebviewController extends ObjectManagementWebviewCon
             }),
 
             targetDatabaseName: createFormItem({
-                type: FormItemType.Dropdown,
+                type: FormItemType.Combobox,
                 propertyName: "targetDatabaseName",
                 label: LocConstants.RestoreDatabase.targetDatabase,
-                required: true,
                 options: [],
+                componentProps: {
+                    freeform: true,
+                },
             }),
 
             accountId: createFormItem({
@@ -756,7 +758,6 @@ export class RestoreDatabaseWebviewController extends ObjectManagementWebviewCon
         restoreViewModel.restorePlan = plan;
 
         const sourceDatabaseName = plan.planDetails.sourceDatabaseName.currentValue;
-        const targetDatabaseName = plan.planDetails.targetDatabaseName.currentValue;
 
         if (
             sourceDatabaseName &&
@@ -767,14 +768,9 @@ export class RestoreDatabaseWebviewController extends ObjectManagementWebviewCon
             state.formState.sourceDatabaseName = sourceDatabaseName;
         }
 
-        if (
-            targetDatabaseName &&
-            state.formComponents["targetDatabaseName"].options.some(
-                (o) => o.value === targetDatabaseName,
-            )
-        ) {
-            state.formState.targetDatabaseName = targetDatabaseName;
-        }
+        state.formState.targetDatabaseName =
+            plan.planDetails.targetDatabaseName.currentValue || state.formState.targetDatabaseName;
+
         state.formState.standbyFile = plan.planDetails.standbyFile?.currentValue || "";
         state.formState.tailLogBackupFile = plan.planDetails.tailLogBackupFile?.currentValue || "";
 

--- a/extensions/mssql/src/reactviews/common/keys.ts
+++ b/extensions/mssql/src/reactviews/common/keys.ts
@@ -62,3 +62,7 @@ export enum KeyCode {
     ContextMenu = "ContextMenu",
     Tab = "Tab",
 }
+
+export enum EventType {
+    Keydown = "keydown",
+}

--- a/extensions/mssql/src/reactviews/pages/ObjectManagement/RestoreDatabase/restoreDatabaseForm.tsx
+++ b/extensions/mssql/src/reactviews/pages/ObjectManagement/RestoreDatabase/restoreDatabaseForm.tsx
@@ -197,6 +197,7 @@ export const RestoreDatabaseForm: React.FC<BackupFormProps> = ({ fileErrors, set
                         context={context}
                         formState={formState}
                         component={component}
+                        componentProps={component.componentProps}
                         idx={index}
                     />
                 </div>

--- a/extensions/mssql/src/sharedInterfaces/form.ts
+++ b/extensions/mssql/src/sharedInterfaces/form.ts
@@ -156,6 +156,7 @@ export enum FormItemType {
     Input = "input",
     Dropdown = "dropdown",
     Checkbox = "checkbox",
+    Combobox = "combobox",
     Password = "password",
     Button = "button",
     TextArea = "textarea",


### PR DESCRIPTION
## Description

Original PR: https://github.com/microsoft/vscode-mssql/pull/21278

![editableTestDb](https://github.com/user-attachments/assets/3b99a129-c25f-4f6a-bf07-3372493ffb63)

Added an editable target database field for restore. The changes consist of adding a combobox as a new form component type. This should be a fairly low risk change to take because the only feature that currently uses the combobox is restore.

Fixes https://github.com/microsoft/vscode-mssql/issues/21237

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)