### PR TITLE
Fix incorrect loading message in restore plan 

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1586,6 +1586,8 @@
     "Backup sets to restore": "Backup sets to restore",
     "Advanced restore options": "Advanced restore options",
     "Could not load restore plan": "Could not load restore plan",
+    "Please choose a backup file to load restore plan": "Please choose a backup file to load restore plan",
+    "Please choose a blob to load restore plan": "Please choose a blob to load restore plan",
     "Object Explorer Filter": "Object Explorer Filter",
     "Azure MFA": "Azure MFA",
     "Windows Authentication": "Windows Authentication",

--- a/extensions/mssql/src/reactviews/common/locConstants.ts
+++ b/extensions/mssql/src/reactviews/common/locConstants.ts
@@ -2446,6 +2446,8 @@ export class LocConstants {
             backupSetsToRestore: l10n.t("Backup sets to restore"),
             advancedRestoreOptions: l10n.t("Advanced restore options"),
             couldNotLoadRestorePlan: l10n.t("Could not load restore plan"),
+            chooseBackupFile: l10n.t("Please choose a backup file to load restore plan"),
+            chooseBlob: l10n.t("Please choose a blob to load restore plan"),
         };
     }
 }

--- a/extensions/mssql/src/reactviews/pages/ObjectManagement/RestoreDatabase/restoreTable.tsx
+++ b/extensions/mssql/src/reactviews/pages/ObjectManagement/RestoreDatabase/restoreTable.tsx
@@ -33,6 +33,7 @@ import {
     RestoreDatabaseViewModel,
     RestorePlanTableType,
 } from "../../../../sharedInterfaces/restore";
+import { DisasterRecoveryType } from "../../../../sharedInterfaces/objectManagement";
 
 const useStyles = makeStyles({
     outerDiv: {
@@ -141,8 +142,30 @@ export const RestorePlanTableContainer = ({
     const errorMessage = useRestoreDatabaseSelector(
         (s) => (s.viewModel.model as RestoreDatabaseViewModel).errorMessage,
     );
+    const type = useRestoreDatabaseSelector(
+        (s) => (s.viewModel.model as RestoreDatabaseViewModel).type,
+    );
+    const backupFiles = useRestoreDatabaseSelector(
+        (s) => (s.viewModel.model as RestoreDatabaseViewModel).backupFiles,
+    );
+    const blob = useRestoreDatabaseSelector((s) => s.formState.blob);
+
+    const getMissingSelectionMessage = () => {
+        if (type === DisasterRecoveryType.BackupFile && backupFiles.length === 0) {
+            return locConstants.restoreDatabase.chooseBackupFile;
+        }
+        if (type === DisasterRecoveryType.Url && !blob) {
+            return locConstants.restoreDatabase.chooseBlob;
+        }
+        return "";
+    };
 
     const renderMainContent = () => {
+        const missingSelectionMessage = getMissingSelectionMessage();
+        if (missingSelectionMessage !== "") {
+            return renderErrorContent(missingSelectionMessage);
+        }
+
         switch (loadState) {
             case ApiStatus.NotStarted:
             case ApiStatus.Loading:

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4354,6 +4354,12 @@
     <trans-unit id="++CODE++2d88a61abeffd59a3bd59240d49c72a6b54deaecde6c449c2a4fd88f698d2628">
       <source xml:lang="en">Please Accept the SQL Server EULA</source>
     </trans-unit>
+    <trans-unit id="++CODE++e08a733c492b2319e9a7c554501990699416bcc3636fae9900a228f1f37a5785">
+      <source xml:lang="en">Please choose a backup file to load restore plan</source>
+    </trans-unit>
+    <trans-unit id="++CODE++a38b089912dad09f6f13bc29ac4da6d9ee55ac22e8e1dff35c42b0ffac3331d5">
+      <source xml:lang="en">Please choose a blob to load restore plan</source>
+    </trans-unit>
     <trans-unit id="++CODE++709d82394b71fbd41c81573ed92990a4f0222ae2ad79fca0c0b14a2bc557658a">
       <source xml:lang="en">Please choose a file</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/vscode-mssql/issues/21340

Previously, restore would display a loading symbol when no file/blob was selected. Now, it prompts the user to select a file/blob

Prev: 
<img width="1890" height="1316" alt="image" src="https://github.com/user-attachments/assets/bc7a1844-5325-41a2-aadb-c3abe338f490" />

Now: 
<img width="677" height="510" alt="image" src="https://github.com/user-attachments/assets/afd3e279-eeea-4c81-9e03-bc88754df728" />

<img width="357" height="229" alt="image" src="https://github.com/user-attachments/assets/7f7fb2d2-b133-4d4d-8b5b-2e23b8caa6ba" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
