### PR TITLE
[Application QuickStart] [Backend] Fix for Mac DAB container pull issue

### DIFF
--- a/extensions/mssql/src/dab/dabContainer.ts
+++ b/extensions/mssql/src/dab/dabContainer.ts
@@ -27,7 +27,7 @@ export async function pullDabContainerImage(): Promise<DockerCommandParams> {
     return pullContainerImage(
         Dab.DAB_CONTAINER_IMAGE,
         LocalContainers.dabPullImageError,
-        "linux/amd64",
+        Dab.DAB_CONTAINER_PLATFORM,
     );
 }
 

--- a/extensions/mssql/src/docker/dockerUtils.ts
+++ b/extensions/mssql/src/docker/dockerUtils.ts
@@ -516,11 +516,9 @@ export async function pullContainerImage(
     try {
         dockerLogger.appendLine(`Pulling container image: ${imageName}`);
         const dockerClient = getDockerodeClient();
-        const pullOptions: Record<string, string> = {};
-        if (platform) {
-            pullOptions.platform = platform;
-        }
-        const pullStream = await dockerClient.pull(imageName, pullOptions);
+        const pullStream = platform
+            ? await dockerClient.pull(imageName, { platform })
+            : await dockerClient.pull(imageName);
         await new Promise<void>((resolve, reject) => {
             dockerClient.modem.followProgress(pullStream, (error) =>
                 error ? reject(error) : resolve(),

--- a/extensions/mssql/src/sharedInterfaces/dab.ts
+++ b/extensions/mssql/src/sharedInterfaces/dab.ts
@@ -356,6 +356,13 @@ export namespace Dab {
     export const DAB_CONTAINER_IMAGE = "mcr.microsoft.com/azure-databases/data-api-builder:latest";
 
     /**
+     * Platform to use when pulling the DAB container image.
+     * DAB only publishes linux/amd64 images, so this must be specified
+     * explicitly to avoid pull failures on Mac ARM (which defaults to linux/arm64).
+     */
+    export const DAB_CONTAINER_PLATFORM = "linux/amd64";
+
+    /**
      * Default port for DAB container
      */
     export const DAB_DEFAULT_PORT = 5000;

--- a/extensions/mssql/test/unit/dab/dabContainer.test.ts
+++ b/extensions/mssql/test/unit/dab/dabContainer.test.ts
@@ -10,6 +10,7 @@ import * as sinon from "sinon";
 import * as os from "os";
 import * as dabContainer from "../../../src/dab/dabContainer";
 import * as dockerodeClient from "../../../src/docker/dockerodeClient";
+import { Dab } from "../../../src/sharedInterfaces/dab";
 import { PassThrough } from "stream";
 import * as fs from "fs";
 import * as path from "path";
@@ -82,7 +83,7 @@ suite("DAB Container", () => {
 
         // Verify platform is passed to pull for cross-platform compatibility (DAB only publishes linux/amd64)
         const pullArgs = pullStub.firstCall.args;
-        expect(pullArgs[1]).to.deep.equal({ platform: "linux/amd64" });
+        expect(pullArgs[1]).to.have.property("platform", Dab.DAB_CONTAINER_PLATFORM);
     });
 
     test("pullDabContainerImage: should return error when pull fails", async () => {


### PR DESCRIPTION
## Description

Recently, the DAB team made a change to move to Docker OCI Indexes for their images (from OCI single images). This caused an issue on Mac (ARM) as Docker defaults to pulling linux/arm64 images. The DAB container image (mcr.microsoft.com/azure-databases/data-api-builder:latest) does not have an ARM64 variant, so the pull fails on Mac. Fix explicitly specify platform: "linux/amd64" when pulling the DAB image. This works on all OSes as DAB publishes only "linux/amd64" images.

- Fixed DAB container image pull failure on Mac ARM by explicitly specifying linux/amd64 platform,
  since DAB only publishes amd64 images
- Add optional platform parameter to pullContainerImage in dockerUtils.ts

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
