### PR TITLE
Disable Ctrl-Shit-E for notebook cells

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1450,7 +1450,7 @@
                 "command": "mssql.runQuery",
                 "key": "ctrl+shift+e",
                 "mac": "cmd+shift+e",
-                "when": "editorTextFocus && editorLangId == 'sql'"
+                "when": "editorTextFocus && editorLangId == 'sql' && !notebookEditorFocused"
             },
             {
                 "command": "mssql.connect",


### PR DESCRIPTION
## Description

Fixes issue https://github.com/microsoft/vscode-mssql/issues/21337.  Notebooks use Ctrl-Alt-Enter to run the current cell so we should follow the same standard convention.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
