### PR TITLE
Use errorMessage in generic connection error notification

### DIFF
--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -1656,8 +1656,9 @@ export default class ConnectionManager {
                     LocalizedConstants.msgConnectionError(errorNumber, errorMessage),
                 );
             } else {
-                if (message) {
-                    Utils.showErrorMsg(LocalizedConstants.msgConnectionError2(message));
+                const displayMsg = errorMessage || message;
+                if (displayMsg) {
+                    Utils.showErrorMsg(LocalizedConstants.msgConnectionError2(displayMsg));
                 }
             }
             return {


### PR DESCRIPTION
## Description

  In handleConnectionErrors, the generic (no error number) branch was using the message field from SqlConnectionError to populate the "Failed to connect: {0}" notification. The message field does  not reliably contain the actual SQL Server or network error text — errorMessage does.

  Change: Fall back to errorMessage when message is absent or unhelpful, so the notification shows the real failure reason instead of nothing (or a placeholder).

  Note: The {0} literal visible in issue #21335 was likely caused by a missing l10n bundle in the private build used for testing, not directly by this code path — but this fix is a correctness improvement regardless.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
