### PR TITLE
[Fix] Adding default sdk version incase config inspect returns null

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -138,9 +138,7 @@ export class ProjectsController {
         }
 
         const sqlProjectsService = await utils.getSqlProjectsService();
-        const microsoftBuildSqlSDKStyleDefaultVersion = getMicrosoftBuildSqlVersion(
-            constants.microsoftBuildSqlVersionKey,
-        );
+        const microsoftBuildSqlSDKStyleDefaultVersion = getMicrosoftBuildSqlVersion();
         const projectStyle = creationParams.sdkStyle
             ? mssqlVscode.ProjectType.SdkStyle
             : mssqlVscode.ProjectType.LegacyStyle;

--- a/extensions/sql-database-projects/src/templates/templates.ts
+++ b/extensions/sql-database-projects/src/templates/templates.ts
@@ -86,12 +86,7 @@ export async function loadTemplates(templateFolderPath: string) {
         Promise.resolve(
             (newSdkSqlProjectTemplate = macroExpansion(
                 await loadTemplate(templateFolderPath, "newSdkSqlProjectTemplate.xml"),
-                new Map([
-                    [
-                        "MICROSOFT_BUILD_SQL_VERSION",
-                        getMicrosoftBuildSqlVersion(constants.microsoftBuildSqlVersionKey),
-                    ],
-                ]),
+                new Map([["MICROSOFT_BUILD_SQL_VERSION", getMicrosoftBuildSqlVersion()]]),
             )),
         ),
         loadObjectTypeInfo(

--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -69,8 +69,7 @@ export class BuildHelper {
             "Microsoft.SqlServer.Server.dll",
         ];
 
-        const sdkVersion = getMicrosoftBuildSqlVersion(constants.microsoftBuildSqlVersionKey);
-
+        const sdkVersion = getMicrosoftBuildSqlVersion();
         const microsoftBuildSqlDllLocation = path.join("tools", "net8.0");
         return this.ensureNugetAndFilesPresence(
             sdkName,

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -17,6 +17,7 @@ import {
     DotnetInstallationConfirmation,
     NetCoreSupportedVersionInstallationConfirmation,
     UpdateDotnetLocation,
+    microsoftBuildSqlVersionKey,
 } from "../common/constants";
 import * as utils from "../common/utils";
 import { ShellCommandOptions, ShellExecutionHelper } from "./shellExecutionHelper";
@@ -57,7 +58,7 @@ const dotnet = os.platform() === "win32" ? "dotnet.exe" : "dotnet";
  *    not a valid semver (e.g. the extension package.json default is missing or the user typed an
  *    invalid version string).
  */
-export function getMicrosoftBuildSqlVersion(microsoftBuildSqlVersionKey: string): string {
+export function getMicrosoftBuildSqlVersion(): string {
     const config = vscode.workspace.getConfiguration(DBProjectConfigurationKey);
     const configured = config.get<string>(microsoftBuildSqlVersionKey)?.trim();
     if (configured && semver.valid(configured)) {

--- a/extensions/sql-database-projects/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/test/netCoreTool.test.ts
@@ -17,6 +17,7 @@ import {
     getMicrosoftBuildSqlVersion,
 } from "../src/tools/netcoreTool";
 import { getQuotedPath } from "../src/common/utils";
+import * as constants from "../src/common/constants";
 import { deleteGeneratedTestFolder, generateTestFolderPath } from "./testUtils";
 import { createContext, TestContext } from "./testContext";
 
@@ -106,23 +107,29 @@ suite("NetCoreTool: Net core tests", function (): void {
     });
 
     suite("getMicrosoftBuildSqlVersion tests", function (): void {
-        const testKey = "microsoftBuildSqlVersion";
-
         teardown(async function (): Promise<void> {
             // Clean up configuration after each test
             await vscode.workspace
                 .getConfiguration(DBProjectConfigurationKey)
-                .update(testKey, undefined, vscode.ConfigurationTarget.Global);
+                .update(
+                    constants.microsoftBuildSqlVersionKey,
+                    undefined,
+                    vscode.ConfigurationTarget.Global,
+                );
         });
 
         test("Should return valid configured value when set", async function (): Promise<void> {
             // Arrange: Set a valid semver version
             await vscode.workspace
                 .getConfiguration(DBProjectConfigurationKey)
-                .update(testKey, "3.0.0", vscode.ConfigurationTarget.Global);
+                .update(
+                    constants.microsoftBuildSqlVersionKey,
+                    "3.0.0",
+                    vscode.ConfigurationTarget.Global,
+                );
 
             // Act
-            const result = getMicrosoftBuildSqlVersion(testKey);
+            const result = getMicrosoftBuildSqlVersion();
 
             // Assert
             expect(result).to.equal("3.0.0");
@@ -132,15 +139,23 @@ suite("NetCoreTool: Net core tests", function (): void {
             // Test with invalid semver
             await vscode.workspace
                 .getConfiguration(DBProjectConfigurationKey)
-                .update(testKey, "not-a-valid-version", vscode.ConfigurationTarget.Global);
-            let result = getMicrosoftBuildSqlVersion(testKey);
+                .update(
+                    constants.microsoftBuildSqlVersionKey,
+                    "not-a-valid-version",
+                    vscode.ConfigurationTarget.Global,
+                );
+            let result = getMicrosoftBuildSqlVersion();
             expect(result).to.equal(FALLBACK_MICROSOFT_BUILD_SQL_VERSION);
 
             // Test with empty config
             await vscode.workspace
                 .getConfiguration(DBProjectConfigurationKey)
-                .update(testKey, undefined, vscode.ConfigurationTarget.Global);
-            result = getMicrosoftBuildSqlVersion(testKey);
+                .update(
+                    constants.microsoftBuildSqlVersionKey,
+                    undefined,
+                    vscode.ConfigurationTarget.Global,
+                );
+            result = getMicrosoftBuildSqlVersion();
             expect(result).to.equal(FALLBACK_MICROSOFT_BUILD_SQL_VERSION);
         });
     });


### PR DESCRIPTION
## Description

Pipeline generated VSIX file does not returns the config defaults (investigating what could be the reason). 
- Adding a default fallback version and comments to make it sync with the release version.
- Could not repro this in local run but pipeline generated vsix repro it.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Before: Was able to repro with the 1.5.8version install
<img width="332" height="166" alt="image" src="https://github.com/user-attachments/assets/0cb26f37-8e79-4c6b-8380-853d90701b0b" />

After: (locally, always working without the fallback version)
<img width="727" height="322" alt="image" src="https://github.com/user-attachments/assets/c8ae90e7-1dca-4ea7-954b-0746f85d159b" />

