### PR TITLE
F5 will execute notebook SQL cells

### DIFF
--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -45,7 +45,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookCellListFocused"
+                "when": "notebookCellListFocused && notebookType == 'sql'"
             },
             {
                 "command": "mssql.runCurrentStatement",


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/vscode-mssql/issues/21337

The PR allows F5 to execute SQL notebook cells

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
