### PR TITLE
Fixing imports to improve tree shaking 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
                 // Uncomment this to use a specified version of STS, see
                 // https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
                 // for more details
-                "MSSQL_SQLTOOLSSERVICE": "/Users/aasim/src/sts2/src/Microsoft.SqlTools.ServiceLayer/bin/Release/net8.0/osx-arm64/publish/"
+                // "MSSQL_SQLTOOLSSERVICE": "<Path to STS>"
             }
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
                 // Uncomment this to use a specified version of STS, see
                 // https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
                 // for more details
-                // "MSSQL_SQLTOOLSSERVICE": "<Path to STS>"
+                "MSSQL_SQLTOOLSSERVICE": "/Users/aasim/src/sts2/src/Microsoft.SqlTools.ServiceLayer/bin/Release/net8.0/osx-arm64/publish/"
             }
         }
     ]

--- a/extensions/mssql/src/reactviews/common/definitionPanel.tsx
+++ b/extensions/mssql/src/reactviews/common/definitionPanel.tsx
@@ -8,7 +8,13 @@ import { Editor } from "@monaco-editor/react";
 import { ImperativePanelHandle, Panel } from "react-resizable-panels";
 import { resolveVscodeThemeType } from "./utils";
 import { ColorThemeKind } from "../../sharedInterfaces/webview";
-import * as FluentIcons from "@fluentui/react-icons";
+import {
+    ChevronDown12Filled,
+    ChevronUp12Filled,
+    Copy16Regular,
+    Dismiss12Regular,
+    Open12Regular,
+} from "@fluentui/react-icons";
 import { locConstants } from "./locConstants";
 import {
     useRef,
@@ -127,7 +133,7 @@ function getScriptTab(
                     size="small"
                     appearance="subtle"
                     title={locConstants.schemaDesigner.openInEditor}
-                    icon={<FluentIcons.Open12Regular />}
+                    icon={<Open12Regular />}
                     onClick={() => props.openInEditor(props.value)}>
                     {locConstants.schemaDesigner.openInEditor}
                 </Button>
@@ -135,7 +141,7 @@ function getScriptTab(
                     size="small"
                     appearance="subtle"
                     title={locConstants.schemaDesigner.copy}
-                    icon={<FluentIcons.Copy16Regular />}
+                    icon={<Copy16Regular />}
                     onClick={() => props.copyToClipboard(props.value)}
                 />
             </>
@@ -170,7 +176,7 @@ const DefinitionPanelInner = <TCustomTabId extends string = never>(
         locConstants.tableDesigner.maximizePanelSize,
     );
     const [expandCollapseButtonIcon, setExpandCollapseButtonIcon] = useState<ReactElement>(
-        <FluentIcons.ChevronUp12Filled />,
+        <ChevronUp12Filled />,
     );
 
     useImperativeHandle(
@@ -212,10 +218,10 @@ const DefinitionPanelInner = <TCustomTabId extends string = never>(
             onResize={(size) => {
                 if (size === MAXIMUMPANEL_SIZE) {
                     setExpandCollapseButtonLabel(locConstants.tableDesigner.restorePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronDown12Filled />);
+                    setExpandCollapseButtonIcon(<ChevronDown12Filled />);
                 } else {
                     setExpandCollapseButtonLabel(locConstants.tableDesigner.maximizePanelSize);
-                    setExpandCollapseButtonIcon(<FluentIcons.ChevronUp12Filled />);
+                    setExpandCollapseButtonIcon(<ChevronUp12Filled />);
                 }
             }}
             onExpand={() => onPanelVisibilityChange?.(true)}
@@ -258,7 +264,7 @@ const DefinitionPanelInner = <TCustomTabId extends string = never>(
                             size="small"
                             appearance="subtle"
                             title={locConstants.schemaDesigner.close}
-                            icon={<FluentIcons.Dismiss12Regular />}
+                            icon={<Dismiss12Regular />}
                             onClick={() => {
                                 if (panelRef.current) {
                                     panelRef.current.collapse();

--- a/extensions/mssql/src/reactviews/common/findWidget.component.tsx
+++ b/extensions/mssql/src/reactviews/common/findWidget.component.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button, SearchBox, Text, makeStyles } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import { ArrowDown16Regular, ArrowUp16Regular, Dismiss16Regular } from "@fluentui/react-icons";
 import { useEffect, useState, useRef, useCallback } from "react";
 import { locConstants } from "./locConstants";
 
@@ -341,7 +341,7 @@ export function FindWidget<T extends SearchableItem>({
             />
             <Button
                 size="small"
-                icon={<FluentIcons.ArrowDown16Regular />}
+                icon={<ArrowDown16Regular />}
                 appearance="subtle"
                 disabled={filteredItems.length === 0}
                 onClick={handleNextItem}
@@ -350,7 +350,7 @@ export function FindWidget<T extends SearchableItem>({
             />
             <Button
                 size="small"
-                icon={<FluentIcons.ArrowUp16Regular />}
+                icon={<ArrowUp16Regular />}
                 appearance="subtle"
                 disabled={filteredItems.length === 0}
                 onClick={handlePreviousItem}
@@ -359,7 +359,7 @@ export function FindWidget<T extends SearchableItem>({
             />
             <Button
                 size="small"
-                icon={<FluentIcons.Dismiss16Regular />}
+                icon={<Dismiss16Regular />}
                 appearance="subtle"
                 onClick={hideSearchWidget}
                 title={locConstants.common.closeFind}

--- a/extensions/mssql/src/reactviews/common/searchableDropdown.component.tsx
+++ b/extensions/mssql/src/reactviews/common/searchableDropdown.component.tsx
@@ -14,7 +14,12 @@ import {
     Text,
     tokens,
 } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import {
+    Checkmark16Regular,
+    ChevronDownRegular,
+    DismissRegular,
+    Warning20Regular,
+} from "@fluentui/react-icons";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import React, {
     CSSProperties,
@@ -126,7 +131,7 @@ export interface SearchableDropdownProps {
  * Icon Map for options in the searchable dropdown. Add more icons here if you need a specific icon
  */
 export const FluentOptionIcons: Record<string, React.JSX.Element> = {
-    Warning20Regular: <FluentIcons.Warning20Regular />,
+    Warning20Regular: <Warning20Regular />,
 };
 
 export function renderColorSwatch(color: string | undefined): React.JSX.Element | undefined {
@@ -447,15 +452,15 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
     const getDropdownIcon = () => {
         if (!props.clearable) {
-            return <FluentIcons.ChevronDownRegular />;
+            return <ChevronDownRegular />;
         }
 
         if (selectedOptionIndex === -1) {
-            return <FluentIcons.ChevronDownRegular />;
+            return <ChevronDownRegular />;
         }
 
         return (
-            <FluentIcons.DismissRegular
+            <DismissRegular
                 style={{ cursor: "pointer" }}
                 onClick={(e) => {
                     updateOption({ value: "" });
@@ -738,7 +743,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                                                     <Text>{option.description}</Text>
                                                 )}
                                                 {option.icon && FluentOptionIcons[option.icon]}
-                                                {isSelected && <FluentIcons.Checkmark16Regular />}
+                                                {isSelected && <Checkmark16Regular />}
                                             </span>
                                         </div>
                                     </div>

--- a/extensions/mssql/src/reactviews/common/theme.ts
+++ b/extensions/mssql/src/reactviews/common/theme.ts
@@ -3,24 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fluentui from "@fluentui/react-components";
+import { Theme, webDarkTheme, webLightTheme } from "@fluentui/react-components";
 import { ColorThemeKind } from "../../sharedInterfaces/webview";
 
 /**
  * This maps the Fluent UI theme variables to the VS Code theme variables.
  */
-export function webviewTheme(themeKind: ColorThemeKind): fluentui.Theme {
+export function webviewTheme(themeKind: ColorThemeKind): Theme {
     let baseTheme;
 
     switch (themeKind) {
         case ColorThemeKind.Light:
         case ColorThemeKind.HighContrastLight:
-            baseTheme = fluentui.webLightTheme;
+            baseTheme = webLightTheme;
             break;
         case ColorThemeKind.Dark:
         case ColorThemeKind.HighContrast:
         default:
-            baseTheme = fluentui.webDarkTheme;
+            baseTheme = webDarkTheme;
             break;
     }
 

--- a/extensions/mssql/src/reactviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/extensions/mssql/src/reactviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -7,7 +7,7 @@ import "azdataGraph/src/css/common.css";
 import "azdataGraph/src/css/explorer.css";
 import "./executionPlan.css";
 
-import * as azdataGraph from "azdataGraph";
+import { mx } from "azdataGraph";
 import * as utils from "./queryPlanSetup";
 
 import { Button, Input, Popover, makeStyles, tokens } from "@fluentui/react-components";
@@ -134,7 +134,7 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
         // @ts-ignore
         window["mxBasePath"] = "./src/reactviews/pages/ExecutionPlan/mxgraph";
 
-        const mxClient = azdataGraph.mx();
+        const mxClient = mx();
 
         function loadExecutionPlan() {
             if (executionPlanState && executionPlanState.executionPlanGraphs) {

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/dab/dabToolbar.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/dab/dabToolbar.tsx
@@ -12,8 +12,13 @@ import {
     Text,
     tokens,
 } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
-import { Dismiss16Regular, Search16Regular } from "@fluentui/react-icons";
+import {
+    ArrowLeft16Regular,
+    Eye16Regular,
+    Play16Filled,
+    Dismiss16Regular,
+    Search16Regular,
+} from "@fluentui/react-icons";
 import { locConstants } from "../../../common/locConstants";
 import { Dab } from "../../../../sharedInterfaces/dab";
 import { useDabContext } from "./dabContext";
@@ -119,7 +124,7 @@ export function DabToolbar({ showDiscovery, onNavigateToSchema, onViewConfig }: 
                     <Button
                         appearance="subtle"
                         size="small"
-                        icon={<FluentIcons.ArrowLeft16Regular />}
+                        icon={<ArrowLeft16Regular />}
                         onClick={onNavigateToSchema}>
                         {locConstants.schemaDesigner.backToSchema}
                     </Button>
@@ -136,7 +141,7 @@ export function DabToolbar({ showDiscovery, onNavigateToSchema, onViewConfig }: 
                     />
                     <Button
                         appearance="subtle"
-                        icon={<FluentIcons.Eye16Regular />}
+                        icon={<Eye16Regular />}
                         size="small"
                         title={locConstants.schemaDesigner.viewConfig}
                         onClick={onViewConfig}>
@@ -144,7 +149,7 @@ export function DabToolbar({ showDiscovery, onNavigateToSchema, onViewConfig }: 
                     </Button>
                     <Button
                         appearance="primary"
-                        icon={<FluentIcons.Play16Filled />}
+                        icon={<Play16Filled />}
                         size="small"
                         title={locConstants.schemaDesigner.deploy}
                         onClick={openDabDeploymentDialog}>

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/diff/diffUtils.ts
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/diff/diffUtils.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as sd from "../../../../sharedInterfaces/schemaDesigner";
-import * as lodash from "lodash";
+import isEqual from "lodash/isEqual";
 
 export enum ChangeAction {
     Add = "add",
@@ -101,7 +101,7 @@ export function diffObject<T extends object>(
     for (const prop of properties) {
         const oldValue = (original as Record<string, unknown>)[prop.key];
         const newValue = (current as Record<string, unknown>)[prop.key];
-        if (!lodash.isEqual(oldValue, newValue)) {
+        if (!isEqual(oldValue, newValue)) {
             changes.push({
                 property: prop.key,
                 displayName: prop.displayName,
@@ -248,7 +248,7 @@ export function calculateSchemaDiff(
 
         const oldColumnOrder = (oldTable.columns ?? []).map((column) => column.id);
         const newColumnOrder = (newTable.columns ?? []).map((column) => column.id);
-        if (!lodash.isEqual(oldColumnOrder, newColumnOrder)) {
+        if (!isEqual(oldColumnOrder, newColumnOrder)) {
             const oldColumnNamesById = new Map(
                 (oldTable.columns ?? []).map((column) => [column.id, column.name]),
             );

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorDrawer.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorDrawer.tsx
@@ -11,7 +11,7 @@ import {
     OverlayDrawer,
     TabValue,
 } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import { Dismiss24Regular } from "@fluentui/react-icons";
 import { SchemaDesignerEditor } from "./schemaDesignerEditor";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
@@ -235,7 +235,7 @@ export const SchemaDesignerEditorDrawer = () => {
                             <Button
                                 appearance="subtle"
                                 aria-label="Close"
-                                icon={<FluentIcons.Dismiss24Regular />}
+                                icon={<Dismiss24Regular />}
                                 onClick={() => setIsEditDrawerOpen(false)}
                             />
                         }>

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorForeignKeyPanel.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorForeignKeyPanel.tsx
@@ -36,7 +36,6 @@ import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import { locConstants } from "../../../common/locConstants";
 import { uuid } from "../../../common/utils";
 import { SearchableDropdown } from "../../../common/searchableDropdown.component";
-import * as FluentIcons from "@fluentui/react-icons";
 import {
     FOREIGN_KEY_ERROR_PREFIX,
     SchemaDesignerEditorContext,
@@ -533,7 +532,7 @@ const ForeignKeyCard = ({
             <div className={classes.mappingTableContainer}>
                 {/* Add Column Mapping Button */}
                 <Button
-                    icon={<FluentIcons.AddRegular />}
+                    icon={<AddRegular />}
                     className={classes.actionButton}
                     onClick={addColumnMapping}
                     size="small">

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorTablePanel.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/editor/schemaDesignerEditorTablePanel.tsx
@@ -34,7 +34,13 @@ import {
 import { locConstants } from "../../../common/locConstants";
 import { uuid } from "../../../common/utils";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import * as FluentIcons from "@fluentui/react-icons";
+import {
+    AddRegular,
+    DeleteRegular,
+    ErrorCircleRegular,
+    MoreHorizontalRegular,
+    ReOrderRegular,
+} from "@fluentui/react-icons";
 import { columnUtils, namingUtils, tableUtils } from "../model";
 import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import { SearchableDropdown } from "../../../common/searchableDropdown.component";
@@ -311,7 +317,7 @@ const ColumnsTable = ({
                         className={`${classes.dragHandleButton} ${
                             draggedRowId === index ? classes.draggingHandleButton : ""
                         }`}
-                        icon={<FluentIcons.ReOrderRegular />}
+                        icon={<ReOrderRegular />}
                         draggable={true}
                         onDragEnter={() => {
                             setDraggedOverRowId(index);
@@ -345,7 +351,7 @@ const ColumnsTable = ({
                                 <PopoverTrigger disableButtonEnhancement>
                                     <Button
                                         icon={
-                                            <FluentIcons.ErrorCircleRegular
+                                            <ErrorCircleRegular
                                                 style={{
                                                     color: "var(--vscode-errorForeground)",
                                                 }}
@@ -442,7 +448,7 @@ const ColumnsTable = ({
                         size="small"
                         appearance="subtle"
                         disabled={Boolean(deleteDisabledReason)}
-                        icon={<FluentIcons.DeleteRegular />}
+                        icon={<DeleteRegular />}
                         onClick={() => deleteColumn(index)}
                     />
                 );
@@ -468,7 +474,7 @@ const ColumnsTable = ({
                             <Button
                                 size="small"
                                 appearance="subtle"
-                                icon={<FluentIcons.MoreHorizontalRegular />}
+                                icon={<MoreHorizontalRegular />}
                             />
                         </PopoverTrigger>
 
@@ -753,7 +759,7 @@ export const SchemaDesignerEditorTablePanel = () => {
             {/* Add Column Button */}
             <Button
                 appearance="secondary"
-                icon={<FluentIcons.AddRegular />}
+                icon={<AddRegular />}
                 className={classes.newColumnButton}
                 onClick={addColumn}>
                 {locConstants.schemaDesigner.newColumn}

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/graph/schemaDesignerTableNode.tsx
@@ -23,7 +23,17 @@ import {
     Text,
     Tooltip,
 } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import {
+    ArrowUndo16Regular,
+    CheckmarkCircle16Regular,
+    ChevronDownRegular,
+    ChevronUpRegular,
+    DeleteRegular,
+    EditRegular,
+    FlowRegular,
+    MoreVerticalRegular,
+    TableRegular,
+} from "@fluentui/react-icons";
 import { locConstants } from "../../../common/locConstants";
 import { Handle, NodeProps, Position, useUpdateNodeInternals } from "@xyflow/react";
 import { useContext, useRef, useEffect, useState, cloneElement, type ComponentProps } from "react";
@@ -309,7 +319,7 @@ const TableHeaderActions = ({ table }: { table: SchemaDesigner.Table }) => {
         <>
             <Button
                 appearance="subtle"
-                icon={<FluentIcons.EditRegular />}
+                icon={<EditRegular />}
                 onClick={handleEditTable}
                 className={styles.actionButton}
                 size="small"
@@ -317,7 +327,7 @@ const TableHeaderActions = ({ table }: { table: SchemaDesigner.Table }) => {
             <Menu>
                 <MenuTrigger disableButtonEnhancement>
                     <MenuButton
-                        icon={<FluentIcons.MoreVerticalRegular />}
+                        icon={<MoreVerticalRegular />}
                         className={styles.actionButton}
                         size="small"
                         appearance="subtle"
@@ -326,12 +336,10 @@ const TableHeaderActions = ({ table }: { table: SchemaDesigner.Table }) => {
 
                 <MenuPopover>
                     <MenuList>
-                        <MenuItem
-                            icon={<FluentIcons.FlowRegular />}
-                            onClick={handleManageRelationships}>
+                        <MenuItem icon={<FlowRegular />} onClick={handleManageRelationships}>
                             {locConstants.schemaDesigner.manageRelationships}
                         </MenuItem>
-                        <MenuItem icon={<FluentIcons.DeleteRegular />} onClick={handleDeleteTable}>
+                        <MenuItem icon={<DeleteRegular />} onClick={handleDeleteTable}>
                             {locConstants.schemaDesigner.delete}
                         </MenuItem>
                     </MenuList>
@@ -405,7 +413,7 @@ const TableHeader = ({ table }: { table: SchemaDesigner.TableWithDeletedFlag }) 
                 showQualifiedDiff && styles.tableHeaderDiffModified,
             )}>
             <div className={styles.tableHeaderRow}>
-                <FluentIcons.TableRegular className={styles.tableIcon} />
+                <TableRegular className={styles.tableIcon} />
                 <ConditionalTooltip content={tooltipContent} relationship="label">
                     <Text
                         className={mergeClasses(
@@ -587,7 +595,7 @@ const TableColumn = ({
                             <Button
                                 appearance="primary"
                                 size="small"
-                                icon={<FluentIcons.CheckmarkCircle16Regular />}
+                                icon={<CheckmarkCircle16Regular />}
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     changeContext.acceptChange!(columnChange);
@@ -605,7 +613,7 @@ const TableColumn = ({
                         <Button
                             appearance="primary"
                             size="small"
-                            icon={<FluentIcons.ArrowUndo16Regular />}
+                            icon={<ArrowUndo16Regular />}
                             disabled={revertInfo ? !revertInfo.canRevert : false}
                             onClick={(event) => {
                                 event.stopPropagation();
@@ -749,13 +757,7 @@ const TableColumns = ({
                     className={styles.collapseButton}
                     onClick={onToggleCollapse}
                     appearance="subtle"
-                    icon={
-                        isCollapsed ? (
-                            <FluentIcons.ChevronDownRegular />
-                        ) : (
-                            <FluentIcons.ChevronUpRegular />
-                        )
-                    }
+                    icon={isCollapsed ? <ChevronDownRegular /> : <ChevronUpRegular />}
                     tabIndex={0}>
                     {isCollapsed ? <span>{EXPAND}</span> : <span>{COLLAPSE}</span>}
                 </Button>
@@ -862,7 +864,7 @@ export const SchemaDesignerTableNode = (props: NodeProps) => {
                             <Button
                                 appearance="primary"
                                 size="small"
-                                icon={<FluentIcons.CheckmarkCircle16Regular />}
+                                icon={<CheckmarkCircle16Regular />}
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     changeContext.acceptChange!(tableChange);
@@ -880,7 +882,7 @@ export const SchemaDesignerTableNode = (props: NodeProps) => {
                         <Button
                             appearance="primary"
                             size="small"
-                            icon={<FluentIcons.ArrowUndo16Regular />}
+                            icon={<ArrowUndo16Regular />}
                             disabled={revertInfo ? !revertInfo.canRevert : false}
                             onClick={(event) => {
                                 event.stopPropagation();

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/model/flowLayout.ts
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/model/flowLayout.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dagre from "@dagrejs/dagre";
+import { graphlib, layout } from "@dagrejs/dagre";
 import { Edge, Node } from "@xyflow/react";
 import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import { FLOW_SPACING, getTableHeight, getTableWidth } from "./flowDimensions";
@@ -32,7 +32,7 @@ export function layoutFlowComponents(
     nodes: Node<SchemaDesigner.Table>[];
     edges: Edge<SchemaDesigner.ForeignKey>[];
 } {
-    const graph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+    const graph = new graphlib.Graph().setDefaultEdgeLabel(() => ({}));
     graph.setGraph(options);
 
     for (const node of nodes) {
@@ -52,7 +52,7 @@ export function layoutFlowComponents(
         }
     }
 
-    dagre.layout(graph);
+    layout(graph);
 
     const layoutedNodes = nodes.map((node) => {
         if (node.hidden) return node;

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/exportDiagramButton.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/exportDiagramButton.tsx
@@ -13,11 +13,11 @@ import {
     Tooltip,
 } from "@fluentui/react-components";
 import { locConstants } from "../../../common/locConstants";
-import * as htmlToImage from "html-to-image";
+import { toJpeg, toPng, toSvg } from "html-to-image";
 import { getNodesBounds, getViewportForBounds, useReactFlow } from "@xyflow/react";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
 import { useContext } from "react";
-import * as FluentIcons from "@fluentui/react-icons";
+import { ArrowExport16Regular } from "@fluentui/react-icons";
 import { useIsToolbarCompact } from "./schemaDesignerToolbarContext";
 
 export function ExportDiagramButton() {
@@ -53,67 +53,61 @@ export function ExportDiagramButton() {
 
         switch (format) {
             case "png":
-                void htmlToImage
-                    .toPng(reactFlowContainer, {
-                        width: width,
-                        height: height,
-                        backgroundColor: graphBackgroundColor,
-                        style: {
-                            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-                            width: `${width}px`,
-                            height: `${height}px`,
-                        },
-                    })
-                    .then((dataUrl) => {
-                        context.saveAsFile({
-                            format,
-                            fileContents: dataUrl,
-                            width,
-                            height,
-                        });
+                void toPng(reactFlowContainer, {
+                    width: width,
+                    height: height,
+                    backgroundColor: graphBackgroundColor,
+                    style: {
+                        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+                        width: `${width}px`,
+                        height: `${height}px`,
+                    },
+                }).then((dataUrl: string) => {
+                    context.saveAsFile({
+                        format,
+                        fileContents: dataUrl,
+                        width,
+                        height,
                     });
+                });
                 break;
             case "jpeg":
-                void htmlToImage
-                    .toJpeg(reactFlowContainer, {
-                        width: width,
-                        height: height,
-                        backgroundColor: graphBackgroundColor,
-                        style: {
-                            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-                            width: `${width}px`,
-                            height: `${height}px`,
-                        },
-                    })
-                    .then((dataUrl) => {
-                        context.saveAsFile({
-                            format,
-                            fileContents: dataUrl,
-                            width,
-                            height,
-                        });
+                void toJpeg(reactFlowContainer, {
+                    width: width,
+                    height: height,
+                    backgroundColor: graphBackgroundColor,
+                    style: {
+                        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+                        width: `${width}px`,
+                        height: `${height}px`,
+                    },
+                }).then((dataUrl: string) => {
+                    context.saveAsFile({
+                        format,
+                        fileContents: dataUrl,
+                        width,
+                        height,
                     });
+                });
                 break;
             case "svg":
-                void htmlToImage
-                    .toSvg(reactFlowContainer, {
-                        width: width,
-                        height: height,
-                        backgroundColor: graphBackgroundColor,
-                        style: {
-                            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-                            width: `${width}px`,
-                            height: `${height}px`,
-                        },
-                    })
-                    .then((dataUrl) => {
-                        context.saveAsFile({
-                            format,
-                            fileContents: dataUrl,
-                            width,
-                            height,
-                        });
+                void toSvg(reactFlowContainer, {
+                    width: width,
+                    height: height,
+                    backgroundColor: graphBackgroundColor,
+                    style: {
+                        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+                        width: `${width}px`,
+                        height: `${height}px`,
+                    },
+                }).then((dataUrl: string) => {
+                    context.saveAsFile({
+                        format,
+                        fileContents: dataUrl,
+                        width,
+                        height,
                     });
+                });
                 break;
         }
         context.setRenderOnlyVisibleTables(true); // Reset to default state after export
@@ -123,10 +117,7 @@ export function ExportDiagramButton() {
         <Menu>
             <MenuTrigger disableButtonEnhancement>
                 <Tooltip content={locConstants.schemaDesigner.export} relationship="label">
-                    <Button
-                        appearance="subtle"
-                        size="small"
-                        icon={<FluentIcons.ArrowExport16Regular />}>
+                    <Button appearance="subtle" size="small" icon={<ArrowExport16Regular />}>
                         {!isCompact && locConstants.schemaDesigner.export}
                     </Button>
                 </Tooltip>

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -18,11 +18,15 @@ import {
     Spinner,
     Tooltip,
 } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import {
+    BranchFilled,
+    CheckmarkCircleFilled,
+    DatabaseArrowUp16Regular,
+    ErrorCircleFilled,
+} from "@fluentui/react-icons";
 import { locConstants } from "../../../common/locConstants";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
-import { useContext, useState } from "react";
-import Markdown from "react-markdown";
+import { lazy, Suspense, useContext, useState } from "react";
 import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import { useMarkdownStyles } from "../../../common/styles";
 import { useSchemaDesignerChangeContext } from "../definition/changes/schemaDesignerChangeContext";
@@ -35,6 +39,8 @@ import {
     schemaDesignerPublishErrorFallbackDetails,
     schemaDesignerPublishErrorPrompt,
 } from "./publishChangesDialogPrompts";
+
+const Markdown = lazy(() => import("react-markdown"));
 
 export enum PublishDialogStages {
     NotStarted = "notStarted",
@@ -143,7 +149,7 @@ export function PublishChangesDialogButton() {
                     size="small"
                     aria-label={locConstants.schemaDesigner.publishChanges}
                     title={locConstants.schemaDesigner.publishChanges}
-                    icon={<FluentIcons.DatabaseArrowUp16Regular />}
+                    icon={<DatabaseArrowUp16Regular />}
                     disabled={publishButtonDisabled || !hasSchemaChanges}
                     onClick={async () => {
                         setState({
@@ -247,7 +253,7 @@ export function PublishChangesDialogButton() {
                     justifyContent: "center",
                     minHeight: "200px",
                 }}>
-                <FluentIcons.ErrorCircleFilled
+                <ErrorCircleFilled
                     style={{
                         marginRight: "10px",
                         width: "50px",
@@ -269,7 +275,7 @@ export function PublishChangesDialogButton() {
                     justifyContent: "center",
                     minHeight: "200px",
                 }}>
-                <FluentIcons.CheckmarkCircleFilled
+                <CheckmarkCircleFilled
                     style={{
                         marginRight: "10px",
                         width: "50px",
@@ -319,7 +325,9 @@ export function PublishChangesDialogButton() {
                             overflow: "auto",
                         }}>
                         <div className={markdownClasses.markdownPage}>
-                            <Markdown>{state?.report?.dacReport?.report ?? ""}</Markdown>
+                            <Suspense fallback={<Spinner size="tiny" />}>
+                                <Markdown>{state?.report?.dacReport?.report ?? ""}</Markdown>
+                            </Suspense>
                         </div>
                     </div>
 
@@ -381,7 +389,7 @@ export function PublishChangesDialogButton() {
                         justifyContent: "center",
                         minHeight: "200px",
                     }}>
-                    <FluentIcons.BranchFilled
+                    <BranchFilled
                         style={{
                             marginRight: "10px",
                             width: "50px",

--- a/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/undoRedoButton.tsx
+++ b/extensions/mssql/src/reactviews/pages/SchemaDesigner/toolbar/undoRedoButton.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button, Tooltip } from "@fluentui/react-components";
-import * as FluentIcons from "@fluentui/react-icons";
+import { ArrowRedo16Regular, ArrowUndo16Regular } from "@fluentui/react-icons";
 import eventBus from "../schemaDesignerEvents";
 import { useEffect, useState } from "react";
 import { locConstants } from "../../../common/locConstants";
@@ -30,7 +30,7 @@ export function UndoRedoButtons() {
                 <Button
                     appearance="subtle"
                     size="small"
-                    icon={<FluentIcons.ArrowUndo16Regular />}
+                    icon={<ArrowUndo16Regular />}
                     onClick={() => {
                         eventBus.emit("undo");
                     }}
@@ -42,7 +42,7 @@ export function UndoRedoButtons() {
                 <Button
                     appearance="subtle"
                     size="small"
-                    icon={<FluentIcons.ArrowRedo16Regular />}
+                    icon={<ArrowRedo16Regular />}
                     onClick={() => {
                         eventBus.emit("redo");
                     }}

--- a/extensions/mssql/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableDesigner/designerChangesPreviewButton.tsx
@@ -26,15 +26,16 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@fluentui/react-dialog";
-import { useContext, useState } from "react";
+import { lazy, Suspense, useContext, useState } from "react";
 
 import { Button } from "@fluentui/react-button";
 import { LoadState } from "../../../sharedInterfaces/tableDesigner";
-import Markdown from "react-markdown";
 import { TableDesignerContext } from "./tableDesignerStateProvider";
 import { useTableDesignerSelector } from "./tableDesignerSelector";
 import { locConstants } from "../../common/locConstants";
 import { useMarkdownStyles } from "../../common/styles";
+
+const Markdown = lazy(() => import("react-markdown"));
 
 const useStyles = makeStyles({
     dialogSurface: {
@@ -218,7 +219,9 @@ export const DesignerChangesPreviewButton = () => {
                             overflow: "hidden",
                         }}>
                         <div className={markdownClasses.markdownPage}>
-                            <Markdown>{generatePreviewReportResult?.report}</Markdown>
+                            <Suspense fallback={<Spinner size="tiny" />}>
+                                <Markdown>{generatePreviewReportResult?.report}</Markdown>
+                            </Suspense>
                         </div>
                         <Checkbox
                             style={{

--- a/extensions/mssql/src/reactviews/pages/TableDesigner/designerTable.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableDesigner/designerTable.tsx
@@ -4,7 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as designer from "../../../sharedInterfaces/tableDesigner";
-import * as fluentui from "@fluentui/react-components";
+import {
+    Button,
+    Table,
+    TableBody,
+    TableCell,
+    TableColumnDefinition,
+    TableColumnId,
+    TableColumnSizingOptions,
+    TableHeader,
+    TableHeaderCell,
+    TableRow,
+    TableRowData,
+    Text,
+    Toolbar,
+    createTableColumn,
+    makeStyles,
+    useArrowNavigationGroup,
+    useTableColumnSizing_unstable,
+    useTableFeatures,
+} from "@fluentui/react-components";
 import * as l10n from "@vscode/l10n";
 
 import {
@@ -35,7 +54,7 @@ export type ErrorPopupProps = {
     message: string | undefined;
 };
 
-const useStyles = fluentui.makeStyles({
+const useStyles = makeStyles({
     tableCell: {
         display: "flex",
         flexDirection: "row",
@@ -105,7 +124,7 @@ const useStyles = fluentui.makeStyles({
 });
 
 export const DesignerTable = ({ component, model, componentPath, UiArea }: DesignerTableProps) => {
-    const keyboardNavAttr = fluentui.useArrowNavigationGroup({ axis: "grid" });
+    const keyboardNavAttr = useArrowNavigationGroup({ axis: "grid" });
 
     const tableProps = component.componentProperties as designer.DesignerTableProperties;
     const context = useContext(TableDesignerContext);
@@ -120,23 +139,23 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
     const MOVE_UP = l10n.t("Move Up");
     const MOVE_DOWN = l10n.t("Move Down");
 
-    const columnsDef: fluentui.TableColumnDefinition<designer.DesignerTableComponentDataItem>[] =
+    const columnsDef: TableColumnDefinition<designer.DesignerTableComponentDataItem>[] =
         tableProps.columns!.map((column) => {
             const colProps = tableProps.itemProperties?.find(
                 (item) => item.propertyName === column,
             );
-            return fluentui.createTableColumn({
+            return createTableColumn({
                 columnId: column,
                 renderHeaderCell: () => (
-                    <fluentui.Text className={classes.tableHeaderCellText}>
+                    <Text className={classes.tableHeaderCellText}>
                         {colProps?.componentProperties.title ?? column}
-                    </fluentui.Text>
+                    </Text>
                 ),
             });
         });
     if (UiArea !== "PropertiesView") {
         columnsDef.push(
-            fluentui.createTableColumn({
+            createTableColumn({
                 columnId: "properties",
                 renderHeaderCell: () => <></>,
             }),
@@ -144,7 +163,7 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
     }
     if (tableProps.canMoveRows) {
         columnsDef.unshift(
-            fluentui.createTableColumn({
+            createTableColumn({
                 columnId: "dragHandle",
                 renderHeaderCell: () => <></>,
             }),
@@ -153,7 +172,7 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
 
     if (tableProps.canRemoveRows) {
         columnsDef.push(
-            fluentui.createTableColumn({
+            createTableColumn({
                 columnId: "remove",
                 renderHeaderCell: () => {
                     const DELETE = l10n.t("Delete");
@@ -169,12 +188,10 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
         }) ?? [];
 
     const [columns] =
-        useState<fluentui.TableColumnDefinition<designer.DesignerTableComponentDataItem>[]>(
-            columnsDef,
-        );
+        useState<TableColumnDefinition<designer.DesignerTableComponentDataItem>[]>(columnsDef);
 
-    const getColumnSizingOptions = (): fluentui.TableColumnSizingOptions => {
-        const result = {} as fluentui.TableColumnSizingOptions;
+    const getColumnSizingOptions = (): TableColumnSizingOptions => {
+        const result = {} as TableColumnSizingOptions;
         tableProps.columns!.forEach((column) => {
             const colProps = tableProps.itemProperties?.find(
                 (item) => item.propertyName === column,
@@ -211,16 +228,15 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
         }
         return result;
     };
-    const [columnSizingOptions] =
-        useState<fluentui.TableColumnSizingOptions>(getColumnSizingOptions());
+    const [columnSizingOptions] = useState<TableColumnSizingOptions>(getColumnSizingOptions());
 
-    const { getRows, columnSizing_unstable, tableRef } = fluentui.useTableFeatures(
+    const { getRows, columnSizing_unstable, tableRef } = useTableFeatures(
         {
             columns,
             items,
         },
         [
-            fluentui.useTableColumnSizing_unstable({
+            useTableColumnSizing_unstable({
                 columnSizingOptions,
                 autoFitColumns: false,
                 containerWidthOffset: 20,
@@ -281,7 +297,7 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
 
     const renderDragHandle = (rowIndex: number) => {
         return (
-            <fluentui.Button
+            <Button
                 appearance="subtle"
                 size="small"
                 className={classes.tableCellButton}
@@ -309,11 +325,9 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
         );
     };
 
-    const renderRemoveButton = (
-        row: fluentui.TableRowData<designer.DesignerTableComponentDataItem>,
-    ) => {
+    const renderRemoveButton = (row: TableRowData<designer.DesignerTableComponentDataItem>) => {
         return (
-            <fluentui.Button
+            <Button
                 disabled={row.item.canBeDeleted ? !row.item.canBeDeleted : false}
                 appearance="subtle"
                 size="small"
@@ -333,11 +347,11 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
     };
 
     const renderPropertiesButton = (
-        row: fluentui.TableRowData<designer.DesignerTableComponentDataItem>,
+        row: TableRowData<designer.DesignerTableComponentDataItem>,
         rowIndex: number,
     ) => {
         return (
-            <fluentui.Button
+            <Button
                 appearance="subtle"
                 size="small"
                 className={classes.tableCellButton}
@@ -358,8 +372,8 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
     };
 
     const getTableCell = (
-        row: fluentui.TableRowData<designer.DesignerTableComponentDataItem>,
-        columnId: fluentui.TableColumnId,
+        row: TableRowData<designer.DesignerTableComponentDataItem>,
+        columnId: TableColumnId,
         rowIndex: number,
     ) => {
         const colProps = tableProps.itemProperties?.find((item) => item.propertyName === columnId);
@@ -431,9 +445,9 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
 
     return (
         <div>
-            <fluentui.Toolbar size="small">
+            <Toolbar size="small">
                 {tableProps.canAddRows && (
-                    <fluentui.Button
+                    <Button
                         appearance="transparent"
                         icon={<AddFilled className={classes.tableActionIcon} />}
                         onClick={() => {
@@ -446,10 +460,10 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                         }}
                         size="small">
                         {tableProps.labelForAddNewButton}
-                    </fluentui.Button>
+                    </Button>
                 )}
                 {tableProps.canMoveRows && (
-                    <fluentui.Button
+                    <Button
                         icon={<ArrowSortUpFilled className={classes.tableActionIcon} />}
                         onClick={(event) => {
                             (event.target as HTMLElement).focus();
@@ -459,10 +473,10 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                         size="small"
                         appearance="transparent">
                         {MOVE_UP}
-                    </fluentui.Button>
+                    </Button>
                 )}
                 {tableProps.canMoveRows && (
-                    <fluentui.Button
+                    <Button
                         icon={<ArrowSortDownFilled className={classes.tableActionIcon} />}
                         onClick={(event) => {
                             (event.target as HTMLElement).focus();
@@ -472,11 +486,11 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                         size="small"
                         appearance="transparent">
                         {MOVE_DOWN}
-                    </fluentui.Button>
+                    </Button>
                 )}
-            </fluentui.Toolbar>
+            </Toolbar>
             <div>
-                <fluentui.Table
+                <Table
                     {...keyboardNavAttr}
                     as="table"
                     size="extra-small"
@@ -489,26 +503,26 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                                 return acc + columnSizingOptions[curr].idealWidth! + 22;
                             }, 0) - 20,
                     }}>
-                    <fluentui.TableHeader
+                    <TableHeader
                         style={{
                             backgroundColor: "var(--vscode-keybindingTable-headerBackground)",
                         }}>
-                        <fluentui.TableRow>
+                        <TableRow>
                             {columnsDef.map((column) => {
                                 return (
-                                    <fluentui.TableHeaderCell
+                                    <TableHeaderCell
                                         {...columnSizing_unstable.getTableHeaderCellProps(
                                             column.columnId,
                                         )}
                                         className={classes.tableHeaderCell}
                                         key={column.columnId}>
                                         {column.renderHeaderCell()}
-                                    </fluentui.TableHeaderCell>
+                                    </TableHeaderCell>
                                 );
                             })}
-                        </fluentui.TableRow>
-                    </fluentui.TableHeader>
-                    <fluentui.TableBody>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
                         {rows.map((row, index) => {
                             const rowError = getRowError(index);
                             let backgroundColor =
@@ -517,7 +531,7 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                                     : "var(--vscode-editor-background)";
                             let draggedOverBorder = "3px solid var(--vscode-focusBorder)";
                             return (
-                                <fluentui.TableRow
+                                <TableRow
                                     style={{
                                         backgroundColor: backgroundColor,
                                         width: "calc(100% - 10px)",
@@ -548,7 +562,7 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                                     key={componentPath.join(".") + index}>
                                     {columnsDef.map((column, columnIndex) => {
                                         return (
-                                            <fluentui.TableCell
+                                            <TableCell
                                                 key={componentPath.join(".") + index + columnIndex}
                                                 {...columnSizing_unstable.getTableCellProps(
                                                     column.columnId,
@@ -564,14 +578,14 @@ export const DesignerTable = ({ component, model, componentPath, UiArea }: Desig
                                                     maxHeight: "30px",
                                                 }}>
                                                 {getTableCell(row, column.columnId, index)}
-                                            </fluentui.TableCell>
+                                            </TableCell>
                                         );
                                     })}
-                                </fluentui.TableRow>
+                                </TableRow>
                             );
                         })}
-                    </fluentui.TableBody>
-                </fluentui.Table>
+                    </TableBody>
+                </Table>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description

This PR removes `import * from "lib"` patterns from our webviews.

Using `import *` can cause the bundler to include more of the library than necessary, which reduces tree shaking and adds unnecessary bundle bloat. By switching away from this pattern, we allow only the required imports to be included, helping reduce webview bundle size.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
