### PR TITLE
Removes row count label from notebook result grid

### DIFF
--- a/extensions/mssql/src/reactviews/pages/NotebookRenderer/notebookResultGrid.css
+++ b/extensions/mssql/src/reactviews/pages/NotebookRenderer/notebookResultGrid.css
@@ -15,13 +15,6 @@
     height: 100%;
 }
 
-.notebook-result-grid-container .row-count-label {
-    padding: 4px 8px;
-    font-style: italic;
-    color: var(--vscode-descriptionForeground, #858585);
-    font-size: 12px;
-}
-
 /* SlickGrid theme overrides for notebook renderer */
 .notebook-result-grid-container .slick-header-column.ui-state-default {
     background-color: var(--vscode-keybindingTable-headerBackground, #eee);

--- a/extensions/mssql/src/reactviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/reactviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -100,7 +100,7 @@ function getColumnFormatter(
     };
 }
 
-export function NotebookResultGrid({ columnInfo, rows, rowCount }: NotebookResultGridProps) {
+export function NotebookResultGrid({ columnInfo, rows }: NotebookResultGridProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const gridRef = useRef<Slick.Grid<Slick.SlickData> | null>(null);
     const dataViewRef = useRef<TableDataView<Slick.SlickData> | null>(null);
@@ -290,11 +290,7 @@ export function NotebookResultGrid({ columnInfo, rows, rowCount }: NotebookResul
             grid.destroy();
             tableDataView.dispose();
         };
-    }, [columnInfo, rows, rowCount]);
+    }, [columnInfo, rows]);
 
-    return (
-        <div className="notebook-result-grid-container" ref={containerRef}>
-            <div className="row-count-label">{rowCount} row(s)</div>
-        </div>
-    );
+    return <div className="notebook-result-grid-container" ref={containerRef}></div>;
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/vscode-mssql/issues/21374

This PR removes a duplicate row count label from the notebooks result grid:

Before - you would see two messages the first was "(< row-count > row affected)" and directly below "< row-count > row(s)" :
<img width="1007" height="282" alt="image" src="https://github.com/user-attachments/assets/c1f8459e-fc59-4f45-aff7-511ea46289b4" />


After:
<img width="1475" height="907" alt="image" src="https://github.com/user-attachments/assets/3301342f-f91f-4635-ae0b-27aaca30cc3a" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
