### PR TITLE
Launch Query Profiler 'in active' instead that beside

### DIFF
--- a/extensions/mssql/src/profiler/profilerWebviewController.ts
+++ b/extensions/mssql/src/profiler/profilerWebviewController.ts
@@ -141,7 +141,7 @@ export class ProfilerWebviewController extends ReactWebviewPanelController<
             },
             {
                 title: title,
-                viewColumn: vscode.ViewColumn.Beside,
+                viewColumn: vscode.ViewColumn.Active,
                 iconPath: {
                     dark: vscode.Uri.joinPath(
                         context.extensionUri,
@@ -257,7 +257,7 @@ export class ProfilerWebviewController extends ReactWebviewPanelController<
                 title: "",
                 run: async () => {
                     this.createWebviewPanel();
-                    this.panel.reveal(vscode.ViewColumn.Beside);
+                    this.panel.reveal(vscode.ViewColumn.Active);
                 },
             };
         }
@@ -792,7 +792,7 @@ export class ProfilerWebviewController extends ReactWebviewPanelController<
      * Reveals the webview panel to the foreground
      */
     public revealToForeground(): void {
-        this.panel.reveal(vscode.ViewColumn.Beside);
+        this.panel.reveal(vscode.ViewColumn.Active);
     }
 
     /**


### PR DESCRIPTION
## Description

Change to launch view in active instead of beside.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
