### PR TITLE
Progress toast for database rename

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1658,6 +1658,10 @@
             "{2} is the error message"
         ]
     },
+    "Renaming database '{0}' to '{1}'.../{0} is the current database name{1} is the new database name": {
+        "message": "Renaming database '{0}' to '{1}'...",
+        "comment": ["{0} is the current database name", "{1} is the new database name"]
+    },
     "View More": "View More",
     "View mssql for Visual Studio Code release notes?": "View mssql for Visual Studio Code release notes?",
     "Started query execution for document \"{0}\"/{0} is the document name": {

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -71,6 +71,13 @@ export function renameDatabaseError(
         ],
     });
 }
+export function renamingDatabase(databaseName: string, newDatabaseName: string) {
+    return l10n.t({
+        message: "Renaming database '{0}' to '{1}'...",
+        args: [databaseName, newDatabaseName],
+        comment: ["{0} is the current database name", "{1} is the new database name"],
+    });
+}
 
 export let viewMore = l10n.t("View More");
 export let releaseNotesPromptDescription = l10n.t(

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -1527,11 +1527,19 @@ export default class MainController implements vscode.Disposable {
                         `Server/Database[@Name='${escapeSingleQuotes(databaseName)}']`;
 
                     try {
-                        await this.objectManagementService.rename(
-                            connectionUri,
-                            Constants.databaseString,
-                            objectUrn,
-                            newName,
+                        await vscode.window.withProgress(
+                            {
+                                location: vscode.ProgressLocation.Notification,
+                                title: LocalizedConstants.renamingDatabase(databaseName, newName),
+                            },
+                            async () => {
+                                await this.objectManagementService.rename(
+                                    connectionUri,
+                                    Constants.databaseString,
+                                    objectUrn,
+                                    newName,
+                                );
+                            },
                         );
                         await refreshNodeChildren(targetNode.parentNode);
                     } catch (error) {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4835,6 +4835,11 @@
     <trans-unit id="++CODE++9f7b45b322d217b0cee6325963502b5a13eb8aa00e3b6330b7099f868f73782f">
       <source xml:lang="en">Rename Database (Preview)</source>
     </trans-unit>
+    <trans-unit id="++CODE++3426e6a23fe6e9ab8ec4d59a46f5e26596e94b9712da61c7a323e0cb0a6ecd25">
+      <source xml:lang="en">Renaming database &apos;{0}&apos; to &apos;{1}&apos;...</source>
+      <note>{0} is the current database name
+{1} is the new database name</note>
+    </trans-unit>
     <trans-unit id="++CODE++0b73ca14b5d89fd5c289af312a66842146e766baf6c5018848b36f086944cb0b">
       <source xml:lang="en">Replication</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/vscode-mssql/issues/21354

At least the first part by displaying a progress toast while it attempts to rename a database.  Full fix would entail prompting the user to switch to single-user mode for the rename to force the issue (only when initial rename errors)

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
