### PR TITLE
Port: Fix flat file import with Entra authentication (#21442) (#21513)

### DIFF
--- a/extensions/mssql/src/controllers/flatFileImportWebviewController.ts
+++ b/extensions/mssql/src/controllers/flatFileImportWebviewController.ts
@@ -17,7 +17,7 @@ import {
 } from "../sharedInterfaces/flatFileImport";
 import { ProseDiscoveryParams, FlatFileProvider } from "../models/contracts/flatFile";
 import { FormItemSpec, FormItemType } from "../sharedInterfaces/form";
-import { defaultSchema, flatFileImportFileTypes } from "../constants/constants";
+import { azureMfa, defaultSchema, flatFileImportFileTypes } from "../constants/constants";
 import SqlToolsServiceClient from "../languageservice/serviceclient";
 import { RequestType } from "vscode-languageclient";
 import { SimpleExecuteResult } from "vscode-mssql";
@@ -31,6 +31,7 @@ import { getErrorMessage } from "../utils/utils";
 import { ConnectionProfile } from "../models/connectionProfile";
 import { FlatFileClient } from "../flatFile/flatFileClient";
 import { ApiType, managerInstance } from "../flatFile/serviceApiManager";
+import { stripEntraAuthPropertiesFromConnectionString } from "../flatFile/flatFileUtils";
 
 /**
  * Controller for the Flat File Import dialog
@@ -186,7 +187,22 @@ export class FlatFileImportWebviewController extends FormWebviewController<
 
                 // Set other default params for the import request
                 const batchSize = 1000; // default batch size
-                const azureAccessToken = this.profile.azureAccountToken;
+                let azureAccessToken: string | undefined;
+                let finalConnectionString = connectionString;
+
+                if (this.profile.authenticationType === azureMfa) {
+                    // Ensure the Entra token is valid (refresh if expired)
+                    await this.connectionManager.confirmEntraTokenValidity(this.profile);
+                    azureAccessToken = this.profile.azureAccountToken;
+
+                    // Strip auth properties from the connection string that conflict with
+                    // setting an access token (SqlConnection disallows UserID/Password/Authentication
+                    // when AccessToken is set).
+                    finalConnectionString =
+                        stripEntraAuthPropertiesFromConnectionString(connectionString);
+                } else {
+                    azureAccessToken = this.profile.azureAccountToken;
+                }
 
                 // Send column changes (if any) before sending the import request
                 for (const colChange of state.columnChanges) {
@@ -199,7 +215,7 @@ export class FlatFileImportWebviewController extends FormWebviewController<
 
                 // Send import request
                 const insertDataResult = await this.provider.sendInsertDataRequest({
-                    connectionString: connectionString,
+                    connectionString: finalConnectionString,
                     batchSize: batchSize,
                     azureAccessToken: azureAccessToken,
                 });

--- a/extensions/mssql/src/flatFile/flatFileUtils.ts
+++ b/extensions/mssql/src/flatFile/flatFileUtils.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Strips authentication-related properties from a connection string that conflict with
+ * setting an access token. SqlConnection in .NET does not allow AccessToken to be set
+ * when UserID, UID, Password, PWD, or Authentication are present in the connection string.
+ *
+ * @param connectionString The connection string to sanitize
+ * @returns The connection string with conflicting auth properties removed
+ */
+export function stripEntraAuthPropertiesFromConnectionString(
+    connectionString: string | undefined,
+): string | undefined {
+    if (!connectionString) {
+        return connectionString;
+    }
+    return connectionString
+        .split(";")
+        .filter(
+            (prop) =>
+                !["user", "uid", "password", "pwd", "authentication"].some((prefix) =>
+                    prop.trim().toLowerCase().startsWith(prefix),
+                ),
+        )
+        .join(";");
+}

--- a/extensions/mssql/test/unit/flatFileUtils.test.ts
+++ b/extensions/mssql/test/unit/flatFileUtils.test.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { stripEntraAuthPropertiesFromConnectionString } from "../../src/flatFile/flatFileUtils";
+
+suite("stripEntraAuthPropertiesFromConnectionString", () => {
+    test("removes User ID property", () => {
+        const input = "Server=myserver;User ID=myuser;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("removes UID property", () => {
+        const input = "Server=myserver;UID=myuser;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("removes Password property", () => {
+        const input = "Server=myserver;Password=secret;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("removes PWD property", () => {
+        const input = "Server=myserver;PWD=secret;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("removes Authentication property", () => {
+        const input = "Server=myserver;Authentication=ActiveDirectoryInteractive;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("removes multiple conflicting properties at once", () => {
+        const input =
+            "Server=myserver;User ID=myuser;Password=secret;Authentication=ActiveDirectoryInteractive;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("is case-insensitive for property names", () => {
+        const input =
+            "Server=myserver;USER ID=myuser;PASSWORD=secret;AUTHENTICATION=ActiveDirectoryMFA;Database=mydb";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal("Server=myserver;Database=mydb");
+    });
+
+    test("returns connection string unchanged when no auth properties are present", () => {
+        const input = "Server=myserver;Database=mydb;Encrypt=True;TrustServerCertificate=False";
+        const result = stripEntraAuthPropertiesFromConnectionString(input);
+        expect(result).to.equal(input);
+    });
+
+    test("returns empty string unchanged", () => {
+        const result = stripEntraAuthPropertiesFromConnectionString("");
+        expect(result).to.equal("");
+    });
+
+    test("returns undefined unchanged", () => {
+        const result = stripEntraAuthPropertiesFromConnectionString(undefined);
+        expect(result).to.be.undefined;
+    });
+});


### PR DESCRIPTION
Port: Fix flat file import with Entra authentication  https://github.com/microsoft/vscode-mssql/pull/21513

Fixes https://github.com/microsoft/vscode-mssql/issues/21442. When using Entra auth, the connection string contains User ID and Authentication properties that conflict with setting AccessToken on SqlConnection. Strip conflicting auth properties from the connection string and refresh the token before sending the import request.