### PR TITLE
Port - Adding default port explicitly for DAB localhost connections

### DIFF
--- a/extensions/mssql/src/services/dabService.ts
+++ b/extensions/mssql/src/services/dabService.ts
@@ -6,6 +6,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { DefaultSqlPortNumber } from "../constants/constants";
 import { DabConfigFileBuilder } from "../dab/dabConfigFileBuilder";
 import {
     checkDockerInstallation,
@@ -350,6 +351,7 @@ export class DabService implements Dab.IDabService {
         //   Containerized SQL Server does not use named instances.
         // - For host SQL Server, replace only the host, preserving instance name and port.
         let newServerValue: string;
+        const hasPort = serverValue.includes(",");
         if (sqlServerContainerName) {
             // Extract port if present (comma-separated), discard any instance name
             const commaIndex = serverValue.indexOf(",");
@@ -361,6 +363,12 @@ export class DabService implements Dab.IDabService {
                 new RegExp(`^${this.escapeRegex(host)}`, "i"),
                 "host.docker.internal",
             );
+        }
+
+        // DAB does not infer the default SQL Server port, so explicitly add it
+        // when the connection string omits the port for a localhost address.
+        if (!hasPort) {
+            newServerValue += `,${DefaultSqlPortNumber}`;
         }
 
         // Replace in connection string

--- a/extensions/mssql/test/unit/dab/dabService.test.ts
+++ b/extensions/mssql/test/unit/dab/dabService.test.ts
@@ -9,6 +9,7 @@ import { DabService } from "../../../src/services/dabService";
 import { Dab } from "../../../src/sharedInterfaces/dab";
 import * as dockerUtils from "../../../src/docker/dockerUtils";
 import * as dabContainer from "../../../src/dab/dabContainer";
+import { DefaultSqlPortNumber } from "../../../src/constants/constants";
 
 function createTestEntity(overrides?: Partial<Dab.DabEntityConfig>): Dab.DabEntityConfig {
     return {
@@ -250,6 +251,56 @@ suite("DabService Tests", () => {
                     "Server=host.docker.internal\\my-container,1433",
                 );
                 expect(result.connectionString).to.not.include("SQLEXPRESS");
+            });
+        });
+
+        // --- Default port injection ---
+
+        suite("should add default SQL Server port when port is missing", () => {
+            test("localhost without port gets default port", () => {
+                const result = transform("Server=localhost;Database=TestDb;");
+                expect(result.connectionString).to.include(
+                    `Server=host.docker.internal,${DefaultSqlPortNumber}`,
+                );
+            });
+
+            test("127.0.0.1 without port gets default port", () => {
+                const result = transform("Server=127.0.0.1;Database=TestDb;");
+                expect(result.connectionString).to.include(
+                    `Server=host.docker.internal,${DefaultSqlPortNumber}`,
+                );
+            });
+
+            test("localhost with instance name but no port gets default port", () => {
+                const result = transform("Server=localhost\\SQLEXPRESS;Database=TestDb;");
+                expect(result.connectionString).to.include(
+                    `Server=host.docker.internal\\SQLEXPRESS,${DefaultSqlPortNumber}`,
+                );
+            });
+
+            test("localhost with container name but no port gets default port", () => {
+                const result = transform("Server=localhost;Database=TestDb;", "my-sql-container");
+                expect(result.connectionString).to.include(
+                    `Server=host.docker.internal\\my-sql-container,${DefaultSqlPortNumber}`,
+                );
+            });
+
+            test("Data Source without port gets default port", () => {
+                const result = transform("data source=127.0.0.1;Database=TestDb;");
+                expect(result.connectionString).to.include(
+                    `host.docker.internal,${DefaultSqlPortNumber}`,
+                );
+            });
+
+            test("should not add default port when port is already specified", () => {
+                const result = transform("Server=localhost,1434;Database=TestDb;");
+                expect(result.connectionString).to.include("Server=host.docker.internal,1434");
+                expect(result.connectionString).to.not.include(`,${DefaultSqlPortNumber}`);
+            });
+
+            test("should not add default port for non-localhost addresses", () => {
+                const result = transform("Server=remote-server;Database=TestDb;");
+                expect(result.connectionString).to.not.include(`,${DefaultSqlPortNumber}`);
             });
         });
 

--- a/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
@@ -18,6 +18,7 @@ import { ReducerRequest } from "../../src/sharedInterfaces/webview";
 import { TreeNodeInfo } from "../../src/objectExplorer/nodes/treeNodeInfo";
 import MainController from "../../src/controllers/mainController";
 import * as copilotUtils from "../../src/copilot/copilotUtils";
+import { DefaultSqlPortNumber } from "../../src/constants/constants";
 import {
     stubExtensionContext,
     stubUserSurvey,
@@ -764,9 +765,10 @@ suite("SchemaDesignerWebviewController tests", () => {
                 const result = await handler({ config: mockDabConfig });
 
                 const parsedConfig = JSON.parse(result.configContent);
-                // localhost is transformed to host.docker.internal for Docker container access
+                // localhost is transformed to host.docker.internal for Docker container access,
+                // with the default SQL Server port appended when not specified
                 expect(parsedConfig["data-source"]["connection-string"]).to.equal(
-                    "Server=host.docker.internal;Database=testdb;",
+                    `Server=host.docker.internal,${DefaultSqlPortNumber};Database=testdb;`,
                 );
             });
 
@@ -788,7 +790,7 @@ suite("SchemaDesignerWebviewController tests", () => {
 
                 const parsedConfig = JSON.parse(result.configContent);
                 expect(parsedConfig["data-source"]["connection-string"]).to.equal(
-                    "Server=host.docker.internal\\my-sql-container;Database=testdb;",
+                    `Server=host.docker.internal\\my-sql-container,${DefaultSqlPortNumber};Database=testdb;`,
                 );
             });
 


### PR DESCRIPTION
## Description

Port for PR: https://github.com/microsoft/vscode-mssql/pull/21546 to resolve https://github.com/microsoft/vscode-mssql/issues/21548

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
