### PR TITLE
Fixing find widget styles when it is hidden. 

### DIFF
--- a/extensions/mssql/src/reactviews/common/findWidget.component.tsx
+++ b/extensions/mssql/src/reactviews/common/findWidget.component.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, SearchBox, Text, makeStyles } from "@fluentui/react-components";
+import { Button, SearchBox, Text, makeStyles, mergeClasses } from "@fluentui/react-components";
 import * as FluentIcons from "@fluentui/react-icons";
 import { useEffect, useState, useRef, useCallback } from "react";
 import { locConstants } from "./locConstants";
@@ -81,10 +81,12 @@ const useStyles = makeStyles({
         borderLeft: "3px solid var(--vscode-editorWidget-border)",
         height: "33px",
         gap: "3px",
+        pointerEvents: "none",
     },
     visible: {
         opacity: "1",
         transform: "translateY(0)",
+        pointerEvents: "auto",
     },
     invisible: {
         display: "none",
@@ -289,7 +291,10 @@ export function FindWidget<T extends SearchableItem>({
             ref={containerRef}
             role="search"
             aria-label={searchLabel}
-            className={`${styles.floatingContainer} ${isVisible ? styles.visible : styles.invisible}`}
+            className={mergeClasses(
+                styles.floatingContainer,
+                isVisible ? styles.visible : styles.invisible,
+            )}
             style={{ zIndex: zIndex }}>
             <SearchBox
                 size="small"


### PR DESCRIPTION
## Description

This fixes #21565 

Since the class names were not applying properly, the find widget was overlapping toolbar buttons even when the widget was not visible. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
