### PR TITLE
Move edit data pagination controls to bottom of view

### DIFF
--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.css
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.css
@@ -12,6 +12,15 @@
     flex-direction: column;
 }
 
+/* SlickgridReact wrapper — propagate flex layout so the grid fills
+   available space and the pagination stays anchored at the bottom. */
+.table-explorer-grid-container > .grid-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
 /* Grid base styles - map SlickGrid CSS custom properties to VS Code theme variables.
  * Setting these on the #id selector (specificity 1-0-0) overrides
  * .slick-dark-mode defaults (specificity 0-1-0) automatically. */

--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableDataGrid.tsx
@@ -444,8 +444,11 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                         enableAutoResize: true,
                         autoResize: {
                             container: "#grid-container",
-                            bottomPadding: 50, // Reserve space for custom pagination
-                            minHeight: 250, // Minimum height to prevent unnecessary scrollbar
+                            calculateAvailableSizeBy: "container",
+                            resizeDetection: "container",
+                            autoHeight: false,
+                            bottomPadding: 10,
+                            minHeight: 180,
                         },
                         forceFitColumns: false, // Allow horizontal scrolling for many columns
 

--- a/extensions/mssql/src/reactviews/pages/TableExplorer/TableExplorerPage.tsx
+++ b/extensions/mssql/src/reactviews/pages/TableExplorer/TableExplorerPage.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles({
     },
     dataGridContainer: {
         ...shorthands.flex(1),
-        ...shorthands.overflow("auto"),
+        ...shorthands.overflow("hidden"),
         minHeight: 0,
         position: "relative",
     },


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/21061

This PR places the pagination controls for Edit Data at the bottom of the view instead of directly below the grid as seen in the screenshot attached to the issue.

<img width="1567" height="984" alt="image" src="https://github.com/user-attachments/assets/b3ef0dc4-766f-4bf0-ad1b-aed41080408e" />

<img width="1570" height="998" alt="image" src="https://github.com/user-attachments/assets/895c4af4-ccac-402a-a29c-d7ecca81d9cd" />

A scrollbar for the edit data grid now only appears when the view is too small for all table data to be seen:
<img width="1574" height="997" alt="image" src="https://github.com/user-attachments/assets/f844477e-916d-405a-997d-5e3633961381" />

If there is enough room for all table data to be seen then a scroll bar will not appear:
<img width="1570" height="1003" alt="image" src="https://github.com/user-attachments/assets/87d6264b-7364-4571-945c-7400d670cf02" />




_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
