### PR TITLE
Fixing issue where JSON and XML with a `%` character breaks opening in a new tab

### DIFF
--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -735,8 +735,13 @@ export default class MainController implements vscode.Disposable {
             // Register a virtual document provider once during extension activation
             vscode.workspace.registerTextDocumentContentProvider("query-result-link", {
                 provideTextDocumentContent: (uri) => {
-                    // The content is stored in the URI fragment
-                    return decodeURIComponent(uri.fragment);
+                    // Attempt to decode the URI fragment
+                    try {
+                        return decodeURIComponent(uri.fragment);
+                    } catch {
+                        // If decoding fails, return the raw fragment as a fallback.  Some characters (like '%') can cause decodeURIComponent to throw an error.
+                        return uri.fragment;
+                    }
                 },
             });
 

--- a/extensions/mssql/src/utils/utils.ts
+++ b/extensions/mssql/src/utils/utils.ts
@@ -220,3 +220,15 @@ export function getExpirationDateForSas(): string {
     const nextYear = new Date(today.getFullYear() + 1, today.getMonth(), today.getDate());
     return nextYear.toUTCString();
 }
+
+/**
+ * Helper to decode a URI fragment from a query result link.  Some characters (like '%') can cause decodeURIComponent to throw an error, so if decoding fails we return the raw fragment as a fallback.
+ */
+export function decodeQueryResultLinkFragment(fragment: string): string {
+    try {
+        return decodeURIComponent(fragment);
+    } catch {
+        // If decoding fails, return the raw fragment as a fallback.  Some characters (like '%') can cause decodeURIComponent to throw an error.
+        return fragment;
+    }
+}

--- a/extensions/mssql/test/unit/utils.test.ts
+++ b/extensions/mssql/test/unit/utils.test.ts
@@ -443,6 +443,28 @@ suite("ConnectionMatcher", () => {
     });
 });
 
+suite("decodeQueryResultLinkFragment", () => {
+    test("falls back to raw fragment on decode error", () => {
+        // Basic case
+        let original = '{"test":"testValue"}';
+        let encoded = encodeURIComponent(original);
+        let result = utilUtils.decodeQueryResultLinkFragment(encoded);
+        expect(result).to.equal(original);
+
+        // Special characters that are valid in URI components and therefore need encoding/decoding
+        original = '{"test":"=:&"}';
+        encoded = encodeURIComponent(original);
+        result = utilUtils.decodeQueryResultLinkFragment(encoded);
+        expect(result).to.equal(original);
+
+        // % character causes decodeURIComponent to throw; fallback should return raw fragment
+        original = '{"test":"%"}';
+        encoded = encodeURIComponent(original);
+        result = utilUtils.decodeQueryResultLinkFragment(encoded);
+        expect(result).to.equal(original);
+    });
+});
+
 export const sqlAuthConn = {
     server: "server1",
     database: "db1",


### PR DESCRIPTION
# Pull Request Template – vscode-mssql

## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/20826

XML and JSON containing a `%` throws when being decoded with the built-in function.  Work-around is to return the raw string if this occurs.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
