### PR TITLE
Add default sort order to database global search results

### DIFF
--- a/extensions/mssql/src/searchDatabase/searchDatabaseWebViewController.ts
+++ b/extensions/mssql/src/searchDatabase/searchDatabaseWebViewController.ts
@@ -347,6 +347,24 @@ export class SearchDatabaseWebViewController extends ReactWebviewPanelController
             // Pre-transform all metadata to SearchResultItems and cache them
             // This avoids re-transforming on every filter change
             const searchResultItems = metadata.map((obj) => this.toSearchResultItem(obj));
+
+            // Sort cached items once by schema, type name, then name (ascending).
+            // Since Array.filter preserves order, subsequent filter operations
+            // in applyFiltersAndSearch will maintain this sort.
+            searchResultItems.sort((a, b) => {
+                const schemaCompare = a.schema.localeCompare(b.schema);
+                if (schemaCompare !== 0) {
+                    return schemaCompare;
+                }
+
+                const typeCompare = a.typeName.localeCompare(b.typeName);
+                if (typeCompare !== 0) {
+                    return typeCompare;
+                }
+
+                return a.name.localeCompare(b.name);
+            });
+
             this._searchResultItemCache.set(cacheKey, searchResultItems);
 
             // Extract unique schemas and sort alphabetically
@@ -456,21 +474,6 @@ export class SearchDatabaseWebViewController extends ReactWebviewPanelController
                 return name.includes(searchLower) || schema.includes(searchLower);
             });
         }
-
-        // Default sort: schema name, object type, then object name (ascending)
-        results.sort((a, b) => {
-            const schemaCompare = a.schema.localeCompare(b.schema);
-            if (schemaCompare !== 0) {
-                return schemaCompare;
-            }
-
-            const typeCompare = a.typeName.localeCompare(b.typeName);
-            if (typeCompare !== 0) {
-                return typeCompare;
-            }
-
-            return a.name.localeCompare(b.name);
-        });
 
         this.state.searchResults = results;
         this.state.totalResultCount = results.length;

--- a/extensions/mssql/test/unit/searchDatabaseWebViewController.test.ts
+++ b/extensions/mssql/test/unit/searchDatabaseWebViewController.test.ts
@@ -916,4 +916,58 @@ suite("SearchDatabaseWebViewController", () => {
             expect(controller["_reducerHandlers"].has("search")).to.be.true;
         });
     });
+
+    suite("Default Sort Order", () => {
+        test("results are sorted by schema, then type name, then name ascending", async () => {
+            createController();
+            await waitForInitialization();
+
+            const results = controller.state.searchResults;
+
+            // Verify the overall sort order: schema (asc), typeName (asc), name (asc)
+            // dbo items first (Function: fn_CalculateTotal; Stored Procedure: sp_GetUsers;
+            // Tables: Orders, Users; View: vw_UserOrders),
+            // then sales items (Table: Products)
+            const names = results.map((r: SearchResultItem) => r.name);
+            expect(names).to.deep.equal([
+                "fn_CalculateTotal",
+                "sp_GetUsers",
+                "Orders",
+                "Users",
+                "vw_UserOrders",
+                "Products",
+            ]);
+        });
+
+        test("sort order is preserved after filtering by search term", async () => {
+            createController();
+            await waitForInitialization();
+
+            const searchReducer = controller["_reducerHandlers"].get("search");
+            // "ord" matches Orders and vw_UserOrders (which contains "Orders")
+            const result = await searchReducer!(controller.state, { searchTerm: "ord" });
+
+            const names = result.searchResults.map((r: SearchResultItem) => r.name);
+            // Sorted by: schema (dbo), then type (Table, View), then name
+            expect(names).to.deep.equal(["Orders", "vw_UserOrders"]);
+        });
+
+        test("items within same schema are grouped by type name alphabetically", async () => {
+            createController();
+            await waitForInitialization();
+
+            const results = controller.state.searchResults;
+            const dboResults = results.filter((r: SearchResultItem) => r.schema === "dbo");
+
+            // Within the dbo schema, items should be grouped by typeName alphabetically:
+            // Function, Stored Procedure, Table, Table, View
+            const typeNames = dboResults.map((r: SearchResultItem) => r.typeName);
+            for (let i = 1; i < typeNames.length; i++) {
+                expect(
+                    typeNames[i - 1].localeCompare(typeNames[i]),
+                    `Expected '${typeNames[i - 1]}' <= '${typeNames[i]}'`,
+                ).to.be.at.most(0);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Description

The PR closes https://github.com/microsoft/vscode-mssql/issues/21260

This PR sorts global search results by schema name, type name, and lastly object name.
<img width="1566" height="1014" alt="image" src="https://github.com/user-attachments/assets/ac93be15-586d-493b-9819-70fc313f2567" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
