### PR TITLE
Fix N-string left-boundary bug in SQL TextMate grammar (#21603)

### DIFF
--- a/extensions/mssql/syntaxes/SQL.plist
+++ b/extensions/mssql/syntaxes/SQL.plist
@@ -840,7 +840,7 @@
 					<key>comment</key>
 					<string>this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.</string>
 					<key>match</key>
-					<string>(N)?(')[^']*(')</string>
+					<string>(?:(?&lt;![a-zA-Z0-9_])(N))?(')[^']*(')</string>
 					<key>name</key>
 					<string>string.quoted.single.sql</string>
 				</dict>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/21603. Wrap the optional N prefix with a negative lookbehind so that identifiers ending in N (e.g. DAMN'foo', columnN'bar') no longer trigger a Unicode string literal match.

<img width="2269" height="2056" alt="image" src="https://github.com/user-attachments/assets/2e91c1a2-f299-47b7-8792-eec27bbb49ea" />