### PR TITLE
Fix "Generate Script" not opening script in Schema Compare

### DIFF
--- a/extensions/mssql/src/services/sqlTasksService.ts
+++ b/extensions/mssql/src/services/sqlTasksService.ts
@@ -69,7 +69,10 @@ type ActiveTaskInfo = {
     lastMessage?: string;
     /** Script content received from any notification, used as fallback when script arrives out of order */
     script?: string;
-    /** Stored completion status when a script-mode task completes before its script notification arrives */
+    /**
+     * Stored completion status when a script-mode task completes before its script notification arrives.
+     * When a subsequent notification delivers the script, this stored status is replayed to finish the task.
+     */
     completedStatus?: TaskProgressInfo;
 };
 type ProgressCallback = (value: { message?: string; increment?: number }) => void;
@@ -258,12 +261,12 @@ export class SqlTasksService {
         // Always store script content from any notification that has one.
         // STS sends script content via a ScriptAdded notification that may arrive
         // out of order relative to the final StatusChanged notification.
-        if (taskProgressInfo.script) {
+        if (taskProgressInfo.script !== undefined) {
             taskInfo.script = taskProgressInfo.script;
         }
 
         if (isTaskCompleted(taskProgressInfo.status)) {
-            const scriptContent = taskProgressInfo.script || taskInfo.script;
+            const scriptContent = taskProgressInfo.script ?? taskInfo.script;
 
             // For script-mode tasks, if we don't have a script yet and haven't already
             // deferred, wait for a subsequent notification that may carry the script.
@@ -272,7 +275,7 @@ export class SqlTasksService {
             // in the AsyncLock (SemaphoreSlim) used for parallel message processing.
             if (
                 taskInfo.taskInfo.taskExecutionMode === TaskExecutionMode.script &&
-                !scriptContent &&
+                scriptContent === undefined &&
                 !taskInfo.completedStatus
             ) {
                 taskInfo.completedStatus = taskProgressInfo;
@@ -344,15 +347,21 @@ export class SqlTasksService {
                 this.showCompletionMessage(taskProgressInfo.status, taskMessage);
             }
 
-            if (taskInfo.taskInfo.taskExecutionMode === TaskExecutionMode.script && scriptContent) {
+            if (
+                taskInfo.taskInfo.taskExecutionMode === TaskExecutionMode.script &&
+                scriptContent !== undefined
+            ) {
                 await this._sqlDocumentService.newQuery({
                     content: scriptContent,
                     connectionStrategy: ConnectionStrategy.CopyLastActive,
                 });
             }
+        } else if (taskInfo.completedStatus && taskInfo.script !== undefined) {
+            // A non-completed notification delivered the script we were waiting for.
+            // Re-process the deferred completion now that the script is available.
+            await this.handleTaskChangedNotification(taskInfo.completedStatus);
         } else {
-            // Task is still ongoing so just update the progress notification with the latest status
-
+            // Task is still ongoing so just update the progress notification
             // The progress notification already has the name, so we just need to update the message with the latest status info.
             // Only include the message if it isn't the same as the task status string we already have - some (but not all) task status
             // notifications include this string as the message

--- a/extensions/mssql/test/unit/sqlTasksService.test.ts
+++ b/extensions/mssql/test/unit/sqlTasksService.test.ts
@@ -870,6 +870,38 @@ suite("SqlTasksService Tests", () => {
             });
         });
 
+        test("should complete deferred task when script arrives on a non-completed notification", async () => {
+            taskCreatedHandler(scriptTaskInfo);
+
+            // Completion arrives first without script — deferred
+            const completionWithoutScript: TaskProgressInfo = {
+                taskId: "script-task-1",
+                status: TaskStatus.Succeeded,
+                message: null!,
+            };
+            await taskStatusChangedHandler(completionWithoutScript);
+
+            // Script should NOT have been opened yet — task is deferred
+            expect(sqlDocumentServiceStub.newQuery).to.not.have.been.called;
+            expect(showInformationMessageStub).to.not.have.been.called;
+
+            // An InProgress notification arrives carrying the script
+            const inProgressWithScript: TaskProgressInfo = {
+                taskId: "script-task-1",
+                status: TaskStatus.InProgress,
+                message: "Generating...",
+                script: "CREATE PROCEDURE [dbo].[MyProc] AS BEGIN SELECT 1 END;",
+            };
+            await taskStatusChangedHandler(inProgressWithScript);
+
+            // Now the deferred task should be completed and script opened
+            expect(sqlDocumentServiceStub.newQuery).to.have.been.calledOnce;
+            expect(sqlDocumentServiceStub.newQuery.firstCall.args[0]).to.deep.include({
+                content: "CREATE PROCEDURE [dbo].[MyProc] AS BEGIN SELECT 1 END;",
+            });
+            expect(showInformationMessageStub).to.have.been.calledOnce;
+        });
+
         test("should complete without opening script when second completion arrives without script (fallback)", async () => {
             taskCreatedHandler(scriptTaskInfo);
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/20176

Before - clicking on the "Generate Script" button wouldn't open the generated script in an editor:
![Generate Script Fails](https://github.com/user-attachments/assets/bb7a76d5-570e-4c65-98f1-c310e8cc59ae)

After - clicking on the "Generate Script" button opens the generated script in an editor::
![Generate Script Succeeds](https://github.com/user-attachments/assets/ccb652fb-a6e6-4d85-a0de-4f9998f5ff5d)


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
