### PR TITLE
vBump STS to 5.0.20260316.4

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20260316.3",
+        version: "5.0.20260316.4",
         downloadFileNames: {
             Windows_64: "win-x64-net8.0.zip",
             Windows_ARM64: "win-arm64-net8.0.zip",


### PR DESCRIPTION
## Description

This PR brings the below changes from STS(main)
<img width="748" height="569" alt="image" src="https://github.com/user-attachments/assets/d4c6e27d-0263-4dfe-b1b8-ef4aea03d0cd" />

Last version 5.0.20260316.3 was created in release branch that has only "Disable unneeded CodeQL warnings" changes

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
