### PR TITLE
Fix fallback VS Code context menu on query results menu overlays

### DIFF
--- a/extensions/mssql/src/reactviews/pages/QueryResult/table/plugins/GridContextMenu.tsx
+++ b/extensions/mssql/src/reactviews/pages/QueryResult/table/plugins/GridContextMenu.tsx
@@ -40,6 +40,7 @@ export const GridContextMenu: React.FC<GridContextMenuProps> = ({
 
     return (
         <div
+            data-vscode-context='{"preventDefaultContextMenuItems": true}'
             // Prevent the browser default context menu if user right-clicks during menu open
             onContextMenu={(e) => {
                 e.preventDefault();

--- a/extensions/mssql/src/reactviews/pages/QueryResult/table/plugins/HeaderContextMenu.tsx
+++ b/extensions/mssql/src/reactviews/pages/QueryResult/table/plugins/HeaderContextMenu.tsx
@@ -52,6 +52,7 @@ export const HeaderContextMenu: React.FC<HeaderContextMenuProps> = ({
 
     return (
         <div
+            data-vscode-context='{"preventDefaultContextMenuItems": true}'
             // Prevent the browser default context menu if user right-clicks during menu open
             onContextMenu={(e) => {
                 e.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/21684

## Fix fallback VS Code context menu when right-clicking query result menus twice

When the query results context menu is open, a second right-click does not hit SlickGrid. It hits the fullscreen overlay element rendered by the Fluent menu.

Since that overlay did not specify a `data-vscode-context`, VS Code showed its default webview context menu (`Cut`, `Copy`, `Paste`) instead of preserving the intended custom-menu behavior.

### Change

Added:

```tsx
data-vscode-context='{"preventDefaultContextMenuItems": true}'
```

to the fullscreen overlay div used by:

* GridContextMenu
* HeaderContextMenu

Outcome

Repeated right-click no longer shows the fallback VS Code context menu. Instead, the second click dismisses the custom menu cleanly, and the next right-click on the grid opens it again.