### PR TITLE
Fix double parentheses in text view rows affected message (#21692)

### DIFF
--- a/extensions/mssql/src/reactviews/pages/QueryResult/textView.tsx
+++ b/extensions/mssql/src/reactviews/pages/QueryResult/textView.tsx
@@ -190,9 +190,9 @@ export const TextView = () => {
 
                         // Add row count information
                         if (resultSetSummary.rowCount > 0) {
-                            content += `(${locConstants.queryResult.rowsAffected(resultSetSummary.rowCount)})${EOL}`;
+                            content += `${locConstants.queryResult.rowsAffected(resultSetSummary.rowCount)}${EOL}`;
                         } else {
-                            content += `(${locConstants.queryResult.rowsAffected(0)})${EOL}`;
+                            content += `${locConstants.queryResult.rowsAffected(0)}${EOL}`;
                         }
 
                         content += `${EOL}`;

--- a/extensions/mssql/test/unit/textView.test.ts
+++ b/extensions/mssql/test/unit/textView.test.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { locConstants } from "../../src/reactviews/common/locConstants";
+
+suite("TextView - rows affected formatting", () => {
+    test("rowsAffected returns string with single parentheses for 0 rows", () => {
+        const result = locConstants.queryResult.rowsAffected(0);
+        expect(result).to.equal("(0 rows affected)");
+        expect(result).to.not.match(/^\(\(/, "should not start with double open paren");
+        expect(result).to.not.match(/\)\)$/, "should not end with double close paren");
+    });
+
+    test("rowsAffected returns string with single parentheses for 1 row", () => {
+        const result = locConstants.queryResult.rowsAffected(1);
+        expect(result).to.equal("(1 row affected)");
+        expect(result).to.not.match(/^\(\(/, "should not start with double open paren");
+        expect(result).to.not.match(/\)\)$/, "should not end with double close paren");
+    });
+
+    test("rowsAffected returns string with single parentheses for multiple rows", () => {
+        const result = locConstants.queryResult.rowsAffected(50);
+        expect(result).to.equal("(50 rows affected)");
+        expect(result).to.not.match(/^\(\(/, "should not start with double open paren");
+        expect(result).to.not.match(/\)\)$/, "should not end with double close paren");
+    });
+
+    test("text view row count line does not produce double parentheses", () => {
+        // Regression test for #21692: textView.tsx was wrapping rowsAffected() output
+        // (which already includes parens) in another set of parens, yielding ((50 rows affected)).
+        // The fix removes the outer parens so the line is emitted as-is.
+        const EOL = "\n";
+        const rowCount = 50;
+
+        // Simulates the fixed code: `${locConstants.queryResult.rowsAffected(rowCount)}${EOL}`
+        const fixedLine = `${locConstants.queryResult.rowsAffected(rowCount)}${EOL}`;
+        expect(fixedLine.trim()).to.equal("(50 rows affected)");
+
+        // Simulates the buggy code: `(${locConstants.queryResult.rowsAffected(rowCount)})${EOL}`
+        const buggyLine = `(${locConstants.queryResult.rowsAffected(rowCount)})${EOL}`;
+        expect(buggyLine.trim()).to.equal("((50 rows affected))");
+
+        // Confirm the fixed line does not contain double parens
+        expect(fixedLine).to.not.include("((");
+        expect(fixedLine).to.not.include("))");
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/21692

`locConstants.queryResult.rowsAffected()` already returns strings like `(50 rows affected)`. The text view was wrapping the result in an extra pair of parens, producing `((50 rows affected))`. Removed the redundant outer parens and added a regression test.

<img width="1457" height="814" alt="image" src="https://github.com/user-attachments/assets/6c97e5c6-3b32-4775-af78-94741009bbb2" />

