### PR TITLE
Bump STS to 5.0.20260320.1 to pickup bug fixes

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20260318.4",
+        version: "5.0.20260320.1",
         downloadFileNames: {
             Windows_64: "win-x64-net8.0.zip",
             Windows_ARM64: "win-arm64-net8.0.zip",


### PR DESCRIPTION
This update contains these commits.

```
121856790c9557c01b3b64e014ce43a88fd2f17b fix(OE): External Tables folder sorts to bottom of Tables node with correct icon (#2630)
60b2e29918619147ccd78f6ae6ef9d8bb53af18d Fix showplan deserialization failure for JSON indexes (SQL Server 2025) (#2632)
c3b466e218180376078bd3798999ad48b62ab291 Add SQL Server 2025 (v17) scripting compatibility support (#2631)
105fff1a4bd05cb061276d1dc1cc7ff38bed7bff Remove Kusto Service files (#2624)
```
