### PR TITLE
[Fix] Left-anchor dialog shell content instead of centering when maxC…

### DIFF
--- a/extensions/mssql/src/reactviews/common/dialogPageShell.tsx
+++ b/extensions/mssql/src/reactviews/common/dialogPageShell.tsx
@@ -168,14 +168,14 @@ export const DialogPageShell = ({
         ? {
               width: "100%",
               maxWidth: resolvedMaxContentWidth,
-              margin: "0 auto",
+              margin: "0",
           }
         : { width: "100%" };
     const footerWidthStyle = resolvedMaxContentWidth
         ? {
               width: "100%",
               maxWidth: `calc(${resolvedMaxContentWidth} + 48px)`,
-              margin: "0 auto",
+              margin: "0",
           }
         : { width: "100%" };
 


### PR DESCRIPTION
…ontentWidth is set

## Description

- The publish dialog fields float to the horizontal center of the webview when the editor panel is wider than the maxContentWidth cap (720px). 
- Resizing left/right panels causes fields to shift, making the layout unstable.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

![publishDialog_moves_before](https://github.com/user-attachments/assets/4c65c908-a890-496d-811b-e452be579346)
![publishDialog_moves_after](https://github.com/user-attachments/assets/25e9c852-5c81-428b-8358-e5f1fddaa5bf)

