### PR TITLE
Fix Windows npm bootstrap script for windows. 

### DIFF
--- a/scripts/bootstrap-install.mjs
+++ b/scripts/bootstrap-install.mjs
@@ -4,7 +4,6 @@ import path from "node:path";
 import process from "node:process";
 import { workspaceTargets } from "./workspace-targets.mjs";
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const installArgs = process.env.CI
     ? ["ci", "--legacy-peer-deps"]
     : ["install", "--legacy-peer-deps"];
@@ -19,10 +18,17 @@ function installDirectory(directory) {
 
     console.log(`\n> bootstrap install :: ${directory}`);
 
-    const result = spawnSync(npmCommand, installArgs, {
+    const command = process.platform === "win32" ? "cmd.exe" : "npm";
+    const commandArgs = process.platform === "win32" ? ["/d", "/s", "/c", "npm.cmd", ...installArgs] : installArgs;
+
+    const result = spawnSync(command, commandArgs, {
         cwd: absoluteDirectory,
         stdio: "inherit",
     });
+
+    if (result.error) {
+        throw result.error;
+    }
 
     if (result.status !== 0) {
         process.exit(result.status ?? 1);


### PR DESCRIPTION
## Description
switching to launc npm.cmd with cmd instead of directly which leads to script not launching. 


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
