### PR TITLE
Bumping STS to 20260325.3

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20260320.1",
+        version: "5.0.20260325.3",
         downloadFileNames: {
             Windows_64: "win-x64-net8.0.zip",
             Windows_ARM64: "win-arm64-net8.0.zip",


### PR DESCRIPTION
## Description

Bumping STS to get early testing out of the new STS pipelines.  Shouldn't be any functional changes.

<img width="463" height="274" alt="image" src="https://github.com/user-attachments/assets/4cf9f464-75c8-4d92-ae09-fe9332e43365" />

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
