### PR TITLE
Fix Deployment connection group bug

### DIFF
--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -265,12 +265,8 @@ export default class MainController implements vscode.Disposable {
             this.registerCommandWithArgs(Constants.cmdDeployNewDatabase);
             this._event.on(Constants.cmdDeployNewDatabase, (args?: any) => {
                 let initialConnectionGroup: string;
-                if (args) {
-                    if (args instanceof ConnectionGroupNode) {
-                        initialConnectionGroup = args.connectionGroup?.id;
-                    } else if (typeof args === "object" && args.id) {
-                        initialConnectionGroup = args.id;
-                    }
+                if (args && args instanceof ConnectionGroupNode) {
+                    initialConnectionGroup = args.connectionGroup?.id;
                 }
                 this.onDeployNewDatabase(initialConnectionGroup);
             });

--- a/extensions/mssql/src/deployment/deploymentWebviewController.ts
+++ b/extensions/mssql/src/deployment/deploymentWebviewController.ts
@@ -69,7 +69,7 @@ export class DeploymentWebviewController extends FormWebviewController<
 
     private async initialize(initialConnectionGroup?: string) {
         // If an initial connection group was provided, try to pre-populate the form state
-        if (initialConnectionGroup && initialConnectionGroup) {
+        if (initialConnectionGroup) {
             this.state.formState.groupId = initialConnectionGroup;
         }
         this.state.connectionGroupOptions =


### PR DESCRIPTION
## Description

Fixes bug where the default connection group is wrongly set if not run on a connection group node.

## Code Changes Checklist

- [X] New or updated **unit tests** added
- [X] All existing tests pass (`npm run test`)
- [X] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [X] Telemetry/logging updated if relevant
- [X] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
