### PR TITLE
Adding a link for central management of VS Code policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 This extension collects telemetry data, which is used to help understand how to improve the product. For example, this usage data helps to debug issues, such as slow start-up times, and to prioritize new features. While we appreciate the insights this data provides, we also know that not everyone wants to send usage data and you can disable telemetry as described in the VS Code [disable telemetry reporting](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting) documentation.
 
-Administrators can set or disable telemetry across their entire organization/tenant with the same mechanism. Learn more [here](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting).
+Administrators can set or disable feedback and telemetry collection across their entire organization/tenant with the same mechanism. Learn more about [setting feedback and telemetry collection policy](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting) and [centrally managing VS Code settings with policies](https://code.visualstudio.com/docs/enterprise/policies).
 
 ## Privacy Statement
 

--- a/extensions/mssql/README.md
+++ b/extensions/mssql/README.md
@@ -325,7 +325,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 This extension collects telemetry data, which is used to help understand how to improve the product. For example, this usage data helps to debug issues, such as slow start-up times, and to prioritize new features. While we appreciate the insights this data provides, we also know that not everyone wants to send usage data and you can disable telemetry as described in the VS Code [disable telemetry reporting](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting) documentation.
 
-Administrators can set or disable telemetry across their entire organization/tenant with the same mechanism. Learn more [here](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting).
+Administrators can set or disable feedback and telemetry collection across their entire organization/tenant with the same mechanism. Learn more about [setting feedback and telemetry collection policy](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting) and [centrally managing VS Code settings with policies](https://code.visualstudio.com/docs/enterprise/policies).
 
 ## Privacy Statement
 


### PR DESCRIPTION
Follow-up update for telemetry policy and control information in README files