### PR TITLE
Fixing execution plan smoke tests

### DIFF
--- a/extensions/mssql/src/queryResult/utils.ts
+++ b/extensions/mssql/src/queryResult/utils.ts
@@ -8,7 +8,6 @@ import * as Constants from "../constants/constants";
 import * as vscode from "vscode";
 import { TelemetryViews, TelemetryActions } from "../sharedInterfaces/telemetry";
 import {
-    createExecutionPlanGraphs,
     openExecutionPlanWebview,
     saveExecutionPlan,
     showPlanXml,
@@ -363,19 +362,6 @@ export function registerCommonRequestHandlers(
     });
     webviewController.registerReducer("saveExecutionPlan", async (state, payload) => {
         return (await saveExecutionPlan(state, payload)) as qr.QueryResultWebviewState;
-    });
-    webviewController.registerReducer("getExecutionPlan", async (state, payload) => {
-        const xmlPlans = Object.values(state.executionPlanState.xmlPlans ?? {});
-        if (state.executionPlanState.executionPlanGraphs?.length || xmlPlans.length === 0) {
-            return state;
-        }
-
-        return (await createExecutionPlanGraphs(
-            state,
-            webviewViewController.executionPlanService,
-            xmlPlans,
-            "QueryResults",
-        )) as qr.QueryResultWebviewState;
     });
     webviewController.registerReducer("showPlanXml", async (state, payload) => {
         return (await showPlanXml(state, payload)) as qr.QueryResultWebviewState;

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanPage.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanPage.tsx
@@ -36,7 +36,11 @@ const useStyles = makeStyles({
     },
 });
 
-export const ExecutionPlanPage = () => {
+interface ExecutionPlanPageProps {
+    autoLoad?: boolean;
+}
+
+export const ExecutionPlanPage = ({ autoLoad = true }: ExecutionPlanPageProps) => {
     const classes = useStyles();
     const context = useContext(ExecutionPlanContext);
     const executionPlanState = useExecutionPlanSelector<ExecutionPlanState>(
@@ -45,6 +49,7 @@ export const ExecutionPlanPage = () => {
     const loadState = executionPlanState?.loadState ?? ApiStatus.Loading;
     useEffect(() => {
         if (
+            autoLoad &&
             context &&
             executionPlanState &&
             // checks if execution plans have already been gotten
@@ -53,7 +58,7 @@ export const ExecutionPlanPage = () => {
         ) {
             context.getExecutionPlan();
         }
-    }, [executionPlanState]);
+    }, [autoLoad, executionPlanState]);
 
     const renderMainContent = () => {
         switch (loadState) {

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryExecutionPlanTab.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryExecutionPlanTab.tsx
@@ -24,7 +24,7 @@ export const QueryExecutionPlanTab = () => {
             className={classes.queryResultContainer}
             style={{ height: "100%", minHeight: "300px" }}>
             <ExecutionPlanStateProvider>
-                <ExecutionPlanPage />
+                <ExecutionPlanPage autoLoad={false} />
             </ExecutionPlanStateProvider>
         </div>
     );

--- a/extensions/mssql/test/unit/queryResultUtils.test.ts
+++ b/extensions/mssql/test/unit/queryResultUtils.test.ts
@@ -8,9 +8,6 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import * as queryResultUtils from "../../src/queryResult/utils";
 import * as Constants from "../../src/constants/constants";
-import { QueryResultWebviewController } from "../../src/queryResult/queryResultWebViewController";
-import * as qr from "../../src/sharedInterfaces/queryResult";
-import * as sharedExecutionPlanUtils from "../../src/controllers/sharedExecutionPlanUtils";
 
 suite("QueryResult Utils Tests", () => {
     let sandbox: sinon.SinonSandbox;
@@ -120,64 +117,5 @@ suite("QueryResult Utils Tests", () => {
                 expect(queryResultUtils.bucketizeRowCount(value)).to.equal(expected);
             });
         }
-    });
-
-    suite("registerCommonRequestHandlers", () => {
-        test("registers getExecutionPlan reducer that creates graphs from query-result xml plans", async () => {
-            const reducers = new Map<string, Function>();
-            const executionPlanService = {};
-            const controller = Object.create(QueryResultWebviewController.prototype) as {
-                onRequest: sinon.SinonStub;
-                onNotification: sinon.SinonStub;
-                registerReducer: (name: string, reducer: Function) => void;
-                executionPlanService: unknown;
-                getSqlOutputContentProvider: sinon.SinonStub;
-            };
-
-            controller.onRequest = sandbox.stub();
-            controller.onNotification = sandbox.stub();
-            controller.getSqlOutputContentProvider = sandbox.stub();
-            controller.registerReducer = (name: string, reducer: Function) => {
-                reducers.set(name, reducer);
-            };
-            sandbox.stub(controller, "executionPlanService").get(() => executionPlanService);
-
-            const createExecutionPlanGraphsStub = sandbox
-                .stub(sharedExecutionPlanUtils, "createExecutionPlanGraphs")
-                .resolves({
-                    executionPlanState: {
-                        executionPlanGraphs: [{ root: { cost: 1, subTreeCost: 2 } }],
-                    },
-                } as qr.QueryResultWebviewState);
-
-            queryResultUtils.registerCommonRequestHandlers(
-                controller as unknown as QueryResultWebviewController,
-                "test-correlation-id",
-            );
-
-            const reducer = reducers.get("getExecutionPlan");
-            expect(reducer).to.exist;
-
-            const state = {
-                resultSetSummaries: {},
-                messages: [],
-                fontSettings: {},
-                executionPlanState: {
-                    executionPlanGraphs: [],
-                    xmlPlans: {
-                        "0,0": "<ShowPlanXML />",
-                    },
-                },
-            } as unknown as qr.QueryResultWebviewState;
-
-            await reducer?.(state, {});
-
-            expect(createExecutionPlanGraphsStub).to.have.been.calledOnceWithExactly(
-                state,
-                executionPlanService,
-                ["<ShowPlanXML />"],
-                "QueryResults",
-            );
-        });
     });
 });


### PR DESCRIPTION
## Description
Fixing smoke test breaks caused by : https://github.com/microsoft/vscode-mssql/pull/21775

1. Fixes property window not loading in execution plan
2. Fixes console errors caused due to execution plan calling reducers that it doens't need when it is part of query results
3. Fixes a unit test that doesn't work on windows. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
