### PR TITLE
Bumping STS to 6.0.20260330.1/.NET 10

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,14 +7,14 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "5.0.20260325.3",
+        version: "6.0.20260330.1",
         downloadFileNames: {
-            Windows_64: "win-x64-net8.0.zip",
-            Windows_ARM64: "win-arm64-net8.0.zip",
-            OSX: "osx-x64-net8.0.tar.gz",
-            OSX_ARM64: "osx-arm64-net8.0.tar.gz",
-            Linux: "linux-x64-net8.0.tar.gz",
-            Linux_ARM64: "linux-arm64-net8.0.tar.gz",
+            Windows_64: "win-x64-net10.0.zip",
+            Windows_ARM64: "win-arm64-net10.0.zip",
+            OSX: "osx-x64-net10.0.tar.gz",
+            OSX_ARM64: "osx-arm64-net10.0.tar.gz",
+            Linux: "linux-x64-net10.0.tar.gz",
+            Linux_ARM64: "linux-arm64-net10.0.tar.gz",
         },
         installDir: "./sqltoolsservice/{#version#}/{#platform#}",
         executableFiles: [


### PR DESCRIPTION
## Description

Bumping SQL Tools Service to 6.0.20260330.1, the first .NET 10 build

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
