### PR TITLE
Fixing smoketests so that they can be run locally

### DIFF
--- a/extensions/mssql/test/e2e/queryExecution.spec.ts
+++ b/extensions/mssql/test/e2e/queryExecution.spec.ts
@@ -46,8 +46,8 @@ test.describe("MSSQL Extension - Query Execution", async () => {
         beforeClose: async ({ page: vsCodePage }) => {
             await openNewQueryEditor(vsCodePage);
             const dropTestDatabaseScript = `
-USE master
-ALTER DATABASE TestDB SET SINGLE_USER WITH ROLLBACK IMMEDIATE
+USE master;
+ALTER DATABASE TestDB SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
 DROP DATABASE TestDB;`;
             await enterTextIntoQueryEditor(vsCodePage, dropTestDatabaseScript);
             await executeQuery(vsCodePage);

--- a/extensions/mssql/test/e2e/utils/launchVscodeWithMsSqlExt.ts
+++ b/extensions/mssql/test/e2e/utils/launchVscodeWithMsSqlExt.ts
@@ -118,11 +118,18 @@ export async function launchVsCodeWithMssqlExtension(
         args: config.useVsix
             ? launchArgs
             : [...launchArgs, `--extensionDevelopmentPath=${devExtensionPath}`],
-        recordVideo: {
-            dir: videoDir,
-            size: { width: 1920, height: 1080 },
-        },
+        // Video recording interferes with Playwright's window detection locally (causes a
+        // blank window to be captured instead of the VS Code workbench). Only enable in CI.
+        ...(process.env.CI
+            ? {
+                  recordVideo: {
+                      dir: videoDir,
+                      size: { width: 1920, height: 1080 },
+                  },
+              }
+            : {}),
     });
+
     const page = await electronApp.firstWindow({ timeout: 10_000 });
 
     await page.setViewportSize({ width: 1920, height: 1080 });


### PR DESCRIPTION
## Description

Attaching the video recorder was causing VS Code launch to hang indefinitely, so I'm having it record only when in the pipeline

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
