### PR TITLE
Adding back vscode notification for sts override launch

### DIFF
--- a/extensions/mssql/src/languageservice/serviceclient.ts
+++ b/extensions/mssql/src/languageservice/serviceclient.ts
@@ -233,11 +233,14 @@ export default class SqlToolsServiceClient {
             try {
                 await launchServer(stsFolderOverride, Runtime.Portable);
                 this.sendServiceLaunchTelemetry("override", Runtime.Portable, platformInfo);
+                vscode.window.showInformationMessage(
+                    `Launched SQL Tools Service from overridden path: ${stsFolderOverride}`,
+                );
                 return;
             } catch (err) {
-                this._logger.error(
-                    `Failed to launch SQL Tools Service with overridden path: ${getErrorMessage(err)}`,
-                );
+                const errorMessage = `Failed to launch SQL Tools Service with overridden path: ${stsFolderOverride} ${getErrorMessage(err)}`;
+                this._logger.error(errorMessage);
+                vscode.window.showErrorMessage(errorMessage);
                 /**
                  * We shouldn't fall back to other launch attempts if the override env variable is set,
                  * since the user explicitly requested to launch from that location.


### PR DESCRIPTION
## Description

<img width="393" height="115" alt="image" src="https://github.com/user-attachments/assets/b530dbfc-415d-4bc6-ade9-44a24193ffea" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
