### PR TITLE
Update tampering test case to be less flaky.

### DIFF
--- a/extensions/mssql/test/unit/encryptionUtils.test.ts
+++ b/extensions/mssql/test/unit/encryptionUtils.test.ts
@@ -29,7 +29,7 @@ suite("encryptionUtils", () => {
         const encryptionKey = generateEncryptionKey();
         const encryptedData = encryptData("sensitive query history", encryptionKey);
 
-        encryptedData.ciphertext = `A${encryptedData.ciphertext.slice(1)}`;
+        encryptedData.ciphertext = `Some tampering${encryptedData.ciphertext.slice(1)}`;
 
         expect(() => decryptData(encryptedData, encryptionKey)).to.throw();
     });


### PR DESCRIPTION
## Description

Previously I just removing the first letter and adding an A. Which means there was 1/64 (since it is base64) chance of the letter already being A and not throwing. 

This fix adds sufficient tampering to avoid that condition. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
