### PR TITLE
Fix extension build scripts failing silently on Windows

### DIFF
--- a/extensions/mssql/scripts/build.js
+++ b/extensions/mssql/scripts/build.js
@@ -1,6 +1,7 @@
 const { execFileSync } = require("child_process");
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCommand = "npm";
+const execOptions = { stdio: "inherit", shell: process.platform === "win32" };
 
 const isProd = process.argv.includes("--prod");
 
@@ -11,7 +12,7 @@ function runScript(scriptName, args = []) {
         npmArgs.push("--", ...args);
     }
 
-    execFileSync(npmCommand, npmArgs, { stdio: "inherit" });
+    execFileSync(npmCommand, npmArgs, execOptions);
 }
 
 try {

--- a/extensions/sql-database-projects/scripts/build.js
+++ b/extensions/sql-database-projects/scripts/build.js
@@ -1,10 +1,11 @@
 const { execFileSync } = require("child_process");
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmCommand = "npm";
+const execOptions = { stdio: "inherit", shell: process.platform === "win32" };
 
 try {
-    execFileSync(npmCommand, ["run", "build:prepare"], { stdio: "inherit" });
-    execFileSync(npmCommand, ["run", "build:extension"], { stdio: "inherit" });
+    execFileSync(npmCommand, ["run", "build:prepare"], execOptions);
+    execFileSync(npmCommand, ["run", "build:extension"], execOptions);
 } catch (error) {
     process.exit(1);
 }


### PR DESCRIPTION
execFileSync cannot run .cmd files (like npm.cmd) without shell:true on Windows. Use "npm" with shell:true on win32 instead, matching the pattern already used in scripts/workspaces.mjs.  

Currently `npm run build` isn't working properly on Windows.  It runs like below and doesn't produce output.

```
>npm run build

> vscode-mssql@1.0.0 build
> node scripts/workspaces.mjs build


> mssql (mssql) :: build

> mssql@1.42.0 build
> node scripts/build.js
```
