### PR TITLE
Adding back preview flag for entra accounts

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1579,6 +1579,15 @@
                     "description": "%mssql.enableExperimentalFeatures.description%",
                     "scope": "application"
                 },
+                "mssql.preview.useVscodeAccountsForEntraMFA": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "%mssql.preview.useVscodeAccountsForEntraMFA.description%",
+                    "scope": "application"
+                },
                 "mssql.openQueryResultsInTabByDefault": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
## Description

`mssql.preview.useVscodeAccountsForEntraMFA` was accidentally removed in https://github.com/microsoft/vscode-mssql/pull/21795

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
