### PR TITLE
Fix VECTOR(n) columns rendering as JSON hyperlinks in results grid

### DIFF
--- a/extensions/mssql/src/models/interfaces.ts
+++ b/extensions/mssql/src/models/interfaces.ts
@@ -126,6 +126,7 @@ export interface IDbColumn {
     dataType: string;
     isXml?: boolean;
     isJson?: boolean;
+    isVector?: boolean;
     isLong?: boolean;
     isReadOnly?: boolean;
     isUnique?: boolean;

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -173,6 +173,7 @@ export interface IDbColumn {
     dataType: string;
     isXml?: boolean;
     isJson?: boolean;
+    isVector?: boolean;
     isLong?: boolean;
     isReadOnly?: boolean;
     isUnique?: boolean;

--- a/extensions/mssql/src/webviews/pages/QueryResult/resultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/resultGrid.tsx
@@ -362,6 +362,12 @@ function getColumnFormatter(columnInfo: qr.IDbColumn): (
         return hyperLinkFormatter;
     }
 
+    // VECTOR columns display as plain text. Their [n,n,n] format looks like a JSON array
+    // but must never be formatted as a JSON hyperlink or opened in the JSON viewer.
+    if (columnInfo.isVector) {
+        return textFormatter;
+    }
+
     // Avoid expensive XML/JSON parsing on every cell render for plain-text columns.
     // Track which rows we've already sampled so SlickGrid re-renders don't
     // exhaust the budget.

--- a/extensions/mssql/typings/vscode-mssql.d.ts
+++ b/extensions/mssql/typings/vscode-mssql.d.ts
@@ -2708,6 +2708,7 @@ declare module "vscode-mssql" {
         dataType: string;
         isXml?: boolean;
         isJson?: boolean;
+        isVector?: boolean;
         isLong?: boolean;
         isReadOnly?: boolean;
         isUnique?: boolean;


### PR DESCRIPTION
VECTOR values like [0.1,2,30] are valid JSON arrays, so the per-cell JSON detection in getColumnFormatter was marking them as isJson=true and rendering them blue/clickable. Add isVector to IDbColumn (populated from DbColumnWrapper.IsVector in sqltoolsservice) and use it in getColumnFormatter to return textFormatter directly, bypassing the XML/JSON sampling path entirely.

Fixes: https://github.com/microsoft/vscode-mssql/issues/21806

Example output without links.  See https://github.com/microsoft/sqltoolsservice/pull/2648 for what it looks like without change.

<img width="767" height="482" alt="image" src="https://github.com/user-attachments/assets/4c9ba4d6-7b0f-42cf-abe0-67ea591c9a59" />
