### PR TITLE
Fix: SQL Notebook cells now display SQL Server error messages inline

### DIFF
--- a/extensions/mssql/src/notebooks/notebookQueryExecutor.ts
+++ b/extensions/mssql/src/notebooks/notebookQueryExecutor.ts
@@ -77,6 +77,10 @@ export class NotebookQueryExecutor {
     ): Promise<NotebookQueryResult> {
         const batchResults = new Map<number, NotebookBatchResult>();
         let canceled = false;
+        // Tracks the most recently started batch so that messages with
+        // batchId=-1 or undefined (e.g. parse/syntax errors) can be attached
+        // to the batch they logically belong to.
+        let lastStartedBatchId = -1;
 
         // Promise that resolves when query/complete arrives
         const completion = new Deferred<QueryExecuteCompleteNotificationResult>();
@@ -87,6 +91,7 @@ export class NotebookQueryExecutor {
             },
             handleBatchStart(result: QueryExecuteBatchNotificationParams): void {
                 const batch = result.batchSummary;
+                lastStartedBatchId = batch.id;
                 batchResults.set(batch.id, {
                     batchSummary: batch,
                     messages: [],
@@ -130,7 +135,15 @@ export class NotebookQueryExecutor {
                 }
             },
             handleMessage(result: QueryExecuteMessageParams): void {
-                const batchEntry = batchResults.get(result.message.batchId);
+                const batchId = result.message.batchId;
+                // batchId can be -1 or undefined for query-level messages such
+                // as parse/syntax errors that aren't tied to a specific batch.
+                // Fall back to the most recently started batch so these errors
+                // are surfaced in cell output rather than silently dropped.
+                const effectiveBatchId =
+                    batchId !== undefined && batchId >= 0 ? batchId : lastStartedBatchId;
+                const batchEntry =
+                    effectiveBatchId >= 0 ? batchResults.get(effectiveBatchId) : undefined;
                 if (batchEntry) {
                     batchEntry.messages.push(result.message);
                 }

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -465,9 +465,16 @@ export class SqlNotebookController implements vscode.Disposable {
                 execution.end(false, Date.now());
                 activity.end(ActivityStatus.Canceled);
             } else {
+                const hasErrors = result.batches.some(
+                    (b) => b.hasError || b.messages.some((m) => m.isError),
+                );
                 execution.replaceOutput(outputs);
-                execution.end(true, Date.now());
-                activity.end(ActivityStatus.Succeeded);
+                execution.end(!hasErrors, Date.now());
+                if (hasErrors) {
+                    activity.endFailed(new Error("Query returned errors"));
+                } else {
+                    activity.end(ActivityStatus.Succeeded);
+                }
             }
         } catch (err: any) {
             execution.replaceOutput([
@@ -494,18 +501,18 @@ export class SqlNotebookController implements vscode.Disposable {
                 .filter((m) => m.isError)
                 .map((m) => m.message);
 
-            if (batch.hasError && errorMessages.length > 0) {
+            // Show error messages when present. We intentionally do NOT gate on
+            // batch.hasError because STS can omit that flag for parse/syntax errors
+            // while still sending error messages with isError=true.
+            if (errorMessages.length > 0) {
                 outputs.push(
                     new vscode.NotebookCellOutput([
-                        vscode.NotebookCellOutputItem.text(
-                            LocalizedConstants.Notebooks.errorPrefix(errorMessages.join(os.EOL)),
-                            MIME_TEXT_PLAIN,
-                        ),
+                        vscode.NotebookCellOutputItem.stderr(errorMessages.join(os.EOL)),
                     ]),
                 );
             }
 
-            // Show non-error messages (PRINT, info, row counts) once before result sets
+            // Show non-error messages (PRINT, info, row counts) before result sets
             if (messages.length > 0) {
                 outputs.push(
                     new vscode.NotebookCellOutput([
@@ -549,8 +556,13 @@ export class SqlNotebookController implements vscode.Disposable {
                 );
             }
 
-            // If no result sets and no messages and no errors, show a generic success message
-            if (batch.resultSets.length === 0 && messages.length === 0 && !batch.hasError) {
+            // Show a generic success message only when the batch produced no
+            // result sets, no informational messages, and no error messages.
+            if (
+                batch.resultSets.length === 0 &&
+                messages.length === 0 &&
+                errorMessages.length === 0
+            ) {
                 outputs.push(
                     new vscode.NotebookCellOutput([
                         vscode.NotebookCellOutputItem.text(

--- a/extensions/mssql/test/unit/notebooks/notebookQueryExecutor.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookQueryExecutor.test.ts
@@ -306,6 +306,106 @@ suite("NotebookQueryExecutor", () => {
         expect(result.batches[0].messages[0].isError).to.be.true;
     });
 
+    test("attaches messages with batchId=-1 to the last started batch", async () => {
+        mockClient.sendRequest.callsFake(() => {
+            capturedHandler.handleBatchStart({
+                batchSummary: {
+                    id: 0,
+                    hasError: false,
+                    selection: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+                    resultSetSummaries: [],
+                    executionElapsed: "00:00:00.001",
+                    executionEnd: "",
+                    executionStart: "",
+                },
+                ownerUri: "test-uri",
+            });
+            // Syntax/parse errors can arrive with batchId=-1
+            capturedHandler.handleMessage({
+                message: {
+                    batchId: -1,
+                    isError: true,
+                    time: new Date().toISOString(),
+                    message: "Incorrect syntax near 'SELEC'.",
+                },
+                ownerUri: "test-uri",
+            });
+            capturedHandler.handleBatchComplete({
+                batchSummary: {
+                    id: 0,
+                    hasError: false, // STS may send false even for parse errors
+                    selection: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+                    resultSetSummaries: [],
+                    executionElapsed: "00:00:00.001",
+                    executionEnd: "",
+                    executionStart: "",
+                },
+                ownerUri: "test-uri",
+            });
+            capturedHandler.handleQueryComplete({
+                ownerUri: "test-uri",
+                batchSummaries: [],
+            });
+            return Promise.resolve({});
+        });
+
+        const result = await executor.execute("test-uri", "SELEC 1");
+
+        expect(result.batches).to.have.length(1);
+        expect(result.batches[0].messages).to.have.length(1);
+        expect(result.batches[0].messages[0].isError).to.be.true;
+        expect(result.batches[0].messages[0].message).to.equal("Incorrect syntax near 'SELEC'.");
+    });
+
+    test("attaches messages with undefined batchId to the last started batch", async () => {
+        mockClient.sendRequest.callsFake(() => {
+            capturedHandler.handleBatchStart({
+                batchSummary: {
+                    id: 0,
+                    hasError: false,
+                    selection: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+                    resultSetSummaries: [],
+                    executionElapsed: "00:00:00.001",
+                    executionEnd: "",
+                    executionStart: "",
+                },
+                ownerUri: "test-uri",
+            });
+            capturedHandler.handleMessage({
+                message: {
+                    batchId: undefined,
+                    isError: true,
+                    time: new Date().toISOString(),
+                    message: "Query-level error",
+                },
+                ownerUri: "test-uri",
+            });
+            capturedHandler.handleBatchComplete({
+                batchSummary: {
+                    id: 0,
+                    hasError: false,
+                    selection: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+                    resultSetSummaries: [],
+                    executionElapsed: "00:00:00.001",
+                    executionEnd: "",
+                    executionStart: "",
+                },
+                ownerUri: "test-uri",
+            });
+            capturedHandler.handleQueryComplete({
+                ownerUri: "test-uri",
+                batchSummaries: [],
+            });
+            return Promise.resolve({});
+        });
+
+        const result = await executor.execute("test-uri", "SELEC 1");
+
+        expect(result.batches).to.have.length(1);
+        expect(result.batches[0].messages).to.have.length(1);
+        expect(result.batches[0].messages[0].message).to.equal("Query-level error");
+    });
+
     test("handles multiple batches", async () => {
         mockClient.sendRequest.callsFake(() => {
             // First batch

--- a/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
+++ b/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
@@ -413,6 +413,170 @@ suite("SqlNotebookController", () => {
             expect(mockExecution.end).to.have.been.calledWith(true, sinon.match.number);
         });
 
+        test("shows error message for batch with isError=true messages (regardless of batch.hasError)", async () => {
+            mockNotebookConnMgr.executeQueryString.resolves(
+                makeQueryResult({
+                    batches: [
+                        {
+                            batchSummary: makeBatchSummary({ hasError: false }), // hasError=false even though there's an error message
+                            messages: [
+                                {
+                                    batchId: 0,
+                                    isError: true,
+                                    time: "",
+                                    message: "Incorrect syntax near 'SELEC'.",
+                                },
+                            ],
+                            resultSets: [],
+                            hasError: false,
+                        },
+                    ],
+                }),
+            );
+
+            const notebook = makeNotebook([{ text: "SELEC 1" }]);
+            const cells = notebook.getCells();
+
+            await mockController.executeHandler(cells, notebook, mockController);
+
+            const outputs = mockExecution.replaceOutput.firstCall.args[0];
+            // Should have one error output, not "Commands completed successfully"
+            expect(outputs).to.have.lengthOf(1);
+            // Error output uses stderr mime type
+            expect(outputs[0].items[0].mime).to.equal("application/vnd.code.notebook.stderr");
+            const errorText = new TextDecoder().decode(outputs[0].items[0].data);
+            expect(errorText).to.include("Incorrect syntax near 'SELEC'.");
+            // Cell should be marked as failed
+            expect(mockExecution.end).to.have.been.calledWith(false, sinon.match.number);
+        });
+
+        test("does not show 'Commands completed successfully' when error messages exist", async () => {
+            mockNotebookConnMgr.executeQueryString.resolves(
+                makeQueryResult({
+                    batches: [
+                        {
+                            batchSummary: makeBatchSummary({ hasError: true }),
+                            messages: [
+                                {
+                                    batchId: 0,
+                                    isError: true,
+                                    time: "",
+                                    message: "Divide by zero error encountered.",
+                                },
+                            ],
+                            resultSets: [],
+                            hasError: true,
+                        },
+                    ],
+                }),
+            );
+
+            const notebook = makeNotebook([{ text: "SELECT 1/0" }]);
+            const cells = notebook.getCells();
+
+            await mockController.executeHandler(cells, notebook, mockController);
+
+            const outputs = mockExecution.replaceOutput.firstCall.args[0];
+            expect(outputs).to.have.lengthOf(1);
+            const text = new TextDecoder().decode(outputs[0].items[0].data);
+            expect(text).to.not.include("Command completed successfully");
+            expect(text).to.include("Divide by zero error encountered.");
+        });
+
+        test("shows PRINT messages as plain text output", async () => {
+            mockNotebookConnMgr.executeQueryString.resolves(
+                makeQueryResult({
+                    batches: [
+                        {
+                            batchSummary: makeBatchSummary(),
+                            messages: [
+                                {
+                                    batchId: 0,
+                                    isError: false,
+                                    time: "",
+                                    message: "hello world",
+                                },
+                            ],
+                            resultSets: [],
+                            hasError: false,
+                        },
+                    ],
+                }),
+            );
+
+            const notebook = makeNotebook([{ text: "PRINT 'hello world'" }]);
+            const cells = notebook.getCells();
+
+            await mockController.executeHandler(cells, notebook, mockController);
+
+            const outputs = mockExecution.replaceOutput.firstCall.args[0];
+            expect(outputs).to.have.lengthOf(1);
+            expect(outputs[0].items[0].mime).to.equal("text/plain");
+            const text = new TextDecoder().decode(outputs[0].items[0].data);
+            expect(text).to.equal("hello world");
+            expect(mockExecution.end).to.have.been.calledWith(true, sinon.match.number);
+        });
+
+        test("multi-batch: shows grid, error, grid in order", async () => {
+            mockNotebookConnMgr.executeQueryString.resolves(
+                makeQueryResult({
+                    batches: [
+                        {
+                            batchSummary: makeBatchSummary({ id: 0 }),
+                            messages: [],
+                            resultSets: [
+                                {
+                                    columnInfo: [makeColumn("n", "int")],
+                                    rows: [[{ displayValue: "1", isNull: false }]],
+                                    rowCount: 1,
+                                },
+                            ],
+                            hasError: false,
+                        },
+                        {
+                            batchSummary: makeBatchSummary({ id: 1, hasError: true }),
+                            messages: [
+                                {
+                                    batchId: 1,
+                                    isError: true,
+                                    time: "",
+                                    message: "Divide by zero error encountered.",
+                                },
+                            ],
+                            resultSets: [],
+                            hasError: true,
+                        },
+                        {
+                            batchSummary: makeBatchSummary({ id: 2 }),
+                            messages: [],
+                            resultSets: [
+                                {
+                                    columnInfo: [makeColumn("n", "int")],
+                                    rows: [[{ displayValue: "2", isNull: false }]],
+                                    rowCount: 1,
+                                },
+                            ],
+                            hasError: false,
+                        },
+                    ],
+                }),
+            );
+
+            const notebook = makeNotebook([{ text: "SELECT 1\nGO\nSELECT 1/0\nGO\nSELECT 2" }]);
+            const cells = notebook.getCells();
+
+            await mockController.executeHandler(cells, notebook, mockController);
+
+            const outputs = mockExecution.replaceOutput.firstCall.args[0];
+            // Expected: result grid (batch 0), error message (batch 1), result grid (batch 2)
+            expect(outputs).to.have.lengthOf(3);
+            expect(outputs[0].items[0].mime).to.equal("application/vnd.mssql.query-result");
+            expect(outputs[1].items[0].mime).to.equal("application/vnd.code.notebook.stderr");
+            expect(outputs[2].items[0].mime).to.equal("application/vnd.mssql.query-result");
+            // Cell should be marked failed because one batch had an error
+            expect(mockExecution.end).to.have.been.calledWith(false, sinon.match.number);
+        });
+
         test("does not show truncation warning when result set is complete", async () => {
             mockNotebookConnMgr.executeQueryString.resolves(
                 makeQueryResult({


### PR DESCRIPTION
- Wire up error messages in cell output regardless of batch.hasError flag (STS can send hasError=false for parse errors even with isError messages)
- Fall back to lastStartedBatchId for messages with batchId=-1 or undefined so syntax/parse errors are captured instead of silently dropped
- Use stderr() mime type for error output so it renders with red styling
- Show 'Commands completed successfully' only when errorMessages is empty
- Mark cell execution as failed (end=false) when any batch has errors
- Add unit tests covering all fixed scenarios

Fixes #21792, #21700


Example output: 

<img width="1529" height="776" alt="Screenshot 2026-04-09 162211" src="https://github.com/user-attachments/assets/c5dd0baa-34a1-4981-a9a7-0ed940f69460" />


ADS Error output (not same error output format):

<img width="1371" height="604" alt="image" src="https://github.com/user-attachments/assets/8a4af45f-7f6e-40e7-b75b-fabba7f43236" />
