### PR TITLE
Improving token refresh messaging and logic

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2270,6 +2270,19 @@
     },
     "Clear cache and refresh token": "Clear cache and refresh token",
     "Clear token cache": "Clear token cache",
+    "Token refreshed successfully.": "Token refreshed successfully.",
+    "Unable to acquire a valid token. (expires: {0}, but is currently {1})/{0} is the token expiration time{1} is the current time": {
+        "message": "Unable to acquire a valid token. (expires: {0}, but is currently {1})",
+        "comment": ["{0} is the token expiration time", "{1} is the current time"]
+    },
+    "Error refreshing token; you may need to sign out and sign back in: {0}/{0} is the error message": {
+        "message": "Error refreshing token; you may need to sign out and sign back in: {0}",
+        "comment": ["{0} is the error message"]
+    },
+    "Error validating Entra authentication token; you may need to refresh your token: {0}/{0} is the error message": {
+        "message": "Error validating Entra authentication token; you may need to refresh your token: {0}",
+        "comment": ["{0} is the error message"]
+    },
     "No workspaces found. Please change Fabric account or tenant to view available workspaces.": "No workspaces found. Please change Fabric account or tenant to view available workspaces.",
     "Unsupported authentication type in connection string: {0}. Only SQL Login, Integrated, Azure MFA, and Active Directory Default authentication are supported./{0} is the authentication type": {
         "message": "Unsupported authentication type in connection string: {0}. Only SQL Login, Integrated, Azure MFA, and Active Directory Default authentication are supported.",

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -51,7 +51,7 @@ import { sendActionEvent, sendErrorEvent, startActivity } from "../telemetry/tel
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { AzureController } from "../azure/azureController";
 import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
-import { ConnectionDetails, IConnectionInfo } from "vscode-mssql";
+import { ConnectionDetails, IConnectionInfo, IToken } from "vscode-mssql";
 import MainController from "../controllers/mainController";
 import { ObjectExplorerProvider } from "../objectExplorer/objectExplorerProvider";
 import { UserSurvey } from "../nps/userSurvey";
@@ -1670,7 +1670,9 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     }
 
     private async getAzureActionButtons(): Promise<FormItemActionButton[]> {
+        const self = this;
         const actionButtons: FormItemActionButton[] = [];
+
         actionButtons.push({
             label: Loc.signIn,
             id: "azureSignIn",
@@ -1744,15 +1746,67 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             const account = (await this._mainController.azureAccountService.getAccounts()).find(
                 (account) => account.displayInfo.userId === this.state.connectionProfile.accountId,
             );
+
             if (account) {
                 let isTokenExpired = false;
 
+                async function refreshToken(): Promise<IToken | undefined> {
+                    const account = (
+                        await self._mainController.azureAccountService.getAccounts()
+                    ).find(
+                        (account) =>
+                            account.displayInfo.userId === self.state.connectionProfile.accountId,
+                    );
+
+                    if (account) {
+                        try {
+                            const token =
+                                await self._mainController.azureAccountService.getAccountSecurityToken(
+                                    account,
+                                    undefined,
+                                );
+
+                            if (AzureController.isTokenValid(token.token, token.expiresOn)) {
+                                self.vscodeWrapper.showInformationMessage(
+                                    Loc.tokenRefreshedSuccessfully,
+                                );
+
+                                self.logger.log(
+                                    `Token refreshed.  Next expiration: ${token.expiresOn}`,
+                                );
+
+                                return token;
+                            } else {
+                                throw new Error(
+                                    Loc.unableToAcquireValidToken(
+                                        token.expiresOn,
+                                        Date.now() / 1000,
+                                    ),
+                                );
+                            }
+                        } catch (err) {
+                            self.logger.error(`Error refreshing token: ${getErrorMessage(err)}`);
+                            self.vscodeWrapper.showErrorMessage(
+                                Loc.errorRefreshingToken(getErrorMessage(err)),
+                            );
+                        }
+                    } else {
+                        self.logger.error(
+                            `Account not found when attempting token refresh: ${self.state.connectionProfile.email} (${self.state.connectionProfile.accountId})`,
+                        );
+                    }
+
+                    return undefined;
+                }
+
                 try {
+                    // Check if token is expired or expiring soon...
                     const session =
                         await this._mainController.azureAccountService.getAccountSecurityToken(
                             account,
                             undefined,
                         );
+
                     isTokenExpired = !AzureController.isTokenValid(
                         session.token,
                         session.expiresOn,
@@ -1762,9 +1816,16 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                         `Error getting token or checking validity; prompting for refresh. Error: ${getErrorMessage(err)}`,
                     );
 
-                    this.vscodeWrapper.showErrorMessage(
-                        "Error validating Entra authentication token; you may need to refresh your token.",
-                    );
+                    void this.vscodeWrapper
+                        .showErrorMessage(
+                            Loc.errorValidatingEntraToken(getErrorMessage(err)),
+                            refreshTokenLabel,
+                        )
+                        .then((result) => {
+                            if (result === refreshTokenLabel) {
+                                void refreshToken();
+                            }
+                        });
 
                     isTokenExpired = true;
                 }
@@ -1774,27 +1835,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                         label: refreshTokenLabel,
                         id: "refreshToken",
                         callback: async () => {
-                            const account = (
-                                await this._mainController.azureAccountService.getAccounts()
-                            ).find(
-                                (account) =>
-                                    account.displayInfo.userId ===
-                                    this.state.connectionProfile.accountId,
-                            );
-                            if (account) {
-                                try {
-                                    const session =
-                                        await this._mainController.azureAccountService.getAccountSecurityToken(
-                                            account,
-                                            undefined,
-                                        );
-                                    this.logger.log("Token refreshed", session.expiresOn);
-                                } catch (err) {
-                                    this.logger.error(
-                                        `Error refreshing token: ${getErrorMessage(err)}`,
-                                    );
-                                }
-                            }
+                            await refreshToken();
                         },
                     });
                 }

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -61,7 +61,7 @@ import {
     getServerTypes,
     getDefaultConnection,
 } from "../models/connectionInfo";
-import { getErrorMessage, uuid } from "../utils/utils";
+import { formatEpochSecondsForDisplay, getErrorMessage, uuid } from "../utils/utils";
 import { l10n } from "vscode";
 import {
     CredentialsQuickPickItemType,
@@ -1772,15 +1772,15 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                                 );
 
                                 self.logger.log(
-                                    `Token refreshed.  Next expiration: ${token.expiresOn}`,
+                                    `Token refreshed.  Next expiration: ${formatEpochSecondsForDisplay(token.expiresOn)}`,
                                 );
 
                                 return token;
                             } else {
                                 throw new Error(
                                     Loc.unableToAcquireValidToken(
-                                        token.expiresOn,
-                                        Date.now() / 1000,
+                                        formatEpochSecondsForDisplay(token.expiresOn),
+                                        formatEpochSecondsForDisplay(Date.now() / 1000),
                                     ),
                                 );
                             }

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1030,10 +1030,11 @@ export class ConnectionDialog {
     public static clearCacheAndRefreshToken = l10n.t("Clear cache and refresh token");
     public static clearTokenCache = l10n.t("Clear token cache");
     public static tokenRefreshedSuccessfully = l10n.t("Token refreshed successfully.");
-    public static unableToAcquireValidToken(expiresOn: number | undefined, currentTime: number) {
+
+    public static unableToAcquireValidToken(expiresOn: string, currentTime: string) {
         return l10n.t({
             message: "Unable to acquire a valid token. (expires: {0}, but is currently {1})",
-            args: [String(expiresOn ?? "unknown"), String(currentTime)],
+            args: [expiresOn, currentTime],
             comment: ["{0} is the token expiration time", "{1} is the current time"],
         });
     }

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1029,6 +1029,29 @@ export class ConnectionDialog {
     }
     public static clearCacheAndRefreshToken = l10n.t("Clear cache and refresh token");
     public static clearTokenCache = l10n.t("Clear token cache");
+    public static tokenRefreshedSuccessfully = l10n.t("Token refreshed successfully.");
+    public static unableToAcquireValidToken(expiresOn: number | undefined, currentTime: number) {
+        return l10n.t({
+            message: "Unable to acquire a valid token. (expires: {0}, but is currently {1})",
+            args: [String(expiresOn ?? "unknown"), String(currentTime)],
+            comment: ["{0} is the token expiration time", "{1} is the current time"],
+        });
+    }
+    public static errorRefreshingToken(errorMessage: string) {
+        return l10n.t({
+            message: "Error refreshing token; you may need to sign out and sign back in: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message"],
+        });
+    }
+    public static errorValidatingEntraToken(errorMessage: string) {
+        return l10n.t({
+            message:
+                "Error validating Entra authentication token; you may need to refresh your token: {0}",
+            args: [errorMessage],
+            comment: ["{0} is the error message"],
+        });
+    }
 
     public static noWorkspacesFound = l10n.t(
         "No workspaces found. Please change Fabric account or tenant to view available workspaces.",

--- a/extensions/mssql/src/utils/utils.ts
+++ b/extensions/mssql/src/utils/utils.ts
@@ -232,3 +232,11 @@ export function decodeQueryResultLinkFragment(fragment: string): string {
         return fragment;
     }
 }
+
+export function formatEpochSecondsForDisplay(epochSeconds: number | undefined): string {
+    if (epochSeconds === undefined) {
+        return "unknown";
+    }
+
+    return new Date(epochSeconds * 1000).toISOString();
+}

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -13,6 +13,7 @@ import {
     CLEAR_TOKEN_CACHE,
     ConnectionDialogWebviewController,
 } from "../../src/connectionconfig/connectionDialogWebviewController";
+import { refreshTokenLabel } from "../../src/constants/locConstants";
 import MainController from "../../src/controllers/mainController";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 import { ObjectExplorerProvider } from "../../src/objectExplorer/objectExplorerProvider";
@@ -1075,6 +1076,52 @@ suite("ConnectionDialogWebviewController Tests", () => {
         buttons = await controller["getAzureActionButtons"]();
         expect(buttons.length).to.equal(2);
         expect(buttons[1].id).to.equal("refreshToken");
+    });
+
+    test("getAzureActionButtons shows error prompt with refreshTokenLabel when token validation fails", async () => {
+        controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+        controller.state.connectionProfile.accountId = "TestUserId";
+
+        azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
+        mockVscodeWrapper.showErrorMessage.resolves(undefined);
+
+        await controller["getAzureActionButtons"]();
+
+        expect(mockVscodeWrapper.showErrorMessage).to.have.been.calledWith(
+            sinon.match.string,
+            refreshTokenLabel,
+        );
+    });
+
+    test("getAzureActionButtons error prompt: selecting refresh triggers a refresh attempt", async () => {
+        controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+        controller.state.connectionProfile.accountId = "TestUserId";
+
+        azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
+        mockVscodeWrapper.showErrorMessage.resolves(refreshTokenLabel);
+
+        await controller["getAzureActionButtons"]();
+
+        // Run a no-op setTimeout so that the chained `then()` in refreshToken() has a chance to run
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Called once for initial validation and once inside refreshToken()
+        expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(2);
+    });
+
+    test("getAzureActionButtons error prompt: dismissing does not trigger a refresh attempt", async () => {
+        controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+        controller.state.connectionProfile.accountId = "TestUserId";
+
+        azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
+        mockVscodeWrapper.showErrorMessage.resolves(undefined);
+
+        await controller["getAzureActionButtons"]();
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Only called once for validation; no refresh attempt was made
+        expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(1);
     });
 
     test("getAzureActionButtons uses VS Code sign-in when VS Code account mode is enabled", async () => {

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -1094,34 +1094,45 @@ suite("ConnectionDialogWebviewController Tests", () => {
     });
 
     test("getAzureActionButtons error prompt: selecting refresh triggers a refresh attempt", async () => {
-        controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
-        controller.state.connectionProfile.accountId = "TestUserId";
+        const clock = sinon.useFakeTimers();
+        try {
+            controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+            controller.state.connectionProfile.accountId = "TestUserId";
 
-        azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
-        mockVscodeWrapper.showErrorMessage.resolves(refreshTokenLabel);
+            azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
+            mockVscodeWrapper.showErrorMessage.resolves(refreshTokenLabel);
 
-        await controller["getAzureActionButtons"]();
+            await controller["getAzureActionButtons"]();
 
-        // Run a no-op setTimeout so that the chained `then()` in refreshToken() has a chance to run
-        await new Promise((resolve) => setTimeout(resolve, 0));
+            // Advance the stubbed clock so the fire-and-forget prompt to refresh and
+            // the async refreshToken() function have a chance to run.
+            await clock.tickAsync(0);
 
-        // Called once for initial validation and once inside refreshToken()
-        expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(2);
+            // Called once for initial validation and once inside refreshToken()
+            expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(2);
+        } finally {
+            clock.restore();
+        }
     });
 
     test("getAzureActionButtons error prompt: dismissing does not trigger a refresh attempt", async () => {
-        controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
-        controller.state.connectionProfile.accountId = "TestUserId";
+        const clock = sinon.useFakeTimers();
+        try {
+            controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+            controller.state.connectionProfile.accountId = "TestUserId";
 
-        azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
-        mockVscodeWrapper.showErrorMessage.resolves(undefined);
+            azureAccountService.getAccountSecurityToken.rejects(new Error("Token error"));
+            mockVscodeWrapper.showErrorMessage.resolves(undefined);
 
-        await controller["getAzureActionButtons"]();
+            await controller["getAzureActionButtons"]();
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
+            await clock.tickAsync(0);
 
-        // Only called once for validation; no refresh attempt was made
-        expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(1);
+            // Only called once for validation; no refresh attempt was made
+            expect(azureAccountService.getAccountSecurityToken.callCount).to.equal(1);
+        } finally {
+            clock.restore();
+        }
     });
 
     test("getAzureActionButtons uses VS Code sign-in when VS Code account mode is enabled", async () => {

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -38,7 +38,7 @@ import {
     IConnectionProfileWithSource,
 } from "../../src/models/interfaces";
 import { AzureAccountService } from "../../src/services/azureAccountService";
-import { ConnectionDetails, IAccount } from "vscode-mssql";
+import { ConnectionDetails, IAccount, IToken } from "vscode-mssql";
 import SqlToolsServerClient from "../../src/languageservice/serviceclient";
 import { MssqlVSCodeAzureSubscriptionProvider } from "../../src/azure/MssqlVSCodeAzureSubscriptionProvider";
 import {
@@ -1055,6 +1055,11 @@ suite("ConnectionDialogWebviewController Tests", () => {
         controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
         controller.state.connectionProfile.accountId = "TestUserId";
 
+        azureAccountService.getAccountSecurityToken.resolves({
+            token: "testToken",
+            expiresOn: Date.now() / 1000,
+        } as IToken);
+
         const isTokenValidStub = sandbox.stub(AzureController, "isTokenValid").returns(false);
 
         // When there's no error, we should have refreshToken button
@@ -1064,6 +1069,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
 
         // Test error handling when getAccountSecurityToken throws
         isTokenValidStub.restore();
+        mockVscodeWrapper.showErrorMessage.resolves(undefined);
         azureAccountService.getAccountSecurityToken.throws(new Error("Test error"));
 
         buttons = await controller["getAzureActionButtons"]();

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2286,6 +2286,10 @@
     <trans-unit id="++CODE++619d1a6dc49f043552f7b8d14e6483de4a2caf1c8270d6168a642c8eccc3a752">
       <source xml:lang="en">Error occurred opening content in editor.</source>
     </trans-unit>
+    <trans-unit id="++CODE++289c8a16e6884fd0e3f1579134fea1a2457efaaecad171ed5ac598eb0ae9ec58">
+      <source xml:lang="en">Error refreshing token; you may need to sign out and sign back in: {0}</source>
+      <note>{0} is the error message</note>
+    </trans-unit>
     <trans-unit id="++CODE++7ce810c92d5881cd4638f73772ee57317b503d0f04dbc5cd2f281f77ac1d697d">
       <source xml:lang="en">Error retrieving server list: {0}</source>
       <note>{0} is the error message</note>
@@ -2295,6 +2299,10 @@
     </trans-unit>
     <trans-unit id="++CODE++7c03518af7ea8058b9f5444011cc402ee48c86c765dfd6ba8e5ce09ed8d836ca">
       <source xml:lang="en">Error signing into Azure: {0}</source>
+      <note>{0} is the error message</note>
+    </trans-unit>
+    <trans-unit id="++CODE++70580f5715d9c53e71db7b7197f59cb412dc2ead9d577067cfbe9f3b5d2d65ca">
+      <source xml:lang="en">Error validating Entra authentication token; you may need to refresh your token: {0}</source>
       <note>{0} is the error message</note>
     </trans-unit>
     <trans-unit id="++CODE++e3bd07d6d5ddff1c7aefd27f1d3af9d23b97fc19d29d732816ea80fddb08f4dc">
@@ -6364,6 +6372,9 @@
       <source xml:lang="en">Toggle selection for {0}</source>
       <note>{0} is the connection group name</note>
     </trans-unit>
+    <trans-unit id="++CODE++4999049f347c8083a5db26ef5fb3f51dc8ec31e0518279072ffdd7a2e8119195">
+      <source xml:lang="en">Token refreshed successfully.</source>
+    </trans-unit>
     <trans-unit id="++CODE++10b7ff2efd404627d5a929c6fb2a97fa57867f169fbf1016834477571a4cedb2">
       <source xml:lang="en">Tool lookup for: {0} - {1}.</source>
       <note>{0} is the part name
@@ -6400,6 +6411,11 @@
     <trans-unit id="++CODE++174af08052d23280b455e65ee7fe31307b6b838514937562db1a66605ce1cd68">
       <source xml:lang="en">Unable to acquire a Microsoft Entra token from VS Code for the selected account: {0}</source>
       <note>{0} is the account label or ID</note>
+    </trans-unit>
+    <trans-unit id="++CODE++0f8e75246db2971314d4ccab6451fac39308e60133f90443516d207a4b717983">
+      <source xml:lang="en">Unable to acquire a valid token. (expires: {0}, but is currently {1})</source>
+      <note>{0} is the token expiration time
+{1} is the current time</note>
     </trans-unit>
     <trans-unit id="++CODE++e395097d9cde221cdb9af8b04e1073d0d3394439fce660d1c954d012cdeae6c1">
       <source xml:lang="en">Unable to execute the command while the extension is initializing. Please try again later.</source>


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/21252

Adds an actionable button to refresh the Entra MFA token when prompted and improves the error message with manual instructions if that fails.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
