### PR TITLE
Dacpac Operations - Implementing message warning if list databases fails

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1204,6 +1204,7 @@
     "Operation failed": "Operation failed",
     "An unexpected error occurred": "An unexpected error occurred",
     "Failed to load databases": "Failed to load databases",
+    "Unable to retrieve the list of databases. You may not have permission to list databases on this server. If your connection specifies a database, it will be preselected.": "Unable to retrieve the list of databases. You may not have permission to list databases on this server. If your connection specifies a database, it will be preselected.",
     "DACPAC deployed successfully": "DACPAC deployed successfully",
     "DACPAC extracted successfully": "DACPAC extracted successfully",
     "BACPAC imported successfully": "BACPAC imported successfully",
@@ -3091,6 +3092,7 @@
     "Reveal in Explorer": "Reveal in Explorer",
     "Reveal in Finder": "Reveal in Finder",
     "Open Containing Folder": "Open Containing Folder",
+    "Unable to retrieve the list of databases. You may not have permission to list databases on this server.": "Unable to retrieve the list of databases. You may not have permission to list databases on this server.",
     "DACPAC deployed successfully to database '{0}'/{0} is the database name": {
         "message": "DACPAC deployed successfully to database '{0}'",
         "comment": ["{0} is the database name"]

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -2776,6 +2776,9 @@ export class DacpacDialog {
     public static RevealInExplorer = l10n.t("Reveal in Explorer");
     public static RevealInFinder = l10n.t("Reveal in Finder");
     public static OpenContainingFolder = l10n.t("Open Containing Folder");
+    public static FailedToListDatabases = l10n.t(
+        "Unable to retrieve the list of databases. You may not have permission to list databases on this server.",
+    );
     public static DeploySuccessWithDatabase(databaseName: string): string {
         return l10n.t({
             message: "DACPAC deployed successfully to database '{0}'",

--- a/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
+++ b/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
@@ -28,6 +28,7 @@ import {
     ConnectionMatcher,
 } from "../models/utils";
 import { UserSurvey } from "../nps/userSurvey";
+import { isSystemDatabase } from "../utils/databaseUtils";
 import { getErrorMessage } from "../utils/utils";
 
 // File extension constants
@@ -599,7 +600,6 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
     private async listDatabases(
         ownerUri: string,
     ): Promise<{ databases: string[]; errorMessage?: string }> {
-        const systemDatabases = ["master", "tempdb", "model", "msdb"];
         const stateDatabaseName = this.state.databaseName;
 
         let errorMessage: string | undefined;
@@ -607,15 +607,13 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
             const databaseNames = await this.connectionManager.listDatabases(ownerUri);
 
             // Filter out system databases
-            const userDatabases = (databaseNames || []).filter(
-                (db) => !systemDatabases.includes(db.toLowerCase()),
-            );
+            const userDatabases = (databaseNames || []).filter((db) => !isSystemDatabase(db));
 
             if (userDatabases.length > 0) {
                 // Ensure the state database is in the list if set
                 if (
                     stateDatabaseName &&
-                    !systemDatabases.includes(stateDatabaseName.toLowerCase()) &&
+                    !isSystemDatabase(stateDatabaseName) &&
                     !userDatabases.includes(stateDatabaseName)
                 ) {
                     userDatabases.unshift(stateDatabaseName);
@@ -635,7 +633,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
 
         // Fallback: if the database list is empty or the request failed,
         // use the database name from the initial state (set via ObjectExplorerUtils.getDatabaseName)
-        if (stateDatabaseName && !systemDatabases.includes(stateDatabaseName.toLowerCase())) {
+        if (stateDatabaseName && !isSystemDatabase(stateDatabaseName)) {
             return {
                 databases: [stateDatabaseName],
                 errorMessage,

--- a/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
+++ b/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
@@ -596,24 +596,50 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
     /**
      * Lists databases on the connected server
      */
-    private async listDatabases(ownerUri: string): Promise<{ databases: string[] }> {
+    private async listDatabases(
+        ownerUri: string,
+    ): Promise<{ databases: string[]; errorMessage?: string }> {
+        const systemDatabases = ["master", "tempdb", "model", "msdb"];
+        const stateDatabaseName = this.state.databaseName;
+
+        let errorMessage: string | undefined;
         try {
-            const result = await this.connectionManager.client.sendRequest(
-                ListDatabasesRequest.type,
-                { ownerUri: ownerUri },
-            );
+            const databaseNames = await this.connectionManager.listDatabases(ownerUri);
 
             // Filter out system databases
-            const systemDatabases = ["master", "tempdb", "model", "msdb"];
-            const userDatabases = (result.databaseNames || []).filter(
+            const userDatabases = (databaseNames || []).filter(
                 (db) => !systemDatabases.includes(db.toLowerCase()),
             );
 
-            return { databases: userDatabases };
+            if (userDatabases.length > 0) {
+                // Ensure the state database is in the list if set
+                if (
+                    stateDatabaseName &&
+                    !systemDatabases.includes(stateDatabaseName.toLowerCase()) &&
+                    !userDatabases.includes(stateDatabaseName)
+                ) {
+                    userDatabases.unshift(stateDatabaseName);
+                }
+                return { databases: userDatabases };
+            }
+
+            // List succeeded but returned no user databases — likely a permissions issue
+            errorMessage = LocConstants.DacpacDialog.FailedToListDatabases;
         } catch (error) {
             this.logger.error(`Failed to list databases: ${error}`);
-            return { databases: [] };
+            errorMessage = error instanceof Error ? error.message : LocConstants.DacpacDialog.FailedToListDatabases;
         }
+
+        // Fallback: if the database list is empty or the request failed,
+        // use the database name from the initial state (set via ObjectExplorerUtils.getDatabaseName)
+        if (stateDatabaseName && !systemDatabases.includes(stateDatabaseName.toLowerCase())) {
+            return {
+                databases: [stateDatabaseName],
+                errorMessage,
+            };
+        }
+
+        return { databases: [], errorMessage };
     }
 
     /**
@@ -803,6 +829,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
         isConnected: boolean;
         errorMessage?: string;
         isFabric?: boolean;
+        databaseName?: string;
     }> {
         try {
             // Find the profile in saved connections
@@ -824,6 +851,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
 
             // Check if this is a Fabric connection
             const isFabric = this.isFabricConnection(profile as IConnectionDialogProfile);
+            const databaseName = profile.database || "";
 
             // Check if already connected and the connection is valid
             let ownerUri = this.connectionManager.getUriForConnection(profile);
@@ -833,6 +861,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
                     ownerUri,
                     isConnected: true,
                     isFabric,
+                    databaseName,
                 };
             }
 
@@ -848,6 +877,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
                     ownerUri,
                     isConnected: true,
                     isFabric,
+                    databaseName,
                 };
             } else {
                 // Check if connection failed due to error or if it was never initiated
@@ -862,6 +892,7 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
                     isConnected: false,
                     errorMessage,
                     isFabric,
+                    databaseName,
                 };
             }
         } catch (error) {
@@ -920,6 +951,13 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
             return { isValid: false, errorMessage };
         }
 
+        // Check if the database matches the one from the active connection.
+        // If the user lacks permissions to list databases but is connected to a specific database,
+        // we should trust the connection's database and skip the server-side existence check.
+        const isConnectionDatabase =
+            this.state.databaseName &&
+            databaseName.toLowerCase() === this.state.databaseName.toLowerCase();
+
         // Check if database exists
         try {
             const result = await this.connectionManager.client.sendRequest(
@@ -951,6 +989,11 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
 
             // For Extract/Export operations, database must exist
             if (!shouldNotExist && !exists) {
+                // If the database matches the connection's database, trust it even if
+                // the list is incomplete (user may lack permissions to list all databases)
+                if (isConnectionDatabase) {
+                    return { isValid: true };
+                }
                 return {
                     isValid: false,
                     errorMessage: LocConstants.DacpacDialog.DatabaseNotFound,
@@ -959,6 +1002,11 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
 
             return { isValid: true };
         } catch (error) {
+            // If listing databases failed but the database matches the connection's database,
+            // allow the operation since the user is already connected to this database
+            if (isConnectionDatabase) {
+                return { isValid: true };
+            }
             const errorMessage =
                 error instanceof Error
                     ? `Failed to validate database name: ${error.message}`

--- a/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
+++ b/extensions/mssql/src/controllers/dacpacDialogWebviewController.ts
@@ -627,7 +627,10 @@ export class DacpacDialogWebviewController extends WebviewPanelController<
             errorMessage = LocConstants.DacpacDialog.FailedToListDatabases;
         } catch (error) {
             this.logger.error(`Failed to list databases: ${error}`);
-            errorMessage = error instanceof Error ? error.message : LocConstants.DacpacDialog.FailedToListDatabases;
+            errorMessage =
+                error instanceof Error
+                    ? error.message
+                    : LocConstants.DacpacDialog.FailedToListDatabases;
         }
 
         // Fallback: if the database list is empty or the request failed,

--- a/extensions/mssql/src/sharedInterfaces/dacpacDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/dacpacDialog.ts
@@ -177,9 +177,11 @@ export namespace ValidateFilePathWebviewRequest {
  * Request to list databases on a server from the webview
  */
 export namespace ListDatabasesWebviewRequest {
-    export const type = new RequestType<{ ownerUri: string }, { databases: string[] }, void>(
-        "dacpacDialog/listDatabases",
-    );
+    export const type = new RequestType<
+        { ownerUri: string },
+        { databases: string[]; errorMessage?: string },
+        void
+    >("dacpacDialog/listDatabases");
 }
 
 /**
@@ -237,7 +239,13 @@ export namespace InitializeConnectionWebviewRequest {
 export namespace ConnectToServerWebviewRequest {
     export const type = new RequestType<
         { profileId: string },
-        { ownerUri: string; isConnected: boolean; errorMessage?: string; isFabric?: boolean },
+        {
+            ownerUri: string;
+            isConnected: boolean;
+            errorMessage?: string;
+            isFabric?: boolean;
+            databaseName?: string;
+        },
         void
     >("dacpacDialog/connectToServer");
 }

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1903,6 +1903,9 @@ export class LocConstants {
             operationFailed: l10n.t("Operation failed"),
             unexpectedError: l10n.t("An unexpected error occurred"),
             failedToLoadDatabases: l10n.t("Failed to load databases"),
+            databasesCannotBeLoadedDueToPermissions: l10n.t(
+                "Unable to retrieve the list of databases. You may not have permission to list databases on this server. If your connection specifies a database, it will be preselected.",
+            ),
             deploySuccess: l10n.t("DACPAC deployed successfully"),
             extractSuccess: l10n.t("DACPAC extracted successfully"),
             importSuccess: l10n.t("BACPAC imported successfully"),

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, Link, makeStyles } from "@fluentui/react-components";
+import { Button, Link, makeStyles, MessageBar, MessageBarBody } from "@fluentui/react-components";
 import { DatabaseArrowRight20Regular, DatabaseArrowRight24Regular } from "@fluentui/react-icons";
 import { useState, useEffect, useContext } from "react";
 import * as dacpacDialog from "../../../sharedInterfaces/dacpacDialog";
@@ -69,6 +69,10 @@ export const DacpacDialogForm = () => {
     const [ownerUri, setOwnerUri] = useState<string>(initialOwnerUri || "");
     const [isConnecting, setIsConnecting] = useState(false);
     const [isFabric, setIsFabric] = useState(false);
+    const [databaseListError, setDatabaseListError] = useState<{
+        message: string;
+        severity: "error" | "warning";
+    } | null>(null);
 
     // Load available connections when component mounts
     useEffect(() => {
@@ -191,6 +195,7 @@ export const DacpacDialogForm = () => {
     const handleServerChange = async (profileId: string) => {
         setSelectedProfileId(profileId);
         setValidationMessages({});
+        setDatabaseListError(null);
 
         // Find the selected connection
         const selectedConnection = availableConnections.find((conn) => conn.id === profileId);
@@ -264,35 +269,26 @@ export const DacpacDialogForm = () => {
                 if (result.databases && result.databases.length > 0) {
                     // We have a fallback database from the connection - show as warning
                     setDatabaseName(result.databases[0]);
-                    setValidationMessages((prev) => ({
-                        ...prev,
-                        database: {
-                            message:
-                                locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
-                            severity: "warning",
-                        },
-                    }));
+                    setDatabaseListError({
+                        message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
+                        severity: "warning",
+                    });
                 } else {
                     // No databases at all - show error
-                    setValidationMessages((prev) => ({
-                        ...prev,
-                        database: {
-                            message:
-                                locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
-                            severity: "error",
-                        },
-                    }));
+                    setDatabaseListError({
+                        message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
+                        severity: "error",
+                    });
                 }
+            } else {
+                setDatabaseListError(null);
             }
         } catch (error) {
             const errorMsg = error instanceof Error ? error.message : String(error);
-            setValidationMessages((prev) => ({
-                ...prev,
-                database: {
-                    message: `${locConstants.dacpacDialog.failedToLoadDatabases}: ${errorMsg}`,
-                    severity: "error",
-                },
-            }));
+            setDatabaseListError({
+                message: `${locConstants.dacpacDialog.failedToLoadDatabases}: ${errorMsg}`,
+                severity: "error",
+            });
         }
     };
 
@@ -722,12 +718,20 @@ export const DacpacDialogForm = () => {
                     isOperationInProgress={isOperationInProgress}
                     onOperationTypeChange={() => {
                         setValidationMessages({});
+                        setDatabaseListError(null);
                         // Reset file path when switching operation types
                         // Import/Deploy need empty (browse for existing file)
                         // Export/Extract will be set when database name changes
                         setFilePath("");
                     }}
                 />
+
+                {databaseListError && (
+                    <MessageBar
+                        intent={databaseListError.severity === "error" ? "error" : "warning"}>
+                        <MessageBarBody>{databaseListError.message}</MessageBarBody>
+                    </MessageBar>
+                )}
 
                 <ServerSelectionSection
                     selectedProfileId={selectedProfileId}

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
@@ -267,7 +267,8 @@ export const DacpacDialogForm = () => {
                     setValidationMessages((prev) => ({
                         ...prev,
                         database: {
-                            message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
+                            message:
+                                locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
                             severity: "warning",
                         },
                     }));
@@ -276,7 +277,8 @@ export const DacpacDialogForm = () => {
                     setValidationMessages((prev) => ({
                         ...prev,
                         database: {
-                            message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
+                            message:
+                                locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
                             severity: "error",
                         },
                     }));

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
@@ -256,6 +256,36 @@ export const DacpacDialogForm = () => {
                     setDatabaseName(result.databases[0]);
                 }
             }
+
+            // If there was an error loading databases (e.g., permission issues)
+            // but we got fallback results from the connection's database, show a warning.
+            // If no databases at all, show an error about permissions.
+            if (result?.errorMessage) {
+                if (result.databases && result.databases.length > 0) {
+                    // We have a fallback database from the connection - show as warning
+                    setDatabaseName(result.databases[0]);
+                    setValidationMessages((prev) => ({
+                        ...prev,
+                        database: {
+                            message:
+                                locConstants.dacpacDialog
+                                    .databasesCannotBeLoadedDueToPermissions,
+                            severity: "warning",
+                        },
+                    }));
+                } else {
+                    // No databases at all - show error
+                    setValidationMessages((prev) => ({
+                        ...prev,
+                        database: {
+                            message:
+                                locConstants.dacpacDialog
+                                    .databasesCannotBeLoadedDueToPermissions,
+                            severity: "error",
+                        },
+                    }));
+                }
+            }
         } catch (error) {
             const errorMsg = error instanceof Error ? error.message : String(error);
             setValidationMessages((prev) => ({

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
@@ -267,9 +267,7 @@ export const DacpacDialogForm = () => {
                     setValidationMessages((prev) => ({
                         ...prev,
                         database: {
-                            message:
-                                locConstants.dacpacDialog
-                                    .databasesCannotBeLoadedDueToPermissions,
+                            message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
                             severity: "warning",
                         },
                     }));
@@ -278,9 +276,7 @@ export const DacpacDialogForm = () => {
                     setValidationMessages((prev) => ({
                         ...prev,
                         database: {
-                            message:
-                                locConstants.dacpacDialog
-                                    .databasesCannotBeLoadedDueToPermissions,
+                            message: locConstants.dacpacDialog.databasesCannotBeLoadedDueToPermissions,
                             severity: "error",
                         },
                     }));

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogStateProvider.tsx
@@ -59,10 +59,18 @@ export interface DacpacDialogRpcMethods {
     connectToServer: (params: {
         profileId: string;
     }) => Promise<
-        | { ownerUri: string; isConnected: boolean; errorMessage?: string; isFabric?: boolean }
+        | {
+              ownerUri: string;
+              isConnected: boolean;
+              errorMessage?: string;
+              isFabric?: boolean;
+              databaseName?: string;
+          }
         | undefined
     >;
-    listDatabases: (params: { ownerUri: string }) => Promise<{ databases: string[] } | undefined>;
+    listDatabases: (params: {
+        ownerUri: string;
+    }) => Promise<{ databases: string[]; errorMessage?: string } | undefined>;
 
     // File browsing methods
     browseInputFile: (params: {

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogStateProvider.tsx
@@ -56,9 +56,7 @@ export interface DacpacDialogRpcMethods {
           }
         | undefined
     >;
-    connectToServer: (params: {
-        profileId: string;
-    }) => Promise<
+    connectToServer: (params: { profileId: string }) => Promise<
         | {
               ownerUri: string;
               isConnected: boolean;

--- a/extensions/mssql/test/unit/dacpacDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/dacpacDialogWebviewController.test.ts
@@ -39,8 +39,8 @@ import {
     ValidateFilePathWebviewRequest,
     BrowseInputFileWebviewRequest,
     BrowseOutputFileWebviewRequest,
+    type DacpacDialogWebviewState,
 } from "../../src/sharedInterfaces/dacpacDialog";
-import type { DacpacDialogWebviewState } from "../../src/sharedInterfaces/dacpacDialog";
 import * as LocConstants from "../../src/constants/locConstants";
 import {
     stubTelemetry,
@@ -815,12 +815,7 @@ suite("DacpacDialogWebviewController", () => {
             expect(response.errorMessage).to.equal("Connection failed");
         });
         test("returns fallback database from state when list returns only system databases", async () => {
-            connectionManagerStub.listDatabases.resolves([
-                "master",
-                "tempdb",
-                "model",
-                "msdb",
-            ]);
+            connectionManagerStub.listDatabases.resolves(["master", "tempdb", "model", "msdb"]);
             createControllerWithState({
                 ...initialState,
                 databaseName: "MyDatabase",
@@ -831,10 +826,7 @@ suite("DacpacDialogWebviewController", () => {
             expect(response.errorMessage).to.be.a("string").that.is.not.empty;
         });
         test("returns error message with empty list when no fallback database available", async () => {
-            connectionManagerStub.listDatabases.resolves([
-                "master",
-                "tempdb",
-            ]);
+            connectionManagerStub.listDatabases.resolves(["master", "tempdb"]);
             createController();
             const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
             const response = await requestHandler!({ ownerUri: ownerUri });

--- a/extensions/mssql/test/unit/dacpacDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/dacpacDialogWebviewController.test.ts
@@ -40,6 +40,7 @@ import {
     BrowseInputFileWebviewRequest,
     BrowseOutputFileWebviewRequest,
 } from "../../src/sharedInterfaces/dacpacDialog";
+import type { DacpacDialogWebviewState } from "../../src/sharedInterfaces/dacpacDialog";
 import * as LocConstants from "../../src/constants/locConstants";
 import {
     stubTelemetry,
@@ -122,6 +123,19 @@ suite("DacpacDialogWebviewController", () => {
             connectionManagerStub,
             dacFxServiceStub,
             initialState,
+            ownerUri,
+        );
+        return controller;
+    }
+    function createControllerWithState(
+        state: DacpacDialogWebviewState,
+    ): DacpacDialogWebviewController {
+        controller = new DacpacDialogWebviewController(
+            mockContext,
+            vscodeWrapperStub,
+            connectionManagerStub,
+            dacFxServiceStub,
+            state,
             ownerUri,
         );
         return controller;
@@ -777,31 +791,66 @@ suite("DacpacDialogWebviewController", () => {
     });
     suite("Database Operations", () => {
         test("lists databases successfully", async () => {
-            const mockDatabases = {
-                databaseNames: ["master", "tempdb", "model", "msdb", "TestDB"],
-            };
-            sqlToolsClientStub.sendRequest
-                .withArgs(ListDatabasesRequest.type, sinon.match.any)
-                .resolves(mockDatabases);
+            connectionManagerStub.listDatabases.resolves([
+                "master",
+                "tempdb",
+                "model",
+                "msdb",
+                "TestDB",
+            ]);
             createController();
             const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
             expect(requestHandler, "Request handler was not registered").to.be.a("function");
             const response = await requestHandler!({ ownerUri: ownerUri });
             // System databases are filtered out, only user databases are returned
             expect(response.databases).to.deep.equal(["TestDB"]);
-            expect(sqlToolsClientStub.sendRequest).to.have.been.calledWith(
-                ListDatabasesRequest.type,
-                { ownerUri: ownerUri },
-            );
+            expect(connectionManagerStub.listDatabases).to.have.been.calledWith(ownerUri);
         });
-        test("returns empty array when list databases fails", async () => {
-            sqlToolsClientStub.sendRequest
-                .withArgs(ListDatabasesRequest.type, sinon.match.any)
-                .rejects(new Error("Connection failed"));
+        test("returns empty array with error message when list databases fails", async () => {
+            connectionManagerStub.listDatabases.rejects(new Error("Connection failed"));
             createController();
             const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
             const response = await requestHandler!({ ownerUri: ownerUri });
             expect(response.databases).to.be.an("array").that.is.empty;
+            expect(response.errorMessage).to.equal("Connection failed");
+        });
+        test("returns fallback database from state when list returns only system databases", async () => {
+            connectionManagerStub.listDatabases.resolves([
+                "master",
+                "tempdb",
+                "model",
+                "msdb",
+            ]);
+            createControllerWithState({
+                ...initialState,
+                databaseName: "MyDatabase",
+            });
+            const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
+            const response = await requestHandler!({ ownerUri: ownerUri });
+            expect(response.databases).to.deep.equal(["MyDatabase"]);
+            expect(response.errorMessage).to.be.a("string").that.is.not.empty;
+        });
+        test("returns error message with empty list when no fallback database available", async () => {
+            connectionManagerStub.listDatabases.resolves([
+                "master",
+                "tempdb",
+            ]);
+            createController();
+            const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
+            const response = await requestHandler!({ ownerUri: ownerUri });
+            expect(response.databases).to.be.an("array").that.is.empty;
+            expect(response.errorMessage).to.be.a("string").that.is.not.empty;
+        });
+        test("returns fallback database from state when list databases throws", async () => {
+            connectionManagerStub.listDatabases.rejects(new Error("Permission denied"));
+            createControllerWithState({
+                ...initialState,
+                databaseName: "MyDatabase",
+            });
+            const requestHandler = requestHandlers.get(ListDatabasesWebviewRequest.type.method);
+            const response = await requestHandler!({ ownerUri: ownerUri });
+            expect(response.databases).to.deep.equal(["MyDatabase"]);
+            expect(response.errorMessage).to.equal("Permission denied");
         });
     });
     suite("Database Name Validation", () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -6416,6 +6416,12 @@
     <trans-unit id="++CODE++96d229ad39923c7fdc914e4075785ffba3c0282697aa7f4f31a289baa4b83996">
       <source xml:lang="en">Unable to read proxy agent options.</source>
     </trans-unit>
+    <trans-unit id="++CODE++5d1ae18e4c82efee8401c895242feeb54a8a5093d2b024877c83a7a08660a945">
+      <source xml:lang="en">Unable to retrieve the list of databases. You may not have permission to list databases on this server.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++5e487cbb896806c4ffd5fd55308a163e5a5ebdb2de5b6e717faff434ddd119dd">
+      <source xml:lang="en">Unable to retrieve the list of databases. You may not have permission to list databases on this server. If your connection specifies a database, it will be preselected.</source>
+    </trans-unit>
     <trans-unit id="++CODE++6be6bf4fae4897b542e648716d3e0fb9d67e3f4457c7b37afd4b217ca93e2914">
       <source xml:lang="en">Unavailable for backups to existing files</source>
     </trans-unit>


### PR DESCRIPTION
## Description

In dacpac operations if list databases fails, a warning message is displayed.

<img width="763" height="681" alt="image" src="https://github.com/user-attachments/assets/913e5766-5416-4a08-b6b3-d39d8d1dccf3" />

New label:

<img width="533" height="555" alt="image" src="https://github.com/user-attachments/assets/e0cd8061-ad4b-48f5-89b2-8f7297432da8" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
