### PR TITLE
Fix AutoRest code generation failing with spawn errors on Windows

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -488,23 +488,6 @@ export async function resolveCommandPath(command: string): Promise<string | unde
 }
 
 /**
- * Detects whether the specified command-line command is available on the current machine
- */
-export async function detectCommandInstallation(command: string): Promise<boolean> {
-    try {
-        const found = await which(command);
-
-        if (found) {
-            return true;
-        }
-    } catch (err) {
-        console.log(getErrorMessage(err));
-    }
-
-    return false;
-}
-
-/**
  * Returns the results of the glob pattern
  * @param pattern Glob pattern to search for
  */

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -476,6 +476,18 @@ export function timeConversion(duration: number): string {
 }
 
 /**
+ * Returns the fully resolved path of a command, or undefined if not found.
+ */
+export async function resolveCommandPath(command: string): Promise<string | undefined> {
+    try {
+        const found = await which(command);
+        return found || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * Detects whether the specified command-line command is available on the current machine
  */
 export async function detectCommandInstallation(command: string): Promise<boolean> {

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -16,9 +16,11 @@ const nodejsDoNotAskAgainKey = "nodejsDoNotAsk";
 const autorestSqlVersionKey = "autorestSqlVersion";
 
 /**
- * On Windows, script files cannot be executed directly by spawn(shell:false).
- * - .cmd/.bat must be routed through cmd.exe /d /c
- * - .ps1 must be routed through pwsh.exe -NoProfile -File
+ * Resolves the correct executable and prefix arguments for a script path returned by `which`.
+ * On Windows, `which` may resolve commands to `.cmd` or `.ps1` wrappers, which cannot be
+ * executed directly by spawn(shell:false) and must be routed through a shell:
+ * - .cmd/.bat → cmd.exe /d /c <path>
+ * - .ps1      → pwsh.exe -NoProfile -File <path>
  * On other platforms, the resolved path is used directly.
  */
 function resolveScriptExecutable(resolvedPath: string): {

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -47,8 +47,8 @@ async function resolveScriptExecutable(resolvedPath: string): Promise<{
                 (await utils.resolveCommandPath("pwsh")) ??
                 (await utils.resolveCommandPath("powershell")) ??
                 "powershell.exe";
-            
-                return {
+
+            return {
                 executable: pwsh,
                 prefixArgs: ["-NoProfile", "-File", resolvedPath],
             };

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -20,13 +20,13 @@ const autorestSqlVersionKey = "autorestSqlVersion";
  * On Windows, `which` may resolve commands to `.cmd` or `.ps1` wrappers, which cannot be
  * executed directly by spawn(shell:false) and must be routed through a shell:
  * - .cmd/.bat → cmd.exe /d /c <path>
- * - .ps1      → pwsh.exe -NoProfile -File <path>
+ * - .ps1      → pwsh.exe -NoProfile -File <path>  (falls back to powershell.exe if pwsh is not installed)
  * On other platforms, the resolved path is used directly.
  */
-function resolveScriptExecutable(resolvedPath: string): {
+async function resolveScriptExecutable(resolvedPath: string): Promise<{
     executable: string;
     prefixArgs: string[];
-} {
+}> {
     if (process.platform === "win32") {
         const ext = path.extname(resolvedPath).toLowerCase();
 
@@ -40,10 +40,16 @@ function resolveScriptExecutable(resolvedPath: string): {
         }
 
         if (ext === ".ps1") {
+            // Prefer PowerShell 7 (pwsh.exe); fall back to Windows PowerShell (powershell.exe).
             // -NoProfile avoids loading user profile scripts that could interfere.
             // -File treats the argument as a script path, not a command string.
-            return {
-                executable: "pwsh.exe",
+            const pwsh =
+                (await utils.resolveCommandPath("pwsh")) ??
+                (await utils.resolveCommandPath("powershell")) ??
+                "powershell.exe";
+            
+                return {
+                executable: pwsh,
                 prefixArgs: ["-NoProfile", "-File", resolvedPath],
             };
         }
@@ -85,7 +91,7 @@ export class AutorestHelper extends ShellExecutionHelper {
         const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
 
         if (resolvedAutorest) {
-            return resolveScriptExecutable(resolvedAutorest);
+            return await resolveScriptExecutable(resolvedAutorest);
         }
 
         const resolvedNpx = await utils.resolveCommandPath(npxCommand);
@@ -103,18 +109,18 @@ export class AutorestHelper extends ShellExecutionHelper {
                 const resolvedNpm = await utils.resolveCommandPath("npm");
 
                 const { executable: npmExe, prefixArgs: npmArgs } = resolvedNpm
-                    ? resolveScriptExecutable(resolvedNpm)
+                    ? await resolveScriptExecutable(resolvedNpm)
                     : { executable: "npm", prefixArgs: [] };
 
                 await this.runStreamedCommand(npmExe, [...npmArgs, "install", "autorest", "-g"]);
                 const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
 
                 return resolvedAutorest
-                    ? resolveScriptExecutable(resolvedAutorest)
+                    ? await resolveScriptExecutable(resolvedAutorest)
                     : { executable: autorestCommand, prefixArgs: [] };
             } else if (response === constants.runViaNpx) {
                 this._outputChannel.appendLine(constants.userSelectionRunNpx);
-                const { executable, prefixArgs } = resolveScriptExecutable(resolvedNpx);
+                const { executable, prefixArgs } = await resolveScriptExecutable(resolvedNpx);
 
                 return { executable, prefixArgs: [...prefixArgs, autorestCommand] };
             } else {

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import * as path from "path";
 import * as constants from "../common/constants";
 import * as utils from "../common/utils";
 import * as semver from "semver";
@@ -15,15 +16,35 @@ const nodejsDoNotAskAgainKey = "nodejsDoNotAsk";
 const autorestSqlVersionKey = "autorestSqlVersion";
 
 /**
- * On Windows, .cmd/.bat files cannot be executed directly by spawn(shell:false).
- * They must be routed through cmd.exe /c.
+ * On Windows, script files cannot be executed directly by spawn(shell:false).
+ * - .cmd/.bat must be routed through cmd.exe /d /c
+ * - .ps1 must be routed through pwsh.exe -NoProfile -File
+ * On other platforms, the resolved path is used directly.
  */
-function wrapCmdIfNeeded(resolvedPath: string): { executable: string; prefixArgs: string[] } {
-    if (process.platform === "win32" && /\.(cmd|bat)$/i.test(resolvedPath)) {
-        const cmdExe = process.env.ComSpec ?? "cmd.exe";
-        // /d disables AutoRun; /c runs the command and exits.
-        // No /s: it triggers quote-stripping that mangles args containing spaces.
-        return { executable: cmdExe, prefixArgs: ["/d", "/c", resolvedPath] };
+function resolveScriptExecutable(resolvedPath: string): {
+    executable: string;
+    prefixArgs: string[];
+} {
+    if (process.platform === "win32") {
+        const ext = path.extname(resolvedPath).toLowerCase();
+
+        if (ext === ".cmd" || ext === ".bat") {
+            const cmdExe = process.env.ComSpec ?? "cmd.exe";
+            // /d disables AutoRun; /c runs the command and exits.
+            // Do NOT manually quote resolvedPath here — spawn passes each prefixArg as a
+            // separate element to CreateProcess, so Node.js handles quoting automatically.
+            // Adding manual quotes causes double-quoting ("\"path\"") which cmd.exe rejects.
+            return { executable: cmdExe, prefixArgs: ["/d", "/c", resolvedPath] };
+        }
+
+        if (ext === ".ps1") {
+            // -NoProfile avoids loading user profile scripts that could interfere.
+            // -File treats the argument as a script path, not a command string.
+            return {
+                executable: "pwsh.exe",
+                prefixArgs: ["-NoProfile", "-File", resolvedPath],
+            };
+        }
     }
     return { executable: resolvedPath, prefixArgs: [] };
 }
@@ -51,20 +72,22 @@ export class AutorestHelper extends ShellExecutionHelper {
     }
 
     /**
-     * @returns the executable and prefix args needed to run autorest, or undefined if unavailable.
+     * @returns the executable and prefix args needed to run autorest,
+     * `undefined` if Node.js/npx is not found, or `"cancelled"` if the user dismissed the install prompt.
      */
     public async detectInstallation(): Promise<
-        { executable: string; prefixArgs: string[] } | undefined
+        { executable: string; prefixArgs: string[] } | "cancelled" | undefined
     > {
         const autorestCommand = "autorest";
         const npxCommand = "npx";
-
         const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
+
         if (resolvedAutorest) {
-            return wrapCmdIfNeeded(resolvedAutorest);
+            return resolveScriptExecutable(resolvedAutorest);
         }
 
         const resolvedNpx = await utils.resolveCommandPath(npxCommand);
+
         if (resolvedNpx) {
             this._outputChannel.appendLine(constants.nodeButNotAutorestFound);
             const response = await vscode.window.showInformationMessage(
@@ -76,20 +99,26 @@ export class AutorestHelper extends ShellExecutionHelper {
             if (response === constants.installGlobally) {
                 this._outputChannel.appendLine(constants.userSelectionInstallGlobally);
                 const resolvedNpm = await utils.resolveCommandPath("npm");
+
                 const { executable: npmExe, prefixArgs: npmArgs } = resolvedNpm
-                    ? wrapCmdIfNeeded(resolvedNpm)
+                    ? resolveScriptExecutable(resolvedNpm)
                     : { executable: "npm", prefixArgs: [] };
+
                 await this.runStreamedCommand(npmExe, [...npmArgs, "install", "autorest", "-g"]);
-                const newResolved = await utils.resolveCommandPath(autorestCommand);
-                return newResolved
-                    ? wrapCmdIfNeeded(newResolved)
+                const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
+
+                return resolvedAutorest
+                    ? resolveScriptExecutable(resolvedAutorest)
                     : { executable: autorestCommand, prefixArgs: [] };
             } else if (response === constants.runViaNpx) {
                 this._outputChannel.appendLine(constants.userSelectionRunNpx);
-                const { executable, prefixArgs } = wrapCmdIfNeeded(resolvedNpx);
+                const { executable, prefixArgs } = resolveScriptExecutable(resolvedNpx);
+
                 return { executable, prefixArgs: [...prefixArgs, autorestCommand] };
             } else {
                 this._outputChannel.appendLine(constants.userSelectionCancelled);
+
+                return "cancelled";
             }
         } else {
             this._outputChannel.appendLine(constants.nodeNotFound);
@@ -110,15 +139,18 @@ export class AutorestHelper extends ShellExecutionHelper {
     ): Promise<string | undefined> {
         const commandExecutable = await this.detectInstallation();
 
+        if (commandExecutable === "cancelled") {
+            return; // user intentionally dismissed the prompt — do not show Node.js install dialog
+        }
+
         if (!commandExecutable) {
             // unable to find autorest or npx
-
             if (
                 vscode.workspace.getConfiguration(DBProjectConfigurationKey)[
                     nodejsDoNotAskAgainKey
-                ] === true
+                ] !== true
             ) {
-                return; // user opted out of being prompted
+                return; // user doesn't want to be prompted about installing it
             }
 
             // prompt user to install Node.js

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -15,6 +15,20 @@ const nodejsDoNotAskAgainKey = "nodejsDoNotAsk";
 const autorestSqlVersionKey = "autorestSqlVersion";
 
 /**
+ * On Windows, .cmd/.bat files cannot be executed directly by spawn(shell:false).
+ * They must be routed through cmd.exe /c.
+ */
+function wrapCmdIfNeeded(resolvedPath: string): { executable: string; prefixArgs: string[] } {
+    if (process.platform === "win32" && /\.(cmd|bat)$/i.test(resolvedPath)) {
+        const cmdExe = process.env.ComSpec ?? "cmd.exe";
+        // /d disables AutoRun; /c runs the command and exits.
+        // No /s: it triggers quote-stripping that mangles args containing spaces.
+        return { executable: cmdExe, prefixArgs: ["/d", "/c", resolvedPath] };
+    }
+    return { executable: resolvedPath, prefixArgs: [] };
+}
+
+/**
  * Helper class for dealing with Autorest generation and detection
  */
 export class AutorestHelper extends ShellExecutionHelper {
@@ -37,15 +51,21 @@ export class AutorestHelper extends ShellExecutionHelper {
     }
 
     /**
-     * @returns the beginning of the command to execute autorest; 'autorest' if available, 'npx autorest' if module not installed, or undefined if neither
+     * @returns the executable and prefix args needed to run autorest, or undefined if unavailable.
      */
-    public async detectInstallation(): Promise<string | undefined> {
+    public async detectInstallation(): Promise<
+        { executable: string; prefixArgs: string[] } | undefined
+    > {
         const autorestCommand = "autorest";
         const npxCommand = "npx";
 
-        if (await utils.detectCommandInstallation(autorestCommand)) {
-            return autorestCommand;
-        } else if (await utils.detectCommandInstallation(npxCommand)) {
+        const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
+        if (resolvedAutorest) {
+            return wrapCmdIfNeeded(resolvedAutorest);
+        }
+
+        const resolvedNpx = await utils.resolveCommandPath(npxCommand);
+        if (resolvedNpx) {
             this._outputChannel.appendLine(constants.nodeButNotAutorestFound);
             const response = await vscode.window.showInformationMessage(
                 constants.nodeButNotAutorestFoundPrompt,
@@ -55,11 +75,19 @@ export class AutorestHelper extends ShellExecutionHelper {
 
             if (response === constants.installGlobally) {
                 this._outputChannel.appendLine(constants.userSelectionInstallGlobally);
-                await this.runStreamedCommand("npm", ["install", "autorest", "-g"]);
-                return autorestCommand;
+                const resolvedNpm = await utils.resolveCommandPath("npm");
+                const { executable: npmExe, prefixArgs: npmArgs } = resolvedNpm
+                    ? wrapCmdIfNeeded(resolvedNpm)
+                    : { executable: "npm", prefixArgs: [] };
+                await this.runStreamedCommand(npmExe, [...npmArgs, "install", "autorest", "-g"]);
+                const newResolved = await utils.resolveCommandPath(autorestCommand);
+                return newResolved
+                    ? wrapCmdIfNeeded(newResolved)
+                    : { executable: autorestCommand, prefixArgs: [] };
             } else if (response === constants.runViaNpx) {
                 this._outputChannel.appendLine(constants.userSelectionRunNpx);
-                return `${npxCommand} ${autorestCommand}`;
+                const { executable, prefixArgs } = wrapCmdIfNeeded(resolvedNpx);
+                return { executable, prefixArgs: [...prefixArgs, autorestCommand] };
             } else {
                 this._outputChannel.appendLine(constants.userSelectionCancelled);
             }
@@ -88,9 +116,9 @@ export class AutorestHelper extends ShellExecutionHelper {
             if (
                 vscode.workspace.getConfiguration(DBProjectConfigurationKey)[
                     nodejsDoNotAskAgainKey
-                ] !== true
+                ] === true
             ) {
-                return; // user doesn't want to be prompted about installing it
+                return; // user opted out of being prompted
             }
 
             // prompt user to install Node.js
@@ -101,8 +129,7 @@ export class AutorestHelper extends ShellExecutionHelper {
             );
 
             if (result === constants.Install) {
-                //open install link
-                const nodejsInstallationUrl = "https://nodejs.dev/download";
+                const nodejsInstallationUrl = "https://nodejs.org/en/download";
                 await vscode.env.openExternal(vscode.Uri.parse(nodejsInstallationUrl));
             } else if (result === constants.DoNotAskAgain) {
                 const config = vscode.workspace.getConfiguration(DBProjectConfigurationKey);
@@ -127,26 +154,26 @@ export class AutorestHelper extends ShellExecutionHelper {
     }
 
     /**
-     *
-     * @param executable either "autorest" or "npx autorest", depending on whether autorest is already present in the global cache
+     * @param installation resolved executable and any prefix args (e.g. npx prefix)
      * @param specPath path to the OpenAPI spec
      * @param outputFolder folder in which to generate the files
-     * @returns composed command to be executed
+     * @returns ready to pass to runStreamedCommand
      */
     public constructAutorestCommand(
-        executable: string,
+        installation: { executable: string; prefixArgs: string[] },
         specPath: string,
         outputFolder: string,
     ): { executable: string; args: string[] } {
         // TODO: should --clear-output-folder be included? We should always be writing to a folder created just for this, but potentially risky
         return {
-            executable,
+            executable: installation.executable,
             args: [
+                ...installation.prefixArgs,
                 `--use:${autorestPackageName}@${this.autorestSqlPackageVersion}`,
                 `--input-file=${specPath}`,
                 `--output-folder=${outputFolder}`,
                 "--clear-output-folder",
-                "--verbose",
+                "--level:error",
             ],
         };
     }

--- a/extensions/sql-database-projects/test/autorestHelper.test.ts
+++ b/extensions/sql-database-projects/test/autorestHelper.test.ts
@@ -130,22 +130,48 @@ suite("Autorest tests", function (): void {
 
     test("Should route .ps1 autorest through pwsh.exe on Windows", async function (): Promise<void> {
         const ps1Path = "C:\\tools\\autorest.ps1";
-        sandbox
-            .stub(utils, "resolveCommandPath")
-            .withArgs("autorest")
-            .returns(Promise.resolve(ps1Path));
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(ps1Path));
+        resolveStub
+            .withArgs("pwsh")
+            .returns(Promise.resolve("C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         const installation = await autorestHelper.detectInstallation();
         const resolved = installation as { executable: string; prefixArgs: string[] };
 
         if (process.platform === "win32") {
-            expect(resolved.executable).to.equal("pwsh.exe");
+            expect(resolved.executable).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe");
             expect(resolved.prefixArgs).to.deep.equal(["-NoProfile", "-File", ps1Path]);
         } else {
-            // Non-Windows: wrapCmdIfNeeded is a no-op, path used directly
+            // Non-Windows: resolveScriptExecutable is a no-op, path used directly
             expect(resolved.executable).to.equal(ps1Path);
             expect(resolved.prefixArgs).to.deep.equal([]);
         }
+    });
+
+    test("Should fall back to powershell.exe for .ps1 when pwsh is not installed", async function (): Promise<void> {
+        if (process.platform !== "win32") {
+            return; // fallback only applies on Windows
+        }
+
+        const ps1Path = "C:\\tools\\autorest.ps1";
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(ps1Path));
+        resolveStub.withArgs("pwsh").returns(Promise.resolve(undefined));
+        resolveStub
+            .withArgs("powershell")
+            .returns(
+                Promise.resolve("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+            );
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+
+        expect(resolved.executable).to.equal(
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        );
+        expect(resolved.prefixArgs).to.deep.equal(["-NoProfile", "-File", ps1Path]);
     });
 });

--- a/extensions/sql-database-projects/test/autorestHelper.test.ts
+++ b/extensions/sql-database-projects/test/autorestHelper.test.ts
@@ -33,9 +33,9 @@ suite("Autorest tests", function (): void {
         sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        const executable = await autorestHelper.detectInstallation();
+        const installation = await autorestHelper.detectInstallation();
         expect(
-            executable === "autorest" || executable === "npx autorest",
+            installation !== undefined,
             "autorest command should be found in default path during unit tests",
         ).to.be.true;
     });
@@ -44,10 +44,10 @@ suite("Autorest tests", function (): void {
         sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        const executable = await autorestHelper.detectInstallation();
+        const installation = await autorestHelper.detectInstallation();
         sandbox.stub(autorestHelper, "constructAutorestCommand").returns({
-            executable: executable!,
-            args: ["--version"],
+            executable: installation!.executable,
+            args: [...installation!.prefixArgs, "--version"],
         });
 
         try {
@@ -64,10 +64,12 @@ suite("Autorest tests", function (): void {
     test("Should construct a correct autorest command for project generation", async function (): Promise<void> {
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
-        sandbox.stub(autorestHelper, "detectInstallation").returns(Promise.resolve("autorest"));
+        sandbox
+            .stub(autorestHelper, "detectInstallation")
+            .returns(Promise.resolve({ executable: "autorest", prefixArgs: [] }));
 
         const result = autorestHelper.constructAutorestCommand(
-            (await autorestHelper.detectInstallation())!,
+            { executable: "autorest", prefixArgs: [] },
             "/some/path/test.yaml",
             "/some/output/path",
         );
@@ -78,7 +80,7 @@ suite("Autorest tests", function (): void {
             "--input-file=/some/path/test.yaml",
             "--output-folder=/some/output/path",
             "--clear-output-folder",
-            "--verbose",
+            "--level:error",
         ]);
     });
 
@@ -86,9 +88,9 @@ suite("Autorest tests", function (): void {
         const promptStub = sandbox
             .stub(window, "showInformationMessage")
             .returns(<any>Promise.resolve());
-        const detectStub = sandbox.stub(utils, "detectCommandInstallation");
-        detectStub.withArgs("autorest").returns(Promise.resolve(false));
-        detectStub.withArgs("npx").returns(Promise.resolve(true));
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(undefined));
+        resolveStub.withArgs("npx").returns(Promise.resolve("/usr/bin/npx"));
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         await autorestHelper.detectInstallation();

--- a/extensions/sql-database-projects/test/autorestHelper.test.ts
+++ b/extensions/sql-database-projects/test/autorestHelper.test.ts
@@ -30,24 +30,32 @@ suite("Autorest tests", function (): void {
     });
 
     test("Should detect autorest", async function (): Promise<void> {
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
+        sandbox
+            .stub(utils, "resolveCommandPath")
+            .withArgs("autorest")
+            .returns(Promise.resolve("autorest"));
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         const installation = await autorestHelper.detectInstallation();
-        expect(
-            installation !== undefined,
-            "autorest command should be found in default path during unit tests",
-        ).to.be.true;
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+        expect(resolved.executable, "autorest command should be detected").to.equal("autorest");
     });
 
     test("Should run an autorest command successfully", async function (): Promise<void> {
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
+        sandbox
+            .stub(window, "showInformationMessage")
+            .returns(
+                Promise.resolve(runViaNpx) as unknown as ReturnType<
+                    typeof window.showInformationMessage
+                >,
+            ); // stub a selection in case test runner doesn't have autorest installed
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
         sandbox.stub(autorestHelper, "constructAutorestCommand").returns({
-            executable: installation!.executable,
-            args: [...installation!.prefixArgs, "--version"],
+            executable: resolved.executable,
+            args: [...resolved.prefixArgs, "--version"],
         });
 
         try {
@@ -56,17 +64,13 @@ suite("Autorest tests", function (): void {
             expect(output, `Substring not found. Expected "${expected}" in "${output}"`).to.contain(
                 expected,
             );
-        } catch (err) {
+        } catch {
             // test is skipped, but handle cleanup gracefully
         }
     });
 
-    test("Should construct a correct autorest command for project generation", async function (): Promise<void> {
+    test("Should construct a correct autorest command for project generation", function (): void {
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
-        sandbox
-            .stub(autorestHelper, "detectInstallation")
-            .returns(Promise.resolve({ executable: "autorest", prefixArgs: [] }));
 
         const result = autorestHelper.constructAutorestCommand(
             { executable: "autorest", prefixArgs: [] },
@@ -87,7 +91,9 @@ suite("Autorest tests", function (): void {
     test("Should prompt user for action when autorest not found", async function (): Promise<void> {
         const promptStub = sandbox
             .stub(window, "showInformationMessage")
-            .returns(<any>Promise.resolve());
+            .returns(
+                Promise.resolve() as unknown as ReturnType<typeof window.showInformationMessage>,
+            );
         const resolveStub = sandbox.stub(utils, "resolveCommandPath");
         resolveStub.withArgs("autorest").returns(Promise.resolve(undefined));
         resolveStub.withArgs("npx").returns(Promise.resolve("/usr/bin/npx"));
@@ -99,5 +105,47 @@ suite("Autorest tests", function (): void {
             promptStub.calledOnce,
             "User should have been prompted for how to run autorest because it wasn't found.",
         ).to.be.true;
+    });
+
+    test("Should return 'cancelled' when user dismisses the install prompt", async function (): Promise<void> {
+        sandbox
+            .stub(window, "showInformationMessage")
+            .returns(
+                Promise.resolve(undefined) as unknown as ReturnType<
+                    typeof window.showInformationMessage
+                >,
+            );
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(undefined));
+        resolveStub.withArgs("npx").returns(Promise.resolve("/usr/bin/npx"));
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const result = await autorestHelper.detectInstallation();
+
+        expect(result).to.equal(
+            "cancelled",
+            "Should return 'cancelled' when user dismisses the prompt.",
+        );
+    });
+
+    test("Should route .ps1 autorest through pwsh.exe on Windows", async function (): Promise<void> {
+        const ps1Path = "C:\\tools\\autorest.ps1";
+        sandbox
+            .stub(utils, "resolveCommandPath")
+            .withArgs("autorest")
+            .returns(Promise.resolve(ps1Path));
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+
+        if (process.platform === "win32") {
+            expect(resolved.executable).to.equal("pwsh.exe");
+            expect(resolved.prefixArgs).to.deep.equal(["-NoProfile", "-File", ps1Path]);
+        } else {
+            // Non-Windows: wrapCmdIfNeeded is a no-op, path used directly
+            expect(resolved.executable).to.equal(ps1Path);
+            expect(resolved.prefixArgs).to.deep.equal([]);
+        }
     });
 });

--- a/extensions/sql-database-projects/test/utils.test.ts
+++ b/extensions/sql-database-projects/test/utils.test.ts
@@ -154,12 +154,12 @@ suite("Tests to verify utils functions", function (): void {
 
     test("Should correctly detect present commands", async () => {
         expect(
-            await utils.detectCommandInstallation("node"),
+            await utils.resolveCommandPath("node"),
             '"node" should have been detected.',
-        ).to.equal(true);
+        ).to.not.equal(undefined);
         expect(
-            await utils.detectCommandInstallation("bogusFakeCommand"),
-            '"bogusFakeCommand" should have been detected.',
-        ).to.equal(false);
+            await utils.resolveCommandPath("bogusFakeCommand"),
+            '"bogusFakeCommand" should not have been detected.',
+        ).to.equal(undefined);
     });
 });


### PR DESCRIPTION
## Description

PR #21570 changed spawn to use shell: false (for security). But on Windows, autorest and npx install as .cmd files (e.g. autorest.cmd). With shell: false, the OS can't find or execute .cmd files directly → ENOENT crash.

What we fixed:
- Resolve the full path, use which to find where autorest.cmd / npx.cmd actually lives on disk (instead of just passing the bare name "autorest")
- Route .cmd through cmd.exe — since shell: false can't run .cmd files directly, we wrap it as cmd.exe /d /c C:\...\autorest.cmd so Windows can execute it properly


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Before FiX:
<img width="2374" height="1402" alt="Apr_Test_AutoRest_Before" src="https://github.com/user-attachments/assets/813a6051-d4b3-4ea9-8112-a3215ecacc74" />

After Fix:
<img width="2373" height="1401" alt="Apr_Test_AutoRest_After" src="https://github.com/user-attachments/assets/9fd85db8-c54d-42ce-a9b7-7cd2cd6db0c5" />

