### PR TITLE
[PORT] Fix AutoRest code generation failing with spawn errors on Windows (#2…

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -476,20 +476,15 @@ export function timeConversion(duration: number): string {
 }
 
 /**
- * Detects whether the specified command-line command is available on the current machine
+ * Returns the fully resolved path of a command, or undefined if not found.
  */
-export async function detectCommandInstallation(command: string): Promise<boolean> {
+export async function resolveCommandPath(command: string): Promise<string | undefined> {
     try {
         const found = await which(command);
-
-        if (found) {
-            return true;
-        }
-    } catch (err) {
-        console.log(getErrorMessage(err));
+        return found || undefined;
+    } catch {
+        return undefined;
     }
-
-    return false;
 }
 
 /**

--- a/extensions/sql-database-projects/src/tools/autorestHelper.ts
+++ b/extensions/sql-database-projects/src/tools/autorestHelper.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import * as path from "path";
 import * as constants from "../common/constants";
 import * as utils from "../common/utils";
 import * as semver from "semver";
@@ -13,6 +14,48 @@ import { ShellExecutionHelper } from "./shellExecutionHelper";
 const autorestPackageName = "autorest-sql-testing"; // name of AutoRest.Sql package on npm
 const nodejsDoNotAskAgainKey = "nodejsDoNotAsk";
 const autorestSqlVersionKey = "autorestSqlVersion";
+
+/**
+ * Resolves the correct executable and prefix arguments for a script path returned by `which`.
+ * On Windows, `which` may resolve commands to `.cmd` or `.ps1` wrappers, which cannot be
+ * executed directly by spawn(shell:false) and must be routed through a shell:
+ * - .cmd/.bat → cmd.exe /d /c <path>
+ * - .ps1      → pwsh.exe -NoProfile -File <path>  (falls back to powershell.exe if pwsh is not installed)
+ * On other platforms, the resolved path is used directly.
+ */
+async function resolveScriptExecutable(resolvedPath: string): Promise<{
+    executable: string;
+    prefixArgs: string[];
+}> {
+    if (process.platform === "win32") {
+        const ext = path.extname(resolvedPath).toLowerCase();
+
+        if (ext === ".cmd" || ext === ".bat") {
+            const cmdExe = process.env.ComSpec ?? "cmd.exe";
+            // /d disables AutoRun; /c runs the command and exits.
+            // Do NOT manually quote resolvedPath here — spawn passes each prefixArg as a
+            // separate element to CreateProcess, so Node.js handles quoting automatically.
+            // Adding manual quotes causes double-quoting ("\"path\"") which cmd.exe rejects.
+            return { executable: cmdExe, prefixArgs: ["/d", "/c", resolvedPath] };
+        }
+
+        if (ext === ".ps1") {
+            // Prefer PowerShell 7 (pwsh.exe); fall back to Windows PowerShell (powershell.exe).
+            // -NoProfile avoids loading user profile scripts that could interfere.
+            // -File treats the argument as a script path, not a command string.
+            const pwsh =
+                (await utils.resolveCommandPath("pwsh")) ??
+                (await utils.resolveCommandPath("powershell")) ??
+                "powershell.exe";
+
+            return {
+                executable: pwsh,
+                prefixArgs: ["-NoProfile", "-File", resolvedPath],
+            };
+        }
+    }
+    return { executable: resolvedPath, prefixArgs: [] };
+}
 
 /**
  * Helper class for dealing with Autorest generation and detection
@@ -37,15 +80,23 @@ export class AutorestHelper extends ShellExecutionHelper {
     }
 
     /**
-     * @returns the beginning of the command to execute autorest; 'autorest' if available, 'npx autorest' if module not installed, or undefined if neither
+     * @returns the executable and prefix args needed to run autorest,
+     * `undefined` if Node.js/npx is not found, or `"cancelled"` if the user dismissed the install prompt.
      */
-    public async detectInstallation(): Promise<string | undefined> {
+    public async detectInstallation(): Promise<
+        { executable: string; prefixArgs: string[] } | "cancelled" | undefined
+    > {
         const autorestCommand = "autorest";
         const npxCommand = "npx";
+        const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
 
-        if (await utils.detectCommandInstallation(autorestCommand)) {
-            return autorestCommand;
-        } else if (await utils.detectCommandInstallation(npxCommand)) {
+        if (resolvedAutorest) {
+            return await resolveScriptExecutable(resolvedAutorest);
+        }
+
+        const resolvedNpx = await utils.resolveCommandPath(npxCommand);
+
+        if (resolvedNpx) {
             this._outputChannel.appendLine(constants.nodeButNotAutorestFound);
             const response = await vscode.window.showInformationMessage(
                 constants.nodeButNotAutorestFoundPrompt,
@@ -55,13 +106,27 @@ export class AutorestHelper extends ShellExecutionHelper {
 
             if (response === constants.installGlobally) {
                 this._outputChannel.appendLine(constants.userSelectionInstallGlobally);
-                await this.runStreamedCommand("npm", ["install", "autorest", "-g"]);
-                return autorestCommand;
+                const resolvedNpm = await utils.resolveCommandPath("npm");
+
+                const { executable: npmExe, prefixArgs: npmArgs } = resolvedNpm
+                    ? await resolveScriptExecutable(resolvedNpm)
+                    : { executable: "npm", prefixArgs: [] };
+
+                await this.runStreamedCommand(npmExe, [...npmArgs, "install", "autorest", "-g"]);
+                const resolvedAutorest = await utils.resolveCommandPath(autorestCommand);
+
+                return resolvedAutorest
+                    ? await resolveScriptExecutable(resolvedAutorest)
+                    : { executable: autorestCommand, prefixArgs: [] };
             } else if (response === constants.runViaNpx) {
                 this._outputChannel.appendLine(constants.userSelectionRunNpx);
-                return `${npxCommand} ${autorestCommand}`;
+                const { executable, prefixArgs } = await resolveScriptExecutable(resolvedNpx);
+
+                return { executable, prefixArgs: [...prefixArgs, autorestCommand] };
             } else {
                 this._outputChannel.appendLine(constants.userSelectionCancelled);
+
+                return "cancelled";
             }
         } else {
             this._outputChannel.appendLine(constants.nodeNotFound);
@@ -82,9 +147,12 @@ export class AutorestHelper extends ShellExecutionHelper {
     ): Promise<string | undefined> {
         const commandExecutable = await this.detectInstallation();
 
+        if (commandExecutable === "cancelled") {
+            return; // user intentionally dismissed the prompt — do not show Node.js install dialog
+        }
+
         if (!commandExecutable) {
             // unable to find autorest or npx
-
             if (
                 vscode.workspace.getConfiguration(DBProjectConfigurationKey)[
                     nodejsDoNotAskAgainKey
@@ -101,8 +169,7 @@ export class AutorestHelper extends ShellExecutionHelper {
             );
 
             if (result === constants.Install) {
-                //open install link
-                const nodejsInstallationUrl = "https://nodejs.dev/download";
+                const nodejsInstallationUrl = "https://nodejs.org/en/download";
                 await vscode.env.openExternal(vscode.Uri.parse(nodejsInstallationUrl));
             } else if (result === constants.DoNotAskAgain) {
                 const config = vscode.workspace.getConfiguration(DBProjectConfigurationKey);
@@ -127,26 +194,26 @@ export class AutorestHelper extends ShellExecutionHelper {
     }
 
     /**
-     *
-     * @param executable either "autorest" or "npx autorest", depending on whether autorest is already present in the global cache
+     * @param installation resolved executable and any prefix args (e.g. npx prefix)
      * @param specPath path to the OpenAPI spec
      * @param outputFolder folder in which to generate the files
-     * @returns composed command to be executed
+     * @returns ready to pass to runStreamedCommand
      */
     public constructAutorestCommand(
-        executable: string,
+        installation: { executable: string; prefixArgs: string[] },
         specPath: string,
         outputFolder: string,
     ): { executable: string; args: string[] } {
         // TODO: should --clear-output-folder be included? We should always be writing to a folder created just for this, but potentially risky
         return {
-            executable,
+            executable: installation.executable,
             args: [
+                ...installation.prefixArgs,
                 `--use:${autorestPackageName}@${this.autorestSqlPackageVersion}`,
                 `--input-file=${specPath}`,
                 `--output-folder=${outputFolder}`,
                 "--clear-output-folder",
-                "--verbose",
+                "--level:error",
             ],
         };
     }

--- a/extensions/sql-database-projects/test/autorestHelper.test.ts
+++ b/extensions/sql-database-projects/test/autorestHelper.test.ts
@@ -30,24 +30,32 @@ suite("Autorest tests", function (): void {
     });
 
     test("Should detect autorest", async function (): Promise<void> {
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
+        sandbox
+            .stub(utils, "resolveCommandPath")
+            .withArgs("autorest")
+            .returns(Promise.resolve("autorest"));
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        const executable = await autorestHelper.detectInstallation();
-        expect(
-            executable === "autorest" || executable === "npx autorest",
-            "autorest command should be found in default path during unit tests",
-        ).to.be.true;
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+        expect(resolved.executable, "autorest command should be detected").to.equal("autorest");
     });
 
     test("Should run an autorest command successfully", async function (): Promise<void> {
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
+        sandbox
+            .stub(window, "showInformationMessage")
+            .returns(
+                Promise.resolve(runViaNpx) as unknown as ReturnType<
+                    typeof window.showInformationMessage
+                >,
+            ); // stub a selection in case test runner doesn't have autorest installed
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        const executable = await autorestHelper.detectInstallation();
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
         sandbox.stub(autorestHelper, "constructAutorestCommand").returns({
-            executable: executable!,
-            args: ["--version"],
+            executable: resolved.executable,
+            args: [...resolved.prefixArgs, "--version"],
         });
 
         try {
@@ -56,18 +64,16 @@ suite("Autorest tests", function (): void {
             expect(output, `Substring not found. Expected "${expected}" in "${output}"`).to.contain(
                 expected,
             );
-        } catch (err) {
+        } catch {
             // test is skipped, but handle cleanup gracefully
         }
     });
 
-    test("Should construct a correct autorest command for project generation", async function (): Promise<void> {
+    test("Should construct a correct autorest command for project generation", function (): void {
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
-        sandbox.stub(window, "showInformationMessage").returns(<any>Promise.resolve(runViaNpx)); // stub a selection in case test runner doesn't have autorest installed
-        sandbox.stub(autorestHelper, "detectInstallation").returns(Promise.resolve("autorest"));
 
         const result = autorestHelper.constructAutorestCommand(
-            (await autorestHelper.detectInstallation())!,
+            { executable: "autorest", prefixArgs: [] },
             "/some/path/test.yaml",
             "/some/output/path",
         );
@@ -78,17 +84,19 @@ suite("Autorest tests", function (): void {
             "--input-file=/some/path/test.yaml",
             "--output-folder=/some/output/path",
             "--clear-output-folder",
-            "--verbose",
+            "--level:error",
         ]);
     });
 
     test("Should prompt user for action when autorest not found", async function (): Promise<void> {
         const promptStub = sandbox
             .stub(window, "showInformationMessage")
-            .returns(<any>Promise.resolve());
-        const detectStub = sandbox.stub(utils, "detectCommandInstallation");
-        detectStub.withArgs("autorest").returns(Promise.resolve(false));
-        detectStub.withArgs("npx").returns(Promise.resolve(true));
+            .returns(
+                Promise.resolve() as unknown as ReturnType<typeof window.showInformationMessage>,
+            );
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(undefined));
+        resolveStub.withArgs("npx").returns(Promise.resolve("/usr/bin/npx"));
 
         const autorestHelper = new AutorestHelper(testContext.outputChannel);
         await autorestHelper.detectInstallation();
@@ -97,5 +105,73 @@ suite("Autorest tests", function (): void {
             promptStub.calledOnce,
             "User should have been prompted for how to run autorest because it wasn't found.",
         ).to.be.true;
+    });
+
+    test("Should return 'cancelled' when user dismisses the install prompt", async function (): Promise<void> {
+        sandbox
+            .stub(window, "showInformationMessage")
+            .returns(
+                Promise.resolve(undefined) as unknown as ReturnType<
+                    typeof window.showInformationMessage
+                >,
+            );
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(undefined));
+        resolveStub.withArgs("npx").returns(Promise.resolve("/usr/bin/npx"));
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const result = await autorestHelper.detectInstallation();
+
+        expect(result).to.equal(
+            "cancelled",
+            "Should return 'cancelled' when user dismisses the prompt.",
+        );
+    });
+
+    test("Should route .ps1 autorest through pwsh.exe on Windows", async function (): Promise<void> {
+        const ps1Path = "C:\\tools\\autorest.ps1";
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(ps1Path));
+        resolveStub
+            .withArgs("pwsh")
+            .returns(Promise.resolve("C:\\Program Files\\PowerShell\\7\\pwsh.exe"));
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+
+        if (process.platform === "win32") {
+            expect(resolved.executable).to.equal("C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+            expect(resolved.prefixArgs).to.deep.equal(["-NoProfile", "-File", ps1Path]);
+        } else {
+            // Non-Windows: resolveScriptExecutable is a no-op, path used directly
+            expect(resolved.executable).to.equal(ps1Path);
+            expect(resolved.prefixArgs).to.deep.equal([]);
+        }
+    });
+
+    test("Should fall back to powershell.exe for .ps1 when pwsh is not installed", async function (): Promise<void> {
+        if (process.platform !== "win32") {
+            return; // fallback only applies on Windows
+        }
+
+        const ps1Path = "C:\\tools\\autorest.ps1";
+        const resolveStub = sandbox.stub(utils, "resolveCommandPath");
+        resolveStub.withArgs("autorest").returns(Promise.resolve(ps1Path));
+        resolveStub.withArgs("pwsh").returns(Promise.resolve(undefined));
+        resolveStub
+            .withArgs("powershell")
+            .returns(
+                Promise.resolve("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+            );
+
+        const autorestHelper = new AutorestHelper(testContext.outputChannel);
+        const installation = await autorestHelper.detectInstallation();
+        const resolved = installation as { executable: string; prefixArgs: string[] };
+
+        expect(resolved.executable).to.equal(
+            "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        );
+        expect(resolved.prefixArgs).to.deep.equal(["-NoProfile", "-File", ps1Path]);
     });
 });

--- a/extensions/sql-database-projects/test/utils.test.ts
+++ b/extensions/sql-database-projects/test/utils.test.ts
@@ -154,12 +154,12 @@ suite("Tests to verify utils functions", function (): void {
 
     test("Should correctly detect present commands", async () => {
         expect(
-            await utils.detectCommandInstallation("node"),
+            await utils.resolveCommandPath("node"),
             '"node" should have been detected.',
-        ).to.equal(true);
+        ).to.not.equal(undefined);
         expect(
-            await utils.detectCommandInstallation("bogusFakeCommand"),
-            '"bogusFakeCommand" should have been detected.',
-        ).to.equal(false);
+            await utils.resolveCommandPath("bogusFakeCommand"),
+            '"bogusFakeCommand" should not have been detected.',
+        ).to.equal(undefined);
     });
 });


### PR DESCRIPTION
…1919)

* Fix AutoRest spawn errors on Windows: resolve full paths and route .cmd through cmd.exe

* addressing all comments

* doc string update

* Fix AutoRest spawn errors on Windows: resolve script executables via shell wrappers

* lint error fix

## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
