### PR TITLE
Adding missed package-lock update

### DIFF
--- a/extensions/sql-database-projects/package-lock.json
+++ b/extensions/sql-database-projects/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sql-database-projects-vscode",
-    "version": "1.5.9",
+    "version": "1.5.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sql-database-projects-vscode",
-            "version": "1.5.9",
+            "version": "1.5.10",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@microsoft/ads-extension-telemetry": "^3.0.1",


### PR DESCRIPTION
## Description

package-lock contains version number now, so that was missed when I did the post-release-split vbump

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
