### PR TITLE
Bump STS to 6.0.20260420.1

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -8,7 +8,7 @@ export const config = {
         dotnetRuntimeVersion: "10.0",
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260409.1",
+        version: "6.0.20260420.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",


### PR DESCRIPTION
Bump STS to 6.0.20260420.1 to pick-up build with the extensive null types handling.

<img width="682" height="1036" alt="image" src="https://github.com/user-attachments/assets/59981a7b-7fe6-4ca4-9612-b12b658b0c0a" />
