### PR TITLE
Fix Edit Data drag selection when starting on cell text

### DIFF
--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -484,6 +484,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                         // Cell navigation and copy buffer
                         enableCellNavigation: true,
                         enableExcelCopyBuffer: true, // Enables cell range selection + copy/paste (Ctrl+C, Ctrl+V)
+                        enableTextSelectionOnCells: false, // Keep drag gestures selecting cells instead of native text
 
                         // Context menu
                         enableContextMenu: true,


### PR DESCRIPTION
Edit Data enables SlickGrid's Excel copy buffer so users can drag out cell ranges, but native text selection was still enabled on the table cells. When a drag started on rendered cell text, the browser selected text instead of letting the grid extend the cell selection.

Disable native text selection in the Table Explorer grid so drag gestures consistently select cells no matter where in the cell the drag begins. This aligns Edit Data behavior with the rest of the grid selection experience and fixes issue #21962.
