### PR TITLE
Fix profiler details grid selection and tab switching

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -40,6 +40,8 @@
     "Find": "Find",
     "Find Next": "Find Next",
     "Find Previous": "Find Previous",
+    "Property": "Property",
+    "Value": "Value",
     "No results": "No results",
     "{0} of {1}/{0} is the number of active elements{1} is the total number of elements": {
         "message": "{0} of {1}",
@@ -104,9 +106,7 @@
         "message": "The first value must be less than the second value for the {0} operator in the {1} filter",
         "comment": ["{0} is the operator for the filter", "{1} is the name of the filter"]
     },
-    "Property": "Property",
     "Operator": "Operator",
-    "Value": "Value",
     "Publishing Changes": "Publishing Changes",
     "Changes published successfully": "Changes published successfully",
     "Close Designer": "Close Designer",

--- a/extensions/mssql/src/webviews/common/FluentSlickGrid/fluentGridOptions.ts
+++ b/extensions/mssql/src/webviews/common/FluentSlickGrid/fluentGridOptions.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { GridOption } from "slickgrid-react";
-import "./fluentSlickGrid.css";
 
 export const baseFluentGridOption: GridOption = {
     contextMenu: {

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -2501,6 +2501,8 @@ export class LocConstants {
             detailsPanel: {
                 textTab: l10n.t("Text"),
                 detailsTab: l10n.t("Details"),
+                propertyColumn: l10n.t("Property"),
+                valueColumn: l10n.t("Value"),
                 openInEditor: l10n.t("Open in Editor"),
                 maximize: l10n.t("Maximize"),
                 restore: l10n.t("Restore"),

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -38,6 +38,8 @@ export class LocConstants {
             find: l10n.t("Find"),
             findNext: l10n.t("Find Next"),
             findPrevious: l10n.t("Find Previous"),
+            property: l10n.t("Property"),
+            value: l10n.t("Value"),
             noResults: l10n.t("No results"),
             searchResultSummary: (activeElement: number, totalElements: number) =>
                 l10n.t({
@@ -135,9 +137,9 @@ export class LocConstants {
                         "{1} is the name of the filter",
                     ],
                 }),
-            property: l10n.t("Property"),
+            property: this.common.property,
             operator: l10n.t("Operator"),
-            value: l10n.t("Value"),
+            value: this.common.value,
             clear: l10n.t("Clear"),
         };
     }
@@ -2501,8 +2503,6 @@ export class LocConstants {
             detailsPanel: {
                 textTab: l10n.t("Text"),
                 detailsTab: l10n.t("Details"),
-                propertyColumn: l10n.t("Property"),
-                valueColumn: l10n.t("Value"),
                 openInEditor: l10n.t("Open in Editor"),
                 maximize: l10n.t("Maximize"),
                 restore: l10n.t("Restore"),

--- a/extensions/mssql/src/webviews/pages/Profiler/profiler.css
+++ b/extensions/mssql/src/webviews/pages/Profiler/profiler.css
@@ -43,7 +43,8 @@
 }
 
 /* Grid base styles — CSS variables consumed by slickgrid-theme-default.css */
-#profilerGrid {
+#profilerGrid,
+#profilerDetailsGrid {
     --slick-border-color: var(--vscode-editorWidget-border);
     --slick-cell-border-right: 1px solid var(--vscode-editorWidget-border);
     --slick-cell-border-top: 1px solid var(--vscode-editorWidget-border);
@@ -58,6 +59,15 @@
 #profilerGrid .slick-header-column {
     border-right: 1px solid var(--vscode-panel-border) !important;
     border-bottom: 1px solid var(--vscode-panel-border) !important;
+}
+
+#profilerDetailsGrid .slick-cell.profiler-details-label-cell {
+    font-weight: 600;
+}
+
+#profilerDetailsGrid .slick-cell.profiler-details-value-cell {
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
 }
 
 /* Hide sort indicators since sorting is managed by custom sort buttons */

--- a/extensions/mssql/src/webviews/pages/Profiler/profiler.tsx
+++ b/extensions/mssql/src/webviews/pages/Profiler/profiler.tsx
@@ -44,6 +44,7 @@ import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import { locConstants } from "../../common/locConstants";
 import "@slickgrid-universal/common/dist/styles/css/slickgrid-theme-fluent.css";
 import "./profiler.css";
+import "../../common/FluentSlickGrid/fluentSlickGrid.css";
 import { baseFluentGridOption } from "../../common/FluentSlickGrid/fluentGridOptions";
 import {
     getProfilerColumnDefaultWidth,

--- a/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsGridConfig.ts
+++ b/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsGridConfig.ts
@@ -6,6 +6,7 @@
 import { Column, GridOption } from "slickgrid-react";
 import { ProfilerEventProperty } from "../../../sharedInterfaces/profiler";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
+import { baseFluentGridOption } from "../../common/FluentSlickGrid/fluentGridOptions";
 
 export interface ProfilerDetailsGridRow {
     id: number;
@@ -63,6 +64,7 @@ export function getProfilerDetailsGridColumns(propertyLabel: string, valueLabel:
 
 export function getProfilerDetailsGridOptions(themeKind: ColorThemeKind): GridOption {
     return {
+        ...baseFluentGridOption,
         autoFitColumnsOnFirstLoad: false,
         autoResize: {
             container: `#${PROFILER_DETAILS_GRID_CONTAINER_ID}`,

--- a/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsGridConfig.ts
+++ b/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsGridConfig.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Column, GridOption } from "slickgrid-react";
+import { ProfilerEventProperty } from "../../../sharedInterfaces/profiler";
+import { ColorThemeKind } from "../../../sharedInterfaces/webview";
+
+export interface ProfilerDetailsGridRow {
+    id: number;
+    label: string;
+    value: string;
+}
+
+export const PROFILER_DETAILS_GRID_ID = "profilerDetailsGrid";
+export const PROFILER_DETAILS_GRID_CONTAINER_ID = "profilerDetailsGridContainer";
+export const PROFILER_DETAILS_LABEL_COLUMN_WIDTH_PX = 220;
+export const PROFILER_DETAILS_LABEL_COLUMN_MIN_WIDTH_PX = 160;
+export const PROFILER_DETAILS_VALUE_COLUMN_WIDTH_PX = 640;
+export const PROFILER_DETAILS_VALUE_COLUMN_MIN_WIDTH_PX = 220;
+
+export function buildProfilerDetailsGridRows(
+    properties: ProfilerEventProperty[],
+): ProfilerDetailsGridRow[] {
+    return properties.map((property, index) => ({
+        id: index,
+        label: property.label,
+        value: property.value,
+    }));
+}
+
+export function getProfilerDetailsGridColumns(propertyLabel: string, valueLabel: string): Column[] {
+    return [
+        {
+            id: "label",
+            name: propertyLabel,
+            field: "label",
+            width: PROFILER_DETAILS_LABEL_COLUMN_WIDTH_PX,
+            minWidth: PROFILER_DETAILS_LABEL_COLUMN_MIN_WIDTH_PX,
+            sortable: false,
+            resizable: true,
+            cssClass: "profiler-details-label-cell",
+            excludeFromColumnPicker: true,
+            excludeFromGridMenu: true,
+            excludeFromHeaderMenu: true,
+        },
+        {
+            id: "value",
+            name: valueLabel,
+            field: "value",
+            width: PROFILER_DETAILS_VALUE_COLUMN_WIDTH_PX,
+            minWidth: PROFILER_DETAILS_VALUE_COLUMN_MIN_WIDTH_PX,
+            sortable: false,
+            resizable: true,
+            cssClass: "profiler-details-value-cell",
+            excludeFromColumnPicker: true,
+            excludeFromGridMenu: true,
+            excludeFromHeaderMenu: true,
+        },
+    ];
+}
+
+export function getProfilerDetailsGridOptions(themeKind: ColorThemeKind): GridOption {
+    return {
+        autoFitColumnsOnFirstLoad: false,
+        autoResize: {
+            container: `#${PROFILER_DETAILS_GRID_CONTAINER_ID}`,
+            calculateAvailableSizeBy: "container",
+            resizeDetection: "container",
+            bottomPadding: 0,
+            minHeight: 50,
+        },
+        enableAutoResize: true,
+        enableCellNavigation: true,
+        enableColumnReorder: false,
+        enableSorting: false,
+        enableFiltering: false,
+        enablePagination: false,
+        enableColumnPicker: false,
+        enableGridMenu: false,
+        enableHeaderMenu: false,
+        enableAutoTooltip: true,
+        enableExcelCopyBuffer: true,
+        enableTextSelectionOnCells: false,
+        selectionOptions: {
+            selectionType: "cell",
+        },
+        showHeaderRow: false,
+        showColumnHeader: false,
+        forceFitColumns: true,
+        rowHeight: 25,
+        headerRowHeight: 0,
+        darkMode: themeKind === ColorThemeKind.Dark || themeKind === ColorThemeKind.HighContrast,
+    };
+}

--- a/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsPanel.tsx
+++ b/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsPanel.tsx
@@ -154,8 +154,8 @@ export const ProfilerDetailsPanel: React.FC<ProfilerDetailsPanelProps> = ({
     const detailsGridColumns = useMemo(
         // slickgrid-react mutates the column array on unmount, so we must recreate
         // it whenever the Details tab is toggled back on.
-        () => getProfilerDetailsGridColumns(loc.propertyColumn, loc.valueColumn),
-        [activeTab, loc.propertyColumn, loc.valueColumn],
+        () => getProfilerDetailsGridColumns(commonLoc.property, commonLoc.value),
+        [activeTab, commonLoc.property, commonLoc.value],
     );
     const detailsGridOptions = useMemo(() => getProfilerDetailsGridOptions(themeKind), [themeKind]);
 

--- a/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsPanel.tsx
+++ b/extensions/mssql/src/webviews/pages/Profiler/profilerDetailsPanel.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import React, { useState, useCallback } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import {
     Button,
     Toolbar,
@@ -12,10 +12,10 @@ import {
     Tooltip,
     makeStyles,
     shorthands,
-    tokens,
     SelectTabEvent,
     SelectTabData,
 } from "@fluentui/react-components";
+import { SlickgridReact } from "slickgrid-react";
 import {
     Open16Regular,
     Copy16Regular,
@@ -23,13 +23,17 @@ import {
     Dismiss16Regular,
     ChevronDown16Regular,
 } from "@fluentui/react-icons";
-import {
-    ProfilerSelectedEventDetails,
-    ProfilerEventProperty,
-} from "../../../sharedInterfaces/profiler";
+import { ProfilerSelectedEventDetails } from "../../../sharedInterfaces/profiler";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
 import { locConstants } from "../../common/locConstants";
 import { VscodeEditor } from "../../common/vscodeMonaco";
+import {
+    buildProfilerDetailsGridRows,
+    getProfilerDetailsGridColumns,
+    getProfilerDetailsGridOptions,
+    PROFILER_DETAILS_GRID_CONTAINER_ID,
+    PROFILER_DETAILS_GRID_ID,
+} from "./profilerDetailsGridConfig";
 
 /**
  * Tab identifiers for the details panel
@@ -99,32 +103,13 @@ const useStyles = makeStyles({
     propertiesContainer: {
         width: "100%",
         height: "100%",
-        ...shorthands.overflow("auto"),
-        ...shorthands.padding("8px"),
+        minHeight: 0,
+        position: "relative",
     },
-    propertyRow: {
-        display: "grid",
-        gridTemplateColumns: "200px 1fr",
-        ...shorthands.padding("4px", "8px"),
-        ...shorthands.borderBottom("1px", "solid", "var(--vscode-editorWidget-border)"),
-        "&:hover": {
-            backgroundColor: "var(--vscode-list-hoverBackground)",
-        },
-    },
-    propertyLabel: {
-        fontWeight: tokens.fontWeightSemibold,
-        color: "var(--vscode-foreground)",
-        ...shorthands.overflow("hidden"),
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-    },
-    propertyValue: {
-        color: "var(--vscode-foreground)",
-        ...shorthands.overflow("hidden"),
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-        fontFamily: "var(--vscode-editor-font-family)",
-        fontSize: "var(--vscode-editor-font-size)",
+    detailsGridContainer: {
+        width: "100%",
+        height: "100%",
+        minHeight: 0,
     },
     noEventMessage: {
         display: "flex",
@@ -162,6 +147,17 @@ export const ProfilerDetailsPanel: React.FC<ProfilerDetailsPanelProps> = ({
     const loc = locConstants.profiler.detailsPanel;
     const commonLoc = locConstants.common;
     const [activeTab, setActiveTab] = useState<DetailsPanelTab>(DetailsPanelTab.Text);
+    const detailsGridRows = useMemo(
+        () => buildProfilerDetailsGridRows(selectedEvent?.properties ?? []),
+        [selectedEvent],
+    );
+    const detailsGridColumns = useMemo(
+        // slickgrid-react mutates the column array on unmount, so we must recreate
+        // it whenever the Details tab is toggled back on.
+        () => getProfilerDetailsGridColumns(loc.propertyColumn, loc.valueColumn),
+        [activeTab, loc.propertyColumn, loc.valueColumn],
+    );
+    const detailsGridOptions = useMemo(() => getProfilerDetailsGridOptions(themeKind), [themeKind]);
 
     // Handle tab change
     const handleTabSelect = useCallback((_event: SelectTabEvent, data: SelectTabData) => {
@@ -181,26 +177,6 @@ export const ProfilerDetailsPanel: React.FC<ProfilerDetailsPanelProps> = ({
             onCopy(selectedEvent.textData);
         }
     }, [selectedEvent, onCopy]);
-
-    // Handle keyboard navigation for property list
-    const handlePropertyKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>, index: number, totalItems: number) => {
-            if (event.key === "ArrowDown" && index < totalItems - 1) {
-                event.preventDefault();
-                const nextElement = document.querySelector(
-                    `[data-property-index="${index + 1}"]`,
-                ) as HTMLElement;
-                nextElement?.focus();
-            } else if (event.key === "ArrowUp" && index > 0) {
-                event.preventDefault();
-                const prevElement = document.querySelector(
-                    `[data-property-index="${index - 1}"]`,
-                ) as HTMLElement;
-                prevElement?.focus();
-            }
-        },
-        [],
-    );
 
     // If no event is selected, show placeholder
     if (!selectedEvent) {
@@ -340,58 +316,19 @@ export const ProfilerDetailsPanel: React.FC<ProfilerDetailsPanelProps> = ({
                         className={classes.propertiesContainer}
                         role="group"
                         aria-label={loc.propertiesListAriaLabel}>
-                        {selectedEvent.properties.map((property, index) => (
-                            <PropertyRow
-                                key={`${property.label}-${index}`}
-                                property={property}
-                                index={index}
-                                totalItems={selectedEvent.properties.length}
-                                classes={classes}
-                                onKeyDown={handlePropertyKeyDown}
+                        <div
+                            id={PROFILER_DETAILS_GRID_CONTAINER_ID}
+                            className={classes.detailsGridContainer}>
+                            <SlickgridReact
+                                gridId={PROFILER_DETAILS_GRID_ID}
+                                columns={detailsGridColumns}
+                                options={detailsGridOptions}
+                                dataset={detailsGridRows}
                             />
-                        ))}
+                        </div>
                     </div>
                 )}
             </div>
-        </div>
-    );
-};
-
-/**
- * Individual property row component for the Details tab
- */
-interface PropertyRowProps {
-    property: ProfilerEventProperty;
-    index: number;
-    totalItems: number;
-    classes: ReturnType<typeof useStyles>;
-    onKeyDown: (
-        event: React.KeyboardEvent<HTMLDivElement>,
-        index: number,
-        totalItems: number,
-    ) => void;
-}
-
-const PropertyRow: React.FC<PropertyRowProps> = ({
-    property,
-    index,
-    totalItems,
-    classes,
-    onKeyDown,
-}) => {
-    return (
-        <div
-            className={classes.propertyRow}
-            tabIndex={0}
-            data-property-index={index}
-            onKeyDown={(e) => onKeyDown(e, index, totalItems)}
-            aria-label={`${property.label}: ${property.value}`}>
-            <span className={classes.propertyLabel} title={property.label}>
-                {property.label}
-            </span>
-            <span className={classes.propertyValue} title={property.value}>
-                {property.value}
-            </span>
         </div>
     );
 };

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -29,6 +29,7 @@ import TableExplorerCustomPager from "./TableExplorerCustomPager";
 import { slickGridLocales } from "./commonGridOptions";
 import "@slickgrid-universal/common/dist/styles/css/slickgrid-theme-fluent.css";
 import "./TableDataGrid.css";
+import "../../common/FluentSlickGrid/fluentSlickGrid.css";
 import { baseFluentGridOption } from "../../common/FluentSlickGrid/fluentGridOptions";
 
 interface TableDataGridProps {

--- a/extensions/mssql/test/unit/profiler/profilerDetailsGridConfig.test.ts
+++ b/extensions/mssql/test/unit/profiler/profilerDetailsGridConfig.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { ColorThemeKind } from "../../../src/sharedInterfaces/webview";
+import {
+    buildProfilerDetailsGridRows,
+    getProfilerDetailsGridColumns,
+    getProfilerDetailsGridOptions,
+    PROFILER_DETAILS_GRID_CONTAINER_ID,
+} from "../../../src/webviews/pages/Profiler/profilerDetailsGridConfig";
+
+suite("ProfilerDetailsGridConfig Tests", () => {
+    test("builds SlickGrid rows from profiler properties", () => {
+        const rows = buildProfilerDetailsGridRows([
+            { label: "EventClass", value: "RPC:Completed" },
+            { label: "Duration", value: "42" },
+        ]);
+
+        expect(rows).to.deep.equal([
+            { id: 0, label: "EventClass", value: "RPC:Completed" },
+            { id: 1, label: "Duration", value: "42" },
+        ]);
+    });
+
+    test("creates the expected property and value columns", () => {
+        const columns = getProfilerDetailsGridColumns("Property", "Value");
+
+        expect(columns).to.have.length(2);
+        expect(columns[0]).to.include({
+            id: "label",
+            name: "Property",
+            field: "label",
+            cssClass: "profiler-details-label-cell",
+        });
+        expect(columns[1]).to.include({
+            id: "value",
+            name: "Value",
+            field: "value",
+            cssClass: "profiler-details-value-cell",
+        });
+    });
+
+    test("enables cell range selection and copy behavior for the details grid", () => {
+        const options = getProfilerDetailsGridOptions(ColorThemeKind.Dark);
+
+        expect(options.enableCellNavigation).to.equal(true);
+        expect(options.enableExcelCopyBuffer).to.equal(true);
+        expect(options.enableTextSelectionOnCells).to.equal(false);
+        expect(options.selectionOptions?.selectionType).to.equal("cell");
+        expect(options.showColumnHeader).to.equal(false);
+        expect(options.autoResize?.container).to.equal(`#${PROFILER_DETAILS_GRID_CONTAINER_ID}`);
+        expect(options.darkMode).to.equal(true);
+    });
+
+    test("does not enable dark mode styling for light themes", () => {
+        const options = getProfilerDetailsGridOptions(ColorThemeKind.Light);
+
+        expect(options.darkMode).to.equal(false);
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/21972 - Replace the profiler Details tab's plain label/value rows with a small SlickGrid so the panel supports real cell range selection and copy behavior instead of browser text selection across cells.

Why this is the right fix:
- matches the ADS/SlickGrid interaction model users expect for profiler details
- centralizes the details-grid row, column, and option setup in a dedicated helper so the behavior is easier to reason about and test
- keeps localized Property/Value headers and profiler-specific cell styling alongside the new grid implementation
- recreates the column definitions whenever the Details tab is shown again because slickgrid-react mutates the column array on unmount; reusing the old array caused the blank grid after switching from Text back to Details
- adds focused unit coverage for the details-grid config so the selection and rendering assumptions stay locked in

Verification:
- npm run build:webviews
- npm run lint
- npx vscode-test --label "Unit Tests" --run out/test/unit/profiler/profilerDetailsGridConfig.test.js --code-version stable
