### PR TITLE
Fix package-extension to work on Windows

### DIFF
--- a/extensions/mssql/scripts/package-extension.js
+++ b/extensions/mssql/scripts/package-extension.js
@@ -112,7 +112,10 @@ function packageExtension(packageName = null) {
 
         logger.debug(`Running: ${npmCommand} ${vsceArgs.join(" ")}`);
 
-        execFileSync(npmCommand, vsceArgs, { stdio: "inherit" });
+        execFileSync(npmCommand, vsceArgs, {
+            stdio: "inherit",
+            shell: process.platform === "win32",
+        });
         logger.success(`Extension packaged${packageName ? `: ${packageName}` : ""}`);
     } catch (error) {
         logger.error(`Packaging failed: ${error.message}`);


### PR DESCRIPTION
The `shell: true` option is required when launching a `.cmd` with Node spawn.  This updates package-extension to work properly on Windows.