### PR TITLE
Updating STS to version accepted by macOS gatekeeper

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -8,7 +8,7 @@ export const config = {
         dotnetRuntimeVersion: "10.0",
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260409.1",
+        version: "6.0.20260424.4",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",


### PR DESCRIPTION
Offline VSIXes (with dotnet runtime bundled) were hitting a signing issue with the macOS gatekeeper