### PR TITLE
Fixing reveal to focus in foreground to avoid switching of webview columns. 

### DIFF
--- a/extensions/mssql/src/controllers/webviewPanelController.ts
+++ b/extensions/mssql/src/controllers/webviewPanelController.ts
@@ -103,7 +103,7 @@ export class WebviewPanelController<State, Reducers, Result = void> extends Webv
      * Displays the webview in the foreground
      * @param viewColumn The view column that the webview will be displayed in
      */
-    public revealToForeground(viewColumn: vscode.ViewColumn = vscode.ViewColumn.One): void {
+    public revealToForeground(viewColumn?: vscode.ViewColumn): void {
         this._panel.reveal(viewColumn, true);
     }
 

--- a/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
@@ -47,7 +47,7 @@ export class ObjectExplorerFilterWebviewController extends WebviewPanelControlle
             },
             {
                 title: vscode.l10n.t("Object Explorer Filter"),
-                viewColumn: vscode.ViewColumn.Beside,
+                viewColumn: vscode.ViewColumn.One,
                 iconPath: {
                     dark: vscode.Uri.joinPath(context.extensionUri, "media", "filter_dark.svg"),
                     light: vscode.Uri.joinPath(context.extensionUri, "media", "filter_light.svg"),

--- a/extensions/mssql/test/unit/webviewPanelController.test.ts
+++ b/extensions/mssql/test/unit/webviewPanelController.test.ts
@@ -140,19 +140,40 @@ suite("WebviewPanelController", () => {
         ).to.equal("function");
     });
 
-    test("Should reveal the panel to the foreground", () => {
-        const controller = createController();
+    test("Should reveal the panel without forcing a view column", () => {
+        const controller = createController({ viewColumn: 2 as vscode.ViewColumn });
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground();
-        expect(revealSpy, "reveal should be called once").to.have.been.calledOnce;
-        expect(revealSpy).to.have.been.calledWith(vscode.ViewColumn.One, true);
+        // Pass undefined so VS Code keeps the panel in its current column;
+        // forcing a column on a freshly-created Beside panel was leaving the
+        // iframe blank (issue #21940).
+        expect(revealSpy).to.have.been.calledWith(undefined, true);
+    });
+
+    test("Should use configured focus behavior when revealing the panel", () => {
+        const controller = createController({
+            viewColumn: 1 as vscode.ViewColumn,
+            preserveFocus: false,
+        });
+        const revealSpy = mockPanel.reveal as sinon.SinonSpy;
+        controller.revealToForeground();
+        expect(revealSpy).to.have.been.calledWith(undefined, false);
+    });
+
+    test("Should preserve focus by default when revealing the panel", () => {
+        const controller = createController({
+            viewColumn: 1 as vscode.ViewColumn,
+            preserveFocus: undefined,
+        });
+        const revealSpy = mockPanel.reveal as sinon.SinonSpy;
+        controller.revealToForeground();
+        expect(revealSpy).to.have.been.calledWith(undefined, true);
     });
 
     test("Should reveal the panel to the foreground with the specified view column", () => {
         const controller = createController();
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground(vscode.ViewColumn.Two);
-        expect(revealSpy, "reveal should be called once").to.have.been.calledOnce;
         expect(revealSpy).to.have.been.calledWith(vscode.ViewColumn.Two, true);
     });
 

--- a/extensions/mssql/test/unit/webviewPanelController.test.ts
+++ b/extensions/mssql/test/unit/webviewPanelController.test.ts
@@ -140,33 +140,13 @@ suite("WebviewPanelController", () => {
         ).to.equal("function");
     });
 
-    test("Should reveal the panel without forcing a view column", () => {
+    test("Should reveal the panel without forcing a view column by default", () => {
         const controller = createController({ viewColumn: 2 as vscode.ViewColumn });
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground();
         // Pass undefined so VS Code keeps the panel in its current column;
         // forcing a column on a freshly-created Beside panel was leaving the
         // iframe blank (issue #21940).
-        expect(revealSpy).to.have.been.calledWith(undefined, true);
-    });
-
-    test("Should use configured focus behavior when revealing the panel", () => {
-        const controller = createController({
-            viewColumn: 1 as vscode.ViewColumn,
-            preserveFocus: false,
-        });
-        const revealSpy = mockPanel.reveal as sinon.SinonSpy;
-        controller.revealToForeground();
-        expect(revealSpy).to.have.been.calledWith(undefined, false);
-    });
-
-    test("Should preserve focus by default when revealing the panel", () => {
-        const controller = createController({
-            viewColumn: 1 as vscode.ViewColumn,
-            preserveFocus: undefined,
-        });
-        const revealSpy = mockPanel.reveal as sinon.SinonSpy;
-        controller.revealToForeground();
         expect(revealSpy).to.have.been.calledWith(undefined, true);
     });
 

--- a/extensions/mssql/test/unit/webviewPanelController.test.ts
+++ b/extensions/mssql/test/unit/webviewPanelController.test.ts
@@ -141,7 +141,7 @@ suite("WebviewPanelController", () => {
     });
 
     test("Should reveal the panel without forcing a view column by default", () => {
-        const controller = createController({ viewColumn: 2 as vscode.ViewColumn });
+        const controller = createController({ viewColumn: vscode.ViewColumn.Two });
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground();
         // Pass undefined so VS Code keeps the panel in its current column;


### PR DESCRIPTION
## Description

Issue: #21940 

Previously, Object Explorer filter webviews were created with ViewColumn.Beside. If a query editor was open in column one, the filter webview could be created in column two.

Immediately after creation, revealToForeground() was called without an explicit column. Its default argument was ViewColumn.One, so VS Code moved the newly-created webview back to column one. In recent VS Code builds, that create-then-move sequence could leave the webview iframe blank until the user switched tabs.

This PR fixes that by changing revealToForeground() so an omitted column stays omitted. VS Code then reveals the webview in its current column instead of moving it.

It also changes Object Explorer Filter to create the webview in ViewColumn.One instead of ViewColumn.Beside, so the filter opens next to Object Explorer rather than beside the active editor column.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
