### PR TITLE
fixes .net tool giving stale cached runtime 

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -5,7 +5,6 @@
 
 export const config = {
     service: {
-        dotnetRuntimeVersion: "10.0",
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
         version: "6.0.20260422.4",

--- a/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
+++ b/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
@@ -7,7 +7,6 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import { ILogger } from "../models/interfaces";
 import * as Constants from "../constants/constants";
-import { config } from "../configurations/config";
 import { ServiceClient } from "../constants/locConstants";
 import { getErrorMessage } from "../utils/utils";
 
@@ -19,8 +18,6 @@ import { getErrorMessage } from "../utils/utils";
  * 2. Error with guidance to install the offline VSIX
  */
 export default class DotnetRuntimeProvider {
-    private _cachedDotnetPath: string | undefined;
-
     constructor(private _logger: ILogger) {}
 
     /**
@@ -28,11 +25,9 @@ export default class DotnetRuntimeProvider {
      * @returns The resolved dotnet executable path.
      * @throws If no runtime can be resolved.
      */
-    public async acquireDotnetRuntime(): Promise<string> {
-        if (this._cachedDotnetPath) {
-            return this._cachedDotnetPath;
-        }
+    public async acquireDotnetRuntime(runtimeConfigPath: string): Promise<string> {
         try {
+            const runtimeVersion = await this.getRuntimeVersion(runtimeConfigPath);
             const extension = vscode.extensions.getExtension(Constants.dotnetRuntimeExtensionId);
             if (!extension) {
                 this._logger.error("The .NET runtime extension is not installed");
@@ -42,7 +37,7 @@ export default class DotnetRuntimeProvider {
             const result = await vscode.commands.executeCommand<{ dotnetPath: string }>(
                 Constants.dotnetAcquireCommand,
                 {
-                    version: config.service.dotnetRuntimeVersion,
+                    version: runtimeVersion,
                     requestingExtensionId: Constants.extensionId,
                     mode: "runtime",
                     forceUpdate: true,
@@ -51,7 +46,6 @@ export default class DotnetRuntimeProvider {
             if (result?.dotnetPath) {
                 await fs.access(result.dotnetPath);
                 this._logger.verbose("Acquired .NET runtime via command: " + result.dotnetPath);
-                this._cachedDotnetPath = result.dotnetPath;
                 return result.dotnetPath;
             }
         } catch (err) {
@@ -59,5 +53,32 @@ export default class DotnetRuntimeProvider {
         }
         this._logger.error("No .NET runtime found");
         throw new Error(ServiceClient.runtimeNotFoundError);
+    }
+
+    private async getRuntimeVersion(runtimeConfigPath: string): Promise<string> {
+        try {
+            const runtimeConfig = JSON.parse(await fs.readFile(runtimeConfigPath, "utf-8")) as {
+                runtimeOptions?: {
+                    framework?: {
+                        name?: string;
+                        version?: string;
+                    };
+                };
+            };
+            const framework = runtimeConfig.runtimeOptions?.framework;
+            if (framework?.name === "Microsoft.NETCore.App" && framework.version) {
+                return framework.version;
+            }
+        } catch (err) {
+            this._logger.error(
+                `Unable to read .NET runtime version from ${runtimeConfigPath}`,
+                getErrorMessage(err),
+            );
+            throw err;
+        }
+
+        throw new Error(
+            `Unable to find Microsoft.NETCore.App version in runtime config: ${runtimeConfigPath}`,
+        );
     }
 }

--- a/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
+++ b/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import { ILogger } from "../models/interfaces";
 import * as Constants from "../constants/constants";
 import { config } from "../configurations/config";
@@ -43,9 +44,12 @@ export default class DotnetRuntimeProvider {
                 {
                     version: config.service.dotnetRuntimeVersion,
                     requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
                 },
             );
             if (result?.dotnetPath) {
+                await fs.access(result.dotnetPath);
                 this._logger.verbose("Acquired .NET runtime via command: " + result.dotnetPath);
                 this._cachedDotnetPath = result.dotnetPath;
                 return result.dotnetPath;

--- a/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
+++ b/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
@@ -66,7 +66,7 @@ export default class DotnetRuntimeProvider {
                 };
             };
             const framework = runtimeConfig.runtimeOptions?.framework;
-            if (framework?.name === "Microsoft.NETCore.App" && framework.version) {
+            if (framework?.version) {
                 return framework.version;
             }
         } catch (err) {

--- a/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
+++ b/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
@@ -66,7 +66,7 @@ export default class DotnetRuntimeProvider {
                 };
             };
             const framework = runtimeConfig.runtimeOptions?.framework;
-            if (framework?.version) {
+            if (framework?.name === "Microsoft.NETCore.App" && framework.version) {
                 return framework.version;
             }
         } catch (err) {

--- a/extensions/mssql/src/languageservice/serviceExecutablePaths.ts
+++ b/extensions/mssql/src/languageservice/serviceExecutablePaths.ts
@@ -42,3 +42,13 @@ export function getServiceExecutablePath(
 ): string {
     return path.join(folderPath, getServiceExecutableFileName(runtime, filePrefix));
 }
+
+/**
+ * Returns the full path to the runtime configuration file for a framework-dependent service.
+ */
+export function getRuntimeConfigPath(servicePath: string): string {
+    return path.join(
+        path.dirname(servicePath),
+        `${path.basename(servicePath, path.extname(servicePath))}.runtimeconfig.json`,
+    );
+}

--- a/extensions/mssql/src/languageservice/serviceclient.ts
+++ b/extensions/mssql/src/languageservice/serviceclient.ts
@@ -35,7 +35,7 @@ import { getAppDataPath, getEnableConnectionPoolingConfig } from "../azure/utils
 import { serviceName } from "../azure/constants";
 import { sendActionEvent, sendErrorEvent } from "../telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
-import { ServiceExecutable } from "./serviceExecutablePaths";
+import { getRuntimeConfigPath, ServiceExecutable } from "./serviceExecutablePaths";
 
 const STS_OVERRIDE_ENV_VAR = "MSSQL_SQLTOOLSSERVICE";
 const SERVICE_LAUNCH_TELEMETRY_VIEW = TelemetryViews.ServiceClient;
@@ -498,7 +498,9 @@ export default class SqlToolsServiceClient {
         if (executablePath.endsWith(".dll")) {
             try {
                 return {
-                    command: await this._dotnetRuntimeProvider.acquireDotnetRuntime(),
+                    command: await this._dotnetRuntimeProvider.acquireDotnetRuntime(
+                        getRuntimeConfigPath(executablePath),
+                    ),
                     args: [executablePath],
                 };
             } catch (err) {

--- a/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
+++ b/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
@@ -11,7 +11,6 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import DotnetRuntimeProvider from "../../src/languageservice/dotnetRuntimeProvider";
 import * as Constants from "../../src/constants/constants";
-import { config } from "../../src/configurations/config";
 import { ILogger } from "../../src/models/interfaces";
 import { ServiceClient } from "../../src/constants/locConstants";
 import { stubILogger } from "./utils";
@@ -26,6 +25,7 @@ suite("DotnetRuntimeProvider tests", () => {
     let activateExtensionStub: sinon.SinonStub;
     let showErrorMessageStub: sinon.SinonStub;
     let fsAccessStub: sinon.SinonStub;
+    let fsReadFileStub: sinon.SinonStub;
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -44,6 +44,16 @@ suite("DotnetRuntimeProvider tests", () => {
             });
         showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
         fsAccessStub = sandbox.stub(fs, "access").resolves();
+        fsReadFileStub = sandbox.stub(fs, "readFile").resolves(
+            JSON.stringify({
+                runtimeOptions: {
+                    framework: {
+                        name: "Microsoft.NETCore.App",
+                        version: "10.0.7",
+                    },
+                },
+            }),
+        );
     });
 
     teardown(() => {
@@ -59,13 +69,15 @@ suite("DotnetRuntimeProvider tests", () => {
             executeCommandStub.resolves({ dotnetPath: "/extension/dotnet" });
 
             const provider = createProvider();
-            const result = await provider.acquireDotnetRuntime();
+            const result = await provider.acquireDotnetRuntime(
+                "/extension/service.runtimeconfig.json",
+            );
 
             expect(result).to.equal("/extension/dotnet");
             expect(executeCommandStub).to.have.been.calledWithExactly(
                 Constants.dotnetAcquireCommand,
                 {
-                    version: config.service.dotnetRuntimeVersion,
+                    version: "10.0.7",
                     requestingExtensionId: Constants.extensionId,
                     mode: "runtime",
                     forceUpdate: true,
@@ -77,6 +89,59 @@ suite("DotnetRuntimeProvider tests", () => {
             expect(logger.verbose).to.have.been.calledWithMatch("Acquired .NET runtime via");
         });
 
+        test("should request the runtime version from the provided runtimeconfig", async () => {
+            executeCommandStub.resolves({ dotnetPath: "/extension/dotnet" });
+            fsReadFileStub.resolves(
+                JSON.stringify({
+                    runtimeOptions: {
+                        framework: {
+                            name: "Microsoft.NETCore.App",
+                            version: "10.0.7",
+                        },
+                    },
+                }),
+            );
+
+            const provider = createProvider();
+            const result = await provider.acquireDotnetRuntime(
+                "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+            );
+
+            expect(result).to.equal("/extension/dotnet");
+            expect(fsReadFileStub).to.have.been.calledWith(
+                "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+                "utf-8",
+            );
+            expect(executeCommandStub).to.have.been.calledWithExactly(
+                Constants.dotnetAcquireCommand,
+                {
+                    version: "10.0.7",
+                    requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
+                },
+            );
+        });
+
+        test("should fall through when runtimeconfig cannot be read", async () => {
+            fsReadFileStub.rejects(new Error("ENOENT"));
+            showErrorMessageStub.resolves(undefined);
+
+            const provider = createProvider();
+            try {
+                await provider.acquireDotnetRuntime(
+                    "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+                );
+                expect.fail("Expected acquireDotnetRuntime to throw");
+            } catch (err) {
+                expect(logger.error).to.have.been.calledWithMatch(
+                    "Unable to read .NET runtime version",
+                );
+                expect(executeCommandStub).not.to.have.been.called;
+                expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
+            }
+        });
+
         test("should fall through when the runtime extension returns no path", async () => {
             executeCommandStub.resolves(undefined);
             showErrorMessageStub.resolves(undefined);
@@ -84,7 +149,7 @@ suite("DotnetRuntimeProvider tests", () => {
             const provider = createProvider();
 
             try {
-                await provider.acquireDotnetRuntime();
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
                 expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
@@ -99,7 +164,7 @@ suite("DotnetRuntimeProvider tests", () => {
             const provider = createProvider();
 
             try {
-                await provider.acquireDotnetRuntime();
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
                 expect(logger.error).to.have.been.calledWithMatch("Error acquiring .NET runtime");
@@ -114,7 +179,7 @@ suite("DotnetRuntimeProvider tests", () => {
             const provider = createProvider();
 
             try {
-                await provider.acquireDotnetRuntime();
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
                 expect(logger.error).to.have.been.calledWithMatch("Error acquiring .NET runtime");

--- a/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
+++ b/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
@@ -8,6 +8,7 @@ import sinonChai from "sinon-chai";
 import * as chai from "chai";
 import { expect } from "chai";
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import DotnetRuntimeProvider from "../../src/languageservice/dotnetRuntimeProvider";
 import * as Constants from "../../src/constants/constants";
 import { config } from "../../src/configurations/config";
@@ -24,6 +25,7 @@ suite("DotnetRuntimeProvider tests", () => {
     let getExtensionStub: sinon.SinonStub;
     let activateExtensionStub: sinon.SinonStub;
     let showErrorMessageStub: sinon.SinonStub;
+    let fsAccessStub: sinon.SinonStub;
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -41,6 +43,7 @@ suite("DotnetRuntimeProvider tests", () => {
                 return undefined;
             });
         showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+        fsAccessStub = sandbox.stub(fs, "access").resolves();
     });
 
     teardown(() => {
@@ -64,8 +67,11 @@ suite("DotnetRuntimeProvider tests", () => {
                 {
                     version: config.service.dotnetRuntimeVersion,
                     requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
                 },
             );
+            expect(fsAccessStub).to.have.been.calledWith("/extension/dotnet");
             expect(getExtensionStub).to.have.been.calledWith(Constants.dotnetRuntimeExtensionId);
             expect(activateExtensionStub).to.have.been.called;
             expect(logger.verbose).to.have.been.calledWithMatch("Acquired .NET runtime via");
@@ -81,6 +87,22 @@ suite("DotnetRuntimeProvider tests", () => {
                 await provider.acquireDotnetRuntime();
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
+                expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
+            }
+        });
+
+        test("should fall through when the runtime extension returns an invalid path", async () => {
+            executeCommandStub.resolves({ dotnetPath: "/missing/dotnet" });
+            fsAccessStub.rejects(new Error("ENOENT"));
+            showErrorMessageStub.resolves(undefined);
+
+            const provider = createProvider();
+
+            try {
+                await provider.acquireDotnetRuntime();
+                expect.fail("Expected acquireDotnetRuntime to throw");
+            } catch (err) {
+                expect(logger.error).to.have.been.calledWithMatch("Error acquiring .NET runtime");
                 expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
             }
         });

--- a/extensions/mssql/test/unit/serviceClient.test.ts
+++ b/extensions/mssql/test/unit/serviceClient.test.ts
@@ -371,6 +371,9 @@ suite("Service Client tests", () => {
                 command: "/usr/local/bin/dotnet",
                 args: ["MicrosoftSqlToolsServiceLayer.dll"],
             });
+            expect(dotnetRuntimeProvider.acquireDotnetRuntime).to.have.been.calledWith(
+                "MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+            );
         });
 
         test("uses the executable path directly for self-contained services", async () => {


### PR DESCRIPTION
## Description

Issue #22015 
Issue #22002

Fix portable SQL Tools Service runtime acquisition so MSSQL requests the exact .NET runtime version declared by the downloaded STS payload.

Previously, MSSQL acquired `.NET 10.0` from the .NET Install Tool. Since that request was broad, the tool could return an existing cached `10.0.x` runtime that was older than the patch version required by the current STS build. That could lead to startup failures such as:

```
You must install or update .NET to run this application.

App: c:\Users\SchabaJo\.vscode\extensions\ms-mssql.mssql-1.42.0\sqltoolsservice\6.0.20260409.1\Portable\SqlToolsResourceProviderService.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '10.0.5' (x64)
.NET location: c:\Users\SchabaJo\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\10.0.1~x64\

The following frameworks were found:
  10.0.1 at [c:\Users\SchabaJo\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\10.0.1~x64\shared\Microsoft.NETCore.App]
```

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
