### PR TITLE
Port #22016: Fix .NET tool giving stale cached runtime

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -5,7 +5,6 @@
 
 export const config = {
     service: {
-        dotnetRuntimeVersion: "10.0",
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
         version: "6.0.20260409.1",

--- a/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
+++ b/extensions/mssql/src/languageservice/dotnetRuntimeProvider.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import { ILogger } from "../models/interfaces";
 import * as Constants from "../constants/constants";
-import { config } from "../configurations/config";
 import { ServiceClient } from "../constants/locConstants";
 import { getErrorMessage } from "../utils/utils";
 
@@ -18,8 +18,6 @@ import { getErrorMessage } from "../utils/utils";
  * 2. Error with guidance to install the offline VSIX
  */
 export default class DotnetRuntimeProvider {
-    private _cachedDotnetPath: string | undefined;
-
     constructor(private _logger: ILogger) {}
 
     /**
@@ -27,11 +25,9 @@ export default class DotnetRuntimeProvider {
      * @returns The resolved dotnet executable path.
      * @throws If no runtime can be resolved.
      */
-    public async acquireDotnetRuntime(): Promise<string> {
-        if (this._cachedDotnetPath) {
-            return this._cachedDotnetPath;
-        }
+    public async acquireDotnetRuntime(runtimeConfigPath: string): Promise<string> {
         try {
+            const runtimeVersion = await this.getRuntimeVersion(runtimeConfigPath);
             const extension = vscode.extensions.getExtension(Constants.dotnetRuntimeExtensionId);
             if (!extension) {
                 this._logger.error("The .NET runtime extension is not installed");
@@ -41,13 +37,15 @@ export default class DotnetRuntimeProvider {
             const result = await vscode.commands.executeCommand<{ dotnetPath: string }>(
                 Constants.dotnetAcquireCommand,
                 {
-                    version: config.service.dotnetRuntimeVersion,
+                    version: runtimeVersion,
                     requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
                 },
             );
             if (result?.dotnetPath) {
+                await fs.access(result.dotnetPath);
                 this._logger.verbose("Acquired .NET runtime via command: " + result.dotnetPath);
-                this._cachedDotnetPath = result.dotnetPath;
                 return result.dotnetPath;
             }
         } catch (err) {
@@ -55,5 +53,32 @@ export default class DotnetRuntimeProvider {
         }
         this._logger.error("No .NET runtime found");
         throw new Error(ServiceClient.runtimeNotFoundError);
+    }
+
+    private async getRuntimeVersion(runtimeConfigPath: string): Promise<string> {
+        try {
+            const runtimeConfig = JSON.parse(await fs.readFile(runtimeConfigPath, "utf-8")) as {
+                runtimeOptions?: {
+                    framework?: {
+                        name?: string;
+                        version?: string;
+                    };
+                };
+            };
+            const framework = runtimeConfig.runtimeOptions?.framework;
+            if (framework?.name === "Microsoft.NETCore.App" && framework.version) {
+                return framework.version;
+            }
+        } catch (err) {
+            this._logger.error(
+                `Unable to read .NET runtime version from ${runtimeConfigPath}`,
+                getErrorMessage(err),
+            );
+            throw err;
+        }
+
+        throw new Error(
+            `Unable to find Microsoft.NETCore.App version in runtime config: ${runtimeConfigPath}`,
+        );
     }
 }

--- a/extensions/mssql/src/languageservice/serviceExecutablePaths.ts
+++ b/extensions/mssql/src/languageservice/serviceExecutablePaths.ts
@@ -42,3 +42,13 @@ export function getServiceExecutablePath(
 ): string {
     return path.join(folderPath, getServiceExecutableFileName(runtime, filePrefix));
 }
+
+/**
+ * Returns the full path to the runtime configuration file for a framework-dependent service.
+ */
+export function getRuntimeConfigPath(servicePath: string): string {
+    return path.join(
+        path.dirname(servicePath),
+        `${path.basename(servicePath, path.extname(servicePath))}.runtimeconfig.json`,
+    );
+}

--- a/extensions/mssql/src/languageservice/serviceclient.ts
+++ b/extensions/mssql/src/languageservice/serviceclient.ts
@@ -35,7 +35,7 @@ import { getAppDataPath, getEnableConnectionPoolingConfig } from "../azure/utils
 import { serviceName } from "../azure/constants";
 import { sendActionEvent, sendErrorEvent } from "../telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
-import { ServiceExecutable } from "./serviceExecutablePaths";
+import { getRuntimeConfigPath, ServiceExecutable } from "./serviceExecutablePaths";
 
 const STS_OVERRIDE_ENV_VAR = "MSSQL_SQLTOOLSSERVICE";
 const SERVICE_LAUNCH_TELEMETRY_VIEW = TelemetryViews.ServiceClient;
@@ -498,7 +498,9 @@ export default class SqlToolsServiceClient {
         if (executablePath.endsWith(".dll")) {
             try {
                 return {
-                    command: await this._dotnetRuntimeProvider.acquireDotnetRuntime(),
+                    command: await this._dotnetRuntimeProvider.acquireDotnetRuntime(
+                        getRuntimeConfigPath(executablePath),
+                    ),
                     args: [executablePath],
                 };
             } catch (err) {

--- a/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
+++ b/extensions/mssql/test/unit/dotnetRuntimeProvider.test.ts
@@ -8,9 +8,9 @@ import sinonChai from "sinon-chai";
 import * as chai from "chai";
 import { expect } from "chai";
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import DotnetRuntimeProvider from "../../src/languageservice/dotnetRuntimeProvider";
 import * as Constants from "../../src/constants/constants";
-import { config } from "../../src/configurations/config";
 import { ILogger } from "../../src/models/interfaces";
 import { ServiceClient } from "../../src/constants/locConstants";
 import { stubILogger } from "./utils";
@@ -24,6 +24,8 @@ suite("DotnetRuntimeProvider tests", () => {
     let getExtensionStub: sinon.SinonStub;
     let activateExtensionStub: sinon.SinonStub;
     let showErrorMessageStub: sinon.SinonStub;
+    let fsAccessStub: sinon.SinonStub;
+    let fsReadFileStub: sinon.SinonStub;
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -41,6 +43,17 @@ suite("DotnetRuntimeProvider tests", () => {
                 return undefined;
             });
         showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+        fsAccessStub = sandbox.stub(fs, "access").resolves();
+        fsReadFileStub = sandbox.stub(fs, "readFile").resolves(
+            JSON.stringify({
+                runtimeOptions: {
+                    framework: {
+                        name: "Microsoft.NETCore.App",
+                        version: "10.0.7",
+                    },
+                },
+            }),
+        );
     });
 
     teardown(() => {
@@ -56,19 +69,77 @@ suite("DotnetRuntimeProvider tests", () => {
             executeCommandStub.resolves({ dotnetPath: "/extension/dotnet" });
 
             const provider = createProvider();
-            const result = await provider.acquireDotnetRuntime();
+            const result = await provider.acquireDotnetRuntime(
+                "/extension/service.runtimeconfig.json",
+            );
 
             expect(result).to.equal("/extension/dotnet");
             expect(executeCommandStub).to.have.been.calledWithExactly(
                 Constants.dotnetAcquireCommand,
                 {
-                    version: config.service.dotnetRuntimeVersion,
+                    version: "10.0.7",
                     requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
                 },
             );
+            expect(fsAccessStub).to.have.been.calledWith("/extension/dotnet");
             expect(getExtensionStub).to.have.been.calledWith(Constants.dotnetRuntimeExtensionId);
             expect(activateExtensionStub).to.have.been.called;
             expect(logger.verbose).to.have.been.calledWithMatch("Acquired .NET runtime via");
+        });
+
+        test("should request the runtime version from the provided runtimeconfig", async () => {
+            executeCommandStub.resolves({ dotnetPath: "/extension/dotnet" });
+            fsReadFileStub.resolves(
+                JSON.stringify({
+                    runtimeOptions: {
+                        framework: {
+                            name: "Microsoft.NETCore.App",
+                            version: "10.0.7",
+                        },
+                    },
+                }),
+            );
+
+            const provider = createProvider();
+            const result = await provider.acquireDotnetRuntime(
+                "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+            );
+
+            expect(result).to.equal("/extension/dotnet");
+            expect(fsReadFileStub).to.have.been.calledWith(
+                "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+                "utf-8",
+            );
+            expect(executeCommandStub).to.have.been.calledWithExactly(
+                Constants.dotnetAcquireCommand,
+                {
+                    version: "10.0.7",
+                    requestingExtensionId: Constants.extensionId,
+                    mode: "runtime",
+                    forceUpdate: true,
+                },
+            );
+        });
+
+        test("should fall through when runtimeconfig cannot be read", async () => {
+            fsReadFileStub.rejects(new Error("ENOENT"));
+            showErrorMessageStub.resolves(undefined);
+
+            const provider = createProvider();
+            try {
+                await provider.acquireDotnetRuntime(
+                    "/extension/sqltoolsservice/MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+                );
+                expect.fail("Expected acquireDotnetRuntime to throw");
+            } catch (err) {
+                expect(logger.error).to.have.been.calledWithMatch(
+                    "Unable to read .NET runtime version",
+                );
+                expect(executeCommandStub).not.to.have.been.called;
+                expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
+            }
         });
 
         test("should fall through when the runtime extension returns no path", async () => {
@@ -78,9 +149,25 @@ suite("DotnetRuntimeProvider tests", () => {
             const provider = createProvider();
 
             try {
-                await provider.acquireDotnetRuntime();
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
+                expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
+            }
+        });
+
+        test("should fall through when the runtime extension returns an invalid path", async () => {
+            executeCommandStub.resolves({ dotnetPath: "/missing/dotnet" });
+            fsAccessStub.rejects(new Error("ENOENT"));
+            showErrorMessageStub.resolves(undefined);
+
+            const provider = createProvider();
+
+            try {
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
+                expect.fail("Expected acquireDotnetRuntime to throw");
+            } catch (err) {
+                expect(logger.error).to.have.been.calledWithMatch("Error acquiring .NET runtime");
                 expect((err as Error).message).to.equal(ServiceClient.runtimeNotFoundError);
             }
         });
@@ -92,7 +179,7 @@ suite("DotnetRuntimeProvider tests", () => {
             const provider = createProvider();
 
             try {
-                await provider.acquireDotnetRuntime();
+                await provider.acquireDotnetRuntime("/extension/service.runtimeconfig.json");
                 expect.fail("Expected acquireDotnetRuntime to throw");
             } catch (err) {
                 expect(logger.error).to.have.been.calledWithMatch("Error acquiring .NET runtime");

--- a/extensions/mssql/test/unit/serviceClient.test.ts
+++ b/extensions/mssql/test/unit/serviceClient.test.ts
@@ -371,6 +371,9 @@ suite("Service Client tests", () => {
                 command: "/usr/local/bin/dotnet",
                 args: ["MicrosoftSqlToolsServiceLayer.dll"],
             });
+            expect(dotnetRuntimeProvider.acquireDotnetRuntime).to.have.been.calledWith(
+                "MicrosoftSqlToolsServiceLayer.runtimeconfig.json",
+            );
         });
 
         test("uses the executable path directly for self-contained services", async () => {


### PR DESCRIPTION
## Description

Port of #22016 to `release/1.42`.

Fixes portable SQL Tools Service runtime acquisition so MSSQL requests the exact .NET runtime version declared by the downloaded STS payload, instead of requesting a broad `.NET 10.0` version that could return a stale cached runtime.

### Original issue
- #22015
- #22002

### Changes
- Reads the exact runtime version from the service's `.runtimeconfig.json` instead of using a hardcoded version
- Passes `forceUpdate: true` and `mode: "runtime"` to the .NET Install Tool acquire command
- Validates the returned dotnet path exists before using it
- Removes the in-memory cached dotnet path (stale cache was part of the problem)
- Adds comprehensive unit tests for the new behavior