### PR TITLE
Port #22010: Fix reveal to focus in foreground to avoid switching of webview columns

### DIFF
--- a/extensions/mssql/src/controllers/webviewPanelController.ts
+++ b/extensions/mssql/src/controllers/webviewPanelController.ts
@@ -103,7 +103,7 @@ export class WebviewPanelController<State, Reducers, Result = void> extends Webv
      * Displays the webview in the foreground
      * @param viewColumn The view column that the webview will be displayed in
      */
-    public revealToForeground(viewColumn: vscode.ViewColumn = vscode.ViewColumn.One): void {
+    public revealToForeground(viewColumn?: vscode.ViewColumn): void {
         this._panel.reveal(viewColumn, true);
     }
 

--- a/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
@@ -47,7 +47,7 @@ export class ObjectExplorerFilterWebviewController extends WebviewPanelControlle
             },
             {
                 title: vscode.l10n.t("Object Explorer Filter"),
-                viewColumn: vscode.ViewColumn.Beside,
+                viewColumn: vscode.ViewColumn.One,
                 iconPath: {
                     dark: vscode.Uri.joinPath(context.extensionUri, "media", "filter_dark.svg"),
                     light: vscode.Uri.joinPath(context.extensionUri, "media", "filter_light.svg"),

--- a/extensions/mssql/test/unit/webviewPanelController.test.ts
+++ b/extensions/mssql/test/unit/webviewPanelController.test.ts
@@ -140,19 +140,20 @@ suite("WebviewPanelController", () => {
         ).to.equal("function");
     });
 
-    test("Should reveal the panel to the foreground", () => {
-        const controller = createController();
+    test("Should reveal the panel without forcing a view column by default", () => {
+        const controller = createController({ viewColumn: vscode.ViewColumn.Two });
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground();
-        expect(revealSpy, "reveal should be called once").to.have.been.calledOnce;
-        expect(revealSpy).to.have.been.calledWith(vscode.ViewColumn.One, true);
+        // Pass undefined so VS Code keeps the panel in its current column;
+        // forcing a column on a freshly-created Beside panel was leaving the
+        // iframe blank (issue #21940).
+        expect(revealSpy).to.have.been.calledWith(undefined, true);
     });
 
     test("Should reveal the panel to the foreground with the specified view column", () => {
         const controller = createController();
         const revealSpy = mockPanel.reveal as sinon.SinonSpy;
         controller.revealToForeground(vscode.ViewColumn.Two);
-        expect(revealSpy, "reveal should be called once").to.have.been.calledOnce;
         expect(revealSpy).to.have.been.calledWith(vscode.ViewColumn.Two, true);
     });
 


### PR DESCRIPTION
## Description

Port of #22010 to `release/1.42`.

Fixes Object Explorer filter webviews appearing blank by correcting how `revealToForeground()` handles the view column parameter.

### Original issue
- #21940

### Changes
- Changed `revealToForeground()` so an omitted column stays omitted, letting VS Code reveal the webview in its current column instead of moving it
- Changed Object Explorer Filter to create the webview in `ViewColumn.One` instead of `ViewColumn.Beside`, so the filter opens next to Object Explorer rather than beside the active editor column