### PR TITLE
Add schema designer artifacts to workspace

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -715,6 +715,7 @@
     "Drizzle": "Drizzle",
     "SQLAlchemy": "SQLAlchemy",
     "EF Core": "EF Core",
+    "Add to workspace": "Add to workspace",
     "Delete Confirmation": "Delete Confirmation",
     "Are you sure you want to delete the selected items?": "Are you sure you want to delete the selected items?",
     "Undo": "Undo",
@@ -2187,6 +2188,10 @@
         "message": "Failed to copy text to clipboard: {0}",
         "comment": ["{0} is the error message"]
     },
+    "Failed to add text to workspace: {0}/{0} is the error message": {
+        "message": "Failed to add text to workspace: {0}",
+        "comment": ["{0} is the error message"]
+    },
     "Schema designer details are not available.": "Schema designer details are not available.",
     "Copying results...": "Copying results...",
     "Results copied to clipboard": "Results copied to clipboard",
@@ -2757,6 +2762,11 @@
         "comment": ["{0} is the file path where the MCP server configuration exists"]
     },
     "No workspace folder is open. Open a folder to add the MCP server configuration.": "No workspace folder is open. Open a folder to add the MCP server configuration.",
+    "No workspace folder is open. Open a folder to add the generated file.": "No workspace folder is open. Open a folder to add the generated file.",
+    "Generated file added to {0}/{0} is the generated file path": {
+        "message": "Generated file added to {0}",
+        "comment": ["{0} is the generated file path"]
+    },
     "Config copied to clipboard": "Config copied to clipboard",
     "URL copied to clipboard": "URL copied to clipboard",
     "Logs copied to clipboard": "Logs copied to clipboard",

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -791,6 +791,12 @@ export let failedToCopyTextToClipboard = (errorMessage: string) =>
         args: [errorMessage],
         comment: ["{0} is the error message"],
     });
+export let failedToAddTextToWorkspace = (errorMessage: string) =>
+    l10n.t({
+        message: "Failed to add text to workspace: {0}",
+        args: [errorMessage],
+        comment: ["{0} is the error message"],
+    });
 export let schemaDesignerDetailsUnavailable = l10n.t("Schema designer details are not available.");
 export let copyingResults = l10n.t("Copying results...");
 export let resultsCopiedToClipboard = l10n.t("Results copied to clipboard");
@@ -2004,6 +2010,15 @@ export class SchemaDesigner {
     public static noWorkspaceOpenForMcp = l10n.t(
         "No workspace folder is open. Open a folder to add the MCP server configuration.",
     );
+    public static noWorkspaceOpenForGeneratedFile = l10n.t(
+        "No workspace folder is open. Open a folder to add the generated file.",
+    );
+    public static generatedFileAddedToWorkspace = (filePath: string) =>
+        l10n.t({
+            message: "Generated file added to {0}",
+            args: [filePath],
+            comment: ["{0} is the generated file path"],
+        });
     public static configCopiedToClipboard = l10n.t("Config copied to clipboard");
     public static urlCopiedToClipboard = l10n.t("URL copied to clipboard");
     public static logsCopiedToClipboard = l10n.t("Logs copied to clipboard");

--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -39,6 +39,31 @@ function isCopilotChatInstalled(): boolean {
 }
 
 const SCHEMA_DESIGNER_VIEW_ID = "schemaDesigner";
+const DAB_CONFIG_FILE_EXTENSION = "json";
+const DEFINITION_FILE_EXTENSION_BY_KIND: Record<SchemaDesigner.DefinitionKind, string> = {
+    [SchemaDesigner.DefinitionKind.Sql]: "sql",
+    [SchemaDesigner.DefinitionKind.Prisma]: "prisma",
+    [SchemaDesigner.DefinitionKind.Sequelize]: "ts",
+    [SchemaDesigner.DefinitionKind.TypeOrm]: "ts",
+    [SchemaDesigner.DefinitionKind.Drizzle]: "ts",
+    [SchemaDesigner.DefinitionKind.SqlAlchemy]: "py",
+    [SchemaDesigner.DefinitionKind.EfCore]: "cs",
+};
+
+function sanitizeFileNamePart(value: string): string {
+    const sanitized = value
+        .trim()
+        .replace(/[^A-Za-z0-9._-]+/g, "_")
+        .replace(/^_+|_+$/g, "");
+    return sanitized || "database";
+}
+
+function getDateFileNamePart(date = new Date()): string {
+    const year = date.getFullYear().toString();
+    const month = (date.getMonth() + 1).toString().padStart(2, "0");
+    const day = date.getDate().toString().padStart(2, "0");
+    return `${year}${month}${day}`;
+}
 
 function getCopilotChatDiscoveryDismissedState(
     context: vscode.ExtensionContext,
@@ -369,6 +394,23 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
             }
         });
 
+        this.onNotification(
+            SchemaDesigner.AddDefinitionToWorkspaceNotification.type,
+            async (params) => {
+                try {
+                    const definition = await this.createDefinitionOutput(params);
+                    await this.addTextToWorkspace(
+                        definition.text,
+                        DEFINITION_FILE_EXTENSION_BY_KIND[params.definitionKind],
+                    );
+                } catch (error) {
+                    await vscode.window.showErrorMessage(
+                        LocConstants.failedToAddTextToWorkspace(getErrorMessage(error)),
+                    );
+                }
+            },
+        );
+
         this.onNotification(SchemaDesigner.OpenInEditorWithConnectionNotification.type, () => {
             const generateScriptActivity = startActivity(
                 TelemetryViews.SchemaDesigner,
@@ -480,6 +522,21 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
             });
 
             await vscode.window.showTextDocument(doc);
+        });
+
+        this.onNotification(Dab.AddConfigToWorkspaceNotification.type, async (payload) => {
+            try {
+                await this.addTextToWorkspace(payload.configContent, DAB_CONFIG_FILE_EXTENSION);
+
+                sendActionEvent(TelemetryViews.SchemaDesigner, TelemetryActions.ExportDabConfig, {
+                    language: "json",
+                    target: "workspace",
+                });
+            } catch (error) {
+                await vscode.window.showErrorMessage(
+                    LocConstants.failedToAddTextToWorkspace(getErrorMessage(error)),
+                );
+            }
         });
 
         this.onNotification(Dab.OpenLogsInNewTabNotification.type, async (payload) => {
@@ -645,6 +702,24 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
         }
 
         return getSchemaDesignerDefinitionOutput(updatedSchema, definitionKind);
+    }
+
+    private async addTextToWorkspace(text: string, fileExtension: string): Promise<vscode.Uri> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri;
+        if (!workspaceFolder) {
+            throw new Error(LocConstants.SchemaDesigner.noWorkspaceOpenForGeneratedFile);
+        }
+
+        const baseName = `${sanitizeFileNamePart(this.databaseName)}_${getDateFileNamePart()}`;
+        const outputUri = await getUniqueFilePath(workspaceFolder, baseName, fileExtension);
+        await vscode.workspace.fs.writeFile(outputUri, Buffer.from(text, "utf8"));
+
+        const document = await vscode.workspace.openTextDocument(outputUri);
+        await vscode.window.showTextDocument(document, { preview: false });
+        await vscode.window.showInformationMessage(
+            LocConstants.SchemaDesigner.generatedFileAddedToWorkspace(outputUri.fsPath),
+        );
+        return outputUri;
     }
 
     private setupConfigurationListener() {

--- a/extensions/mssql/src/sharedInterfaces/dab.ts
+++ b/extensions/mssql/src/sharedInterfaces/dab.ts
@@ -394,6 +394,19 @@ export namespace Dab {
     }
 
     /**
+     * Notification to add the generated config to the open workspace.
+     */
+    export interface AddConfigToWorkspaceParams {
+        configContent: string;
+    }
+
+    export namespace AddConfigToWorkspaceNotification {
+        export const type = new NotificationType<AddConfigToWorkspaceParams>(
+            "dab/addConfigToWorkspace",
+        );
+    }
+
+    /**
      * Notification to open deployment logs in a new tab.
      */
     export interface OpenLogsInNewTabParams {

--- a/extensions/mssql/src/sharedInterfaces/schemaDesigner.ts
+++ b/extensions/mssql/src/sharedInterfaces/schemaDesigner.ts
@@ -379,6 +379,11 @@ export namespace SchemaDesigner {
         definitionKind?: DefinitionKind;
     }
 
+    export interface AddDefinitionToWorkspaceOptions {
+        updatedSchema: Schema;
+        definitionKind: DefinitionKind;
+    }
+
     export interface SchemaDesignerReducers {
         exportToFile: ExportFileOptions;
         getScript: GetScriptOptions;
@@ -424,6 +429,12 @@ export namespace SchemaDesigner {
     }
     export namespace OpenInEditorNotification {
         export const type = new NotificationType<OpenInEditorOptions>("openInEditor");
+    }
+
+    export namespace AddDefinitionToWorkspaceNotification {
+        export const type = new NotificationType<AddDefinitionToWorkspaceOptions>(
+            "addDefinitionToWorkspace",
+        );
     }
 
     export namespace CopyToClipboardNotification {

--- a/extensions/mssql/src/webviews/common/definitionPanel.tsx
+++ b/extensions/mssql/src/webviews/common/definitionPanel.tsx
@@ -90,6 +90,7 @@ export interface ScriptTabProps {
     themeKind: ColorThemeKind;
     language?: string;
     headerActions?: ReactNode;
+    addToWorkspace?: (script: string) => void;
     openInEditor: (script: string) => void;
     copyToClipboard: (script: string) => void;
 }
@@ -127,6 +128,16 @@ function getScriptTab(
         headerActions: (
             <>
                 {props.headerActions}
+                {props.addToWorkspace && (
+                    <Button
+                        size="small"
+                        appearance="subtle"
+                        title={locConstants.schemaDesigner.addToWorkspace}
+                        icon={<FluentIcons.DocumentAdd16Regular />}
+                        onClick={() => props.addToWorkspace?.(props.value)}>
+                        {locConstants.schemaDesigner.addToWorkspace}
+                    </Button>
+                )}
                 <Button
                     size="small"
                     appearance="subtle"

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1098,6 +1098,7 @@ export class LocConstants {
             definitionTypeDrizzle: l10n.t("Drizzle"),
             definitionTypeSqlAlchemy: l10n.t("SQLAlchemy"),
             definitionTypeEfCore: l10n.t("EF Core"),
+            addToWorkspace: l10n.t("Add to workspace"),
             copy: l10n.t("Copy"),
             close: l10n.t("Close"),
             deleteConfirmation: l10n.t("Delete Confirmation"),

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabContext.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabContext.tsx
@@ -28,6 +28,7 @@ interface DabContextProps {
     setDabTextFilter: (text: string) => void;
     dabConfigTextFileContent: string;
     openDabConfigInEditor: (configContent: string) => void;
+    addDabConfigToWorkspace: (configContent: string) => void;
     dabDeploymentState: Dab.DabDeploymentState;
     openDabDeploymentDialog: () => void;
     closeDabDeploymentDialog: () => void;
@@ -270,6 +271,15 @@ export const DabProvider: React.FC<DabProviderProps> = ({ children }) => {
         [extensionRpc],
     );
 
+    const addDabConfigToWorkspace = useCallback(
+        (configContent: string) => {
+            void extensionRpc.sendNotification(Dab.AddConfigToWorkspaceNotification.type, {
+                configContent,
+            });
+        },
+        [extensionRpc],
+    );
+
     const openLogsInNewTab = useCallback(
         (logsContent: string) => {
             void extensionRpc.sendNotification(Dab.OpenLogsInNewTabNotification.type, {
@@ -477,6 +487,7 @@ export const DabProvider: React.FC<DabProviderProps> = ({ children }) => {
                 setDabTextFilter,
                 dabConfigTextFileContent,
                 openDabConfigInEditor,
+                addDabConfigToWorkspace,
                 dabDeploymentState,
                 openDabDeploymentDialog,
                 closeDabDeploymentDialog,

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabDefinitionsPanel.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabDefinitionsPanel.tsx
@@ -43,6 +43,7 @@ export const DabDefinitionsPanel = forwardRef<DabDefinitionsPanelRef, {}>((_, re
                 value: context.dabConfigTextFileContent,
                 language: "json",
                 themeKind,
+                addToWorkspace: context.addDabConfigToWorkspace,
                 openInEditor: context.openDabConfigInEditor,
                 copyToClipboard: (text: string) =>
                     context.copyToClipboard(text, Dab.CopyTextType.Config),

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/definition/schemaDesignerScriptTab.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/definition/schemaDesignerScriptTab.ts
@@ -21,6 +21,7 @@ type SchemaDesignerScriptTabOptions = {
     language: string;
     themeKind: ColorThemeKind;
     headerActions?: ReactNode;
+    addToWorkspace?: (script: string) => void;
     openInEditor: (script: string) => void;
     copyToClipboard: (script: string) => void;
 };
@@ -30,6 +31,7 @@ export const getSchemaDesignerScriptTab = ({
     language,
     themeKind,
     headerActions,
+    addToWorkspace,
     openInEditor,
     copyToClipboard,
 }: SchemaDesignerScriptTabOptions): ScriptTabProps => ({
@@ -37,13 +39,14 @@ export const getSchemaDesignerScriptTab = ({
     language,
     themeKind,
     headerActions,
+    addToWorkspace,
     openInEditor,
     copyToClipboard,
 });
 
 export const useSchemaDesignerScriptTab = (): ScriptTabProps => {
     const context = useContext(SchemaDesignerContext);
-    const { copyToClipboard, extractSchema, openInEditor } = context;
+    const { addDefinitionToWorkspace, copyToClipboard, extractSchema, openInEditor } = context;
     const { code, selectedDefinitionKind } = useSchemaDesignerDefinitionPanelContext();
     const { themeKind } = useVscodeWebview<
         SchemaDesigner.SchemaDesignerWebviewState,
@@ -68,10 +71,15 @@ export const useSchemaDesignerScriptTab = (): ScriptTabProps => {
                 language: definitionOutput.language,
                 themeKind: themeKind as ColorThemeKind,
                 headerActions: createElement(SchemaDesignerDefinitionTypePicker),
+                addToWorkspace:
+                    selectedDefinitionKind === SchemaDesignerDefinitionKind.Sql
+                        ? undefined
+                        : () => addDefinitionToWorkspace(selectedDefinitionKind),
                 openInEditor: () => openInEditor(selectedDefinitionKind),
                 copyToClipboard: () => copyToClipboard(selectedDefinitionKind),
             }),
         [
+            addDefinitionToWorkspace,
             copyToClipboard,
             definitionOutput.language,
             definitionOutput.text,

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerStateProvider.tsx
@@ -45,6 +45,7 @@ export interface SchemaDesignerContextProps extends CoreRPCs {
     saveAsFile: (fileProps: SchemaDesigner.ExportFileOptions) => void;
     getReport: () => Promise<SchemaDesigner.GetReportWebviewResponse | undefined>;
     openInEditor: (definitionKind?: SchemaDesigner.DefinitionKind) => void;
+    addDefinitionToWorkspace: (definitionKind: SchemaDesigner.DefinitionKind) => void;
     openInEditorWithConnection: () => void;
     copyToClipboard: (definitionKind?: SchemaDesigner.DefinitionKind) => void;
     extractSchema: () => SchemaDesigner.Schema;
@@ -342,6 +343,19 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
         [extensionRpc, extractSchema],
     );
 
+    const addDefinitionToWorkspace = useCallback(
+        (definitionKind: SchemaDesigner.DefinitionKind) => {
+            void extensionRpc.sendNotification(
+                SchemaDesigner.AddDefinitionToWorkspaceNotification.type,
+                {
+                    updatedSchema: extractSchema(),
+                    definitionKind,
+                },
+            );
+        },
+        [extensionRpc, extractSchema],
+    );
+
     const openInEditorWithConnection = () => {
         void extensionRpc.sendNotification(
             SchemaDesigner.OpenInEditorWithConnectionNotification.type,
@@ -569,6 +583,7 @@ const SchemaDesignerStateProvider: React.FC<SchemaDesignerProviderProps> = ({ ch
                 saveAsFile,
                 getReport,
                 openInEditor,
+                addDefinitionToWorkspace,
                 openInEditorWithConnection,
                 copyToClipboard,
                 extractSchema,

--- a/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
@@ -9,6 +9,9 @@ import sinonChai from "sinon-chai";
 import { expect } from "chai";
 import * as chai from "chai";
 import * as jsonRpc from "vscode-jsonrpc/node";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 import { SchemaDesignerWebviewController } from "../../src/schemaDesigner/schemaDesignerWebviewController";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 import { SchemaDesigner } from "../../src/sharedInterfaces/schemaDesigner";
@@ -225,6 +228,11 @@ suite("SchemaDesignerWebviewController tests", () => {
                 .to.be.true;
             expect(notificationHandlers.has(SchemaDesigner.OpenInEditorNotification.type.method)).to
                 .be.true;
+            expect(
+                notificationHandlers.has(
+                    SchemaDesigner.AddDefinitionToWorkspaceNotification.type.method,
+                ),
+            ).to.be.true;
             expect(
                 notificationHandlers.has(
                     SchemaDesigner.OpenInEditorWithConnectionNotification.type.method,
@@ -625,6 +633,75 @@ suite("SchemaDesignerWebviewController tests", () => {
         });
     });
 
+    suite("AddDefinitionToWorkspaceNotification handler", () => {
+        test("should add generated ORM text to the workspace", async () => {
+            const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mssql-schema-designer-"));
+            try {
+                const workspaceFolder = vscode.Uri.file(tempDir);
+                sandbox
+                    .stub(vscode.workspace, "workspaceFolders")
+                    .value([{ uri: workspaceFolder }]);
+                const document = { uri: vscode.Uri.file(path.join(tempDir, "opened.prisma")) };
+                const openTextDocumentStub = sandbox
+                    .stub(vscode.workspace, "openTextDocument")
+                    .resolves(document as any);
+                const showTextDocumentStub = sandbox
+                    .stub(vscode.window, "showTextDocument")
+                    .resolves();
+                const showInfoStub = sandbox
+                    .stub(vscode.window, "showInformationMessage")
+                    .resolves();
+
+                const ctrl = createController();
+                ctrl.schemaDesignerDetails = mockCreateSessionResponse;
+
+                const handler = notificationHandlers.get(
+                    SchemaDesigner.AddDefinitionToWorkspaceNotification.type.method,
+                );
+                expect(handler).to.be.a("function");
+
+                await handler({
+                    updatedSchema: mockSchema,
+                    definitionKind: SchemaDesigner.DefinitionKind.Prisma,
+                });
+
+                expect(mockSchemaDesignerService.getDefinition).to.not.have.been.called;
+                expect(openTextDocumentStub).to.have.been.calledOnce;
+                const writtenUri = openTextDocumentStub.firstCall.args[0] as vscode.Uri;
+                const content = await fs.readFile(writtenUri.fsPath, "utf8");
+                expect(writtenUri.fsPath).to.match(/testdb_\d{8}\.prisma$/);
+                expect(content).to.contain("model Users");
+                expect(showTextDocumentStub).to.have.been.calledOnceWith(document, {
+                    preview: false,
+                });
+                expect(showInfoStub).to.have.been.calledOnce;
+            } finally {
+                await fs.rm(tempDir, { recursive: true, force: true });
+            }
+        });
+
+        test("should show an error when no workspace folder is open", async () => {
+            sandbox.stub(vscode.workspace, "workspaceFolders").value(undefined);
+            const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
+
+            const ctrl = createController();
+            ctrl.schemaDesignerDetails = mockCreateSessionResponse;
+
+            const handler = notificationHandlers.get(
+                SchemaDesigner.AddDefinitionToWorkspaceNotification.type.method,
+            );
+            expect(handler).to.be.a("function");
+
+            await handler({
+                updatedSchema: mockSchema,
+                definitionKind: SchemaDesigner.DefinitionKind.TypeOrm,
+            });
+
+            expect(showErrorStub).to.have.been.calledOnce;
+            expect(showErrorStub.firstCall.args[0]).to.contain("No workspace folder is open");
+        });
+    });
+
     suite("OpenInEditorWithConnectionNotification handler", () => {
         test("should open script with connection from TreeNode", async () => {
             mockSchemaDesignerService.generateScript.resolves({ script: "ALTER TABLE Test;" });
@@ -962,6 +1039,8 @@ suite("SchemaDesignerWebviewController tests", () => {
 
                 expect(notificationHandlers.has(Dab.OpenConfigInEditorNotification.type.method)).to
                     .be.true;
+                expect(notificationHandlers.has(Dab.AddConfigToWorkspaceNotification.type.method))
+                    .to.be.true;
             });
 
             test("should open config content in a new editor", async () => {
@@ -988,6 +1067,50 @@ suite("SchemaDesignerWebviewController tests", () => {
                     language: "json",
                 });
                 expect(showTextDocumentStub).to.have.been.calledOnceWith(mockDocument);
+            });
+
+            test("should add config content to the workspace", async () => {
+                const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mssql-dab-config-"));
+                try {
+                    const workspaceFolder = vscode.Uri.file(tempDir);
+                    sandbox
+                        .stub(vscode.workspace, "workspaceFolders")
+                        .value([{ uri: workspaceFolder }]);
+                    const mockDocument = {
+                        uri: vscode.Uri.file(path.join(tempDir, "opened.json")),
+                    };
+                    const openTextDocumentStub = sandbox
+                        .stub(vscode.workspace, "openTextDocument")
+                        .resolves(mockDocument as any);
+                    const showTextDocumentStub = sandbox
+                        .stub(vscode.window, "showTextDocument")
+                        .resolves();
+                    const showInfoStub = sandbox
+                        .stub(vscode.window, "showInformationMessage")
+                        .resolves();
+
+                    createController();
+
+                    const handler = notificationHandlers.get(
+                        Dab.AddConfigToWorkspaceNotification.type.method,
+                    );
+                    expect(handler).to.be.a("function");
+
+                    const configContent = '{"$schema": "test"}';
+                    await handler({ configContent });
+
+                    expect(openTextDocumentStub).to.have.been.calledOnce;
+                    const writtenUri = openTextDocumentStub.firstCall.args[0] as vscode.Uri;
+                    const content = await fs.readFile(writtenUri.fsPath, "utf8");
+                    expect(writtenUri.fsPath).to.match(/testdb_\d{8}\.json$/);
+                    expect(content).to.equal(configContent);
+                    expect(showTextDocumentStub).to.have.been.calledOnceWith(mockDocument, {
+                        preview: false,
+                    });
+                    expect(showInfoStub).to.have.been.calledOnce;
+                } finally {
+                    await fs.rm(tempDir, { recursive: true, force: true });
+                }
             });
         });
 

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -211,6 +211,9 @@
     <trans-unit id="++CODE++4eeee164cd7b783f58eca583f898bdb923ed56ab94ae7d3604dc11738090fe7f">
       <source xml:lang="en">Add to VS Code</source>
     </trans-unit>
+    <trans-unit id="++CODE++dcc475b31b6d6d1bc68eede1badaf4b6af93c3683fe3a25ae08c8544b572e7fa">
+      <source xml:lang="en">Add to workspace</source>
+    </trans-unit>
     <trans-unit id="++CODE++6b02e0d363a4af1c95eef50364bb0202c8b250aa05a48a69e68fd7787b4b0632">
       <source xml:lang="en">Added</source>
     </trans-unit>
@@ -2559,6 +2562,10 @@
     <trans-unit id="++CODE++3927725937fc2d8467f978ee4999cb561f8e2ab71290423f122a8dc95f4f2e51">
       <source xml:lang="en">Failed to add table.</source>
     </trans-unit>
+    <trans-unit id="++CODE++49ef2a693ef05aa09893afe15b7f44c2c94cd84039e438baa9c76e7130c9baf7">
+      <source xml:lang="en">Failed to add text to workspace: {0}</source>
+      <note>{0} is the error message</note>
+    </trans-unit>
     <trans-unit id="++CODE++65b387854eab2ea5751dfeaf4b61e988e28642ef25dc8c09b8bd4e4ee99f6372">
       <source xml:lang="en">Failed to apply changes: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the publish changes operation</note>
@@ -3118,6 +3125,10 @@
     </trans-unit>
     <trans-unit id="++CODE++553f9778e20ce771fa5313659bcd804d36168900a284dde2d5f1cf7e1f43446b">
       <source xml:lang="en">Generate sqlpackage command</source>
+    </trans-unit>
+    <trans-unit id="++CODE++2617124e87bf1506e42eea651c54fa179c29090a0a58e9829860984f03eca2fa">
+      <source xml:lang="en">Generated file added to {0}</source>
+      <note>{0} is the generated file path</note>
     </trans-unit>
     <trans-unit id="++CODE++15bb1f371098735851e4d1d531c37e3652b2ceaf16055231f0a38312650cb08b">
       <source xml:lang="en">Generating Report. This may take a while...</source>
@@ -4344,6 +4355,9 @@
     </trans-unit>
     <trans-unit id="++CODE++751ae077912b834895870d0d5210c09ca02659375aab7843a26689a7aa50a0fc">
       <source xml:lang="en">No workspace folder is open. Open a folder to add the MCP server configuration.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++2e2fde2243e1e09534c9955387549ec84e351284a8ef12942f9d1cbab4a58039">
+      <source xml:lang="en">No workspace folder is open. Open a folder to add the generated file.</source>
     </trans-unit>
     <trans-unit id="++CODE++1507d637b267b1f20c1238414d7e51458fe7d6b98b292a8497d9982634fbe83c">
       <source xml:lang="en">No workspaces found</source>


### PR DESCRIPTION
## Description

Adds an Add to workspace action for generated ORM definitions and Data API builder config files from the schema designer definition toolbar. Generated artifacts are written to the open workspace with a database/date-based filename and opened for editing.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation run: `npm run build:extension -- --noEmit`, `npm run build:webviews -- --noEmit`, and `npm run test -- --target mssql --grep "SchemaDesignerWebviewController"`.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)