### PR TITLE
Fix schema designer diff anchoring

### DIFF
--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/definition/changes/schemaDesignerChangesDiffView.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/definition/changes/schemaDesignerChangesDiffView.tsx
@@ -36,6 +36,12 @@ export const SchemaDesignerChangesDiffView = () => {
                 themeKind={themeKind}
                 options={{
                     readOnly: true,
+                    /**
+                     * Generated CREATE TABLE blocks often end with identical PRIMARY KEY/closing lines.
+                     * Monaco's advanced algorithm can anchor those repeated tails to the new table block,
+                     * which makes added tables look like they start inside the previous table.
+                     */
+                    diffAlgorithm: "legacy",
                     renderSideBySide: true,
                     renderOverviewRuler: true,
                 }}


### PR DESCRIPTION
## Description

Fixes #21538 by using Monaco's legacy diff algorithm for the Schema Designer SQL diff view, which avoids anchoring added CREATE TABLE blocks to repeated trailing lines in the previous table.
| Before | After |
|-------|---------|
| <img width="1317" height="406" alt="image" src="https://github.com/user-attachments/assets/06bf666a-8526-4dc1-b003-26baf577c36c" /> |  <img width="1524" height="433" alt="image" src="https://github.com/user-attachments/assets/29da348b-e4b9-4384-b1e0-09ad3d4a4e0c" /> |



## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (
pm run test)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)