### PR TITLE
Lowering sts runtime floor in 1.42 release. 

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260424.4",
+        version: "6.0.20260429.3",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",


### PR DESCRIPTION
## Description

Issue: https://github.com/microsoft/vscode-mssql/issues/22015

This removes the patch check for sts dlls during launch. STS dlls now launch from dotnet as long as it `10.0.x` 

Here are the difference between 2 STS versions. 
https://github.com/microsoft/sqltoolsservice/compare/6.0.20260424.4...6.0.20260429.3

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
