### PR TITLE
Copy Long Messages in SQL Notebooks

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2209,10 +2209,7 @@
     "No connection selected.": "No connection selected.",
     "Copy messages": "Copy messages",
     "Copy all text output for this cell (messages, PRINT, errors)": "Copy all text output for this cell (messages, PRINT, errors)",
-    "$(check) Copied {0} characters/{0} is the number of characters copied to the clipboard": {
-        "message": "$(check) Copied {0} characters",
-        "comment": ["{0} is the number of characters copied to the clipboard"]
-    },
+    "$(check) Copied messages": "$(check) Copied messages",
     "({0} row(s) affected)/{0} is the number of rows affected": {
         "message": "({0} row(s) affected)",
         "comment": ["{0} is the number of rows affected"]

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2207,6 +2207,12 @@
     "No active notebook.": "No active notebook.",
     "No active connection.": "No active connection.",
     "No connection selected.": "No connection selected.",
+    "Copy messages": "Copy messages",
+    "Copy all text output for this cell (messages, PRINT, errors)": "Copy all text output for this cell (messages, PRINT, errors)",
+    "$(check) Copied {0} characters/{0} is the number of characters copied to the clipboard": {
+        "message": "$(check) Copied {0} characters",
+        "comment": ["{0} is the number of characters copied to the clipboard"]
+    },
     "({0} row(s) affected)/{0} is the number of rows affected": {
         "message": "({0} row(s) affected)",
         "comment": ["{0} is the number of rows affected"]

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -907,6 +907,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "mssql.notebooks.copyCellOutput",
+                    "when": "false"
+                },
+                {
                     "command": "mssql.runQueryWithUriOwnership",
                     "when": "false"
                 },
@@ -1607,6 +1611,11 @@
             {
                 "command": "mssql.notebooks.changeConnection",
                 "title": "%mssql.notebooks.changeConnection%",
+                "category": "MS SQL"
+            },
+            {
+                "command": "mssql.notebooks.copyCellOutput",
+                "title": "%mssql.notebooks.copyCellOutput%",
                 "category": "MS SQL"
             }
         ],

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -907,7 +907,7 @@
                     "when": "false"
                 },
                 {
-                    "command": "mssql.notebooks.copyCellOutput",
+                    "command": "mssql.notebooks.copyCellMessages",
                     "when": "false"
                 },
                 {
@@ -1614,8 +1614,8 @@
                 "category": "MS SQL"
             },
             {
-                "command": "mssql.notebooks.copyCellOutput",
-                "title": "%mssql.notebooks.copyCellOutput%",
+                "command": "mssql.notebooks.copyCellMessages",
+                "title": "%mssql.notebooks.copyCellMessages%",
                 "category": "MS SQL"
             }
         ],

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -294,5 +294,5 @@
     "mssql.notebooks.createNotebook": "New SQL Notebook (Preview)",
     "mssql.notebooks.changeDatabase": "Change Notebook Database",
     "mssql.notebooks.changeConnection": "Change Notebook Connection",
-    "mssql.notebooks.copyCellOutput": "Copy Cell Messages"
+    "mssql.notebooks.copyCellMessages": "Copy Cell Messages"
 }

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -293,5 +293,6 @@
     "mssql.flatFileImport": "Import Data...",
     "mssql.notebooks.createNotebook": "New SQL Notebook (Preview)",
     "mssql.notebooks.changeDatabase": "Change Notebook Database",
-    "mssql.notebooks.changeConnection": "Change Notebook Connection"
+    "mssql.notebooks.changeConnection": "Change Notebook Connection",
+    "mssql.notebooks.copyCellOutput": "Copy Cell Messages"
 }

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -158,7 +158,7 @@ export const cmdFlatFileImport = "mssql.flatFileImport";
 export const cmdNotebooksCreate = "mssql.notebooks.createNotebook";
 export const cmdNotebooksChangeDatabase = "mssql.notebooks.changeDatabase";
 export const cmdNotebooksChangeConnection = "mssql.notebooks.changeConnection";
-export const cmdNotebooksCopyCellOutput = "mssql.notebooks.copyCellOutput";
+export const cmdNotebooksCopyCellMessages = "mssql.notebooks.copyCellMessages";
 
 export const piiLogging = "piiLogging";
 export const mssqlPiiLogging = "mssql.piiLogging";

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -158,6 +158,7 @@ export const cmdFlatFileImport = "mssql.flatFileImport";
 export const cmdNotebooksCreate = "mssql.notebooks.createNotebook";
 export const cmdNotebooksChangeDatabase = "mssql.notebooks.changeDatabase";
 export const cmdNotebooksChangeConnection = "mssql.notebooks.changeConnection";
+export const cmdNotebooksCopyCellOutput = "mssql.notebooks.copyCellOutput";
 
 export const piiLogging = "piiLogging";
 export const mssqlPiiLogging = "mssql.piiLogging";

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -824,6 +824,19 @@ export class Notebooks {
     public static noActiveConnection = l10n.t("No active connection.");
     public static noConnectionSelected = l10n.t("No connection selected.");
 
+    // Copy cell output
+    public static copyMessages = l10n.t("Copy messages");
+    public static copyMessagesTooltip = l10n.t(
+        "Copy all text output for this cell (messages, PRINT, errors)",
+    );
+    public static copiedCharacters(count: number) {
+        return l10n.t({
+            message: "$(check) Copied {0} characters",
+            args: [count.toLocaleString()],
+            comment: ["{0} is the number of characters copied to the clipboard"],
+        });
+    }
+
     // Execution results
     public static rowsAffected(count: number) {
         return l10n.t({

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -829,13 +829,7 @@ export class Notebooks {
     public static copyMessagesTooltip = l10n.t(
         "Copy all text output for this cell (messages, PRINT, errors)",
     );
-    public static copiedCharacters(count: number) {
-        return l10n.t({
-            message: "$(check) Copied {0} characters",
-            args: [count.toLocaleString()],
-            comment: ["{0} is the number of characters copied to the clipboard"],
-        });
-    }
+    public static copiedMessages = l10n.t("$(check) Copied messages");
 
     // Execution results
     public static rowsAffected(count: number) {

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -81,6 +81,7 @@ import { CreateSessionResult } from "../objectExplorer/objectExplorerService";
 import { SqlCodeLensProvider } from "../queryResult/sqlCodeLensProvider";
 import { ConnectionSharingService } from "../connectionSharing/connectionSharingService";
 import { SqlNotebookController } from "../notebooks/sqlNotebookController";
+import { registerNotebookCopyOutput } from "../notebooks/notebookCopyOutputProvider";
 import { ConnectTool } from "../copilot/tools/connectTool";
 import { ListServersTool } from "../copilot/tools/listServersTool";
 import { DisconnectTool } from "../copilot/tools/disconnectTool";
@@ -715,6 +716,8 @@ export default class MainController implements vscode.Disposable {
             this._event.on(Constants.cmdNotebooksChangeConnection, () => {
                 void this.sqlNotebookController.changeConnectionInteractive();
             });
+
+            registerNotebookCopyOutput(this._context);
 
             const providerInstance = new this.ExecutionPlanCustomEditorProvider(
                 this._context,

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -34,7 +34,7 @@ export function registerNotebookCopyOutput(context: vscode.ExtensionContext): vo
                 }
                 await vscode.env.clipboard.writeText(text);
                 vscode.window.setStatusBarMessage(
-                    LocalizedConstants.Notebooks.copiedCharacters(text.length),
+                    LocalizedConstants.Notebooks.copiedMessages,
                     2000,
                 );
             },

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -17,18 +17,9 @@ const MIME_STDERR = "application/vnd.code.notebook.stderr";
 const MIME_NOTEBOOK_QUERY_RESULT = "application/vnd.mssql.query-result";
 
 /**
- * Adds a "Copy messages" status bar item to SQL notebook cells that emit
- * text-only output (PRINT, RAISERROR, row-count, execution time, errors).
- *
- * The built-in text/plain renderer virtualizes long output, which breaks
- * cross-viewport selection (vscode-mssql#21378). This provider reads raw
- * output data from the cell model instead of the rendered DOM, so the
- * full content copies regardless of virtualization.
- *
- * When a cell emits a result grid, the controller bundles grid + messages
- * into a single rich output. We unpack its JSON payload and copy only the
- * text/error blocks, skipping the tabular data — users copy grid contents
- * through the grid itself, not this command.
+ * Registers a "Copy messages" status bar item for SQL notebook cells.
+ * Reads raw output from the cell model to avoid virtualization issues (#21378).
+ * For rich outputs (result grids), copies only text/error blocks.
  */
 export function registerNotebookCopyOutput(context: vscode.ExtensionContext): void {
     context.subscriptions.push(

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -7,9 +7,14 @@ import * as os from "os";
 import * as vscode from "vscode";
 import * as Constants from "../constants/constants";
 import * as LocalizedConstants from "../constants/locConstants";
+import type {
+    NotebookQueryResultBlock,
+    NotebookQueryResultOutputData,
+} from "../sharedInterfaces/notebookQueryResult";
 
 const MIME_TEXT_PLAIN = "text/plain";
 const MIME_STDERR = "application/vnd.code.notebook.stderr";
+const MIME_NOTEBOOK_QUERY_RESULT = "application/vnd.mssql.query-result";
 
 /**
  * Adds a "Copy messages" status bar item to SQL notebook cells that emit
@@ -20,8 +25,10 @@ const MIME_STDERR = "application/vnd.code.notebook.stderr";
  * output data from the cell model instead of the rendered DOM, so the
  * full content copies regardless of virtualization.
  *
- * Excludes the rich result-set output (custom mssql mimetype) — users
- * copy grid data through the grid itself, not this command.
+ * When a cell emits a result grid, the controller bundles grid + messages
+ * into a single rich output. We unpack its JSON payload and copy only the
+ * text/error blocks, skipping the tabular data — users copy grid contents
+ * through the grid itself, not this command.
  */
 export function registerNotebookCopyOutput(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
@@ -70,18 +77,50 @@ function isCopyableTextOutput(output: vscode.NotebookCellOutput): boolean {
     if (output.items.length === 0) {
         return false;
     }
-    return output.items.every((item) => item.mime === MIME_TEXT_PLAIN || item.mime === MIME_STDERR);
+    const rich = findRichItem(output);
+    if (rich) {
+        return extractRichMessageText(rich).length > 0;
+    }
+    return output.items.some((item) => item.mime === MIME_TEXT_PLAIN || item.mime === MIME_STDERR);
 }
 
 function collectTextOutput(cell: vscode.NotebookCell): string {
     const chunks: string[] = [];
     for (const output of cell.outputs) {
-        if (!isCopyableTextOutput(output)) {
+        const rich = findRichItem(output);
+        if (rich) {
+            chunks.push(...extractRichMessageText(rich));
             continue;
         }
         for (const item of output.items) {
-            chunks.push(Buffer.from(item.data).toString("utf8"));
+            if (item.mime === MIME_TEXT_PLAIN || item.mime === MIME_STDERR) {
+                chunks.push(Buffer.from(item.data).toString("utf8"));
+            }
         }
     }
     return chunks.join(os.EOL);
+}
+
+function findRichItem(
+    output: vscode.NotebookCellOutput,
+): vscode.NotebookCellOutputItem | undefined {
+    return output.items.find((item) => item.mime === MIME_NOTEBOOK_QUERY_RESULT);
+}
+
+function extractRichMessageText(item: vscode.NotebookCellOutputItem): string[] {
+    let data: NotebookQueryResultOutputData;
+    try {
+        data = JSON.parse(Buffer.from(item.data).toString("utf8"));
+    } catch {
+        return [];
+    }
+    if (!data || !Array.isArray(data.blocks)) {
+        return [];
+    }
+    return data.blocks
+        .filter(
+            (block): block is Exclude<NotebookQueryResultBlock, { type: "resultSet" }> =>
+                block.type !== "resultSet",
+        )
+        .map((block) => block.text);
 }

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from "os";
+import * as vscode from "vscode";
+import * as Constants from "../constants/constants";
+import * as LocalizedConstants from "../constants/locConstants";
+
+const MIME_TEXT_PLAIN = "text/plain";
+const MIME_STDERR = "application/vnd.code.notebook.stderr";
+
+/**
+ * Adds a "Copy messages" status bar item to SQL notebook cells that emit
+ * text-only output (PRINT, RAISERROR, row-count, execution time, errors).
+ *
+ * The built-in text/plain renderer virtualizes long output, which breaks
+ * cross-viewport selection (vscode-mssql#21378). This provider reads raw
+ * output data from the cell model instead of the rendered DOM, so the
+ * full content copies regardless of virtualization.
+ *
+ * Excludes the rich result-set output (custom mssql mimetype) — users
+ * copy grid data through the grid itself, not this command.
+ */
+export function registerNotebookCopyOutput(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            Constants.cmdNotebooksCopyCellOutput,
+            async (cell: vscode.NotebookCell) => {
+                const text = collectTextOutput(cell);
+                if (!text) {
+                    return;
+                }
+                await vscode.env.clipboard.writeText(text);
+                vscode.window.setStatusBarMessage(
+                    LocalizedConstants.Notebooks.copiedCharacters(text.length),
+                    2000,
+                );
+            },
+        ),
+    );
+
+    context.subscriptions.push(
+        vscode.notebooks.registerNotebookCellStatusBarItemProvider("jupyter-notebook", {
+            provideCellStatusBarItems(cell) {
+                if (cell.document.languageId !== "sql") {
+                    return;
+                }
+                if (!cell.outputs.some(isCopyableTextOutput)) {
+                    return;
+                }
+                const item = new vscode.NotebookCellStatusBarItem(
+                    `$(copy) ${LocalizedConstants.Notebooks.copyMessages}`,
+                    vscode.NotebookCellStatusBarAlignment.Right,
+                );
+                item.command = {
+                    command: Constants.cmdNotebooksCopyCellOutput,
+                    title: LocalizedConstants.Notebooks.copyMessages,
+                    arguments: [cell],
+                };
+                item.tooltip = LocalizedConstants.Notebooks.copyMessagesTooltip;
+                return item;
+            },
+        }),
+    );
+}
+
+function isCopyableTextOutput(output: vscode.NotebookCellOutput): boolean {
+    if (output.items.length === 0) {
+        return false;
+    }
+    return output.items.every((item) => item.mime === MIME_TEXT_PLAIN || item.mime === MIME_STDERR);
+}
+
+function collectTextOutput(cell: vscode.NotebookCell): string {
+    const chunks: string[] = [];
+    for (const output of cell.outputs) {
+        if (!isCopyableTextOutput(output)) {
+            continue;
+        }
+        for (const item of output.items) {
+            chunks.push(Buffer.from(item.data).toString("utf8"));
+        }
+    }
+    return chunks.join(os.EOL);
+}

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -24,7 +24,7 @@ const MIME_NOTEBOOK_QUERY_RESULT = "application/vnd.mssql.query-result";
 export function registerNotebookCopyOutput(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            Constants.cmdNotebooksCopyCellOutput,
+            Constants.cmdNotebooksCopyCellMessages,
             async (cell: vscode.NotebookCell | undefined) => {
                 if (!cell) {
                     return;
@@ -56,7 +56,7 @@ export function registerNotebookCopyOutput(context: vscode.ExtensionContext): vo
                     vscode.NotebookCellStatusBarAlignment.Right,
                 );
                 item.command = {
-                    command: Constants.cmdNotebooksCopyCellOutput,
+                    command: Constants.cmdNotebooksCopyCellMessages,
                     title: LocalizedConstants.Notebooks.copyMessages,
                     arguments: [cell],
                 };
@@ -73,9 +73,19 @@ function isCopyableTextOutput(output: vscode.NotebookCellOutput): boolean {
     }
     const rich = findRichItem(output);
     if (rich) {
-        return extractRichMessageText(rich).length > 0;
+        return hasNonResultSetBlock(rich);
     }
     return output.items.some((item) => item.mime === MIME_TEXT_PLAIN || item.mime === MIME_STDERR);
+}
+
+/**
+ * Checks whether a rich output contains any non-resultSet blocks (text/error)
+ * without deserializing the full JSON payload. This avoids the cost of
+ * materializing large resultSet row arrays during frequent status-bar updates.
+ */
+function hasNonResultSetBlock(item: vscode.NotebookCellOutputItem): boolean {
+    const raw = Buffer.from(item.data).toString("utf8");
+    return /\"type\"\s*:\s*\"(?:text|error)\"/.test(raw);
 }
 
 function collectTextOutput(cell: vscode.NotebookCell): string {

--- a/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
+++ b/extensions/mssql/src/notebooks/notebookCopyOutputProvider.ts
@@ -34,7 +34,10 @@ export function registerNotebookCopyOutput(context: vscode.ExtensionContext): vo
     context.subscriptions.push(
         vscode.commands.registerCommand(
             Constants.cmdNotebooksCopyCellOutput,
-            async (cell: vscode.NotebookCell) => {
+            async (cell: vscode.NotebookCell | undefined) => {
+                if (!cell) {
+                    return;
+                }
                 const text = collectTextOutput(cell);
                 if (!text) {
                     return;

--- a/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
@@ -294,16 +294,28 @@ suite("registerNotebookCopyOutput", () => {
             expect(setStatusBarMessageStub).to.not.have.been.called;
         });
 
+        test("does nothing when invoked without a cell argument", async () => {
+            await capturedHandler(undefined as unknown as vscode.NotebookCell);
+
+            expect(clipboardWriteTextStub).to.not.have.been.called;
+            expect(setStatusBarMessageStub).to.not.have.been.called;
+        });
+
         test("preserves large content verbatim (repro for vscode-mssql#21378)", async () => {
             const manyLines = Array.from({ length: 5000 }, (_, i) => `debug message ${i + 1}`);
             const cell = makeCell([textOutput(manyLines.join("\n"))]);
             await capturedHandler(cell);
 
-            expect(clipboardWriteTextStub).to.have.been.calledOnce;
-            const copied = clipboardWriteTextStub.firstCall.args[0] as string;
-            expect(copied.split("\n")).to.have.length(5000);
-            expect(copied).to.include("debug message 1");
-            expect(copied).to.include("debug message 5000");
+            expect(clipboardWriteTextStub).to.have.been.calledWithMatch(
+                sinon.match(
+                    (value: unknown) =>
+                        typeof value === "string" &&
+                        value.split("\n").length === 5000 &&
+                        value.includes("debug message 1") &&
+                        value.includes("debug message 5000"),
+                    "clipboard payload with 5000 debug lines",
+                ),
+            );
         });
     });
 });

--- a/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
@@ -1,0 +1,243 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from "os";
+import * as sinon from "sinon";
+import * as chai from "chai";
+import sinonChai from "sinon-chai";
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+chai.use(sinonChai);
+import * as Constants from "../../../src/constants/constants";
+import * as LocalizedConstants from "../../../src/constants/locConstants";
+import { registerNotebookCopyOutput } from "../../../src/notebooks/notebookCopyOutputProvider";
+
+const MIME_MSSQL_RICH = "application/vnd.mssql.query-result";
+
+function textOutput(text: string): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(text, "text/plain")]);
+}
+
+function stderrOutput(text: string): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.stderr(text)]);
+}
+
+function richOutput(plainFallback: string): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput([
+        vscode.NotebookCellOutputItem.json({ version: 1, blocks: [] }, MIME_MSSQL_RICH),
+        vscode.NotebookCellOutputItem.text(plainFallback, "text/plain"),
+    ]);
+}
+
+function emptyOutput(): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput([]);
+}
+
+function makeCell(outputs: vscode.NotebookCellOutput[], languageId = "sql"): vscode.NotebookCell {
+    return {
+        document: { languageId },
+        outputs,
+    } as unknown as vscode.NotebookCell;
+}
+
+suite("registerNotebookCopyOutput", () => {
+    let sandbox: sinon.SinonSandbox;
+    let context: { subscriptions: vscode.Disposable[] };
+    let capturedHandler: (cell: vscode.NotebookCell) => Promise<void>;
+    let capturedProvider: vscode.NotebookCellStatusBarItemProvider;
+    let clipboardWriteTextStub: sinon.SinonStub;
+    let setStatusBarMessageStub: sinon.SinonStub;
+    let registerCommandStub: sinon.SinonStub;
+    let registerProviderStub: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        context = { subscriptions: [] };
+
+        registerCommandStub = sandbox
+            .stub(vscode.commands, "registerCommand")
+            .callsFake((_cmd: string, handler: (...args: unknown[]) => unknown) => {
+                capturedHandler = handler as (cell: vscode.NotebookCell) => Promise<void>;
+                return { dispose: () => {} };
+            });
+
+        registerProviderStub = sandbox
+            .stub(vscode.notebooks, "registerNotebookCellStatusBarItemProvider")
+            .callsFake((_type: string, provider: vscode.NotebookCellStatusBarItemProvider) => {
+                capturedProvider = provider;
+                return { dispose: () => {} };
+            });
+
+        clipboardWriteTextStub = sandbox.stub().resolves();
+        sandbox.stub(vscode.env, "clipboard").value({ writeText: clipboardWriteTextStub });
+        setStatusBarMessageStub = sandbox
+            .stub(vscode.window, "setStatusBarMessage")
+            .returns({ dispose: () => {} } as vscode.Disposable);
+
+        registerNotebookCopyOutput(context as unknown as vscode.ExtensionContext);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function runProvider(
+        cell: vscode.NotebookCell,
+    ): vscode.NotebookCellStatusBarItem | vscode.NotebookCellStatusBarItem[] | undefined {
+        return capturedProvider.provideCellStatusBarItems(cell, {} as vscode.CancellationToken) as
+            | vscode.NotebookCellStatusBarItem
+            | vscode.NotebookCellStatusBarItem[]
+            | undefined;
+    }
+
+    suite("registration", () => {
+        test("registers the copy command", () => {
+            expect(registerCommandStub).to.have.been.calledOnceWith(
+                Constants.cmdNotebooksCopyCellOutput,
+            );
+        });
+
+        test("registers the status bar provider for jupyter-notebook", () => {
+            expect(registerProviderStub).to.have.been.calledOnceWith("jupyter-notebook");
+        });
+
+        test("pushes both disposables onto the context subscriptions", () => {
+            expect(context.subscriptions).to.have.length(2);
+        });
+    });
+
+    suite("provideCellStatusBarItems", () => {
+        test("returns undefined for non-SQL cells", () => {
+            const cell = makeCell([textOutput("hi")], "python");
+            expect(runProvider(cell)).to.be.undefined;
+        });
+
+        test("returns undefined when the cell has no outputs", () => {
+            const cell = makeCell([]);
+            expect(runProvider(cell)).to.be.undefined;
+        });
+
+        test("returns undefined for outputs with no items", () => {
+            const cell = makeCell([emptyOutput()]);
+            expect(runProvider(cell)).to.be.undefined;
+        });
+
+        test("returns undefined when only rich result-set output is present", () => {
+            const cell = makeCell([richOutput("header\n1\n2\n")]);
+            expect(runProvider(cell)).to.be.undefined;
+        });
+
+        test("returns a status bar item for text/plain output", () => {
+            const cell = makeCell([textOutput("PRINT message")]);
+            const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
+
+            expect(item).to.not.be.undefined;
+            expect(item.text).to.equal(`$(copy) ${LocalizedConstants.Notebooks.copyMessages}`);
+            expect(item.alignment).to.equal(vscode.NotebookCellStatusBarAlignment.Right);
+            expect(item.tooltip).to.equal(LocalizedConstants.Notebooks.copyMessagesTooltip);
+        });
+
+        test("returns a status bar item for stderr output", () => {
+            const cell = makeCell([stderrOutput("ERROR: boom")]);
+            const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
+
+            expect(item).to.not.be.undefined;
+        });
+
+        test("returns a status bar item when a rich output coexists with plain text", () => {
+            const cell = makeCell([richOutput("table"), textOutput("PRINT after")]);
+            const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
+
+            expect(item).to.not.be.undefined;
+        });
+
+        test("item invokes the copy command with the cell as argument", () => {
+            const cell = makeCell([textOutput("hi")]);
+            const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
+
+            const command = item.command as vscode.Command;
+            expect(command.command).to.equal(Constants.cmdNotebooksCopyCellOutput);
+            expect(command.arguments).to.deep.equal([cell]);
+        });
+    });
+
+    suite("copy command handler", () => {
+        test("copies text/plain output to the clipboard", async () => {
+            const cell = makeCell([textOutput("hello world")]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith("hello world");
+        });
+
+        test("copies stderr output to the clipboard", async () => {
+            const cell = makeCell([stderrOutput("ERROR: failure")]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith("ERROR: failure");
+        });
+
+        test("joins multiple copyable outputs with os.EOL", async () => {
+            const cell = makeCell([
+                textOutput("first"),
+                stderrOutput("second"),
+                textOutput("third"),
+            ]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith(
+                `first${os.EOL}second${os.EOL}third`,
+            );
+        });
+
+        test("skips rich result-set outputs and copies only text-only outputs", async () => {
+            const cell = makeCell([
+                richOutput("tabular fallback text"),
+                textOutput("PRINT after grid"),
+            ]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith("PRINT after grid");
+        });
+
+        test("shows the confirmation status bar message after a successful copy", async () => {
+            const cell = makeCell([textOutput("hi")]);
+            await capturedHandler(cell);
+
+            expect(setStatusBarMessageStub).to.have.been.calledOnceWith(
+                LocalizedConstants.Notebooks.copiedMessages,
+                2000,
+            );
+        });
+
+        test("does nothing when the cell has no copyable output", async () => {
+            const cell = makeCell([richOutput("grid only")]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.not.have.been.called;
+            expect(setStatusBarMessageStub).to.not.have.been.called;
+        });
+
+        test("does nothing when the cell has no outputs at all", async () => {
+            const cell = makeCell([]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.not.have.been.called;
+            expect(setStatusBarMessageStub).to.not.have.been.called;
+        });
+
+        test("preserves large content verbatim (repro for vscode-mssql#21378)", async () => {
+            const manyLines = Array.from({ length: 5000 }, (_, i) => `debug message ${i + 1}`);
+            const cell = makeCell([textOutput(manyLines.join("\n"))]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnce;
+            const copied = clipboardWriteTextStub.firstCall.args[0] as string;
+            expect(copied.split("\n")).to.have.length(5000);
+            expect(copied).to.include("debug message 1");
+            expect(copied).to.include("debug message 5000");
+        });
+    });
+});

--- a/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
@@ -32,6 +32,16 @@ function richOutput(plainFallback: string): vscode.NotebookCellOutput {
     ]);
 }
 
+function richOutputWithBlocks(
+    blocks: Array<Record<string, unknown>>,
+    plainFallback = "fallback",
+): vscode.NotebookCellOutput {
+    return new vscode.NotebookCellOutput([
+        vscode.NotebookCellOutputItem.json({ version: 1, blocks }, MIME_MSSQL_RICH),
+        vscode.NotebookCellOutputItem.text(plainFallback, "text/plain"),
+    ]);
+}
+
 function emptyOutput(): vscode.NotebookCellOutput {
     return new vscode.NotebookCellOutput([]);
 }
@@ -154,6 +164,29 @@ suite("registerNotebookCopyOutput", () => {
             expect(item).to.not.be.undefined;
         });
 
+        test("returns a status bar item when a rich output bundles messages with a result set", () => {
+            // Mirrors sqlNotebookController.buildRichBatchOutput: when a batch has
+            // both messages and a grid, all blocks land in a single rich output.
+            const cell = makeCell([
+                richOutputWithBlocks([
+                    { type: "text", text: "DEBUG #1" },
+                    { type: "resultSet", columnInfo: [], rows: [], rowCount: 0 },
+                ]),
+            ]);
+            const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
+
+            expect(item).to.not.be.undefined;
+        });
+
+        test("returns undefined when a rich output contains only a result-set block", () => {
+            const cell = makeCell([
+                richOutputWithBlocks([
+                    { type: "resultSet", columnInfo: [], rows: [], rowCount: 0 },
+                ]),
+            ]);
+            expect(runProvider(cell)).to.be.undefined;
+        });
+
         test("item invokes the copy command with the cell as argument", () => {
             const cell = makeCell([textOutput("hi")]);
             const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
@@ -200,6 +233,39 @@ suite("registerNotebookCopyOutput", () => {
             await capturedHandler(cell);
 
             expect(clipboardWriteTextStub).to.have.been.calledOnceWith("PRINT after grid");
+        });
+
+        test("extracts message blocks from a rich output that bundles messages with a grid", async () => {
+            // Repro for the scenario where a single batch emits both RAISERROR
+            // messages and a SELECT result — the controller packs them into one
+            // rich output whose text/plain fallback concatenates everything.
+            const cell = makeCell([
+                richOutputWithBlocks([
+                    { type: "text", text: "DEBUG #1" },
+                    { type: "text", text: "DEBUG #2" },
+                    { type: "resultSet", columnInfo: [], rows: [], rowCount: 0 },
+                    { type: "text", text: "Total execution time: 00:00:03.900" },
+                ]),
+            ]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith(
+                `DEBUG #1${os.EOL}DEBUG #2${os.EOL}Total execution time: 00:00:03.900`,
+            );
+        });
+
+        test("includes error blocks from a rich output and skips the result set", async () => {
+            const cell = makeCell([
+                richOutputWithBlocks([
+                    { type: "error", text: "Msg 208: Invalid object name" },
+                    { type: "resultSet", columnInfo: [], rows: [], rowCount: 0 },
+                ]),
+            ]);
+            await capturedHandler(cell);
+
+            expect(clipboardWriteTextStub).to.have.been.calledOnceWith(
+                "Msg 208: Invalid object name",
+            );
         });
 
         test("shows the confirmation status bar message after a successful copy", async () => {

--- a/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookCopyOutputProvider.test.ts
@@ -106,7 +106,7 @@ suite("registerNotebookCopyOutput", () => {
     suite("registration", () => {
         test("registers the copy command", () => {
             expect(registerCommandStub).to.have.been.calledOnceWith(
-                Constants.cmdNotebooksCopyCellOutput,
+                Constants.cmdNotebooksCopyCellMessages,
             );
         });
 
@@ -192,7 +192,7 @@ suite("registerNotebookCopyOutput", () => {
             const item = runProvider(cell) as vscode.NotebookCellStatusBarItem;
 
             const command = item.command as vscode.Command;
-            expect(command.command).to.equal(Constants.cmdNotebooksCopyCellOutput);
+            expect(command.command).to.equal(Constants.cmdNotebooksCopyCellMessages);
             expect(command.arguments).to.deep.equal([cell]);
         });
     });

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4,6 +4,10 @@
     <trans-unit id="++CODE++fd10453f63e5c663d4e640ea9cbe1adcc832b6fed0454e62686773ac486ce64d">
       <source xml:lang="en"> is required.</source>
     </trans-unit>
+    <trans-unit id="++CODE++cb073b0f8a6fe17dee09765fb0725c13898190b82e30c5a91b7f7d5e61f25d89">
+      <source xml:lang="en">$(check) Copied {0} characters</source>
+      <note>{0} is the number of characters copied to the clipboard</note>
+    </trans-unit>
     <trans-unit id="++CODE++18b63db64aa0aff55a9f4784ad62abdc2b70cedb95b5e89d5551996cc9bd25ac">
       <source xml:lang="en">$(plug)  Connect to MSSQL</source>
     </trans-unit>
@@ -1478,6 +1482,9 @@
     <trans-unit id="++CODE++84f5172141bab484104cf73fd00dc9d1d9426606ec2f0a3785ede261956f1ed2">
       <source xml:lang="en">Copy Script to Clipboard</source>
     </trans-unit>
+    <trans-unit id="++CODE++bd0768aa6b547da2466d49441410931420e8beb78cc1d3051e68242a04e8583b">
+      <source xml:lang="en">Copy all text output for this cell (messages, PRINT, errors)</source>
+    </trans-unit>
     <trans-unit id="++CODE++ac030299960c4d5cba2b13fa5f358cb7f1b1531ce5f2e5315eff17b7c93a97bf">
       <source xml:lang="en">Copy as CSV</source>
     </trans-unit>
@@ -1501,6 +1508,9 @@
     </trans-unit>
     <trans-unit id="++CODE++dbf362d4f210c780513a9258278d4d07abe8a224f84ba7ad775d819039342e77">
       <source xml:lang="en">Copy link</source>
+    </trans-unit>
+    <trans-unit id="++CODE++cc4b07f956793d518a1f073565e7dceef4aab9bebae6e515dc7c9b046a38bc9d">
+      <source xml:lang="en">Copy messages</source>
     </trans-unit>
     <trans-unit id="++CODE++c8b5428b9ac790b3952e08ceea5a8a170ad8b0af1e0f51c98a159f1147631e8a">
       <source xml:lang="en">Copy script</source>
@@ -7396,6 +7406,9 @@
     </trans-unit>
     <trans-unit id="mssql.copyAll">
       <source xml:lang="en">Copy All</source>
+    </trans-unit>
+    <trans-unit id="mssql.notebooks.copyCellOutput">
+      <source xml:lang="en">Copy Cell Messages</source>
     </trans-unit>
     <trans-unit id="mssql.copyConnectionString">
       <source xml:lang="en">Copy Connection String</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7406,7 +7406,7 @@
     <trans-unit id="mssql.copyAll">
       <source xml:lang="en">Copy All</source>
     </trans-unit>
-    <trans-unit id="mssql.notebooks.copyCellOutput">
+    <trans-unit id="mssql.notebooks.copyCellMessages">
       <source xml:lang="en">Copy Cell Messages</source>
     </trans-unit>
     <trans-unit id="mssql.copyConnectionString">

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4,9 +4,8 @@
     <trans-unit id="++CODE++fd10453f63e5c663d4e640ea9cbe1adcc832b6fed0454e62686773ac486ce64d">
       <source xml:lang="en"> is required.</source>
     </trans-unit>
-    <trans-unit id="++CODE++cb073b0f8a6fe17dee09765fb0725c13898190b82e30c5a91b7f7d5e61f25d89">
-      <source xml:lang="en">$(check) Copied {0} characters</source>
-      <note>{0} is the number of characters copied to the clipboard</note>
+    <trans-unit id="++CODE++fd3bd9305a1a7d5dfd79fa21b626163609a8f298aab892396554e74842a84f9b">
+      <source xml:lang="en">$(check) Copied messages</source>
     </trans-unit>
     <trans-unit id="++CODE++18b63db64aa0aff55a9f4784ad62abdc2b70cedb95b5e89d5551996cc9bd25ac">
       <source xml:lang="en">$(plug)  Connect to MSSQL</source>


### PR DESCRIPTION
## Description

This PR fixes #21378 

"Copy All" works regardless of virtualization because the raw text contained in the cell model is copied and not the text that appears in the iframe.

<img width="1445" height="866" alt="Copy Long Text and exclude Query Results" src="https://github.com/user-attachments/assets/b0a021cd-2a97-49e1-84f1-bc7717263e6d" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
