### PR TITLE
[Perf]: Remove unnecessary T-SQL parsing to improve project load time

### DIFF
--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -9,6 +9,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [1.5.10] - 2026-06-02
 
 - Improved Publish Project dialog performance for faster initial loading, and improved port number validation in Publish Project dialog to correctly show available port.
+- Improved SQL project loading performance.
 
 ## [1.5.9] - 2026-04-22
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -769,7 +769,6 @@ export enum DatabaseProjectItemType {
     folder = "databaseProject.itemType.folder",
     file = "databaseProject.itemType.file",
     externalStreamingJob = "databaseProject.itemType.file.externalStreamingJob",
-    table = "databaseProject.itemType.file.table",
     referencesRoot = "databaseProject.itemType.referencesRoot",
     reference = "databaseProject.itemType.reference",
     sqlProjectReference = "databaseProject.itemType.reference.sqlProject",

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1111,7 +1111,6 @@ export class ProjectsController {
 
             switch (node.type) {
                 case constants.DatabaseProjectItemType.sqlObjectScript:
-                case constants.DatabaseProjectItemType.table:
                 case constants.DatabaseProjectItemType.externalStreamingJob:
                     await project.excludeSqlObjectScript(node.entryKey);
                     break;
@@ -1186,7 +1185,6 @@ export class ProjectsController {
             } else if (node instanceof FileNode) {
                 switch (node.type) {
                     case constants.DatabaseProjectItemType.sqlObjectScript:
-                    case constants.DatabaseProjectItemType.table:
                     case constants.DatabaseProjectItemType.externalStreamingJob:
                         await project.deleteSqlObjectScript(node.entryKey);
                         break;

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -442,47 +442,10 @@ export class Project implements ISqlProject {
         const sqlObjectScriptEntries: FileProjectEntry[] = [];
 
         for (let f of Array.from(filesSet.values())) {
-            const containsCreateTableStatement = await this.checkForCreateTableStatement(f);
-
-            sqlObjectScriptEntries.push(
-                this.createFileProjectEntry(
-                    f,
-                    EntryType.File,
-                    undefined,
-                    containsCreateTableStatement,
-                ),
-            );
+            sqlObjectScriptEntries.push(this.createFileProjectEntry(f, EntryType.File, undefined));
         }
 
         this._sqlObjectScripts = sqlObjectScriptEntries;
-    }
-
-    /**
-     * Checks if a SQL script file contains a CREATE TABLE statement
-     * @param relativePath Relative path to the script file
-     * @returns true if the file contains a CREATE TABLE statement, false otherwise
-     */
-    private async checkForCreateTableStatement(relativePath: string): Promise<boolean> {
-        const fullPath = path.join(
-            utils.getPlatformSafeFileEntryPath(this.projectFolderPath),
-            utils.getPlatformSafeFileEntryPath(relativePath),
-        );
-
-        if (!(await utils.exists(fullPath))) {
-            return false;
-        }
-
-        try {
-            const dacFxService = await utils.getDacFxService();
-            const parseResult = await dacFxService.parseTSqlScript(
-                fullPath,
-                this._databaseSchemaProvider,
-            );
-            return parseResult.containsCreateTableStatement;
-        } catch {
-            // If parsing fails, silently default to false
-            return false;
-        }
     }
 
     private async readFolders(): Promise<void> {
@@ -1397,7 +1360,6 @@ export class Project implements ISqlProject {
         relativePath: string,
         entryType: EntryType,
         sqlObjectType?: string,
-        containsCreateTableStatement?: boolean,
     ): FileProjectEntry {
         let platformSafeRelativePath = utils.getPlatformSafeFileEntryPath(relativePath);
         return new FileProjectEntry(
@@ -1405,7 +1367,6 @@ export class Project implements ISqlProject {
             utils.convertSlashesForSqlProj(relativePath),
             entryType,
             sqlObjectType,
-            containsCreateTableStatement,
         );
     }
 

--- a/extensions/sql-database-projects/src/models/projectEntry.ts
+++ b/extensions/sql-database-projects/src/models/projectEntry.ts
@@ -33,20 +33,12 @@ export class FileProjectEntry extends ProjectEntry implements IFileProjectEntry 
     fsUri: Uri;
     relativePath: string;
     sqlObjectType: string | undefined;
-    containsCreateTableStatement: boolean | undefined;
 
-    constructor(
-        uri: Uri,
-        relativePath: string,
-        entryType: EntryType,
-        sqlObjectType?: string,
-        containsCreateTableStatement?: boolean,
-    ) {
+    constructor(uri: Uri, relativePath: string, entryType: EntryType, sqlObjectType?: string) {
         super(entryType);
         this.fsUri = uri;
         this.relativePath = relativePath;
         this.sqlObjectType = sqlObjectType;
-        this.containsCreateTableStatement = containsCreateTableStatement;
     }
 
     public override toString(): string {

--- a/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
@@ -105,19 +105,6 @@ export class ExternalStreamingJobFileNode extends SqlObjectFileNode {
     }
 }
 
-export class TableFileNode extends SqlObjectFileNode {
-    public override get treeItem(): vscode.TreeItem {
-        const treeItem = super.treeItem;
-        treeItem.contextValue = this.type;
-
-        return treeItem;
-    }
-
-    public override get type(): DatabaseProjectItemType {
-        return DatabaseProjectItemType.table;
-    }
-}
-
 export class PreDeployNode extends FileNode {
     public override get treeItem(): vscode.TreeItem {
         const treeItem = super.treeItem;

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -156,12 +156,6 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
                     this.projectFileUri,
                     entry.relativePath,
                 );
-            } else if (entry.containsCreateTableStatement) {
-                newNode = new fileTree.TableFileNode(
-                    entry.fsUri,
-                    this.projectFileUri,
-                    entry.relativePath,
-                );
             } else {
                 newNode = new fileTree.SqlObjectFileNode(
                     entry.fsUri,

--- a/extensions/sql-database-projects/test/projectController.test.ts
+++ b/extensions/sql-database-projects/test/projectController.test.ts
@@ -1366,11 +1366,6 @@ suite("ProjectsController", function (): void {
                 }
                 return <any>{ exports: dataWorkspaceMock };
             });
-            sandbox.stub(utils, "getDacFxService").returns(<any>{
-                parseTSqlScript: (_: string, __: string) => {
-                    return Promise.resolve({ containsCreateTableStatement: true });
-                },
-            });
 
             // add project reference from project1 to project2
             await projController.addDatabaseReferenceCallback(
@@ -1427,11 +1422,6 @@ suite("ProjectsController", function (): void {
                     return realMssqlExt;
                 }
                 return <any>{ exports: dataWorkspaceMock };
-            });
-            sandbox.stub(utils, "getDacFxService").returns(<any>{
-                parseTSqlScript: (_: string, __: string) => {
-                    return Promise.resolve({ containsCreateTableStatement: true });
-                },
             });
             // add dacpac reference to something in the same folder
             expect(project1.databaseReferences.length).to.equal(


### PR DESCRIPTION
## Description

SQL Database Projects with large numbers of SQL files (2,000-8,000+) experienced severe startup latency (1-2 minutes) due to T-SQL parsing during project load. Each SQL file was being parsed to detect CREATE TABLE statements, which:

- Consumed ~10ms per file on average
- Provided zero functional value in VS Code (no UI features use this information)
- Was originally intended for ADS-specific "Open in Designer" feature
- Blocked project initialization until all files were parsed

This PR: 
- Removes the unnecessary parsing all files where there is no use at present.
- It helps to load the project instantly
- When vscode sql-projects support the table designer feature, we can get the info from the metadata provider also

Original Intent:
ADS: Enable "Open in Designer" command on table nodes using built-in table designer UI
VS Code: None - table designer component doesn't exist

Is Keeping It Necessary?
VS Code: ❌ NO - provides zero functionality, massive performance cost
ADS: ❌ NO - platform retired, feature not worth the cost
Correct Action: ✅ Remove cross-platform technical debt
<img width="527" height="475" alt="image" src="https://github.com/user-attachments/assets/a0829d35-94c1-4583-a49d-a87bab2aa8de" />


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Before: Recording took 119seconds from open project to fully load.
<img width="1582" height="920" alt="Latency_BeforeFix_119seconds" src="https://github.com/user-attachments/assets/d7f96196-d8a9-4332-a7d0-3cd3301f9792" />

After: took less than 10seconds to fully load the proejct.
<img width="1582" height="920" alt="Latency_AfterFix" src="https://github.com/user-attachments/assets/c8b6ccc9-6e98-4fcf-b8fc-adbcfa69bd7f" />


