### PR TITLE
Add setting to disable opening saved query results

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2033,6 +2033,12 @@
                     "default": null,
                     "scope": "resource"
                 },
+                "mssql.results.openAfterSave": {
+                    "type": "boolean",
+                    "description": "%mssql.results.openAfterSave%",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "mssql.saveAsCsv.includeHeaders": {
                     "type": "boolean",
                     "description": "%mssql.saveAsCsv.includeHeaders%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -127,6 +127,7 @@
     "mssql.messagesDefaultOpen": "True for the messages pane to be open by default; false for closed",
     "mssql.resultsFontFamily": "Set the font family for the results grid; set to blank to use the editor font",
     "mssql.resultsFontSize": "Set the font size for the results grid; set to blank to use the editor size",
+    "mssql.results.openAfterSave": "When enabled, saved query result exports are opened after export. Excel exports open with the system file handler; text exports open in VS Code.",
     "mssql.saveAsCsv.includeHeaders": "[Optional] When true, column headers are included when saving results as CSV",
     "mssql.saveAsCsv.delimiter": "[Optional] Delimiter for separating data items when saving results as CSV. Choose from common separators like comma (,), tab (\\t), semicolon (;), or pipe (|)",
     "mssql.saveAsCsv.lineSeparator": "[Optional] Character(s) used for separating rows when saving results as CSV",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -266,6 +266,7 @@ export const configMyConnections = "connections";
 export const configSaveAsCsv = "saveAsCsv";
 export const configSaveAsJson = "saveAsJson";
 export const configSaveAsExcel = "saveAsExcel";
+export const configResultsOpenAfterSave = "results.openAfterSave";
 export const configRecentConnections = "recentConnections";
 export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";

--- a/extensions/mssql/src/models/resultsSerializer.ts
+++ b/extensions/mssql/src/models/resultsSerializer.ts
@@ -74,7 +74,7 @@ export default class ResultsSerializer {
 
     private getConfigForCsv(): Contracts.SaveResultsAsCsvRequestParams {
         // get save results config from vscode config
-        let config = this._vscodeWrapper.getConfiguration(
+        const config = this._vscodeWrapper.getConfiguration(
             Constants.extensionConfigSectionName,
             this._uri,
         );
@@ -201,6 +201,18 @@ export default class ResultsSerializer {
         );
     }
 
+    private shouldOpenSavedFile(): boolean {
+        const config = this._vscodeWrapper.getConfiguration(
+            Constants.extensionConfigSectionName,
+            this._uri,
+        );
+        const configuredValue =
+            typeof config.get === "function"
+                ? config.get<boolean>(Constants.configResultsOpenAfterSave)
+                : config[Constants.configResultsOpenAfterSave];
+        return configuredValue ?? true;
+    }
+
     /**
      * Send request to sql tools service to save a result set
      */
@@ -254,7 +266,9 @@ export default class ResultsSerializer {
                     self._vscodeWrapper.logToOutputChannel(
                         LocalizedConstants.msgSaveSucceeded + filePath,
                     );
-                    self.openSavedFile(self._filePath, format);
+                    if (self.shouldOpenSavedFile()) {
+                        self.openSavedFile(self._filePath, format);
+                    }
                 }
             },
             (error) => {

--- a/extensions/mssql/src/models/resultsSerializer.ts
+++ b/extensions/mssql/src/models/resultsSerializer.ts
@@ -206,11 +206,7 @@ export default class ResultsSerializer {
             Constants.extensionConfigSectionName,
             this._uri,
         );
-        const configuredValue =
-            typeof config.get === "function"
-                ? config.get<boolean>(Constants.configResultsOpenAfterSave)
-                : config[Constants.configResultsOpenAfterSave];
-        return configuredValue ?? true;
+        return config.get<boolean>(Constants.configResultsOpenAfterSave, true);
     }
 
     /**

--- a/extensions/mssql/test/unit/saveResults.test.ts
+++ b/extensions/mssql/test/unit/saveResults.test.ts
@@ -92,16 +92,20 @@ suite("save results tests", () => {
     function testSaveSuccess(format: string): Thenable<void> {
         configureSuccess();
         const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
         return saveResults.onSaveResults(testFile, 0, 0, format, undefined).then(() => {
             expect(vscodeWrapper.showInformationMessage).to.have.been.calledOnce;
+            expect(openSavedFileStub).to.have.been.calledOnceWith(fileUri.fsPath, format);
         });
     }
 
     function testSaveFailure(format: string): Thenable<void> {
         configureFailure("failure");
         const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
         return saveResults.onSaveResults(testFile, 0, 0, format, undefined).then(() => {
             expect(vscodeWrapper.showErrorMessage).to.have.been.calledOnce;
+            expect(openSavedFileStub).to.not.have.been.called;
         });
     }
 
@@ -127,6 +131,44 @@ suite("save results tests", () => {
 
     test("Save as Excel - test if error message is displayed on failure to save", () => {
         return testSaveFailure("excel");
+    });
+
+    test("Save as CSV - opens saved file when openAfterSave is enabled by default", () => {
+        configureSuccess();
+        const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
+
+        return saveResults.onSaveResults(testFile, 0, 0, "csv", undefined).then(() => {
+            expect(openSavedFileStub).to.have.been.calledOnceWith(fileUri.fsPath, "csv");
+        });
+    });
+
+    test("Save as CSV - does not open saved file when openAfterSave is disabled", () => {
+        configureSuccess();
+        (vscodeWrapper.getConfiguration as sinon.SinonStub).returns({
+            get: (key: string) => (key === "results.openAfterSave" ? false : undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+        const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
+
+        return saveResults.onSaveResults(testFile, 0, 0, "csv", undefined).then(() => {
+            expect(vscodeWrapper.showInformationMessage).to.have.been.calledOnce;
+            expect(openSavedFileStub).to.not.have.been.called;
+        });
+    });
+
+    test("Save as Excel - does not open saved file when openAfterSave is disabled", () => {
+        configureSuccess();
+        (vscodeWrapper.getConfiguration as sinon.SinonStub).returns({
+            get: (key: string) => (key === "results.openAfterSave" ? false : undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+        const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
+
+        return saveResults.onSaveResults(testFile, 0, 0, "excel", undefined).then(() => {
+            expect(vscodeWrapper.showInformationMessage).to.have.been.calledOnce;
+            expect(openSavedFileStub).to.not.have.been.called;
+        });
     });
 
     test("Save as with selection - test if selected range is passed in parameters", () => {
@@ -179,14 +221,22 @@ suite("save results tests", () => {
         (vscodeWrapper.showSaveDialog as sinon.SinonStub).resolves(undefined);
 
         const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
         await saveResults.onSaveResults(testFile, 0, 0, "csv", undefined);
 
         expect(serverClient.sendRequest).to.not.have.been.called;
+        expect(openSavedFileStub).to.not.have.been.called;
     });
 
     test("CSV configuration options are properly applied", (done) => {
         const customWrapper = stubVscodeWrapper(sandbox);
         (customWrapper.showSaveDialog as sinon.SinonStub).resolves(fileUri);
+        (customWrapper.openTextDocument as sinon.SinonStub).resolves(
+            undefined as unknown as vscode.TextDocument,
+        );
+        (customWrapper.showTextDocument as sinon.SinonStub).resolves(
+            undefined as unknown as vscode.TextEditor,
+        );
         (customWrapper.getConfiguration as sinon.SinonStub).returns({
             saveAsCsv: {
                 delimiter: "\t",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7985,6 +7985,9 @@
     <trans-unit id="mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription">
       <source xml:lang="en">When enabled, connection groups will be collapsed instead of expanded at startup.</source>
     </trans-unit>
+    <trans-unit id="mssql.results.openAfterSave">
+      <source xml:lang="en">When enabled, saved query result exports are opened after export. Excel exports open with the system file handler; text exports open in VS Code.</source>
+    </trans-unit>
     <trans-unit id="mssql.objectExplorer.groupBySchema">
       <source xml:lang="en">When enabled, the database objects in Object Explorer will be categorized by schema.</source>
     </trans-unit>


### PR DESCRIPTION
## Summary
- add mssql.results.openAfterSave to control whether Query Results exports open after save
- keep existing auto-open behavior by default for CSV, JSON, INSERT, and Excel
- add unit coverage for default behavior, disabled behavior, failed saves, and canceled save dialogs

Fixes #22059

## Validation
- npm run build:extension
- npx eslint --quiet src/models/resultsSerializer.ts test/unit/saveResults.test.ts
- npx vscode-test --label "Unit Tests" --run out/test/unit/saveResults.test.js