### PR TITLE
Remove SQL notebook preview tags

### DIFF
--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -291,7 +291,7 @@
     "mssql.backupDatabase": "Backup Database...",
     "mssql.restoreDatabase": "Restore Database...",
     "mssql.flatFileImport": "Import Data...",
-    "mssql.notebooks.createNotebook": "New SQL Notebook (Preview)",
+    "mssql.notebooks.createNotebook": "New SQL Notebook",
     "mssql.notebooks.changeDatabase": "Change Notebook Database",
     "mssql.notebooks.changeConnection": "Change Notebook Connection"
 }

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7653,7 +7653,7 @@
       <source xml:lang="en">New Query</source>
     </trans-unit>
     <trans-unit id="mssql.notebooks.createNotebook">
-      <source xml:lang="en">New SQL Notebook (Preview)</source>
+      <source xml:lang="en">New SQL Notebook</source>
     </trans-unit>
     <trans-unit id="mssql.newTable">
       <source xml:lang="en">New Table</source>


### PR DESCRIPTION
## Description

This PR removes the preview tags that appear in the two entry points to make a new SQL notebook. Here's the updated context menu option:

1. OE Context Menu Item
<img width="340" height="527" alt="image" src="https://github.com/user-attachments/assets/00a923cb-f875-4e6e-bd72-e9fcdc485c85" />

<br />
<br />
2. Command Palette:
<img width="613" height="63" alt="image" src="https://github.com/user-attachments/assets/74daafc6-5f05-45d2-a813-a6ff6a3bf097" />



_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
