### PR TITLE
Fix SQL notebook execute cell keyboard shortcut

### DIFF
--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -51,7 +51,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookCellListFocused && notebookType == 'sql'"
+                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
             },
             {
                 "command": "mssql.runCurrentStatement",

--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -51,7 +51,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
             },
             {
                 "command": "mssql.runCurrentStatement",

--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -51,7 +51,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+                "when": "notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && notebookKernelId == 'ms-mssql.sql-notebook-controller' && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
             },
             {
                 "command": "mssql.runCurrentStatement",

--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -51,7 +51,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookType == 'sql' && notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && (notebookMissingKernelExtension || notebookKernelCount > 0 || notebookKernelSourceCount > 0)"
+                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
             },
             {
                 "command": "mssql.runCurrentStatement",

--- a/extensions/database-management-keymap/package.json
+++ b/extensions/database-management-keymap/package.json
@@ -51,7 +51,7 @@
                 "command": "notebook.cell.execute",
                 "key": "f5",
                 "mac": "f5",
-                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+                "when": "notebookType == 'sql' && notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && (notebookMissingKernelExtension || notebookKernelCount > 0 || notebookKernelSourceCount > 0)"
             },
             {
                 "command": "mssql.runCurrentStatement",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1623,6 +1623,12 @@
                 "when": "editorTextFocus && editorLangId == 'sql' && !notebookEditorFocused"
             },
             {
+                "command": "notebook.cell.execute",
+                "key": "ctrl+shift+e",
+                "mac": "cmd+shift+e",
+                "when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+            },
+            {
                 "command": "mssql.connect",
                 "key": "ctrl+shift+c",
                 "mac": "cmd+shift+c",


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/21337

The PR adjusts the when clause for the keyboard shortcut to execute a notebook cell correctly.

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
