### PR TITLE
Fix Execute Current Statement selection behavior

### DIFF
--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -1,6 +1,6 @@
 {
     "mssql.runQuery": "Execute Query (MSSQL)",
-    "mssql.runCurrentStatement": "Execute Current Statement (MSSQL)",
+    "mssql.runCurrentStatement": "Execute Selection or Current Statement (MSSQL)",
     "mssql.cancelQuery": "Cancel Query (MSSQL)",
     "mssql.revealQueryResult": "Reveal Query Result (MSSQL)",
     "mssql.toggleQueryResultPanel": "Toggle Query Result Panel Visibility (MSSQL)",

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -2761,6 +2761,37 @@ export default class MainController implements vscode.Disposable {
                 return;
             }
 
+            // Do not execute when there are multiple selections in the editor until it can be properly handled.
+            // Otherwise only the first selection will be executed and cause unexpected issues.
+            if (editor.selections?.length > 1) {
+                self._vscodeWrapper.showErrorMessage(
+                    LocalizedConstants.msgMultipleSelectionModeNotSupported,
+                );
+                return;
+            }
+
+            if (!editor.selection.isEmpty) {
+                if (editor.document.getText(editor.selection).trim().length === 0) {
+                    return;
+                }
+
+                let selection = editor.selection;
+                let querySelection: ISelectionData = {
+                    startLine: selection.start.line,
+                    startColumn: selection.start.character,
+                    endLine: selection.end.line,
+                    endColumn: selection.end.character,
+                };
+
+                await self._outputContentProvider.runQuery(
+                    self._statusview,
+                    uri,
+                    querySelection,
+                    title,
+                );
+                return;
+            }
+
             // only the start line and column are used to determine the current statement
             let querySelection: ISelectionData = {
                 startLine: editor.selection.start.line,

--- a/extensions/mssql/test/unit/mainController.test.ts
+++ b/extensions/mssql/test/unit/mainController.test.ts
@@ -29,9 +29,16 @@ type MainControllerTestAccess = {
     validateTextDocumentHasFocus(): boolean;
     _vscodeWrapper: {
         activeTextEditorUri?: string;
+        activeTextEditor?: vscode.TextEditor;
         isEditingSqlFile?: boolean;
         showInformationMessage(message: string): Thenable<unknown> | void;
+        showErrorMessage?(message: string): Thenable<unknown> | void;
     };
+    _outputContentProvider: {
+        runCurrentStatement: sinon.SinonStub;
+        runQuery: sinon.SinonStub;
+    };
+    _statusview: unknown;
     openCopilotChatFromUi(args?: CopilotChat.OpenFromUiArgs): Promise<void>;
     findChatOpenAgentCommand(): Promise<string | undefined>;
     registerLanguageModelTools(): void;
@@ -57,6 +64,24 @@ suite("MainController Tests", function () {
                 uri: vscode.Uri.parse(uri),
                 languageId,
             },
+        } as unknown as vscode.TextEditor;
+    }
+
+    function createQueryTextEditor(
+        selection: vscode.Selection,
+        fullText: string,
+        selectedText?: string,
+        selections: vscode.Selection[] = [selection],
+    ): vscode.TextEditor {
+        return {
+            document: {
+                uri: vscode.Uri.parse("file:///test/query.sql"),
+                fileName: "query.sql",
+                languageId: Constants.languageId,
+                getText: (range?: vscode.Range) => (range ? (selectedText ?? "") : fullText),
+            },
+            selection,
+            selections,
         } as unknown as vscode.TextEditor;
     }
 
@@ -129,6 +154,119 @@ suite("MainController Tests", function () {
         await controller.onManageProfiles();
 
         expect(connectionManager.onManageProfiles).to.have.been.called;
+    });
+
+    suite("onRunCurrentStatement Tests", () => {
+        let controllerAccess: MainControllerTestAccess;
+        let runCurrentStatementStub: sinon.SinonStub;
+        let runQueryStub: sinon.SinonStub;
+        let statusView: unknown;
+
+        setup(() => {
+            controllerAccess = accessMainController(mainController);
+            sandbox.stub(mainController, "ensureReadyToExecuteQuery").resolves(true);
+            sandbox.stub(vscodeWrapper, "activeTextEditorUri").get(() => "file:///test/query.sql");
+
+            runCurrentStatementStub = sandbox.stub().resolves();
+            runQueryStub = sandbox.stub().resolves();
+            controllerAccess._outputContentProvider = {
+                runCurrentStatement: runCurrentStatementStub,
+                runQuery: runQueryStub,
+            };
+            statusView = {};
+            controllerAccess._statusview = statusView;
+        });
+
+        test("runs the current statement when there is no selection", async () => {
+            const selection = new vscode.Selection(1, 7, 1, 7);
+            sandbox
+                .stub(vscodeWrapper, "activeTextEditor")
+                .get(() => createQueryTextEditor(selection, "select 'a';\nselect 'b';"));
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runCurrentStatementStub).to.have.been.calledOnceWithExactly(
+                statusView,
+                "file:///test/query.sql",
+                {
+                    startLine: 1,
+                    startColumn: 7,
+                    endLine: 0,
+                    endColumn: 0,
+                },
+                "query.sql",
+            );
+            expect(runQueryStub).to.not.have.been.called;
+        });
+
+        test("runs selected text when there is a non-empty selection", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 11);
+            sandbox
+                .stub(vscodeWrapper, "activeTextEditor")
+                .get(() =>
+                    createQueryTextEditor(selection, "select 'a'; select 'b';", "select 'a';"),
+                );
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runQueryStub).to.have.been.calledOnceWithExactly(
+                statusView,
+                "file:///test/query.sql",
+                {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 11,
+                },
+                "query.sql",
+            );
+            expect(runCurrentStatementStub).to.not.have.been.called;
+        });
+
+        test("does not execute when the selection contains only whitespace", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 4);
+            sandbox
+                .stub(vscodeWrapper, "activeTextEditor")
+                .get(() => createQueryTextEditor(selection, "    select 'a';", "    "));
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runQueryStub).to.not.have.been.called;
+            expect(runCurrentStatementStub).to.not.have.been.called;
+        });
+
+        test("shows an error and does not execute when there are multiple selections", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 11);
+            const secondSelection = new vscode.Selection(1, 0, 1, 11);
+            sandbox
+                .stub(vscodeWrapper, "activeTextEditor")
+                .get(() =>
+                    createQueryTextEditor(selection, "select 'a';\nselect 'b';", "select 'a';", [
+                        selection,
+                        secondSelection,
+                    ]),
+                );
+
+            await mainController.onRunCurrentStatement();
+
+            expect(vscodeWrapper.showErrorMessage).to.have.been.calledOnceWithExactly(
+                LocalizedConstants.msgMultipleSelectionModeNotSupported,
+            );
+            expect(runQueryStub).to.not.have.been.called;
+            expect(runCurrentStatementStub).to.not.have.been.called;
+        });
+
+        test("does not execute when the document is empty", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 0);
+            sandbox
+                .stub(vscodeWrapper, "activeTextEditor")
+                .get(() => createQueryTextEditor(selection, ""));
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runQueryStub).to.not.have.been.called;
+            expect(runCurrentStatementStub).to.not.have.been.called;
+        });
     });
 
     test("Proxy settings are checked on initialization", async () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7569,11 +7569,11 @@
     <trans-unit id="mssql.showEstimatedPlan">
       <source xml:lang="en">Estimated Plan (MSSQL)</source>
     </trans-unit>
-    <trans-unit id="mssql.runCurrentStatement">
-      <source xml:lang="en">Execute Selection or Current Statement (MSSQL)</source>
-    </trans-unit>
     <trans-unit id="mssql.runQuery">
       <source xml:lang="en">Execute Query (MSSQL)</source>
+    </trans-unit>
+    <trans-unit id="mssql.runCurrentStatement">
+      <source xml:lang="en">Execute Selection or Current Statement (MSSQL)</source>
     </trans-unit>
     <trans-unit id="mssql.copilot.explainQuery">
       <source xml:lang="en">Explain Query</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7570,7 +7570,7 @@
       <source xml:lang="en">Estimated Plan (MSSQL)</source>
     </trans-unit>
     <trans-unit id="mssql.runCurrentStatement">
-      <source xml:lang="en">Execute Current Statement (MSSQL)</source>
+      <source xml:lang="en">Execute Selection or Current Statement (MSSQL)</source>
     </trans-unit>
     <trans-unit id="mssql.runQuery">
       <source xml:lang="en">Execute Query (MSSQL)</source>


### PR DESCRIPTION
## Description

Fixes #20348.

Updates `mssql.runCurrentStatement` so it executes selected SQL when text is selected, and otherwise continues to execute the statement under the cursor. Also updates the command label to `Execute Selection or Current Statement (MSSQL)` so the Command Palette text matches the behavior.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Validation:
- `npm run build:extension:typecheck`
- `npx vscode-test --label "Unit Tests" --skip-extension-dependencies --run "out/test/unit/mainController.test.js" --grep "onRunCurrentStatement Tests"`
