### PR TITLE
Add Change Connection to SQL editor context menu

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -471,6 +471,11 @@
                     "group": "0_mssql"
                 },
                 {
+                    "command": "mssql.changeConnection",
+                    "when": "editorLangId == sql && !isInDiffEditor && resource in mssql.connections && resourcePath not in mssql.runningQueries && !mssql.hideUIElements",
+                    "group": "0_mssql"
+                },
+                {
                     "submenu": "mssql.copilot.editorSubmenu",
                     "when": "editorLangId == sql && mssql.copilot.isGHCInstalled && !mssql.hideUIElements",
                     "group": "0_mssql"


### PR DESCRIPTION
## Description

Adds the existing `mssql.changeConnection` command to the SQL editor right-click context menu so users can switch connections from an open editor tab without using the command palette.

Fixes #20383

Validation:

- Parsed `extensions/mssql/package.json` with Node to verify the manifest remains valid JSON.
- Precommit hook ran successfully during commit.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
