### PR TITLE
Adding support for Entra Service Principal auth

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
                 // Uncomment this to use a specified version of STS, see
                 // https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
                 // for more details
-                // "MSSQL_SQLTOOLSSERVICE": "<Path to STS>"
+                "MSSQL_SQLTOOLSSERVICE": "C:\\Users\\benjind\\Source\\Codex\\SQL Tools Service\\sqltoolsservice\\artifacts\\publish\\Microsoft.SqlTools.ServiceLayer\\default\\net10.0"
             }
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
                 // Uncomment this to use a specified version of STS, see
                 // https://github.com/microsoft/vscode-mssql/blob/main/DEVELOPMENT.md#using-mssql_sqltoolsservice-environment-variable
                 // for more details
-                "MSSQL_SQLTOOLSSERVICE": "C:\\Users\\benjind\\Source\\Codex\\SQL Tools Service\\sqltoolsservice\\artifacts\\publish\\Microsoft.SqlTools.ServiceLayer\\default\\net10.0"
+                // "MSSQL_SQLTOOLSSERVICE": "<Path to STS>"
             }
         }
     ]

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1852,6 +1852,7 @@
     "SQL Login": "SQL Login",
     "Microsoft Entra Id - Universal w/ MFA Support": "Microsoft Entra Id - Universal w/ MFA Support",
     "Microsoft Entra Id - Default": "Microsoft Entra Id - Default",
+    "Microsoft Entra Id - Service Principal": "Microsoft Entra Id - Service Principal",
     "Azure Code Grant": "Azure Code Grant",
     "Azure Device Code": "Azure Device Code",
     "MSSQL - Azure Auth Logs": "MSSQL - Azure Auth Logs",
@@ -2334,6 +2335,13 @@
     "<Default>": "<Default>",
     "Automatically selects an available Microsoft Entra ID identity from providers installed on your system. Click the info icon to learn more.": "Automatically selects an available Microsoft Entra ID identity from providers installed on your system. Click the info icon to learn more.",
     "Sign in with your Microsoft Entra ID account, including accounts with multi-factor authentication. Click the info icon to learn more.": "Sign in with your Microsoft Entra ID account, including accounts with multi-factor authentication. Click the info icon to learn more.",
+    "Authenticate using a Microsoft Entra service principal. Enter the Application (client) ID as the user name and the client secret as the password. Click the info icon to learn more.": "Authenticate using a Microsoft Entra service principal. Enter the Application (client) ID as the user name and the client secret as the password. Click the info icon to learn more.",
+    "Application (Client) ID": "Application (Client) ID",
+    "The Application (Client) ID of your Microsoft Entra app registration.": "The Application (Client) ID of your Microsoft Entra app registration.",
+    "Client Secret": "Client Secret",
+    "The client secret for your Microsoft Entra app registration.": "The client secret for your Microsoft Entra app registration.",
+    "Application (Client) ID is required.": "Application (Client) ID is required.",
+    "Client secret is required.": "Client secret is required.",
     "+ Create Connection Group": "+ Create Connection Group",
     "Select a connection group": "Select a connection group",
     "Search connection groups": "Search connection groups",
@@ -2368,8 +2376,8 @@
     "No workspaces found. Please change Fabric account or tenant to view available workspaces.": "No workspaces found. Please change Fabric account or tenant to view available workspaces.",
     "User databases": "User databases",
     "System databases": "System databases",
-    "Unable to load database list from server: {0}/{0} is the connection error message": {
-        "message": "Unable to load database list from server: {0}",
+    "Unable to load database list from server: {0} You may enter the database name directly./{0} is the connection error message": {
+        "message": "Unable to load database list from server: {0} You may enter the database name directly.",
         "comment": ["{0} is the connection error message"]
     },
     "Unsupported authentication type in connection string: {0}. Only SQL Login, Integrated, Azure MFA, and Active Directory Default authentication are supported./{0} is the authentication type": {

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2342,6 +2342,7 @@
     "The client secret for your Microsoft Entra app registration.": "The client secret for your Microsoft Entra app registration.",
     "Application (Client) ID is required.": "Application (Client) ID is required.",
     "Client secret is required.": "Client secret is required.",
+    "Save Secret": "Save Secret",
     "+ Create Connection Group": "+ Create Connection Group",
     "Select a connection group": "Select a connection group",
     "Search connection groups": "Search connection groups",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1836,7 +1836,8 @@
                                 "enum": [
                                     "Integrated",
                                     "SqlLogin",
-                                    "AzureMFA"
+                                    "AzureMFA",
+                                    "ActiveDirectoryServicePrincipal"
                                 ],
                                 "description": "%mssql.connection.authenticationType%"
                             },

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260507.1",
+        version: "6.0.20260519.2",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -166,7 +166,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     /** Cache of database lists keyed by fetch key, reused within the same dialog session. */
     private _databaseListCache: Map<string, string[]> = new Map();
 
-    // Original capability-sourced labels/tooltips for user/password fields, cached so they
+    // Original labels/tooltips for user/password fields from STS, cached so they
     // can be restored when switching away from Service Principal auth.
     private _originalUserLabel: string | undefined;
     private _originalUserTooltip: string | undefined;

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -166,6 +166,13 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     /** Cache of database lists keyed by fetch key, reused within the same dialog session. */
     private _databaseListCache: Map<string, string[]> = new Map();
 
+    // Original capability-sourced labels/tooltips for user/password fields, cached so they
+    // can be restored when switching away from Service Principal auth.
+    private _originalUserLabel: string | undefined;
+    private _originalUserTooltip: string | undefined;
+    private _originalPasswordLabel: string | undefined;
+    private _originalPasswordTooltip: string | undefined;
+
     //#endregion
 
     constructor(
@@ -1082,21 +1089,34 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             AuthenticationType.ActiveDirectoryServicePrincipal;
         const userComp = this.state.formComponents["user"];
         if (userComp) {
+            // Lazily cache the original capability-sourced label/tooltip the first time we see them
+            if (userComp.label && !this._originalUserLabel) {
+                this._originalUserLabel = userComp.label;
+            }
+            if (userComp.tooltip && !this._originalUserTooltip) {
+                this._originalUserTooltip = userComp.tooltip;
+            }
             userComp.label = isServicePrincipal
                 ? LocAll.ConnectionDialog.applicationClientId
-                : undefined; // undefined falls back to the label from capabilities
+                : this._originalUserLabel;
             userComp.tooltip = isServicePrincipal
                 ? LocAll.ConnectionDialog.applicationClientIdTooltip
-                : undefined;
+                : this._originalUserTooltip;
         }
         const passwordComp = this.state.formComponents["password"];
         if (passwordComp) {
+            if (passwordComp.label && !this._originalPasswordLabel) {
+                this._originalPasswordLabel = passwordComp.label;
+            }
+            if (passwordComp.tooltip && !this._originalPasswordTooltip) {
+                this._originalPasswordTooltip = passwordComp.tooltip;
+            }
             passwordComp.label = isServicePrincipal
                 ? LocAll.ConnectionDialog.clientSecret
-                : undefined;
+                : this._originalPasswordLabel;
             passwordComp.tooltip = isServicePrincipal
                 ? LocAll.ConnectionDialog.clientSecretTooltip
-                : undefined;
+                : this._originalPasswordTooltip;
         }
 
         for (const component of Object.values(this.state.formComponents)) {

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -172,6 +172,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private _originalUserTooltip: string | undefined;
     private _originalPasswordLabel: string | undefined;
     private _originalPasswordTooltip: string | undefined;
+    private _originalSavePasswordLabel: string | undefined;
 
     //#endregion
 
@@ -1117,6 +1118,15 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             passwordComp.tooltip = isServicePrincipal
                 ? LocAll.ConnectionDialog.clientSecretTooltip
                 : this._originalPasswordTooltip;
+        }
+        const savePasswordComp = this.state.formComponents["savePassword"];
+        if (savePasswordComp) {
+            if (savePasswordComp.label && !this._originalSavePasswordLabel) {
+                this._originalSavePasswordLabel = savePasswordComp.label;
+            }
+            savePasswordComp.label = isServicePrincipal
+                ? LocAll.ConnectionDialog.saveSecret
+                : this._originalSavePasswordLabel;
         }
 
         for (const component of Object.values(this.state.formComponents)) {

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -591,6 +591,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                     AuthenticationType.Integrated,
                     AuthenticationType.AzureMFA,
                     AuthenticationType.ActiveDirectoryDefault,
+                    AuthenticationType.ActiveDirectoryServicePrincipal,
                 ];
 
                 if (
@@ -889,6 +890,8 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 [AuthenticationType.ActiveDirectoryDefault]:
                     "https://aka.ms/vscode-mssql-auth-entra-default",
                 [AuthenticationType.AzureMFA]: "https://aka.ms/vscode-mssql-auth-entra-mfa",
+                [AuthenticationType.ActiveDirectoryServicePrincipal]:
+                    "https://learn.microsoft.com/en-us/sql/connect/ado-net/sql/azure-active-directory-authentication?view=sql-server-ver17#using-service-principal-authentication",
             };
 
             const url = infoLinkMap[payload.option.value as AuthenticationType];
@@ -1024,19 +1027,27 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         if (
             this.state.connectionProfile.authenticationType !== AuthenticationType.SqlLogin &&
             this.state.connectionProfile.authenticationType !==
-                AuthenticationType.ActiveDirectoryDefault
+                AuthenticationType.ActiveDirectoryDefault &&
+            this.state.connectionProfile.authenticationType !==
+                AuthenticationType.ActiveDirectoryServicePrincipal
         ) {
             hiddenProperties.push("user");
         }
-        if (this.state.connectionProfile.authenticationType !== AuthenticationType.SqlLogin) {
+        if (
+            this.state.connectionProfile.authenticationType !== AuthenticationType.SqlLogin &&
+            this.state.connectionProfile.authenticationType !==
+                AuthenticationType.ActiveDirectoryServicePrincipal
+        ) {
             hiddenProperties.push("password", "savePassword");
         }
 
         const userComponent = this.state.formComponents["user"];
         if (userComponent) {
-            // userId is required for SQL Login, optional for AD Default, and hidden (above) for everything else
+            // userId is required for SQL Login and Service Principal, optional for AD Default, and hidden (above) for everything else
             userComponent.required =
-                this.state.connectionProfile.authenticationType === AuthenticationType.SqlLogin;
+                this.state.connectionProfile.authenticationType === AuthenticationType.SqlLogin ||
+                this.state.connectionProfile.authenticationType ===
+                    AuthenticationType.ActiveDirectoryServicePrincipal;
         }
 
         if (this.state.connectionProfile.authenticationType !== AuthenticationType.AzureMFA) {
@@ -1063,6 +1074,29 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                     hiddenProperties.push("tenantId");
                 }
             }
+        }
+
+        // Relabel user/password fields for Service Principal to disambiguate from SQL Login
+        const isServicePrincipal =
+            this.state.connectionProfile.authenticationType ===
+            AuthenticationType.ActiveDirectoryServicePrincipal;
+        const userComp = this.state.formComponents["user"];
+        if (userComp) {
+            userComp.label = isServicePrincipal
+                ? LocAll.ConnectionDialog.applicationClientId
+                : undefined; // undefined falls back to the label from capabilities
+            userComp.tooltip = isServicePrincipal
+                ? LocAll.ConnectionDialog.applicationClientIdTooltip
+                : undefined;
+        }
+        const passwordComp = this.state.formComponents["password"];
+        if (passwordComp) {
+            passwordComp.label = isServicePrincipal
+                ? LocAll.ConnectionDialog.clientSecret
+                : undefined;
+            passwordComp.tooltip = isServicePrincipal
+                ? LocAll.ConnectionDialog.clientSecretTooltip
+                : undefined;
         }
 
         for (const component of Object.values(this.state.formComponents)) {
@@ -1455,6 +1489,8 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             case AuthenticationType.Integrated:
             case AuthenticationType.ActiveDirectoryDefault:
                 return true;
+            case AuthenticationType.ActiveDirectoryServicePrincipal:
+                return !!(profile.user && profile.password);
             default:
                 return false;
         }

--- a/extensions/mssql/src/connectionconfig/formComponentHelpers.ts
+++ b/extensions/mssql/src/connectionconfig/formComponentHelpers.ts
@@ -287,6 +287,8 @@ export async function completeFormComponents(
                 option.infoTooltip = Loc.entraDefaultAuthTooltip;
             } else if (option.value === AuthenticationType.AzureMFA) {
                 option.infoTooltip = Loc.entraMfaAuthTooltip;
+            } else if (option.value === AuthenticationType.ActiveDirectoryServicePrincipal) {
+                option.infoTooltip = Loc.entraServicePrincipalAuthTooltip;
             }
         }
     }
@@ -316,10 +318,19 @@ export async function completeFormComponents(
     };
 
     components["user"].validate = (state: ConnectionDialogWebviewState, value: string) => {
-        if (state.connectionProfile.authenticationType === AuthenticationType.SqlLogin && !value) {
+        if (
+            (state.connectionProfile.authenticationType === AuthenticationType.SqlLogin ||
+                state.connectionProfile.authenticationType ===
+                    AuthenticationType.ActiveDirectoryServicePrincipal) &&
+            !value
+        ) {
             return {
                 isValid: false,
-                validationMessage: Loc.usernameIsRequired,
+                validationMessage:
+                    state.connectionProfile.authenticationType ===
+                    AuthenticationType.ActiveDirectoryServicePrincipal
+                        ? Loc.applicationClientIdIsRequired
+                        : Loc.usernameIsRequired,
             };
         }
         return {
@@ -327,6 +338,26 @@ export async function completeFormComponents(
             validationMessage: "",
         };
     };
+
+    if (components["password"]) {
+        components["password"].validate = (state: ConnectionDialogWebviewState, value: string) => {
+            if (
+                state.connectionProfile.authenticationType ===
+                    AuthenticationType.ActiveDirectoryServicePrincipal &&
+                !value &&
+                !state.connectionProfile.emptyPasswordInput
+            ) {
+                return {
+                    isValid: false,
+                    validationMessage: Loc.clientSecretIsRequired,
+                };
+            }
+            return {
+                isValid: true,
+                validationMessage: "",
+            };
+        };
+    }
 }
 
 export function getGroupIdFormItem(connectionGroupOptions: FormItemOptions[]) {

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -170,6 +170,7 @@ export const defaultCommandTimeout = 30;
 export const stsImmediateActivityTimeout = 5000; // 5 seconds
 export const azureDatabase = "Azure";
 export const azureMfa = "AzureMFA";
+export const azureServicePrincipal = "ActiveDirectoryServicePrincipal";
 export const defaultPortNumber = 1433;
 export const integratedauth = "Integrated";
 export const sqlAuthentication = "SqlLogin";

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -176,6 +176,7 @@ export let authTypeIntegrated = l10n.t("Integrated");
 export let authTypeSql = l10n.t("SQL Login");
 export let authTypeAzureActiveDirectory = l10n.t("Microsoft Entra Id - Universal w/ MFA Support");
 export let authTypeAzureActiveDirectoryDefault = l10n.t("Microsoft Entra Id - Default");
+export let authTypeAzureServicePrincipal = l10n.t("Microsoft Entra Id - Service Principal");
 export let azureAuthTypeCodeGrant = l10n.t("Azure Code Grant");
 export let azureAuthTypeDeviceCode = l10n.t("Azure Device Code");
 export let azureLogChannelName = l10n.t("MSSQL - Azure Auth Logs");
@@ -1023,6 +1024,19 @@ export class ConnectionDialog {
     public static entraMfaAuthTooltip = l10n.t(
         "Sign in with your Microsoft Entra ID account, including accounts with multi-factor authentication. Click the info icon to learn more.",
     );
+    public static entraServicePrincipalAuthTooltip = l10n.t(
+        "Authenticate using a Microsoft Entra service principal. Enter the Application (client) ID as the user name and the client secret as the password. Click the info icon to learn more.",
+    );
+    public static applicationClientId = l10n.t("Application (Client) ID");
+    public static applicationClientIdTooltip = l10n.t(
+        "The Application (Client) ID of your Microsoft Entra app registration.",
+    );
+    public static clientSecret = l10n.t("Client Secret");
+    public static clientSecretTooltip = l10n.t(
+        "The client secret for your Microsoft Entra app registration.",
+    );
+    public static applicationClientIdIsRequired = l10n.t("Application (Client) ID is required.");
+    public static clientSecretIsRequired = l10n.t("Client secret is required.");
     public static createConnectionGroup = l10n.t("+ Create Connection Group");
     public static selectConnectionGroup = l10n.t("Select a connection group");
     public static searchConnectionGroups = l10n.t("Search connection groups");
@@ -1091,7 +1105,8 @@ export class ConnectionDialog {
     public static systemDatabasesGroup = l10n.t("System databases");
     public static unableToLoadDatabaseList(errorMessage: string) {
         return l10n.t({
-            message: "Unable to load database list from server: {0}",
+            message:
+                "Unable to load database list from server: {0} You may enter the database name directly.",
             args: [errorMessage],
             comment: ["{0} is the connection error message"],
         });

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1037,6 +1037,7 @@ export class ConnectionDialog {
     );
     public static applicationClientIdIsRequired = l10n.t("Application (Client) ID is required.");
     public static clientSecretIsRequired = l10n.t("Client secret is required.");
+    public static saveSecret = l10n.t("Save Secret");
     public static createConnectionGroup = l10n.t("+ Create Connection Group");
     public static selectConnectionGroup = l10n.t("Select a connection group");
     public static searchConnectionGroups = l10n.t("Search connection groups");

--- a/extensions/mssql/src/models/connectionCredentials.ts
+++ b/extensions/mssql/src/models/connectionCredentials.ts
@@ -205,7 +205,11 @@ export class ConnectionCredentials implements IConnectionInfo {
         if (typeof credentials.authenticationType === "undefined") {
             authenticationType = utils.authTypeToString(AuthenticationTypes.SqlLogin);
         }
-        return authenticationType === utils.authTypeToString(AuthenticationTypes.SqlLogin);
+        return (
+            authenticationType === utils.authTypeToString(AuthenticationTypes.SqlLogin) ||
+            authenticationType ===
+                utils.authTypeToString(AuthenticationTypes.ActiveDirectoryServicePrincipal)
+        );
     }
 
     public static isPasswordBasedConnectionString(connectionString: string): boolean {
@@ -246,6 +250,10 @@ export class ConnectionCredentials implements IConnectionInfo {
             {
                 name: LocalizedConstants.authTypeAzureActiveDirectoryDefault,
                 value: utils.authTypeToString(AuthenticationTypes.ActiveDirectoryDefault),
+            },
+            {
+                name: LocalizedConstants.authTypeAzureServicePrincipal,
+                value: utils.authTypeToString(AuthenticationTypes.ActiveDirectoryServicePrincipal),
             },
         ];
 

--- a/extensions/mssql/src/models/connectionProfile.ts
+++ b/extensions/mssql/src/models/connectionProfile.ts
@@ -71,6 +71,16 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
                     AuthenticationTypes[AuthenticationTypes.ActiveDirectoryDefault]
             ) {
                 return utils.isNotEmpty(this.server);
+            } else if (
+                this.authenticationType ===
+                AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal]
+            ) {
+                // Service Principal requires server, App (client) ID (user), and client secret (password)
+                return (
+                    utils.isNotEmpty(this.server) &&
+                    utils.isNotEmpty(this.user) &&
+                    utils.isNotEmpty(this.password)
+                );
             } else {
                 return utils.isNotEmpty(this.server) && utils.isNotEmpty(this.user);
             }
@@ -79,7 +89,11 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
     }
 
     public isAzureActiveDirectory(): boolean {
-        return this.authenticationType === AuthenticationTypes[AuthenticationTypes.AzureMFA];
+        return (
+            this.authenticationType === AuthenticationTypes[AuthenticationTypes.AzureMFA] ||
+            this.authenticationType ===
+                AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal]
+        );
     }
 
     public static getAzureAuthChoices(): INameValueChoice[] {

--- a/extensions/mssql/src/models/interfaces.ts
+++ b/extensions/mssql/src/models/interfaces.ts
@@ -32,6 +32,7 @@ export enum AuthenticationTypes {
     SqlLogin = 2,
     AzureMFA = 3,
     ActiveDirectoryDefault = 4,
+    ActiveDirectoryServicePrincipal = 5,
 }
 
 export enum EncryptOptions {

--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -98,7 +98,7 @@ export function isEmpty(str: any): boolean {
 }
 
 export function isNotEmpty(str: any): boolean {
-    return <boolean>(str && "" !== str);
+    return !!(str && "" !== str);
 }
 
 export function authTypeToString(value: AuthenticationTypes): string {

--- a/extensions/mssql/src/objectExplorer/objectExplorerUtils.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerUtils.ts
@@ -47,7 +47,10 @@ export class ObjectExplorerUtils {
             uri = fields.join(";");
             return uri;
         }
-        if (profile.authenticationType === Constants.sqlAuthentication) {
+        if (
+            profile.authenticationType === Constants.sqlAuthentication ||
+            profile.authenticationType === Constants.azureServicePrincipal
+        ) {
             uri = `${profile.server}_${profile.database}_${profile.user}_${profile.profileName}`;
         } else {
             uri = `${profile.server}_${profile.database}_${profile.profileName}`;

--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -221,6 +221,10 @@ export enum AuthenticationType {
      */
     AzureMFAAndUser = "AzureMFAAndUser",
     /**
+     * Microsoft Entra Id - Service Principal (client ID + client secret)
+     */
+    ActiveDirectoryServicePrincipal = "ActiveDirectoryServicePrincipal",
+    /**
      * Datacenter Security Token Service Authentication
      */
     DSTSAuth = "dstsAuth",

--- a/extensions/mssql/test/unit/connectionCredentials.test.ts
+++ b/extensions/mssql/test/unit/connectionCredentials.test.ts
@@ -139,5 +139,66 @@ suite("ConnectionCredentials Tests", () => {
                 AuthenticationTypes[AuthenticationTypes.ActiveDirectoryDefault],
             );
         });
+
+        test("createConnectionInfo preserves ActiveDirectoryServicePrincipal auth type", () => {
+            const connDetails: ConnectionDetails = {
+                options: {
+                    server: "someServer",
+                    authenticationType:
+                        AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal],
+                },
+            };
+
+            const connInfo = ConnectionCredentials.createConnectionInfo(connDetails);
+            expect(connInfo.authenticationType).to.equal(
+                AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal],
+            );
+        });
+    });
+
+    suite("isPasswordBasedCredential", () => {
+        test("returns true for SqlLogin", () => {
+            const creds = new ConnectionCredentials();
+            creds.authenticationType = AuthenticationTypes[AuthenticationTypes.SqlLogin];
+            expect(ConnectionCredentials.isPasswordBasedCredential(creds)).to.be.true;
+        });
+
+        test("returns true for ActiveDirectoryServicePrincipal", () => {
+            const creds = new ConnectionCredentials();
+            creds.authenticationType =
+                AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal];
+            expect(ConnectionCredentials.isPasswordBasedCredential(creds)).to.be.true;
+        });
+
+        test("returns false for AzureMFA", () => {
+            const creds = new ConnectionCredentials();
+            creds.authenticationType = AuthenticationTypes[AuthenticationTypes.AzureMFA];
+            expect(ConnectionCredentials.isPasswordBasedCredential(creds)).to.be.false;
+        });
+
+        test("returns false for Integrated", () => {
+            const creds = new ConnectionCredentials();
+            creds.authenticationType = AuthenticationTypes[AuthenticationTypes.Integrated];
+            expect(ConnectionCredentials.isPasswordBasedCredential(creds)).to.be.false;
+        });
+
+        test("returns false for ActiveDirectoryDefault", () => {
+            const creds = new ConnectionCredentials();
+            creds.authenticationType =
+                AuthenticationTypes[AuthenticationTypes.ActiveDirectoryDefault];
+            expect(ConnectionCredentials.isPasswordBasedCredential(creds)).to.be.false;
+        });
+    });
+
+    suite("getAuthenticationTypesChoice", () => {
+        test("includes ActiveDirectoryServicePrincipal option", () => {
+            const choices = ConnectionCredentials.getAuthenticationTypesChoice();
+            const spChoice = choices.find(
+                (c) =>
+                    c.value ===
+                    AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal],
+            );
+            expect(spChoice, "Service Principal choice should be present").to.not.be.undefined;
+        });
     });
 });

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -1171,7 +1171,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
                     options: {
                         server: "myServer",
                         database: "myDB",
-                        authenticationType: "ActiveDirectoryServicePrincipal", // unsupported
+                        authenticationType: "UnknownAuthType", // unsupported
                     },
                 } as ConnectionDetails;
 
@@ -1185,7 +1185,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 );
                 expect(
                     (controller.state.dialog as ConnectionStringDialogProps).connectionStringError,
-                ).to.contain("ActiveDirectoryServicePrincipal");
+                ).to.contain("UnknownAuthType");
             });
 
             test("should display error message if parsing connection string throws", async () => {

--- a/extensions/mssql/test/unit/connectionProfile.test.ts
+++ b/extensions/mssql/test/unit/connectionProfile.test.ts
@@ -125,4 +125,57 @@ suite("Connection Profile tests", () => {
 
         expect(profile.isValidProfile()).to.be.true;
     });
+
+    test("ActiveDirectoryServicePrincipal profile requires server, user (App ID), and password (secret)", () => {
+        const profile = new ConnectionProfile();
+        profile.server = "my-server";
+        profile.authenticationType =
+            AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal];
+
+        expect(profile.isValidProfile(), "Missing user and password should be invalid").to.be.false;
+
+        profile.user = "app-client-id";
+        expect(profile.isValidProfile(), "Missing password should be invalid").to.be.false;
+
+        profile.password = "client-secret";
+        expect(profile.isValidProfile(), "Server + user + password should be valid").to.be.true;
+    });
+
+    test("isAzureActiveDirectory returns true for AzureMFA", () => {
+        const profile = new ConnectionProfile();
+        profile.authenticationType = AuthenticationTypes[AuthenticationTypes.AzureMFA];
+        expect(profile.isAzureActiveDirectory()).to.be.true;
+    });
+
+    test("isAzureActiveDirectory returns true for ActiveDirectoryServicePrincipal", () => {
+        const profile = new ConnectionProfile();
+        profile.authenticationType =
+            AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal];
+        expect(profile.isAzureActiveDirectory()).to.be.true;
+    });
+
+    test("isAzureActiveDirectory returns false for SqlLogin", () => {
+        const profile = new ConnectionProfile();
+        profile.authenticationType = AuthenticationTypes[AuthenticationTypes.SqlLogin];
+        expect(profile.isAzureActiveDirectory()).to.be.false;
+    });
+});
+
+test("isAzureActiveDirectory returns true for AzureMFA", () => {
+    const profile = new ConnectionProfile();
+    profile.authenticationType = AuthenticationTypes[AuthenticationTypes.AzureMFA];
+    expect(profile.isAzureActiveDirectory()).to.be.true;
+});
+
+test("isAzureActiveDirectory returns true for ActiveDirectoryServicePrincipal", () => {
+    const profile = new ConnectionProfile();
+    profile.authenticationType =
+        AuthenticationTypes[AuthenticationTypes.ActiveDirectoryServicePrincipal];
+    expect(profile.isAzureActiveDirectory()).to.be.true;
+});
+
+test("isAzureActiveDirectory returns false for SqlLogin", () => {
+    const profile = new ConnectionProfile();
+    profile.authenticationType = AuthenticationTypes[AuthenticationTypes.SqlLogin];
+    expect(profile.isAzureActiveDirectory()).to.be.false;
 });

--- a/extensions/mssql/test/unit/objectExplorerUtils.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerUtils.test.ts
@@ -300,6 +300,25 @@ suite("Object Explorer Utils Tests", () => {
         expect(result).to.equal("testServer_testDB_testProfile");
     });
 
+    test("should create URI for Service Principal authentication including client ID", () => {
+        // Setup
+        const profile: IConnectionProfile = {
+            server: "spServer",
+            database: "spDB",
+            authenticationType: Constants.azureServicePrincipal,
+            user: "my-client-id",
+            profileName: "spProfile",
+            id: "id",
+        } as IConnectionProfile;
+
+        // Execute
+        const result = ObjectExplorerUtils.getNodeUriFromProfile(profile);
+
+        // Verify — client ID (user) must be in the URI so different service principals
+        // connecting to the same server/database get distinct connection nodes.
+        expect(result).to.equal("spServer_spDB_my-client-id_spProfile");
+    });
+
     test("Test getDatabaseName", () => {
         const testProfile = new ConnectionProfile();
         testProfile.server = "test_server";

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -356,6 +356,12 @@
     <trans-unit id="++CODE++a6f31505cd1943fe9695363ab1c0a08e79c015c0747830d411a24e29689f4899">
       <source xml:lang="en">Append to the existing backup set</source>
     </trans-unit>
+    <trans-unit id="++CODE++a7168cfe83fa5085e397d074c440ebc49d8f9d65f5241ff5f2ea586f9a4db451">
+      <source xml:lang="en">Application (Client) ID</source>
+    </trans-unit>
+    <trans-unit id="++CODE++e6e909c5bd0a3e25a1abcddd1dab13780ce9e4f673139a56842b1e3a26c981c0">
+      <source xml:lang="en">Application (Client) ID is required.</source>
+    </trans-unit>
     <trans-unit id="++CODE++f548fb847184961d59c59fd5b4ff10720726475e1768037348dec8e7c6bd6468">
       <source xml:lang="en">Application Intent</source>
     </trans-unit>
@@ -438,6 +444,9 @@
     </trans-unit>
     <trans-unit id="++CODE++8ff1f9a47f14327a26fd3a548d2babeec226cb63828a0803433b4a34a19c09ff">
       <source xml:lang="en">Auth type</source>
+    </trans-unit>
+    <trans-unit id="++CODE++59480e87da5310e5046d84f52931338703cc3c68aaa8fc535e025eb621677ed9">
+      <source xml:lang="en">Authenticate using a Microsoft Entra service principal. Enter the Application (client) ID as the user name and the client secret as the password. Click the info icon to learn more.</source>
     </trans-unit>
     <trans-unit id="++CODE++6ab694cfc6fa5d8c7045d318bba5f3eb791ab0a859ea54c54b1c660a4ccf8ed1">
       <source xml:lang="en">Authenticated</source>
@@ -1032,6 +1041,12 @@
     </trans-unit>
     <trans-unit id="++CODE++88af7d4ffbbad0f31d9dd918e49ceb713036db12524cbdc4b93e8922b0655429">
       <source xml:lang="en">Click to sign into an Azure account</source>
+    </trans-unit>
+    <trans-unit id="++CODE++ae21cf6d24b8ca460e91fe9dc61432a60403b1dabea53792a9c95c63a7cb0db2">
+      <source xml:lang="en">Client Secret</source>
+    </trans-unit>
+    <trans-unit id="++CODE++b88d22f627afd019becae5972c1ad1c05cca30f1c24c21e6a1ebf5492207904b">
+      <source xml:lang="en">Client secret is required.</source>
     </trans-unit>
     <trans-unit id="++CODE++7d9eb7acb13e24625c404401d8e88b2350e32162455885f18276cf802f7701ed">
       <source xml:lang="en">Close</source>
@@ -3960,6 +3975,9 @@
     <trans-unit id="++CODE++585389836e18976b372ada3cfd7a57608ccff88fc27ade1458fd968b3c089ff5">
       <source xml:lang="en">Microsoft Entra Id - Default</source>
     </trans-unit>
+    <trans-unit id="++CODE++abb07d0f4dfada778581c9b19ad0453201ea6d075bc434debb65d96b65f2adbc">
+      <source xml:lang="en">Microsoft Entra Id - Service Principal</source>
+    </trans-unit>
     <trans-unit id="++CODE++d24b24ff2640e9b5731d40ac97ea534034176c1478b681eca122262c4d98a8a2">
       <source xml:lang="en">Microsoft Entra Id - Universal w/ MFA Support</source>
     </trans-unit>
@@ -6366,6 +6384,9 @@
     <trans-unit id="++CODE++33c3b491fa743d2c355067a31dceaf799d4baaef0778d786cf5aafa5406ecf47">
       <source xml:lang="en">Text tab - displays SQL text data</source>
     </trans-unit>
+    <trans-unit id="++CODE++c2deec07495a278190de83a0820519064e332fc00b050c4fd053bae70c44da8e">
+      <source xml:lang="en">The Application (Client) ID of your Microsoft Entra app registration.</source>
+    </trans-unit>
     <trans-unit id="++CODE++b0ccb68c36737cb5ef6c7a74871ab7845533f64d89c74dd7db735bb555c401e1">
       <source xml:lang="en">The Query Profiler now supports SQL database in Microsoft Fabric connections, with new Azure SQL Database templates including {code-snippet-0} for lightweight T-SQL profiling.</source>
     </trans-unit>
@@ -6381,6 +6402,9 @@
     </trans-unit>
     <trans-unit id="++CODE++1a4205e9f5cc50eaf70719b64956352b74a99badba266027a6244def0d016b73">
       <source xml:lang="en">The behavior when a user tries to update a row with data that is involved in a foreign key relationship.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++b3ed9d46f7671d126e86925d532363313c1f6795e877d3d348d134f6e7051bc3">
+      <source xml:lang="en">The client secret for your Microsoft Entra app registration.</source>
     </trans-unit>
     <trans-unit id="++CODE++4002a5b20dd0c7a8caf9764ba024343e8f87e2ba8221aaeae4c5112d1d7bb4ed">
       <source xml:lang="en">The columns of the index.</source>
@@ -6624,8 +6648,8 @@
     <trans-unit id="++CODE++4355e7352a614a58a8051157468baaf1102b9be2bdc6334597a8298aefbfbed6">
       <source xml:lang="en">Unable to load backup configuration. Please try again.</source>
     </trans-unit>
-    <trans-unit id="++CODE++c8a8ab1cef4a26f5a47e6aff86611314a34effe284539cfe1421067648432eab">
-      <source xml:lang="en">Unable to load database list from server: {0}</source>
+    <trans-unit id="++CODE++d11ea02689601a129dda01909b71622e7f1a166ce25bef3aa0589beb6db8c1d7">
+      <source xml:lang="en">Unable to load database list from server: {0} You may enter the database name directly.</source>
       <note>{0} is the connection error message</note>
     </trans-unit>
     <trans-unit id="++CODE++955b62784673f0081b2a54d867245fa50ca1e830cea22348ff69caa6317e7889">

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -5429,6 +5429,9 @@
     <trans-unit id="++CODE++22995cab793b6ddc02993f48d7042dff97e62df3faf4b7742629243a36ce968d">
       <source xml:lang="en">Save Plan</source>
     </trans-unit>
+    <trans-unit id="++CODE++072fb040dae019a32d416f0ad48852b98a2544da0e126c054ea338011ae0d63a">
+      <source xml:lang="en">Save Secret</source>
+    </trans-unit>
     <trans-unit id="++CODE++e50761ebedbdddb4dd4afb99a7c0964cf8bfed33ec03cb39f5a08e65812c795a">
       <source xml:lang="en">Save as CSV</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Dependent on https://github.com/microsoft/sqltoolsservice/pull/2690

Adding support for Entra Service Principal auth.  Users can enter their Service Principal's client ID and secret to authenticate.  Certificates not support (same as SSMS)

<img width="945" height="259" alt="image" src="https://github.com/user-attachments/assets/f8ec51ff-a1ac-4416-9390-c4913eadd8b0" />

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
