### PR TITLE
Fix DAB MCP apply changes consistency

### DIFF
--- a/extensions/mssql/src/sharedInterfaces/dab.ts
+++ b/extensions/mssql/src/sharedInterfaces/dab.ts
@@ -56,6 +56,47 @@ export namespace Dab {
         return restMethodSortOrder.filter((method) => uniqueMethods.has(method));
     }
 
+    export const maxDabEntityNameLength = 128;
+    export const maxDabRoutePathLength = 256;
+
+    const dabEntityNamePattern = /^[A-Za-z][A-Za-z0-9_]*$/;
+    const dabGraphQLTypePattern = /^[_A-Za-z][_0-9A-Za-z]*$/;
+    const dabRestPathPattern = /^\/?[A-Za-z0-9._~-]+(?:\/[A-Za-z0-9._~-]+)*$/;
+
+    export function normalizeDabIdentifier(value: string | undefined): string {
+        return (value ?? "").trim().toLowerCase();
+    }
+
+    export function validateDabEntityName(value: string): string | undefined {
+        if (value.length > maxDabEntityNameLength) {
+            return `entityName must be ${maxDabEntityNameLength} characters or fewer.`;
+        }
+        if (!dabEntityNamePattern.test(value)) {
+            return "entityName must start with a letter and contain only letters, numbers, and underscores.";
+        }
+        return undefined;
+    }
+
+    export function validateDabCustomRestPath(value: string): string | undefined {
+        if (value.length > maxDabRoutePathLength) {
+            return `customRestPath must be ${maxDabRoutePathLength} characters or fewer.`;
+        }
+        if (!dabRestPathPattern.test(value)) {
+            return "customRestPath must be a relative route path using letters, numbers, slash, dot, underscore, tilde, or hyphen.";
+        }
+        return undefined;
+    }
+
+    export function validateDabCustomGraphQLType(value: string): string | undefined {
+        if (value.length > maxDabEntityNameLength) {
+            return `customGraphQLType must be ${maxDabEntityNameLength} characters or fewer.`;
+        }
+        if (!dabGraphQLTypePattern.test(value)) {
+            return "customGraphQLType must be a valid GraphQL name.";
+        }
+        return undefined;
+    }
+
     export enum GraphQLOperation {
         Query = "query",
         Mutation = "mutation",

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabContext.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabContext.tsx
@@ -96,6 +96,7 @@ export const DabProvider: React.FC<DabProviderProps> = ({ children }) => {
                 ...dabSourceObjectsRef.current,
             ],
             commitDabConfig: (config) => {
+                dabConfigRef.current = config;
                 setDabConfig(config);
             },
         });

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -199,6 +199,7 @@ const useStyles = makeStyles({
 
 interface DabEntitySettingsDialogProps {
     entity: Dab.DabEntityConfig;
+    existingEntityNames: string[];
     isRestEnabled: boolean;
     isGraphQLEnabled: boolean;
     isMcpEnabled: boolean;
@@ -210,6 +211,7 @@ interface DabEntitySettingsDialogProps {
 
 export function DabEntitySettingsDialog({
     entity,
+    existingEntityNames,
     isRestEnabled,
     isGraphQLEnabled,
     isMcpEnabled,
@@ -231,10 +233,6 @@ export function DabEntitySettingsDialog({
             setLocalSettings(entity.advancedSettings);
         }
     }, [open, entity.advancedSettings]);
-
-    const handleApply = () => {
-        onApply(localSettings);
-    };
 
     const handleCancel = () => {
         onOpenChange(false);
@@ -300,6 +298,41 @@ export function DabEntitySettingsDialog({
         localSettings.storedProcedureGraphQLOperation ?? Dab.GraphQLOperation.Mutation;
     const exposeAsMcpCustomTool = localSettings.exposeAsMcpCustomTool !== false;
     const sourceObjectName = `${entity.schemaName}.${entity.sourceName ?? entity.tableName}`;
+    const entityName = localSettings.entityName.trim();
+    const customRestPath = localSettings.customRestPath?.trim() ?? "";
+    const customGraphQLType = localSettings.customGraphQLType?.trim() ?? "";
+    const normalizedExistingEntityNames = new Set(
+        existingEntityNames.map(Dab.normalizeDabIdentifier),
+    );
+    const entityNameValidationMessage =
+        entityName.length === 0
+            ? "entityName must be a non-empty string."
+            : normalizedExistingEntityNames.has(Dab.normalizeDabIdentifier(entityName))
+              ? `entityName must be unique across entities. Duplicate: ${entityName}`
+              : Dab.validateDabEntityName(entityName);
+    const customRestPathValidationMessage =
+        customRestPath.length > 0 ? Dab.validateDabCustomRestPath(customRestPath) : undefined;
+    const customGraphQLTypeValidationMessage =
+        customGraphQLType.length > 0
+            ? Dab.validateDabCustomGraphQLType(customGraphQLType)
+            : undefined;
+    const hasValidationError =
+        !!entityNameValidationMessage ||
+        !!customRestPathValidationMessage ||
+        !!customGraphQLTypeValidationMessage;
+
+    const handleApply = () => {
+        if (hasValidationError) {
+            return;
+        }
+
+        onApply({
+            ...localSettings,
+            entityName,
+            customRestPath: customRestPath.length > 0 ? customRestPath : undefined,
+            customGraphQLType: customGraphQLType.length > 0 ? customGraphQLType : undefined,
+        });
+    };
 
     const renderSourceIcon = () => {
         switch (entity.sourceType ?? Dab.EntitySourceType.Table) {
@@ -369,6 +402,10 @@ export function DabEntitySettingsDialog({
                             <div className={classes.sectionBody}>
                                 <Field
                                     label={locConstants.schemaDesigner.entityName}
+                                    validationState={
+                                        entityNameValidationMessage ? "error" : undefined
+                                    }
+                                    validationMessage={entityNameValidationMessage}
                                     hint={{
                                         children: locConstants.schemaDesigner.entityNameHelp,
                                         className: classes.fieldHint,
@@ -480,6 +517,14 @@ export function DabEntitySettingsDialog({
                                                     label={
                                                         locConstants.schemaDesigner.customRestPath
                                                     }
+                                                    validationState={
+                                                        customRestPathValidationMessage
+                                                            ? "error"
+                                                            : undefined
+                                                    }
+                                                    validationMessage={
+                                                        customRestPathValidationMessage
+                                                    }
                                                     hint={{
                                                         children:
                                                             locConstants.schemaDesigner
@@ -578,6 +623,14 @@ export function DabEntitySettingsDialog({
                                                     label={
                                                         locConstants.schemaDesigner
                                                             .customGraphQLType
+                                                    }
+                                                    validationState={
+                                                        customGraphQLTypeValidationMessage
+                                                            ? "error"
+                                                            : undefined
+                                                    }
+                                                    validationMessage={
+                                                        customGraphQLTypeValidationMessage
                                                     }
                                                     hint={{
                                                         children:
@@ -694,6 +747,7 @@ export function DabEntitySettingsDialog({
                         <Button
                             appearance="primary"
                             className={classes.actionButton}
+                            disabled={hasValidationError}
                             onClick={handleApply}>
                             {locConstants.schemaDesigner.applyChanges}
                         </Button>

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntityTable.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntityTable.tsx
@@ -1405,6 +1405,9 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
             {settingsEntity && dabConfig && (
                 <DabEntitySettingsDialog
                     entity={settingsEntity}
+                    existingEntityNames={dabConfig.entities
+                        .filter((entity) => entity.id !== settingsEntity.id)
+                        .map((entity) => entity.advancedSettings.entityName)}
                     isRestEnabled={dabConfig.apiTypes.includes(Dab.ApiType.Rest)}
                     isGraphQLEnabled={dabConfig.apiTypes.includes(Dab.ApiType.GraphQL)}
                     isMcpEnabled={dabConfig.apiTypes.includes(Dab.ApiType.Mcp)}

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
@@ -1609,7 +1609,18 @@ function applyDabToolChange(
                                 message: "entityName must be a non-empty string.",
                             };
                         }
-                        updatedSettings.entityName = value.trim();
+                        {
+                            const trimmedValue = value.trim();
+                            const validationError = Dab.validateDabEntityName(trimmedValue);
+                            if (validationError) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message: validationError,
+                                };
+                            }
+                            updatedSettings.entityName = trimmedValue;
+                        }
                         break;
                     case "authorizationRole":
                         if (
@@ -1644,7 +1655,18 @@ function applyDabToolChange(
                                 message: "customRestPath cannot be an empty string.",
                             };
                         }
-                        updatedSettings.customRestPath = value.trim();
+                        {
+                            const trimmedValue = value.trim();
+                            const validationError = Dab.validateDabCustomRestPath(trimmedValue);
+                            if (validationError) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message: validationError,
+                                };
+                            }
+                            updatedSettings.customRestPath = trimmedValue;
+                        }
                         break;
                     case "restEnabled":
                         if (typeof value !== "boolean") {
@@ -1675,7 +1697,18 @@ function applyDabToolChange(
                                 message: "customGraphQLType cannot be an empty string.",
                             };
                         }
-                        updatedSettings.customGraphQLType = value.trim();
+                        {
+                            const trimmedValue = value.trim();
+                            const validationError = Dab.validateDabCustomGraphQLType(trimmedValue);
+                            if (validationError) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message: validationError,
+                                };
+                            }
+                            updatedSettings.customGraphQLType = trimmedValue;
+                        }
                         break;
                     case "graphQLEnabled":
                         if (typeof value !== "boolean") {
@@ -1967,15 +2000,14 @@ export function registerSchemaDesignerDabToolHandlers(params: {
         for (let i = 0; i < request.changes.length; i++) {
             const applyResult = applyDabToolChange(workingSnapshot, request.changes[i]);
             if (applyResult.success === false) {
-                commitDabConfig(workingSnapshot);
                 return {
                     success: false,
                     reason: applyResult.reason,
                     message: applyResult.message,
                     failedChangeIndex: i,
-                    appliedChanges,
-                    version: await computeDabVersion(workingSnapshot),
-                    summary: buildDabSummary(workingSnapshot),
+                    appliedChanges: 0,
+                    version,
+                    summary: buildDabSummary(baseSnapshot),
                 };
             }
             appliedChanges++;

--- a/extensions/mssql/test/unit/dab/dabSharedInterfaces.test.ts
+++ b/extensions/mssql/test/unit/dab/dabSharedInterfaces.test.ts
@@ -46,6 +46,28 @@ suite("DAB shared interface helpers", () => {
         ).to.deep.equal([Dab.RestMethod.Get, Dab.RestMethod.Post, Dab.RestMethod.Delete]);
     });
 
+    test("validates DAB entity setting strings", () => {
+        expect(Dab.validateDabEntityName("UsersApi")).to.equal(undefined);
+        expect(Dab.validateDabEntityName("<script>alert('xss')</script>")).to.include(
+            "entityName must start with a letter",
+        );
+        expect(Dab.validateDabEntityName(`A${"a".repeat(500)}`)).to.include(
+            "128 characters or fewer",
+        );
+
+        expect(Dab.validateDabCustomRestPath("/users/by-id")).to.equal(undefined);
+        expect(Dab.validateDabCustomRestPath("users.by_id")).to.equal(undefined);
+        expect(Dab.validateDabCustomRestPath("'; DROP TABLE dbo.Todos; --")).to.include(
+            "customRestPath must be a relative route path",
+        );
+
+        expect(Dab.validateDabCustomGraphQLType("UsersType")).to.equal(undefined);
+        expect(Dab.validateDabCustomGraphQLType("_UsersType")).to.equal(undefined);
+        expect(Dab.validateDabCustomGraphQLType("こんにちは")).to.equal(
+            "customGraphQLType must be a valid GraphQL name.",
+        );
+    });
+
     test("validateSourceObjectForDab uses view fields for primary key support", () => {
         const supportedView = createSourceObject({
             id: "view:dbo.ActiveUsers",

--- a/extensions/mssql/test/unit/dabTool.test.ts
+++ b/extensions/mssql/test/unit/dabTool.test.ts
@@ -908,7 +908,7 @@ suite("DabTool Tests", () => {
             expect(unsupportedReturnState.message).to.include("Unsupported returnState");
         });
 
-        test("apply_changes validates set_api_types and fails at index 0 with partial receipt", async () => {
+        test("apply_changes validates set_api_types and fails at index 0 without committing", async () => {
             const harness = createDabHandlerHarness({
                 tables: [createTable("t1", "dbo", "Users")],
                 dabConfig: null,
@@ -934,7 +934,7 @@ suite("DabTool Tests", () => {
             expect(result.message).to.equal("apiTypes must be unique.");
             expect(result.failedChangeIndex).to.equal(0);
             expect(result.appliedChanges).to.equal(0);
-            expect(harness.commitSpy.calledOnce).to.equal(true);
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes validates set_entity_actions payload", async () => {
@@ -962,7 +962,7 @@ suite("DabTool Tests", () => {
             }
             expect(emptyActions.reason).to.equal("validation_error");
             expect(emptyActions.message).to.equal("enabledActions must be a non-empty array.");
-            expect(harness.commitSpy.calledOnce).to.equal(true);
+            expect(harness.commitSpy.called).to.equal(false);
             harness.commitSpy.resetHistory();
 
             const result = await harness.applyChanges({
@@ -984,7 +984,7 @@ suite("DabTool Tests", () => {
             expect(result.message).to.equal("enabledActions contains unsupported values.");
             expect(result.failedChangeIndex).to.equal(0);
             expect(result.appliedChanges).to.equal(0);
-            expect(harness.commitSpy.calledOnce).to.equal(true);
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes updates column exposure by column name", async () => {
@@ -1069,14 +1069,7 @@ suite("DabTool Tests", () => {
             }
             expect(result.reason).to.equal("validation_error");
             expect(result.message).to.equal("Primary key columns must remain exposed.");
-            expect(harness.commitSpy).to.have.been.calledWithMatch(
-                sinon.match((config: Dab.DabConfig) => {
-                    const entity = config.entities.find((candidate) => candidate.id === "t1");
-                    return (
-                        entity?.columns.find((column) => column.id === "t1-id")?.isExposed === true
-                    );
-                }),
-            );
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes supports add/remove aliases and source refs for views", async () => {
@@ -1215,6 +1208,8 @@ suite("DabTool Tests", () => {
             }
             expect(duplicateName.reason).to.equal("validation_error");
             expect(duplicateName.message).to.include("entityName must be unique");
+            expect(harness.getConfig()?.entities[0].advancedSettings.entityName).to.equal("Users");
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes patch_entity_settings rejects whitespace-only strings and trims accepted values", async () => {
@@ -1305,6 +1300,88 @@ suite("DabTool Tests", () => {
             expect(settings?.entityName).to.equal("UsersApi");
             expect(settings?.customRestPath).to.equal("/users");
             expect(settings?.customGraphQLType).to.equal("UsersType");
+        });
+
+        test("apply_changes patch_entity_settings rejects unsafe string values", async () => {
+            const harness = createDabHandlerHarness({
+                tables: [createTable("t1", "dbo", "Users")],
+                dabConfig: null,
+            });
+            let currentState = await harness.getState();
+
+            const scriptEntityName = await harness.applyChanges({
+                expectedVersion: currentState.version,
+                changes: [
+                    {
+                        type: "patch_entity_settings",
+                        entity: { id: "t1" },
+                        set: { entityName: "<script>alert('xss')</script>" },
+                    },
+                ],
+            });
+            expect(scriptEntityName.success).to.equal(false);
+            if (scriptEntityName.success) {
+                throw new Error("Expected failure response");
+            }
+            expect(scriptEntityName.reason).to.equal("invalid_request");
+            expect(scriptEntityName.message).to.include("entityName must start with a letter");
+
+            currentState = await harness.getState();
+            const unsafeRestPath = await harness.applyChanges({
+                expectedVersion: currentState.version,
+                changes: [
+                    {
+                        type: "patch_entity_settings",
+                        entity: { id: "t1" },
+                        set: { customRestPath: "'; DROP TABLE dbo.Todos; --" },
+                    },
+                ],
+            });
+            expect(unsafeRestPath.success).to.equal(false);
+            if (unsafeRestPath.success) {
+                throw new Error("Expected failure response");
+            }
+            expect(unsafeRestPath.reason).to.equal("invalid_request");
+            expect(unsafeRestPath.message).to.include(
+                "customRestPath must be a relative route path",
+            );
+
+            currentState = await harness.getState();
+            const unsafeGraphQLType = await harness.applyChanges({
+                expectedVersion: currentState.version,
+                changes: [
+                    {
+                        type: "patch_entity_settings",
+                        entity: { id: "t1" },
+                        set: { customGraphQLType: "こんにちは" },
+                    },
+                ],
+            });
+            expect(unsafeGraphQLType.success).to.equal(false);
+            if (unsafeGraphQLType.success) {
+                throw new Error("Expected failure response");
+            }
+            expect(unsafeGraphQLType.reason).to.equal("invalid_request");
+            expect(unsafeGraphQLType.message).to.equal(
+                "customGraphQLType must be a valid GraphQL name.",
+            );
+
+            currentState = await harness.getState();
+            const tooLongEntityName = await harness.applyChanges({
+                expectedVersion: currentState.version,
+                changes: [
+                    {
+                        type: "patch_entity_settings",
+                        entity: { id: "t1" },
+                        set: { entityName: `A${"a".repeat(500)}` },
+                    },
+                ],
+            });
+            expect(tooLongEntityName.success).to.equal(false);
+            if (tooLongEntityName.success) {
+                throw new Error("Expected failure response");
+            }
+            expect(tooLongEntityName.message).to.include("128 characters or fewer");
         });
 
         test("apply_changes lets Copilot patch stored procedure MCP custom tool setting", async () => {
@@ -1762,7 +1839,7 @@ suite("DabTool Tests", () => {
                 throw new Error("Expected failure response");
             }
             expect(settingsResult.reason).to.equal("entity_not_supported");
-            expect(harness.commitSpy.callCount).to.equal(3);
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes allows disabling unsupported entities", async () => {
@@ -1832,7 +1909,7 @@ suite("DabTool Tests", () => {
             ).to.deep.equal([Dab.EntityAction.Read, Dab.EntityAction.Create]);
         });
 
-        test("apply_changes failure path uses fail-fast prefix commit semantics", async () => {
+        test("apply_changes failure path is atomic and does not commit partial changes", async () => {
             const harness = createDabHandlerHarness({
                 tables: [createTable("t1", "dbo", "Users"), createTable("t2", "sales", "Orders")],
                 dabConfig: null,
@@ -1840,6 +1917,7 @@ suite("DabTool Tests", () => {
 
             const currentState = await harness.getState();
             harness.commitSpy.resetHistory();
+            const originalVersion = currentState.version;
 
             const result = await harness.applyChanges({
                 expectedVersion: currentState.version,
@@ -1858,10 +1936,51 @@ suite("DabTool Tests", () => {
                 throw new Error("Expected failure response");
             }
             expect(result.failedChangeIndex).to.equal(1);
-            expect(result.appliedChanges).to.equal(1);
-            expect(result.version).to.match(/^dabcfg_[a-f0-9]{64}$/);
-            expect(result.summary?.apiTypes).to.deep.equal([Dab.ApiType.Rest, Dab.ApiType.GraphQL]);
-            expect(harness.commitSpy.calledOnce).to.equal(true);
+            expect(result.appliedChanges).to.equal(0);
+            expect(result.version).to.equal(originalVersion);
+            expect(result.summary?.apiTypes).to.deep.equal([Dab.ApiType.Rest]);
+            expect(harness.getConfig()?.apiTypes).to.deep.equal([Dab.ApiType.Rest]);
+            expect(harness.commitSpy.called).to.equal(false);
+        });
+
+        test("apply_changes preserves entity enablement across immediate sequential calls", async () => {
+            const harness = createDabHandlerHarness({
+                tables: [createTable("t1", "dbo", "Users"), createTable("t2", "sales", "Orders")],
+                dabConfig: null,
+            });
+
+            const currentState = await harness.getState();
+            const disableResult = await harness.applyChanges({
+                expectedVersion: currentState.version,
+                changes: [{ type: "set_entity_enabled", entity: { id: "t1" }, isEnabled: false }],
+            });
+
+            expect(disableResult.success).to.equal(true);
+            if (!disableResult.success) {
+                throw new Error("Expected success response");
+            }
+            expect(
+                disableResult.config?.entities.find((entity) => entity.id === "t1")?.isEnabled,
+            ).to.equal(false);
+
+            const secondResult = await harness.applyChanges({
+                expectedVersion: disableResult.version,
+                changes: [
+                    {
+                        type: "patch_entity_settings",
+                        entity: { id: "t2" },
+                        set: { customRestPath: "orders" },
+                    },
+                ],
+            });
+
+            expect(secondResult.success).to.equal(true);
+            if (!secondResult.success) {
+                throw new Error("Expected success response");
+            }
+            expect(
+                secondResult.config?.entities.find((entity) => entity.id === "t1")?.isEnabled,
+            ).to.equal(false);
         });
 
         test("apply_changes defaults to full returnState and auto-downgrades to summary when entityCount > 100", async () => {
@@ -1966,7 +2085,7 @@ suite("DabTool Tests", () => {
             expect(result.reason).to.equal("entity_not_supported");
             expect(result.failedChangeIndex).to.equal(0);
             expect(result.appliedChanges).to.equal(0);
-            expect(harness.commitSpy.calledOnce).to.equal(true);
+            expect(harness.commitSpy.called).to.equal(false);
         });
 
         test("apply_changes set_all_entities_enabled(true) leaves unsupported entities disabled", async () => {


### PR DESCRIPTION
## Description

Putting some shared validation code in sharedInterfaces. Will think of a better location for them in a follow up PR. 

Fixes several DAB MCP `apply_changes` consistency and validation issues reported against Schema Designer:

- Makes `apply_changes` atomic so failed batches do not commit partial mutations.
- Keeps the DAB config ref synchronized immediately after MCP commits so back-to-back calls see the latest state.
- Rejects duplicate entity names without mutating the persisted state.
- Adds domain validation for `entityName`, `customRestPath`, and `customGraphQLType`, while preserving `null` clearing for optional path/type settings.
- Updates DAB MCP unit tests for atomic failures, duplicate-name rollback, unsafe string rejection, and sequential enablement persistence.

Fixes #22107
Fixes #22108
Fixes #22109
Fixes #22110
Fixes #22111


## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Validation

- [x] `npm run build -- --target mssql`
- [x] `npm run lint -- --target mssql`
- [x] `npm run test -- --target mssql --grep "DabTool"`

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)