### PR TITLE
Fix DAB designer quickstart issues

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -877,7 +877,7 @@
     "Expose this entity through GraphQL": "Expose this entity through GraphQL",
     "Enable GraphQL in API Type to expose this entity through GraphQL.": "Enable GraphQL in API Type to expose this entity through GraphQL.",
     "Stored procedure REST methods": "Stored procedure REST methods",
-    "Select the HTTP methods that can execute this stored procedure. DAB defaults to POST.": "Select the HTTP methods that can execute this stored procedure. DAB defaults to POST.",
+    "Select the HTTP method that can execute this stored procedure. DAB defaults to POST.": "Select the HTTP method that can execute this stored procedure. DAB defaults to POST.",
     "Stored procedure GraphQL operation": "Stored procedure GraphQL operation",
     "Choose whether this stored procedure appears as a GraphQL mutation or query. DAB defaults to mutation.": "Choose whether this stored procedure appears as a GraphQL mutation or query. DAB defaults to mutation.",
     "Mutation": "Mutation",
@@ -967,6 +967,7 @@
     "Used in API routes and responses": "Used in API routes and responses",
     "Authorization Role": "Authorization Role",
     "Define who can access this endpoint": "Define who can access this endpoint",
+    "Define who can execute this stored procedure": "Define who can execute this stored procedure",
     "Disabled globally": "Disabled globally",
     "Anonymous": "Anonymous",
     "No authentication required": "No authentication required",
@@ -975,7 +976,10 @@
     "Custom REST Path": "Custom REST Path",
     "Optional - Override default api/entityName path": "Optional - Override default api/entityName path",
     "Custom GraphQL Type": "Custom GraphQL Type",
-    "Optional - Override default GraphQL type name": "Optional - Override default GraphQL type name",
+    "Custom GraphQL Singular Type": "Custom GraphQL Singular Type",
+    "Optional - Override default GraphQL singular type name": "Optional - Override default GraphQL singular type name",
+    "Custom GraphQL Plural Type": "Custom GraphQL Plural Type",
+    "Optional - Override default GraphQL plural type name": "Optional - Override default GraphQL plural type name",
     "Source": "Source",
     "Source: {0}/{0} is the fully qualified DAB source object name": {
         "message": "Source: {0}",
@@ -983,6 +987,7 @@
     },
     "Initializing DAB configuration...": "Initializing DAB configuration...",
     "No entities found": "No entities found",
+    "Select all entities": "Select all entities",
     "Toggle all entities in {0}/{0} is the schema name": {
         "message": "Toggle all entities in {0}",
         "comment": ["{0} is the schema name"]

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -965,7 +965,7 @@
     "REST": "REST",
     "Entity Name": "Entity Name",
     "Used in API routes and responses": "Used in API routes and responses",
-    "Authorization Role": "Authorization Role",
+    "Permissions": "Permissions",
     "Define who can access this endpoint": "Define who can access this endpoint",
     "Define who can execute this stored procedure": "Define who can execute this stored procedure",
     "Disabled globally": "Disabled globally",

--- a/extensions/mssql/src/dab/dabConfigFileBuilder.ts
+++ b/extensions/mssql/src/dab/dabConfigFileBuilder.ts
@@ -50,10 +50,12 @@ interface DabEntityOutput {
         "primary-key"?: boolean;
     }>;
     rest: boolean | { path?: string; methods?: string[] } | undefined;
-    graphql: boolean | { type?: string; operation?: string } | undefined;
+    graphql: boolean | { type?: DabGraphQLTypeOutput; operation?: string } | undefined;
     permissions: DabPermissionEntry[];
     mcp?: { "custom-tool"?: boolean; "dml-tools"?: boolean };
 }
+
+type DabGraphQLTypeOutput = string | { singular: string; plural?: string };
 
 interface DabPermissionEntry {
     role: string;
@@ -265,7 +267,9 @@ export class DabConfigFileBuilder {
         const customPath = entity.advancedSettings.customRestPath;
         const restMethods =
             entity.sourceType === Dab.EntitySourceType.StoredProcedure
-                ? entity.advancedSettings.storedProcedureRestMethods
+                ? this.getStoredProcedureRestMethod(
+                      entity.advancedSettings.storedProcedureRestMethods,
+                  )
                 : undefined;
         const restConfig: { path?: string; methods?: string[] } = {};
         if (customPath) {
@@ -275,6 +279,16 @@ export class DabConfigFileBuilder {
             restConfig.methods = Dab.normalizeRestMethods(restMethods);
         }
         return Object.keys(restConfig).length > 0 ? restConfig : undefined;
+    }
+
+    private getStoredProcedureRestMethod(methods?: Dab.RestMethod[]): Dab.RestMethod[] {
+        const method =
+            methods?.find((configuredMethod) =>
+                Dab.storedProcedureAllowedRestMethods.some(
+                    (allowedMethod) => allowedMethod === configuredMethod,
+                ),
+            ) ?? Dab.RestMethod.Post;
+        return [method];
     }
 
     /**
@@ -287,13 +301,13 @@ export class DabConfigFileBuilder {
      */
     private buildGraphQLProperty(
         entity: Dab.DabEntityConfig,
-    ): undefined | { type?: string; operation?: string } {
-        const customType = entity.advancedSettings.customGraphQLType;
+    ): undefined | { type?: DabGraphQLTypeOutput; operation?: string } {
+        const customType = this.buildGraphQLTypeProperty(entity.advancedSettings);
         const graphQLOperation =
             entity.sourceType === Dab.EntitySourceType.StoredProcedure
                 ? entity.advancedSettings.storedProcedureGraphQLOperation
                 : undefined;
-        const graphqlConfig: { type?: string; operation?: string } = {};
+        const graphqlConfig: { type?: DabGraphQLTypeOutput; operation?: string } = {};
         if (customType) {
             graphqlConfig.type = customType;
         }
@@ -301,6 +315,26 @@ export class DabConfigFileBuilder {
             graphqlConfig.operation = graphQLOperation;
         }
         return Object.keys(graphqlConfig).length > 0 ? graphqlConfig : undefined;
+    }
+
+    private buildGraphQLTypeProperty(
+        settings: Dab.EntityAdvancedSettings,
+    ): DabGraphQLTypeOutput | undefined {
+        const singular = settings.customGraphQLSingularType ?? settings.customGraphQLType;
+        const plural = settings.customGraphQLPluralType;
+
+        if (!singular) {
+            return undefined;
+        }
+
+        if (singular && !plural) {
+            return singular;
+        }
+
+        return {
+            singular,
+            plural,
+        };
     }
 
     private buildParameterProperty(parameter: Dab.DabParameterConfig): DabParameterOutput {

--- a/extensions/mssql/src/sharedInterfaces/dab.ts
+++ b/extensions/mssql/src/sharedInterfaces/dab.ts
@@ -46,6 +46,7 @@ export namespace Dab {
         RestMethod.Patch,
         RestMethod.Delete,
     ];
+    export const storedProcedureAllowedRestMethods = [RestMethod.Get, RestMethod.Post] as const;
 
     /**
      * Canonicalizes REST methods so semantically equivalent method sets do not
@@ -87,12 +88,15 @@ export namespace Dab {
         return undefined;
     }
 
-    export function validateDabCustomGraphQLType(value: string): string | undefined {
+    export function validateDabCustomGraphQLType(
+        value: string,
+        fieldName = "customGraphQLType",
+    ): string | undefined {
         if (value.length > maxDabEntityNameLength) {
-            return `customGraphQLType must be ${maxDabEntityNameLength} characters or fewer.`;
+            return `${fieldName} must be ${maxDabEntityNameLength} characters or fewer.`;
         }
         if (!dabGraphQLTypePattern.test(value)) {
-            return "customGraphQLType must be a valid GraphQL name.";
+            return `${fieldName} must be a valid GraphQL name.`;
         }
         return undefined;
     }
@@ -141,9 +145,18 @@ export namespace Dab {
          */
         restEnabled?: boolean;
         /**
-         * Custom GraphQL type name (overrides default entity name)
+         * Legacy custom GraphQL type name (overrides default entity name).
+         * Kept so older cached DAB configs continue to load.
          */
         customGraphQLType?: string;
+        /**
+         * Custom singular GraphQL type name (overrides default entity name).
+         */
+        customGraphQLSingularType?: string;
+        /**
+         * Custom plural GraphQL type name (overrides default pluralization).
+         */
+        customGraphQLPluralType?: string;
         /**
          * Whether this entity should be exposed through GraphQL when GraphQL is globally enabled.
          * Defaults to true.
@@ -427,11 +440,17 @@ export namespace Dab {
     export type DabEntitySettingsPatch = Partial<
         Omit<
             EntityAdvancedSettings,
-            "customRestPath" | "customGraphQLType" | "storedProcedureRestMethods"
+            | "customRestPath"
+            | "customGraphQLType"
+            | "customGraphQLSingularType"
+            | "customGraphQLPluralType"
+            | "storedProcedureRestMethods"
         >
     > & {
         customRestPath?: string | null;
-        customGraphQLType?: string | null;
+        customGraphQLType?: string | { singular: string; plural?: string | null } | null;
+        customGraphQLSingularType?: string | null;
+        customGraphQLPluralType?: string | null;
         storedProcedureRestMethods?: RestMethod[] | null;
     };
 

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1357,7 +1357,7 @@ export class LocConstants {
             ),
             storedProcedureRestMethods: l10n.t("Stored procedure REST methods"),
             storedProcedureRestMethodsHelp: l10n.t(
-                "Select the HTTP methods that can execute this stored procedure. DAB defaults to POST.",
+                "Select the HTTP method that can execute this stored procedure. DAB defaults to POST.",
             ),
             storedProcedureGraphQLOperation: l10n.t("Stored procedure GraphQL operation"),
             storedProcedureGraphQLOperationHelp: l10n.t(
@@ -1495,6 +1495,9 @@ export class LocConstants {
             entityNameHelp: l10n.t("Used in API routes and responses"),
             authorizationRole: l10n.t("Authorization Role"),
             authorizationRoleHelp: l10n.t("Define who can access this endpoint"),
+            authorizationRoleStoredProcedureHelp: l10n.t(
+                "Define who can execute this stored procedure",
+            ),
             disabledGlobally: l10n.t("Disabled globally"),
             anonymous: l10n.t("Anonymous"),
             anonymousDescription: l10n.t("No authentication required"),
@@ -1503,7 +1506,14 @@ export class LocConstants {
             customRestPath: l10n.t("Custom REST Path"),
             customRestPathHelp: l10n.t("Optional - Override default api/entityName path"),
             customGraphQLType: l10n.t("Custom GraphQL Type"),
-            customGraphQLTypeHelp: l10n.t("Optional - Override default GraphQL type name"),
+            customGraphQLSingularType: l10n.t("Custom GraphQL Singular Type"),
+            customGraphQLSingularTypeHelp: l10n.t(
+                "Optional - Override default GraphQL singular type name",
+            ),
+            customGraphQLPluralType: l10n.t("Custom GraphQL Plural Type"),
+            customGraphQLPluralTypeHelp: l10n.t(
+                "Optional - Override default GraphQL plural type name",
+            ),
             applyChanges: l10n.t("Apply Changes"),
             source: l10n.t("Source"),
             sourceWithName: (sourceName: string) =>
@@ -1515,6 +1525,7 @@ export class LocConstants {
             loading: l10n.t("Loading..."),
             initializingDabConfig: l10n.t("Initializing DAB configuration..."),
             noEntitiesFound: l10n.t("No entities found"),
+            selectAllEntities: l10n.t("Select all entities"),
             toggleAllEntitiesInSchema: (schemaName: string) =>
                 l10n.t({
                     message: "Toggle all entities in {0}",

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1493,7 +1493,7 @@ export class LocConstants {
             rest: l10n.t("REST"),
             entityName: l10n.t("Entity Name"),
             entityNameHelp: l10n.t("Used in API routes and responses"),
-            authorizationRole: l10n.t("Authorization Role"),
+            authorizationRole: l10n.t("Permissions"),
             authorizationRoleHelp: l10n.t("Define who can access this endpoint"),
             authorizationRoleStoredProcedureHelp: l10n.t(
                 "Define who can execute this stored procedure",

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -37,12 +37,18 @@ const useStyles = makeStyles({
     drawer: {
         width: "640px",
         maxWidth: "calc(100vw - 32px)",
+        backgroundColor: "var(--vscode-editor-background)",
+    },
+    drawerHeader: {
+        backgroundColor: "var(--vscode-editorWidget-background, var(--vscode-editor-background))",
+        borderBottom: "1px solid var(--vscode-editorGroup-border)",
     },
     drawerBody: {
         display: "flex",
         flexDirection: "column",
         rowGap: "16px",
         overflowY: "auto",
+        backgroundColor: "var(--vscode-editor-background)",
     },
     headerTitleContent: {
         display: "flex",
@@ -174,6 +180,8 @@ const useStyles = makeStyles({
         columnGap: "12px",
         paddingTop: "12px",
         marginTop: 0,
+        backgroundColor: "var(--vscode-editorWidget-background, var(--vscode-editor-background))",
+        borderTop: "1px solid var(--vscode-editorGroup-border)",
     },
     actionButton: {
         minWidth: "132px",
@@ -414,7 +422,7 @@ export function DabEntitySettingsDialog({
             open={open}
             onOpenChange={(_, { open }) => onOpenChange(open)}
             className={classes.drawer}>
-            <DrawerHeader>
+            <DrawerHeader className={classes.drawerHeader}>
                 <DrawerHeaderTitle
                     action={
                         <Button

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -24,9 +24,10 @@ import {
     RadioGroup,
     Text,
     ToggleButton,
+    Tooltip,
     tokens,
 } from "@fluentui/react-components";
-import { Dismiss24Regular, Table16Regular } from "@fluentui/react-icons";
+import { Dismiss24Regular, Info16Regular, Table16Regular } from "@fluentui/react-icons";
 import { useEffect, useState } from "react";
 import { locConstants } from "../../../common/locConstants";
 import { Dab } from "../../../../sharedInterfaces/dab";
@@ -119,6 +120,19 @@ const useStyles = makeStyles({
         fontSize: tokens.fontSizeBase200,
         fontWeight: tokens.fontWeightRegular,
         lineHeight: tokens.lineHeightBase200,
+    },
+    labelWithInfo: {
+        display: "inline-flex",
+        alignItems: "center",
+        columnGap: "4px",
+    },
+    infoButton: {
+        color: tokens.colorNeutralForeground3,
+        minWidth: "16px",
+        width: "16px",
+        height: "16px",
+        padding: 0,
+        verticalAlign: "middle",
     },
     roleButtonsContainer: {
         display: "flex",
@@ -294,9 +308,6 @@ export function DabEntitySettingsDialog({
     const storedProcedureGraphQLOperation =
         localSettings.storedProcedureGraphQLOperation ?? Dab.GraphQLOperation.Mutation;
     const exposeAsMcpCustomTool = localSettings.exposeAsMcpCustomTool !== false;
-    const authorizationRoleHelp = isStoredProcedure
-        ? locConstants.schemaDesigner.authorizationRoleStoredProcedureHelp
-        : locConstants.schemaDesigner.authorizationRoleHelp;
     const sourceObjectName = `${entity.schemaName}.${entity.sourceName ?? entity.tableName}`;
     const entityName = localSettings.entityName.trim();
     const customRestPath = localSettings.customRestPath?.trim() ?? "";
@@ -369,6 +380,21 @@ export function DabEntitySettingsDialog({
         <Text className={classes.sectionTitle}>{title}</Text>
     );
 
+    const renderLabelWithInfo = (label: string, infoText: string) => (
+        <span className={classes.labelWithInfo}>
+            <span>{label}</span>
+            <Tooltip content={infoText} relationship="description" positioning="after" withArrow>
+                <Button
+                    appearance="transparent"
+                    className={classes.infoButton}
+                    icon={<Info16Regular />}
+                    size="small"
+                    aria-label={infoText}
+                />
+            </Tooltip>
+        </span>
+    );
+
     const renderDisabledBanner = (apiType: Dab.ApiType, label: string, helpText?: string) => (
         <MessageBar
             intent="warning"
@@ -425,11 +451,7 @@ export function DabEntitySettingsDialog({
                                     validationState={
                                         entityNameValidationMessage ? "error" : undefined
                                     }
-                                    validationMessage={entityNameValidationMessage}
-                                    hint={{
-                                        children: locConstants.schemaDesigner.entityNameHelp,
-                                        className: classes.fieldHint,
-                                    }}>
+                                    validationMessage={entityNameValidationMessage}>
                                     <Input
                                         value={localSettings.entityName}
                                         onChange={(_, data) => updateEntityName(data.value)}
@@ -441,7 +463,6 @@ export function DabEntitySettingsDialog({
                         <section className={classes.section}>
                             {renderSectionTitle(locConstants.schemaDesigner.authorizationRole)}
                             <div className={classes.sectionBody}>
-                                <span className={classes.fieldHint}>{authorizationRoleHelp}</span>
                                 <div className={classes.roleButtonsContainer}>
                                     <ToggleButton
                                         className={classes.roleButton}
@@ -532,9 +553,11 @@ export function DabEntitySettingsDialog({
                                         {isEntityRestEnabled && (
                                             <>
                                                 <Field
-                                                    label={
-                                                        locConstants.schemaDesigner.customRestPath
-                                                    }
+                                                    label={renderLabelWithInfo(
+                                                        locConstants.schemaDesigner.customRestPath,
+                                                        locConstants.schemaDesigner
+                                                            .customRestPathHelp,
+                                                    )}
                                                     validationState={
                                                         customRestPathValidationMessage
                                                             ? "error"
@@ -542,13 +565,7 @@ export function DabEntitySettingsDialog({
                                                     }
                                                     validationMessage={
                                                         customRestPathValidationMessage
-                                                    }
-                                                    hint={{
-                                                        children:
-                                                            locConstants.schemaDesigner
-                                                                .customRestPathHelp,
-                                                        className: classes.fieldHint,
-                                                    }}>
+                                                    }>
                                                     <Input
                                                         value={localSettings.customRestPath ?? ""}
                                                         placeholder={(
@@ -562,17 +579,13 @@ export function DabEntitySettingsDialog({
 
                                                 {isStoredProcedure && (
                                                     <Field
-                                                        label={
+                                                        label={renderLabelWithInfo(
                                                             locConstants.schemaDesigner
-                                                                .storedProcedureRestMethods
-                                                        }
-                                                        required
-                                                        hint={{
-                                                            children:
-                                                                locConstants.schemaDesigner
-                                                                    .storedProcedureRestMethodsHelp,
-                                                            className: classes.fieldHint,
-                                                        }}>
+                                                                .storedProcedureRestMethods,
+                                                            locConstants.schemaDesigner
+                                                                .storedProcedureRestMethodsHelp,
+                                                        )}
+                                                        required>
                                                         <RadioGroup
                                                             className={classes.methodGroup}
                                                             value={storedProcedureRestMethod}
@@ -627,10 +640,12 @@ export function DabEntitySettingsDialog({
                                         {isEntityGraphQLEnabled && (
                                             <>
                                                 <Field
-                                                    label={
+                                                    label={renderLabelWithInfo(
                                                         locConstants.schemaDesigner
-                                                            .customGraphQLSingularType
-                                                    }
+                                                            .customGraphQLSingularType,
+                                                        locConstants.schemaDesigner
+                                                            .customGraphQLSingularTypeHelp,
+                                                    )}
                                                     required={customGraphQLPluralType.length > 0}
                                                     validationState={
                                                         customGraphQLSingularTypeValidationMessage
@@ -639,13 +654,7 @@ export function DabEntitySettingsDialog({
                                                     }
                                                     validationMessage={
                                                         customGraphQLSingularTypeValidationMessage
-                                                    }
-                                                    hint={{
-                                                        children:
-                                                            locConstants.schemaDesigner
-                                                                .customGraphQLSingularTypeHelp,
-                                                        className: classes.fieldHint,
-                                                    }}>
+                                                    }>
                                                     <Input
                                                         value={customGraphQLSingularType}
                                                         placeholder={
@@ -659,10 +668,12 @@ export function DabEntitySettingsDialog({
                                                     />
                                                 </Field>
                                                 <Field
-                                                    label={
+                                                    label={renderLabelWithInfo(
                                                         locConstants.schemaDesigner
-                                                            .customGraphQLPluralType
-                                                    }
+                                                            .customGraphQLPluralType,
+                                                        locConstants.schemaDesigner
+                                                            .customGraphQLPluralTypeHelp,
+                                                    )}
                                                     validationState={
                                                         customGraphQLPluralTypeValidationMessage
                                                             ? "error"
@@ -670,13 +681,7 @@ export function DabEntitySettingsDialog({
                                                     }
                                                     validationMessage={
                                                         customGraphQLPluralTypeValidationMessage
-                                                    }
-                                                    hint={{
-                                                        children:
-                                                            locConstants.schemaDesigner
-                                                                .customGraphQLPluralTypeHelp,
-                                                        className: classes.fieldHint,
-                                                    }}>
+                                                    }>
                                                     <Input
                                                         value={customGraphQLPluralType}
                                                         placeholder={`${
@@ -692,17 +697,13 @@ export function DabEntitySettingsDialog({
 
                                                 {isStoredProcedure && (
                                                     <Field
-                                                        label={
+                                                        label={renderLabelWithInfo(
                                                             locConstants.schemaDesigner
-                                                                .storedProcedureGraphQLOperation
-                                                        }
-                                                        required
-                                                        hint={{
-                                                            children:
-                                                                locConstants.schemaDesigner
-                                                                    .storedProcedureGraphQLOperationHelp,
-                                                            className: classes.fieldHint,
-                                                        }}>
+                                                                .storedProcedureGraphQLOperation,
+                                                            locConstants.schemaDesigner
+                                                                .storedProcedureGraphQLOperationHelp,
+                                                        )}
+                                                        required>
                                                         <RadioGroup
                                                             value={storedProcedureGraphQLOperation}
                                                             layout="horizontal"

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -49,6 +49,8 @@ const useStyles = makeStyles({
         rowGap: "16px",
         overflowY: "auto",
         backgroundColor: "var(--vscode-editor-background)",
+        paddingTop: "16px",
+        paddingBottom: "16px",
     },
     headerTitleContent: {
         display: "flex",

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -185,16 +185,6 @@ const useStyles = makeStyles({
         flexWrap: "wrap",
         gap: "6px",
     },
-    methodChip: {
-        borderRadius: "999px",
-        fontSize: "12px",
-        minWidth: "unset",
-    },
-    methodChipSelected: {
-        border: "1px solid var(--vscode-textLink-foreground)",
-        color: "var(--vscode-textLink-foreground)",
-        backgroundColor: "color-mix(in srgb, var(--vscode-textLink-foreground) 20%, transparent)",
-    },
 });
 
 interface DabEntitySettingsDialogProps {
@@ -254,27 +244,30 @@ export function DabEntitySettingsDialog({
         setLocalSettings((prev) => ({ ...prev, restEnabled: value }));
     };
 
-    const updateCustomGraphQLType = (value: string) => {
-        setLocalSettings((prev) => ({ ...prev, customGraphQLType: value || undefined }));
+    const updateCustomGraphQLSingularType = (value: string) => {
+        setLocalSettings((prev) => ({
+            ...prev,
+            customGraphQLType: undefined,
+            customGraphQLSingularType: value || undefined,
+        }));
+    };
+
+    const updateCustomGraphQLPluralType = (value: string) => {
+        setLocalSettings((prev) => ({
+            ...prev,
+            customGraphQLPluralType: value || undefined,
+        }));
     };
 
     const updateGraphQLEnabled = (value: boolean) => {
         setLocalSettings((prev) => ({ ...prev, graphQLEnabled: value }));
     };
 
-    const updateStoredProcedureRestMethod = (method: Dab.RestMethod, isEnabled: boolean) => {
-        setLocalSettings((prev) => {
-            const methods = prev.storedProcedureRestMethods ?? [Dab.RestMethod.Post];
-            const nextMethods = isEnabled
-                ? [...methods, method]
-                : methods.filter((existingMethod) => existingMethod !== method);
-            return {
-                ...prev,
-                storedProcedureRestMethods: nextMethods.length
-                    ? Dab.normalizeRestMethods(nextMethods)
-                    : [Dab.RestMethod.Post],
-            };
-        });
+    const updateStoredProcedureRestMethod = (method: Dab.RestMethod) => {
+        setLocalSettings((prev) => ({
+            ...prev,
+            storedProcedureRestMethods: [method],
+        }));
     };
 
     const updateStoredProcedureGraphQLOperation = (operation: Dab.GraphQLOperation) => {
@@ -294,13 +287,22 @@ export function DabEntitySettingsDialog({
     const storedProcedureRestMethods = localSettings.storedProcedureRestMethods ?? [
         Dab.RestMethod.Post,
     ];
+    const storedProcedureRestMethod =
+        storedProcedureRestMethods.find((method) =>
+            Dab.storedProcedureAllowedRestMethods.some((allowedMethod) => allowedMethod === method),
+        ) ?? Dab.RestMethod.Post;
     const storedProcedureGraphQLOperation =
         localSettings.storedProcedureGraphQLOperation ?? Dab.GraphQLOperation.Mutation;
     const exposeAsMcpCustomTool = localSettings.exposeAsMcpCustomTool !== false;
+    const authorizationRoleHelp = isStoredProcedure
+        ? locConstants.schemaDesigner.authorizationRoleStoredProcedureHelp
+        : locConstants.schemaDesigner.authorizationRoleHelp;
     const sourceObjectName = `${entity.schemaName}.${entity.sourceName ?? entity.tableName}`;
     const entityName = localSettings.entityName.trim();
     const customRestPath = localSettings.customRestPath?.trim() ?? "";
-    const customGraphQLType = localSettings.customGraphQLType?.trim() ?? "";
+    const customGraphQLSingularType =
+        (localSettings.customGraphQLSingularType ?? localSettings.customGraphQLType)?.trim() ?? "";
+    const customGraphQLPluralType = localSettings.customGraphQLPluralType?.trim() ?? "";
     const normalizedExistingEntityNames = new Set(
         existingEntityNames.map(Dab.normalizeDabIdentifier),
     );
@@ -312,14 +314,24 @@ export function DabEntitySettingsDialog({
               : Dab.validateDabEntityName(entityName);
     const customRestPathValidationMessage =
         customRestPath.length > 0 ? Dab.validateDabCustomRestPath(customRestPath) : undefined;
-    const customGraphQLTypeValidationMessage =
-        customGraphQLType.length > 0
-            ? Dab.validateDabCustomGraphQLType(customGraphQLType)
+    const customGraphQLSingularTypeValidationMessage =
+        customGraphQLPluralType.length > 0 && customGraphQLSingularType.length === 0
+            ? "customGraphQLSingularType is required when customGraphQLPluralType is set."
+            : customGraphQLSingularType.length > 0
+              ? Dab.validateDabCustomGraphQLType(
+                    customGraphQLSingularType,
+                    "customGraphQLSingularType",
+                )
+              : undefined;
+    const customGraphQLPluralTypeValidationMessage =
+        customGraphQLPluralType.length > 0
+            ? Dab.validateDabCustomGraphQLType(customGraphQLPluralType, "customGraphQLPluralType")
             : undefined;
     const hasValidationError =
         !!entityNameValidationMessage ||
         !!customRestPathValidationMessage ||
-        !!customGraphQLTypeValidationMessage;
+        !!customGraphQLSingularTypeValidationMessage ||
+        !!customGraphQLPluralTypeValidationMessage;
 
     const handleApply = () => {
         if (hasValidationError) {
@@ -330,7 +342,14 @@ export function DabEntitySettingsDialog({
             ...localSettings,
             entityName,
             customRestPath: customRestPath.length > 0 ? customRestPath : undefined,
-            customGraphQLType: customGraphQLType.length > 0 ? customGraphQLType : undefined,
+            customGraphQLType: undefined,
+            customGraphQLSingularType:
+                customGraphQLSingularType.length > 0 ? customGraphQLSingularType : undefined,
+            customGraphQLPluralType:
+                customGraphQLPluralType.length > 0 ? customGraphQLPluralType : undefined,
+            ...(isStoredProcedure
+                ? { storedProcedureRestMethods: [storedProcedureRestMethod] }
+                : {}),
         });
     };
 
@@ -402,6 +421,7 @@ export function DabEntitySettingsDialog({
                             <div className={classes.sectionBody}>
                                 <Field
                                     label={locConstants.schemaDesigner.entityName}
+                                    required
                                     validationState={
                                         entityNameValidationMessage ? "error" : undefined
                                     }
@@ -421,9 +441,7 @@ export function DabEntitySettingsDialog({
                         <section className={classes.section}>
                             {renderSectionTitle(locConstants.schemaDesigner.authorizationRole)}
                             <div className={classes.sectionBody}>
-                                <span className={classes.fieldHint}>
-                                    {locConstants.schemaDesigner.authorizationRoleHelp}
-                                </span>
+                                <span className={classes.fieldHint}>{authorizationRoleHelp}</span>
                                 <div className={classes.roleButtonsContainer}>
                                     <ToggleButton
                                         className={classes.roleButton}
@@ -548,43 +566,32 @@ export function DabEntitySettingsDialog({
                                                             locConstants.schemaDesigner
                                                                 .storedProcedureRestMethods
                                                         }
+                                                        required
                                                         hint={{
                                                             children:
                                                                 locConstants.schemaDesigner
                                                                     .storedProcedureRestMethodsHelp,
                                                             className: classes.fieldHint,
                                                         }}>
-                                                        <div className={classes.methodGroup}>
-                                                            {Object.values(Dab.RestMethod).map(
+                                                        <RadioGroup
+                                                            className={classes.methodGroup}
+                                                            value={storedProcedureRestMethod}
+                                                            layout="horizontal"
+                                                            onChange={(_, data) =>
+                                                                updateStoredProcedureRestMethod(
+                                                                    data.value as Dab.RestMethod,
+                                                                )
+                                                            }>
+                                                            {Dab.storedProcedureAllowedRestMethods.map(
                                                                 (method) => (
-                                                                    <ToggleButton
+                                                                    <Radio
                                                                         key={method}
-                                                                        shape="circular"
-                                                                        size="small"
-                                                                        className={mergeClasses(
-                                                                            classes.methodChip,
-                                                                            storedProcedureRestMethods.includes(
-                                                                                method,
-                                                                            ) &&
-                                                                                classes.methodChipSelected,
-                                                                        )}
-                                                                        checked={storedProcedureRestMethods.includes(
-                                                                            method,
-                                                                        )}
-                                                                        onClick={() =>
-                                                                            updateStoredProcedureRestMethod(
-                                                                                method,
-                                                                                !storedProcedureRestMethods.includes(
-                                                                                    method,
-                                                                                ),
-                                                                            )
-                                                                        }
-                                                                        aria-label={method.toUpperCase()}>
-                                                                        {method.toUpperCase()}
-                                                                    </ToggleButton>
+                                                                        value={method}
+                                                                        label={method.toUpperCase()}
+                                                                    />
                                                                 ),
                                                             )}
-                                                        </div>
+                                                        </RadioGroup>
                                                     </Field>
                                                 )}
                                             </>
@@ -622,31 +629,63 @@ export function DabEntitySettingsDialog({
                                                 <Field
                                                     label={
                                                         locConstants.schemaDesigner
-                                                            .customGraphQLType
+                                                            .customGraphQLSingularType
                                                     }
+                                                    required={customGraphQLPluralType.length > 0}
                                                     validationState={
-                                                        customGraphQLTypeValidationMessage
+                                                        customGraphQLSingularTypeValidationMessage
                                                             ? "error"
                                                             : undefined
                                                     }
                                                     validationMessage={
-                                                        customGraphQLTypeValidationMessage
+                                                        customGraphQLSingularTypeValidationMessage
                                                     }
                                                     hint={{
                                                         children:
                                                             locConstants.schemaDesigner
-                                                                .customGraphQLTypeHelp,
+                                                                .customGraphQLSingularTypeHelp,
                                                         className: classes.fieldHint,
                                                     }}>
                                                     <Input
-                                                        value={
-                                                            localSettings.customGraphQLType ?? ""
-                                                        }
+                                                        value={customGraphQLSingularType}
                                                         placeholder={
                                                             entity.sourceName ?? entity.tableName
                                                         }
                                                         onChange={(_, data) =>
-                                                            updateCustomGraphQLType(data.value)
+                                                            updateCustomGraphQLSingularType(
+                                                                data.value,
+                                                            )
+                                                        }
+                                                    />
+                                                </Field>
+                                                <Field
+                                                    label={
+                                                        locConstants.schemaDesigner
+                                                            .customGraphQLPluralType
+                                                    }
+                                                    validationState={
+                                                        customGraphQLPluralTypeValidationMessage
+                                                            ? "error"
+                                                            : undefined
+                                                    }
+                                                    validationMessage={
+                                                        customGraphQLPluralTypeValidationMessage
+                                                    }
+                                                    hint={{
+                                                        children:
+                                                            locConstants.schemaDesigner
+                                                                .customGraphQLPluralTypeHelp,
+                                                        className: classes.fieldHint,
+                                                    }}>
+                                                    <Input
+                                                        value={customGraphQLPluralType}
+                                                        placeholder={`${
+                                                            entity.sourceName ?? entity.tableName
+                                                        }s`}
+                                                        onChange={(_, data) =>
+                                                            updateCustomGraphQLPluralType(
+                                                                data.value,
+                                                            )
                                                         }
                                                     />
                                                 </Field>
@@ -657,6 +696,7 @@ export function DabEntitySettingsDialog({
                                                             locConstants.schemaDesigner
                                                                 .storedProcedureGraphQLOperation
                                                         }
+                                                        required
                                                         hint={{
                                                             children:
                                                                 locConstants.schemaDesigner

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntitySettingsDialog.tsx
@@ -6,12 +6,10 @@
 import {
     Button,
     Checkbox,
-    Dialog,
-    DialogActions,
-    DialogBody,
-    DialogContent,
-    DialogSurface,
-    DialogTitle,
+    DrawerBody,
+    DrawerFooter,
+    DrawerHeader,
+    DrawerHeaderTitle,
     Field,
     Input,
     makeStyles,
@@ -22,6 +20,7 @@ import {
     mergeClasses,
     Radio,
     RadioGroup,
+    OverlayDrawer,
     Text,
     ToggleButton,
     Tooltip,
@@ -35,24 +34,15 @@ import { StoredProcedureIcon16Regular } from "../../../common/icons/storedProced
 import { ViewIcon16Regular } from "../../../common/icons/view";
 
 const useStyles = makeStyles({
-    dialogSurface: {
+    drawer: {
         width: "640px",
-        maxWidth: "calc(100vw - 48px)",
-        maxHeight: "calc(100vh - 48px)",
-        height: "calc(100vh - 48px)",
+        maxWidth: "calc(100vw - 32px)",
     },
-    dialogBody: {
-        height: "100%",
-        minHeight: 0,
-    },
-    dialogContent: {
+    drawerBody: {
         display: "flex",
         flexDirection: "column",
         rowGap: "16px",
-        paddingTop: "16px",
-        paddingBottom: "16px",
         overflowY: "auto",
-        minHeight: 0,
     },
     headerTitleContent: {
         display: "flex",
@@ -179,7 +169,7 @@ const useStyles = makeStyles({
         fontSize: "12px",
         color: tokens.colorNeutralForeground3,
     },
-    dialogActions: {
+    drawerFooter: {
         alignSelf: "stretch",
         columnGap: "12px",
         paddingTop: "12px",
@@ -419,382 +409,349 @@ export function DabEntitySettingsDialog({
     );
 
     return (
-        <Dialog open={open} modalType="modal" onOpenChange={(_, data) => onOpenChange(data.open)}>
-            <DialogSurface className={classes.dialogSurface}>
-                <DialogBody className={classes.dialogBody}>
-                    <DialogTitle
-                        action={
-                            <Button
-                                appearance="subtle"
-                                aria-label={locConstants.common.close}
-                                icon={<Dismiss24Regular />}
-                                onClick={handleCancel}
-                            />
-                        }>
-                        <div className={classes.headerTitleContent}>
-                            <div className={classes.headerObjectRow}>
-                                {renderSourceIcon()}
-                                <span className={classes.headerObjectName}>{sourceObjectName}</span>
-                            </div>
-                            <span className={classes.headerSubtitle}>
-                                {locConstants.schemaDesigner.advancedEntityConfiguration}
-                            </span>
+        <OverlayDrawer
+            position="end"
+            open={open}
+            onOpenChange={(_, { open }) => onOpenChange(open)}
+            className={classes.drawer}>
+            <DrawerHeader>
+                <DrawerHeaderTitle
+                    action={
+                        <Button
+                            appearance="subtle"
+                            aria-label={locConstants.common.close}
+                            icon={<Dismiss24Regular />}
+                            onClick={handleCancel}
+                        />
+                    }>
+                    <div className={classes.headerTitleContent}>
+                        <div className={classes.headerObjectRow}>
+                            {renderSourceIcon()}
+                            <span className={classes.headerObjectName}>{sourceObjectName}</span>
                         </div>
-                    </DialogTitle>
-                    <DialogContent className={classes.dialogContent}>
-                        <section className={classes.section}>
-                            {renderSectionTitle(locConstants.schemaDesigner.identity)}
-                            <div className={classes.sectionBody}>
-                                <Field
-                                    label={locConstants.schemaDesigner.entityName}
-                                    required
-                                    validationState={
-                                        entityNameValidationMessage ? "error" : undefined
-                                    }
-                                    validationMessage={entityNameValidationMessage}>
-                                    <Input
-                                        value={localSettings.entityName}
-                                        onChange={(_, data) => updateEntityName(data.value)}
-                                    />
-                                </Field>
-                            </div>
-                        </section>
+                        <span className={classes.headerSubtitle}>
+                            {locConstants.schemaDesigner.advancedEntityConfiguration}
+                        </span>
+                    </div>
+                </DrawerHeaderTitle>
+            </DrawerHeader>
+            <DrawerBody className={classes.drawerBody}>
+                <section className={classes.section}>
+                    {renderSectionTitle(locConstants.schemaDesigner.identity)}
+                    <div className={classes.sectionBody}>
+                        <Field
+                            label={locConstants.schemaDesigner.entityName}
+                            required
+                            validationState={entityNameValidationMessage ? "error" : undefined}
+                            validationMessage={entityNameValidationMessage}>
+                            <Input
+                                value={localSettings.entityName}
+                                onChange={(_, data) => updateEntityName(data.value)}
+                            />
+                        </Field>
+                    </div>
+                </section>
 
-                        <section className={classes.section}>
-                            {renderSectionTitle(locConstants.schemaDesigner.authorizationRole)}
-                            <div className={classes.sectionBody}>
-                                <div className={classes.roleButtonsContainer}>
-                                    <ToggleButton
-                                        className={classes.roleButton}
-                                        appearance={isAnonymousSelected ? "primary" : "outline"}
-                                        checked={isAnonymousSelected}
-                                        onClick={() =>
-                                            updateAuthorizationRole(Dab.AuthorizationRole.Anonymous)
-                                        }>
-                                        <div className={classes.roleButtonContent}>
-                                            <span
-                                                className={mergeClasses(
-                                                    classes.roleButtonLabel,
-                                                    isAnonymousSelected
-                                                        ? classes.roleButtonLabelSelected
-                                                        : classes.roleButtonLabelUnselected,
-                                                )}>
-                                                {locConstants.schemaDesigner.anonymous}
-                                            </span>
-                                            <span
-                                                className={mergeClasses(
-                                                    classes.roleButtonDescription,
-                                                    isAnonymousSelected
-                                                        ? classes.roleButtonDescriptionSelected
-                                                        : classes.roleButtonDescriptionUnselected,
-                                                )}>
-                                                {locConstants.schemaDesigner.anonymousDescription}
-                                            </span>
-                                        </div>
-                                    </ToggleButton>
-                                    <ToggleButton
-                                        className={classes.roleButton}
-                                        appearance={isAuthenticatedSelected ? "primary" : "outline"}
-                                        checked={isAuthenticatedSelected}
-                                        onClick={() =>
-                                            updateAuthorizationRole(
-                                                Dab.AuthorizationRole.Authenticated,
-                                            )
-                                        }>
-                                        <div className={classes.roleButtonContent}>
-                                            <span
-                                                className={mergeClasses(
-                                                    classes.roleButtonLabel,
-                                                    isAuthenticatedSelected
-                                                        ? classes.roleButtonLabelSelected
-                                                        : classes.roleButtonLabelUnselected,
-                                                )}>
-                                                {locConstants.schemaDesigner.authenticated}
-                                            </span>
-                                            <span
-                                                className={mergeClasses(
-                                                    classes.roleButtonDescription,
-                                                    isAuthenticatedSelected
-                                                        ? classes.roleButtonDescriptionSelected
-                                                        : classes.roleButtonDescriptionUnselected,
-                                                )}>
-                                                {
-                                                    locConstants.schemaDesigner
-                                                        .authenticatedDescription
-                                                }
-                                            </span>
-                                        </div>
-                                    </ToggleButton>
+                <section className={classes.section}>
+                    {renderSectionTitle(locConstants.schemaDesigner.authorizationRole)}
+                    <div className={classes.sectionBody}>
+                        <div className={classes.roleButtonsContainer}>
+                            <ToggleButton
+                                className={classes.roleButton}
+                                appearance={isAnonymousSelected ? "primary" : "outline"}
+                                checked={isAnonymousSelected}
+                                onClick={() =>
+                                    updateAuthorizationRole(Dab.AuthorizationRole.Anonymous)
+                                }>
+                                <div className={classes.roleButtonContent}>
+                                    <span
+                                        className={mergeClasses(
+                                            classes.roleButtonLabel,
+                                            isAnonymousSelected
+                                                ? classes.roleButtonLabelSelected
+                                                : classes.roleButtonLabelUnselected,
+                                        )}>
+                                        {locConstants.schemaDesigner.anonymous}
+                                    </span>
+                                    <span
+                                        className={mergeClasses(
+                                            classes.roleButtonDescription,
+                                            isAnonymousSelected
+                                                ? classes.roleButtonDescriptionSelected
+                                                : classes.roleButtonDescriptionUnselected,
+                                        )}>
+                                        {locConstants.schemaDesigner.anonymousDescription}
+                                    </span>
                                 </div>
-                            </div>
-                        </section>
+                            </ToggleButton>
+                            <ToggleButton
+                                className={classes.roleButton}
+                                appearance={isAuthenticatedSelected ? "primary" : "outline"}
+                                checked={isAuthenticatedSelected}
+                                onClick={() =>
+                                    updateAuthorizationRole(Dab.AuthorizationRole.Authenticated)
+                                }>
+                                <div className={classes.roleButtonContent}>
+                                    <span
+                                        className={mergeClasses(
+                                            classes.roleButtonLabel,
+                                            isAuthenticatedSelected
+                                                ? classes.roleButtonLabelSelected
+                                                : classes.roleButtonLabelUnselected,
+                                        )}>
+                                        {locConstants.schemaDesigner.authenticated}
+                                    </span>
+                                    <span
+                                        className={mergeClasses(
+                                            classes.roleButtonDescription,
+                                            isAuthenticatedSelected
+                                                ? classes.roleButtonDescriptionSelected
+                                                : classes.roleButtonDescriptionUnselected,
+                                        )}>
+                                        {locConstants.schemaDesigner.authenticatedDescription}
+                                    </span>
+                                </div>
+                            </ToggleButton>
+                        </div>
+                    </div>
+                </section>
 
-                        <section
-                            className={mergeClasses(
-                                classes.section,
-                                !isRestEnabled && classes.sectionDisabled,
-                            )}>
-                            {renderSectionTitle(locConstants.schemaDesigner.rest)}
-                            <div className={classes.sectionBody}>
-                                {!isRestEnabled ? (
-                                    renderDisabledBanner(
-                                        Dab.ApiType.Rest,
-                                        locConstants.schemaDesigner.rest,
-                                    )
-                                ) : (
+                <section
+                    className={mergeClasses(
+                        classes.section,
+                        !isRestEnabled && classes.sectionDisabled,
+                    )}>
+                    {renderSectionTitle(locConstants.schemaDesigner.rest)}
+                    <div className={classes.sectionBody}>
+                        {!isRestEnabled ? (
+                            renderDisabledBanner(Dab.ApiType.Rest, locConstants.schemaDesigner.rest)
+                        ) : (
+                            <>
+                                <Checkbox
+                                    checked={isEntityRestEnabled}
+                                    onChange={(_, data) => updateRestEnabled(!!data.checked)}
+                                    label={locConstants.schemaDesigner.enableRestForEntity}
+                                />
+                                {isEntityRestEnabled && (
                                     <>
-                                        <Checkbox
-                                            checked={isEntityRestEnabled}
-                                            onChange={(_, data) =>
-                                                updateRestEnabled(!!data.checked)
+                                        <Field
+                                            label={renderLabelWithInfo(
+                                                locConstants.schemaDesigner.customRestPath,
+                                                locConstants.schemaDesigner.customRestPathHelp,
+                                            )}
+                                            validationState={
+                                                customRestPathValidationMessage
+                                                    ? "error"
+                                                    : undefined
                                             }
-                                            label={locConstants.schemaDesigner.enableRestForEntity}
-                                        />
-                                        {isEntityRestEnabled && (
-                                            <>
-                                                <Field
-                                                    label={renderLabelWithInfo(
-                                                        locConstants.schemaDesigner.customRestPath,
-                                                        locConstants.schemaDesigner
-                                                            .customRestPathHelp,
-                                                    )}
-                                                    validationState={
-                                                        customRestPathValidationMessage
-                                                            ? "error"
-                                                            : undefined
-                                                    }
-                                                    validationMessage={
-                                                        customRestPathValidationMessage
-                                                    }>
-                                                    <Input
-                                                        value={localSettings.customRestPath ?? ""}
-                                                        placeholder={(
-                                                            entity.sourceName ?? entity.tableName
-                                                        ).toLowerCase()}
-                                                        onChange={(_, data) =>
-                                                            updateCustomRestPath(data.value)
-                                                        }
-                                                    />
-                                                </Field>
-
-                                                {isStoredProcedure && (
-                                                    <Field
-                                                        label={renderLabelWithInfo(
-                                                            locConstants.schemaDesigner
-                                                                .storedProcedureRestMethods,
-                                                            locConstants.schemaDesigner
-                                                                .storedProcedureRestMethodsHelp,
-                                                        )}
-                                                        required>
-                                                        <RadioGroup
-                                                            className={classes.methodGroup}
-                                                            value={storedProcedureRestMethod}
-                                                            layout="horizontal"
-                                                            onChange={(_, data) =>
-                                                                updateStoredProcedureRestMethod(
-                                                                    data.value as Dab.RestMethod,
-                                                                )
-                                                            }>
-                                                            {Dab.storedProcedureAllowedRestMethods.map(
-                                                                (method) => (
-                                                                    <Radio
-                                                                        key={method}
-                                                                        value={method}
-                                                                        label={method.toUpperCase()}
-                                                                    />
-                                                                ),
-                                                            )}
-                                                        </RadioGroup>
-                                                    </Field>
-                                                )}
-                                            </>
-                                        )}
-                                    </>
-                                )}
-                            </div>
-                        </section>
-
-                        <section
-                            className={mergeClasses(
-                                classes.section,
-                                !isGraphQLEnabled && classes.sectionDisabled,
-                            )}>
-                            {renderSectionTitle(locConstants.schemaDesigner.graphql)}
-                            <div className={classes.sectionBody}>
-                                {!isGraphQLEnabled ? (
-                                    renderDisabledBanner(
-                                        Dab.ApiType.GraphQL,
-                                        locConstants.schemaDesigner.graphql,
-                                    )
-                                ) : (
-                                    <>
-                                        <Checkbox
-                                            checked={isEntityGraphQLEnabled}
-                                            onChange={(_, data) =>
-                                                updateGraphQLEnabled(!!data.checked)
-                                            }
-                                            label={
-                                                locConstants.schemaDesigner.enableGraphQLForEntity
-                                            }
-                                        />
-                                        {isEntityGraphQLEnabled && (
-                                            <>
-                                                <Field
-                                                    label={renderLabelWithInfo(
-                                                        locConstants.schemaDesigner
-                                                            .customGraphQLSingularType,
-                                                        locConstants.schemaDesigner
-                                                            .customGraphQLSingularTypeHelp,
-                                                    )}
-                                                    required={customGraphQLPluralType.length > 0}
-                                                    validationState={
-                                                        customGraphQLSingularTypeValidationMessage
-                                                            ? "error"
-                                                            : undefined
-                                                    }
-                                                    validationMessage={
-                                                        customGraphQLSingularTypeValidationMessage
-                                                    }>
-                                                    <Input
-                                                        value={customGraphQLSingularType}
-                                                        placeholder={
-                                                            entity.sourceName ?? entity.tableName
-                                                        }
-                                                        onChange={(_, data) =>
-                                                            updateCustomGraphQLSingularType(
-                                                                data.value,
-                                                            )
-                                                        }
-                                                    />
-                                                </Field>
-                                                <Field
-                                                    label={renderLabelWithInfo(
-                                                        locConstants.schemaDesigner
-                                                            .customGraphQLPluralType,
-                                                        locConstants.schemaDesigner
-                                                            .customGraphQLPluralTypeHelp,
-                                                    )}
-                                                    validationState={
-                                                        customGraphQLPluralTypeValidationMessage
-                                                            ? "error"
-                                                            : undefined
-                                                    }
-                                                    validationMessage={
-                                                        customGraphQLPluralTypeValidationMessage
-                                                    }>
-                                                    <Input
-                                                        value={customGraphQLPluralType}
-                                                        placeholder={`${
-                                                            entity.sourceName ?? entity.tableName
-                                                        }s`}
-                                                        onChange={(_, data) =>
-                                                            updateCustomGraphQLPluralType(
-                                                                data.value,
-                                                            )
-                                                        }
-                                                    />
-                                                </Field>
-
-                                                {isStoredProcedure && (
-                                                    <Field
-                                                        label={renderLabelWithInfo(
-                                                            locConstants.schemaDesigner
-                                                                .storedProcedureGraphQLOperation,
-                                                            locConstants.schemaDesigner
-                                                                .storedProcedureGraphQLOperationHelp,
-                                                        )}
-                                                        required>
-                                                        <RadioGroup
-                                                            value={storedProcedureGraphQLOperation}
-                                                            layout="horizontal"
-                                                            onChange={(_, data) =>
-                                                                updateStoredProcedureGraphQLOperation(
-                                                                    data.value as Dab.GraphQLOperation,
-                                                                )
-                                                            }>
-                                                            <Radio
-                                                                value={
-                                                                    Dab.GraphQLOperation.Mutation
-                                                                }
-                                                                label={
-                                                                    locConstants.schemaDesigner
-                                                                        .graphqlMutation
-                                                                }
-                                                            />
-                                                            <Radio
-                                                                value={Dab.GraphQLOperation.Query}
-                                                                label={
-                                                                    locConstants.schemaDesigner
-                                                                        .graphqlQuery
-                                                                }
-                                                            />
-                                                        </RadioGroup>
-                                                    </Field>
-                                                )}
-                                            </>
-                                        )}
-                                    </>
-                                )}
-                            </div>
-                        </section>
-
-                        {isStoredProcedure && (
-                            <section
-                                className={mergeClasses(
-                                    classes.section,
-                                    !isMcpEnabled && classes.sectionDisabled,
-                                )}>
-                                {renderSectionTitle(locConstants.schemaDesigner.mcp)}
-                                <div className={classes.sectionBody}>
-                                    {!isMcpEnabled ? (
-                                        renderDisabledBanner(
-                                            Dab.ApiType.Mcp,
-                                            locConstants.schemaDesigner.mcp,
-                                            locConstants.schemaDesigner.enableMcpForCustomToolHelp,
-                                        )
-                                    ) : (
-                                        <>
-                                            <Checkbox
-                                                checked={exposeAsMcpCustomTool}
+                                            validationMessage={customRestPathValidationMessage}>
+                                            <Input
+                                                value={localSettings.customRestPath ?? ""}
+                                                placeholder={(
+                                                    entity.sourceName ?? entity.tableName
+                                                ).toLowerCase()}
                                                 onChange={(_, data) =>
-                                                    updateExposeAsMcpCustomTool(!!data.checked)
-                                                }
-                                                label={
-                                                    locConstants.schemaDesigner
-                                                        .exposeAsMcpCustomTool
+                                                    updateCustomRestPath(data.value)
                                                 }
                                             />
-                                            {exposeAsMcpCustomTool && (
-                                                <span className={classes.fieldHint}>
-                                                    {
-                                                        locConstants.schemaDesigner
-                                                            .exposeAsMcpCustomToolHelp
-                                                    }
-                                                </span>
-                                            )}
-                                        </>
-                                    )}
-                                </div>
-                            </section>
+                                        </Field>
+
+                                        {isStoredProcedure && (
+                                            <Field
+                                                label={renderLabelWithInfo(
+                                                    locConstants.schemaDesigner
+                                                        .storedProcedureRestMethods,
+                                                    locConstants.schemaDesigner
+                                                        .storedProcedureRestMethodsHelp,
+                                                )}
+                                                required>
+                                                <RadioGroup
+                                                    className={classes.methodGroup}
+                                                    value={storedProcedureRestMethod}
+                                                    layout="horizontal"
+                                                    onChange={(_, data) =>
+                                                        updateStoredProcedureRestMethod(
+                                                            data.value as Dab.RestMethod,
+                                                        )
+                                                    }>
+                                                    {Dab.storedProcedureAllowedRestMethods.map(
+                                                        (method) => (
+                                                            <Radio
+                                                                key={method}
+                                                                value={method}
+                                                                label={method.toUpperCase()}
+                                                            />
+                                                        ),
+                                                    )}
+                                                </RadioGroup>
+                                            </Field>
+                                        )}
+                                    </>
+                                )}
+                            </>
                         )}
-                    </DialogContent>
-                    <DialogActions className={classes.dialogActions}>
-                        <Button
-                            appearance="secondary"
-                            className={classes.actionButton}
-                            onClick={handleCancel}>
-                            {locConstants.common.cancel}
-                        </Button>
-                        <Button
-                            appearance="primary"
-                            className={classes.actionButton}
-                            disabled={hasValidationError}
-                            onClick={handleApply}>
-                            {locConstants.schemaDesigner.applyChanges}
-                        </Button>
-                    </DialogActions>
-                </DialogBody>
-            </DialogSurface>
-        </Dialog>
+                    </div>
+                </section>
+
+                <section
+                    className={mergeClasses(
+                        classes.section,
+                        !isGraphQLEnabled && classes.sectionDisabled,
+                    )}>
+                    {renderSectionTitle(locConstants.schemaDesigner.graphql)}
+                    <div className={classes.sectionBody}>
+                        {!isGraphQLEnabled ? (
+                            renderDisabledBanner(
+                                Dab.ApiType.GraphQL,
+                                locConstants.schemaDesigner.graphql,
+                            )
+                        ) : (
+                            <>
+                                <Checkbox
+                                    checked={isEntityGraphQLEnabled}
+                                    onChange={(_, data) => updateGraphQLEnabled(!!data.checked)}
+                                    label={locConstants.schemaDesigner.enableGraphQLForEntity}
+                                />
+                                {isEntityGraphQLEnabled && (
+                                    <>
+                                        <Field
+                                            label={renderLabelWithInfo(
+                                                locConstants.schemaDesigner
+                                                    .customGraphQLSingularType,
+                                                locConstants.schemaDesigner
+                                                    .customGraphQLSingularTypeHelp,
+                                            )}
+                                            required={customGraphQLPluralType.length > 0}
+                                            validationState={
+                                                customGraphQLSingularTypeValidationMessage
+                                                    ? "error"
+                                                    : undefined
+                                            }
+                                            validationMessage={
+                                                customGraphQLSingularTypeValidationMessage
+                                            }>
+                                            <Input
+                                                value={customGraphQLSingularType}
+                                                placeholder={entity.sourceName ?? entity.tableName}
+                                                onChange={(_, data) =>
+                                                    updateCustomGraphQLSingularType(data.value)
+                                                }
+                                            />
+                                        </Field>
+                                        <Field
+                                            label={renderLabelWithInfo(
+                                                locConstants.schemaDesigner.customGraphQLPluralType,
+                                                locConstants.schemaDesigner
+                                                    .customGraphQLPluralTypeHelp,
+                                            )}
+                                            validationState={
+                                                customGraphQLPluralTypeValidationMessage
+                                                    ? "error"
+                                                    : undefined
+                                            }
+                                            validationMessage={
+                                                customGraphQLPluralTypeValidationMessage
+                                            }>
+                                            <Input
+                                                value={customGraphQLPluralType}
+                                                placeholder={`${
+                                                    entity.sourceName ?? entity.tableName
+                                                }s`}
+                                                onChange={(_, data) =>
+                                                    updateCustomGraphQLPluralType(data.value)
+                                                }
+                                            />
+                                        </Field>
+
+                                        {isStoredProcedure && (
+                                            <Field
+                                                label={renderLabelWithInfo(
+                                                    locConstants.schemaDesigner
+                                                        .storedProcedureGraphQLOperation,
+                                                    locConstants.schemaDesigner
+                                                        .storedProcedureGraphQLOperationHelp,
+                                                )}
+                                                required>
+                                                <RadioGroup
+                                                    value={storedProcedureGraphQLOperation}
+                                                    layout="horizontal"
+                                                    onChange={(_, data) =>
+                                                        updateStoredProcedureGraphQLOperation(
+                                                            data.value as Dab.GraphQLOperation,
+                                                        )
+                                                    }>
+                                                    <Radio
+                                                        value={Dab.GraphQLOperation.Mutation}
+                                                        label={
+                                                            locConstants.schemaDesigner
+                                                                .graphqlMutation
+                                                        }
+                                                    />
+                                                    <Radio
+                                                        value={Dab.GraphQLOperation.Query}
+                                                        label={
+                                                            locConstants.schemaDesigner.graphqlQuery
+                                                        }
+                                                    />
+                                                </RadioGroup>
+                                            </Field>
+                                        )}
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </div>
+                </section>
+
+                {isStoredProcedure && (
+                    <section
+                        className={mergeClasses(
+                            classes.section,
+                            !isMcpEnabled && classes.sectionDisabled,
+                        )}>
+                        {renderSectionTitle(locConstants.schemaDesigner.mcp)}
+                        <div className={classes.sectionBody}>
+                            {!isMcpEnabled ? (
+                                renderDisabledBanner(
+                                    Dab.ApiType.Mcp,
+                                    locConstants.schemaDesigner.mcp,
+                                    locConstants.schemaDesigner.enableMcpForCustomToolHelp,
+                                )
+                            ) : (
+                                <>
+                                    <Checkbox
+                                        checked={exposeAsMcpCustomTool}
+                                        onChange={(_, data) =>
+                                            updateExposeAsMcpCustomTool(!!data.checked)
+                                        }
+                                        label={locConstants.schemaDesigner.exposeAsMcpCustomTool}
+                                    />
+                                    {exposeAsMcpCustomTool && (
+                                        <span className={classes.fieldHint}>
+                                            {locConstants.schemaDesigner.exposeAsMcpCustomToolHelp}
+                                        </span>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </section>
+                )}
+            </DrawerBody>
+            <DrawerFooter className={classes.drawerFooter}>
+                <Button
+                    appearance="secondary"
+                    className={classes.actionButton}
+                    onClick={handleCancel}>
+                    {locConstants.common.cancel}
+                </Button>
+                <Button
+                    appearance="primary"
+                    className={classes.actionButton}
+                    disabled={hasValidationError}
+                    onClick={handleApply}>
+                    {locConstants.schemaDesigner.applyChanges}
+                </Button>
+            </DrawerFooter>
+        </OverlayDrawer>
     );
 }

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntityTable.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/dab/dabEntityTable.tsx
@@ -127,10 +127,6 @@ function formatUnsupportedReasons(entity: Dab.DabEntityConfig): string {
         .join("; ");
 }
 
-function getEntityFullName(entity: Dab.DabEntityConfig): string {
-    return `${entity.schemaName}.${entity.sourceName ?? entity.tableName}`;
-}
-
 function getSchemaGroupKey(schemaName: string): string {
     return schemaName.trim().toLowerCase();
 }
@@ -433,7 +429,6 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
         updateDabEntitySettings,
         updateDabApiTypes,
         dabTextFilter,
-        currentFilteredTables,
     } = context;
 
     const [expandedRows, setExpandedRows] = useState<Set<string>>(() =>
@@ -446,12 +441,6 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
     const hasInitializedExpandedRows = useRef(Boolean(dabConfig));
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
-    const initialEnabledEntities = useRef<Set<string>>(
-        new Set(
-            dabConfig?.entities.filter((e) => e.isEnabled).map((e) => getEntityFullName(e)) ?? [],
-        ),
-    );
-
     useEffect(() => {
         if (!dabConfig) {
             return;
@@ -459,30 +448,9 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
 
         if (!hasInitializedExpandedRows.current) {
             setExpandedRows(createDefaultExpandedRows(dabConfig));
-            initialEnabledEntities.current = new Set(
-                dabConfig.entities.filter((e) => e.isEnabled).map((e) => getEntityFullName(e)),
-            );
             hasInitializedExpandedRows.current = true;
         }
-
-        const tablesToCheck: Set<string> =
-            currentFilteredTables.length > 0
-                ? new Set(currentFilteredTables)
-                : initialEnabledEntities.current;
-
-        dabConfig.entities.forEach((entity) => {
-            if ((entity.sourceType ?? Dab.EntitySourceType.Table) !== Dab.EntitySourceType.Table) {
-                return;
-            }
-
-            const fullName = getEntityFullName(entity);
-            const shouldCheck = tablesToCheck.has(fullName);
-
-            if (initialEnabledEntities.current.has(fullName) && shouldCheck !== entity.isEnabled) {
-                toggleDabEntity(entity.id, shouldCheck);
-            }
-        });
-    }, [currentFilteredTables, dabConfig, toggleDabEntity]);
+    }, [dabConfig]);
 
     const allActions = useMemo(
         () => [
@@ -717,18 +685,30 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
         [filteredEntities, headerActionState, toggleDabEntityAction],
     );
 
-    // ── Schema-level checkbox ──
+    // ── Entity selection checkboxes ──
 
-    const toggleSchemaEntities = useCallback(
+    const entitySelectionState = useCallback((entities: Dab.DabEntityConfig[]): CheckedState => {
+        const supported = entities.filter((e) => e.isSupported);
+        const enabledCount = supported.filter((e) => e.isEnabled).length;
+        return getCheckedState(supported.length, enabledCount);
+    }, []);
+
+    const toggleEntities = useCallback(
         (entities: Dab.DabEntityConfig[]) => {
             const supported = entities.filter((e) => e.isSupported);
-            const enabledCount = supported.filter((e) => e.isEnabled).length;
-            const shouldEnable = getCheckedState(supported.length, enabledCount) !== "checked";
+            const shouldEnable = entitySelectionState(supported) !== "checked";
             for (const entity of supported) {
-                toggleDabEntity(entity.id, shouldEnable);
+                if (entity.isEnabled !== shouldEnable) {
+                    toggleDabEntity(entity.id, shouldEnable);
+                }
             }
         },
-        [toggleDabEntity],
+        [entitySelectionState, toggleDabEntity],
+    );
+
+    const headerSelectionState = useMemo(
+        () => entitySelectionState(filteredEntities),
+        [entitySelectionState, filteredEntities],
     );
 
     // ── Settings dialog ──
@@ -782,15 +762,14 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
         (row: FlatRow) => {
             if (row.type === "schema") {
                 const supported = row.entities.filter((e) => e.isSupported);
-                const enabledCount = supported.filter((e) => e.isEnabled).length;
-                const checkState = getCheckedState(supported.length, enabledCount);
+                const checkState = entitySelectionState(row.entities);
 
                 return (
                     <div className={classes.centeredCell}>
                         <Checkbox
                             checked={toNativeChecked(checkState)}
                             disabled={supported.length === 0}
-                            onChange={() => toggleSchemaEntities(row.entities)}
+                            onChange={() => toggleEntities(row.entities)}
                             aria-label={locConstants.schemaDesigner.toggleAllEntitiesInSchema(
                                 row.schemaName,
                             )}
@@ -801,15 +780,14 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
 
             if (row.type === "objectGroup") {
                 const supported = row.entities.filter((e) => e.isSupported);
-                const enabledCount = supported.filter((e) => e.isEnabled).length;
-                const checkState = getCheckedState(supported.length, enabledCount);
+                const checkState = entitySelectionState(row.entities);
 
                 return (
                     <div className={classes.centeredCell}>
                         <Checkbox
                             checked={toNativeChecked(checkState)}
                             disabled={supported.length === 0}
-                            onChange={() => toggleSchemaEntities(row.entities)}
+                            onChange={() => toggleEntities(row.entities)}
                             aria-label={sourceTypeLabels[row.sourceType]}
                         />
                     </div>
@@ -879,10 +857,11 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
         },
         [
             classes.centeredCell,
+            entitySelectionState,
             sourceTypeLabels,
             toggleDabColumnExposure,
             toggleDabEntity,
-            toggleSchemaEntities,
+            toggleEntities,
         ],
     );
 
@@ -1181,7 +1160,16 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
         () => [
             createTableColumn<FlatRow>({
                 columnId: "select",
-                renderHeaderCell: () => <span />,
+                renderHeaderCell: () => (
+                    <div className={classes.headerActionCell}>
+                        <Checkbox
+                            checked={toNativeChecked(headerSelectionState)}
+                            disabled={filteredEntities.filter((e) => e.isSupported).length === 0}
+                            onChange={() => toggleEntities(filteredEntities)}
+                            aria-label={locConstants.schemaDesigner.selectAllEntities}
+                        />
+                    </div>
+                ),
                 renderCell: renderSelectContent,
             }),
             createTableColumn<FlatRow>({
@@ -1260,6 +1248,7 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
             classes.sortableHeader,
             filteredEntities,
             headerActionState,
+            headerSelectionState,
             renderActionContent,
             renderExpandContent,
             renderNameContent,
@@ -1267,6 +1256,7 @@ export const DabEntityTable = ({ entityFilters }: DabEntityTableProps) => {
             renderSettingsContent,
             renderSourceContent,
             sortDirection,
+            toggleEntities,
             toggleHeaderAction,
         ],
     );

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
@@ -1164,6 +1164,14 @@ function normalizeDabConfigForVersion(config: Dab.DabConfig) {
                         entity.advancedSettings.customGraphQLType !== undefined
                             ? entity.advancedSettings.customGraphQLType
                             : undefined,
+                    customGraphQLSingularType:
+                        entity.advancedSettings.customGraphQLSingularType !== undefined
+                            ? entity.advancedSettings.customGraphQLSingularType
+                            : undefined,
+                    customGraphQLPluralType:
+                        entity.advancedSettings.customGraphQLPluralType !== undefined
+                            ? entity.advancedSettings.customGraphQLPluralType
+                            : undefined,
                     graphQLEnabled: entity.advancedSettings.graphQLEnabled,
                     storedProcedureRestMethods:
                         entity.advancedSettings.storedProcedureRestMethods !== undefined
@@ -1681,23 +1689,29 @@ function applyDabToolChange(
                     case "customGraphQLType":
                         if (value === null || typeof value === "undefined") {
                             delete updatedSettings.customGraphQLType;
+                            delete updatedSettings.customGraphQLSingularType;
+                            delete updatedSettings.customGraphQLPluralType;
                             break;
                         }
-                        if (typeof value !== "string") {
+                        if (
+                            typeof value !== "string" &&
+                            !(typeof value === "object" && value !== null && !Array.isArray(value))
+                        ) {
                             return {
                                 success: false,
                                 reason: "invalid_request",
-                                message: "customGraphQLType must be a string or null.",
+                                message:
+                                    "customGraphQLType must be a string, singular/plural object, or null.",
                             };
                         }
-                        if (value.trim().length === 0) {
+                        if (typeof value === "string" && value.trim().length === 0) {
                             return {
                                 success: false,
                                 reason: "invalid_request",
                                 message: "customGraphQLType cannot be an empty string.",
                             };
                         }
-                        {
+                        if (typeof value === "string") {
                             const trimmedValue = value.trim();
                             const validationError = Dab.validateDabCustomGraphQLType(trimmedValue);
                             if (validationError) {
@@ -1707,9 +1721,116 @@ function applyDabToolChange(
                                     message: validationError,
                                 };
                             }
-                            updatedSettings.customGraphQLType = trimmedValue;
+                            delete updatedSettings.customGraphQLType;
+                            updatedSettings.customGraphQLSingularType = trimmedValue;
+                            delete updatedSettings.customGraphQLPluralType;
+                        } else {
+                            const graphQLTypeValue = value as Record<string, unknown>;
+                            const singularValue = graphQLTypeValue.singular;
+                            const pluralValue = graphQLTypeValue.plural;
+                            if (typeof singularValue !== "string" || singularValue.trim() === "") {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message:
+                                        "customGraphQLType.singular must be a non-empty string.",
+                                };
+                            }
+                            if (
+                                typeof pluralValue !== "undefined" &&
+                                pluralValue !== null &&
+                                (typeof pluralValue !== "string" || pluralValue.trim() === "")
+                            ) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message:
+                                        "customGraphQLType.plural must be a non-empty string or null.",
+                                };
+                            }
+
+                            const singular = singularValue.trim();
+                            const plural =
+                                typeof pluralValue === "string" ? pluralValue.trim() : undefined;
+                            const singularValidationError = Dab.validateDabCustomGraphQLType(
+                                singular,
+                                "customGraphQLType.singular",
+                            );
+                            if (singularValidationError) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message: singularValidationError,
+                                };
+                            }
+                            const pluralValidationError = plural
+                                ? Dab.validateDabCustomGraphQLType(
+                                      plural,
+                                      "customGraphQLType.plural",
+                                  )
+                                : undefined;
+                            if (pluralValidationError) {
+                                return {
+                                    success: false,
+                                    reason: "invalid_request",
+                                    message: pluralValidationError,
+                                };
+                            }
+
+                            delete updatedSettings.customGraphQLType;
+                            updatedSettings.customGraphQLSingularType = singular;
+                            if (plural) {
+                                updatedSettings.customGraphQLPluralType = plural;
+                            } else {
+                                delete updatedSettings.customGraphQLPluralType;
+                            }
                         }
                         break;
+                    case "customGraphQLSingularType":
+                    case "customGraphQLPluralType": {
+                        const propertyName = key;
+                        if (value === null || typeof value === "undefined") {
+                            if (propertyName === "customGraphQLSingularType") {
+                                delete updatedSettings.customGraphQLSingularType;
+                            } else {
+                                delete updatedSettings.customGraphQLPluralType;
+                            }
+                            break;
+                        }
+                        if (typeof value !== "string") {
+                            return {
+                                success: false,
+                                reason: "invalid_request",
+                                message: `${propertyName} must be a string or null.`,
+                            };
+                        }
+                        if (value.trim().length === 0) {
+                            return {
+                                success: false,
+                                reason: "invalid_request",
+                                message: `${propertyName} cannot be an empty string.`,
+                            };
+                        }
+                        const trimmedValue = value.trim();
+                        const validationError = Dab.validateDabCustomGraphQLType(
+                            trimmedValue,
+                            propertyName,
+                        );
+                        if (validationError) {
+                            return {
+                                success: false,
+                                reason: "invalid_request",
+                                message: validationError,
+                            };
+                        }
+                        delete updatedSettings.customGraphQLType;
+                        if (propertyName === "customGraphQLSingularType") {
+                            updatedSettings.customGraphQLSingularType = trimmedValue;
+                        } else {
+                            updatedSettings.customGraphQLPluralType = trimmedValue;
+                        }
+                        break;
+                    }
                     case "graphQLEnabled":
                         if (typeof value !== "boolean") {
                             return {
@@ -1736,26 +1857,29 @@ function applyDabToolChange(
                                     "storedProcedureRestMethods can only be set for stored procedure entities.",
                             };
                         }
-                        if (!Array.isArray(value) || value.length === 0) {
+                        if (!Array.isArray(value) || value.length !== 1) {
                             return {
                                 success: false,
                                 reason: "invalid_request",
-                                message: "storedProcedureRestMethods must be a non-empty array.",
+                                message:
+                                    "storedProcedureRestMethods must contain exactly one method.",
                             };
                         }
                         for (const method of value) {
-                            if (!Object.values(Dab.RestMethod).includes(method as Dab.RestMethod)) {
+                            if (
+                                !Dab.storedProcedureAllowedRestMethods.some(
+                                    (allowedMethod) => allowedMethod === method,
+                                )
+                            ) {
                                 return {
                                     success: false,
                                     reason: "invalid_request",
                                     message:
-                                        "storedProcedureRestMethods must contain valid REST methods.",
+                                        "storedProcedureRestMethods must contain either 'get' or 'post'.",
                                 };
                             }
                         }
-                        updatedSettings.storedProcedureRestMethods = Dab.normalizeRestMethods(
-                            value as Dab.RestMethod[],
-                        );
+                        updatedSettings.storedProcedureRestMethods = [value[0] as Dab.RestMethod];
                         break;
                     case "storedProcedureGraphQLOperation":
                         if (
@@ -1810,6 +1934,19 @@ function applyDabToolChange(
                             message: `Unsupported patch property: ${key}.`,
                         };
                 }
+            }
+
+            if (
+                updatedSettings.customGraphQLPluralType &&
+                !updatedSettings.customGraphQLSingularType &&
+                !updatedSettings.customGraphQLType
+            ) {
+                return {
+                    success: false,
+                    reason: "validation_error",
+                    message:
+                        "customGraphQLSingularType is required when customGraphQLPluralType is set.",
+                };
             }
 
             config.entities[resolvedEntity.index] = {

--- a/extensions/mssql/test/unit/dab/dabConfigFileBuilder.test.ts
+++ b/extensions/mssql/test/unit/dab/dabConfigFileBuilder.test.ts
@@ -427,7 +427,7 @@ suite("DabConfigFileBuilder Tests", () => {
                 expect(entity.permissions).to.deep.equal([
                     { role: "anonymous", actions: ["execute"] },
                 ]);
-                expect(entity.rest).to.be.undefined;
+                expect(entity.rest).to.deep.equal({ methods: ["post"] });
                 expect(entity.graphql).to.be.undefined;
                 expect(entity.mcp).to.deep.equal({
                     "custom-tool": true,
@@ -579,7 +579,6 @@ suite("DabConfigFileBuilder Tests", () => {
                                 entityName: "GetUsers",
                                 authorizationRole: Dab.AuthorizationRole.Anonymous,
                                 storedProcedureRestMethods: [
-                                    Dab.RestMethod.Post,
                                     Dab.RestMethod.Get,
                                     Dab.RestMethod.Post,
                                 ],
@@ -590,7 +589,7 @@ suite("DabConfigFileBuilder Tests", () => {
                 const result = builder.build(config, defaultConnectionInfo);
                 const parsed = JSON.parse(result);
                 expect(parsed.entities["GetUsers"].rest).to.deep.equal({
-                    methods: ["get", "post"],
+                    methods: ["get"],
                 });
             });
         });

--- a/extensions/mssql/test/unit/dabTool.test.ts
+++ b/extensions/mssql/test/unit/dabTool.test.ts
@@ -1299,7 +1299,9 @@ suite("DabTool Tests", () => {
             expect(settings).to.exist;
             expect(settings?.entityName).to.equal("UsersApi");
             expect(settings?.customRestPath).to.equal("/users");
-            expect(settings?.customGraphQLType).to.equal("UsersType");
+            expect(settings?.customGraphQLType).to.equal(undefined);
+            expect(settings?.customGraphQLSingularType).to.equal("UsersType");
+            expect(settings?.customGraphQLPluralType).to.equal(undefined);
         });
 
         test("apply_changes patch_entity_settings rejects unsafe string values", async () => {
@@ -1499,11 +1501,7 @@ suite("DabTool Tests", () => {
                         type: "patch_entity_settings",
                         entity: { id: "stored-procedure:dbo.GetUsers" },
                         set: {
-                            storedProcedureRestMethods: [
-                                Dab.RestMethod.Post,
-                                Dab.RestMethod.Get,
-                                Dab.RestMethod.Post,
-                            ],
+                            storedProcedureRestMethods: [Dab.RestMethod.Get],
                             storedProcedureGraphQLOperation: Dab.GraphQLOperation.Query,
                         },
                     },
@@ -1515,7 +1513,7 @@ suite("DabTool Tests", () => {
                 throw new Error("Expected success response");
             }
             const settings = result.config?.entities[0].advancedSettings;
-            expect(settings?.storedProcedureRestMethods).to.deep.equal(["get", "post"]);
+            expect(settings?.storedProcedureRestMethods).to.deep.equal(["get"]);
             expect(settings?.storedProcedureGraphQLOperation).to.equal("query");
         });
 

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -483,9 +483,6 @@
     <trans-unit id="++CODE++7eaca18a3c11c60ab2d50c764174699f66bb634b8d7324a2303d1e3ea541b626">
       <source xml:lang="en">Authentication not supported</source>
     </trans-unit>
-    <trans-unit id="++CODE++a06725099766746b634d3d1caf6928e6553311ad0e910f795ab97c69fac0f246">
-      <source xml:lang="en">Authorization Role</source>
-    </trans-unit>
     <trans-unit id="++CODE++d58bbb838e095ea400fb432477d5657a6b5a32da8da836299f4f7e20020bb42d">
       <source xml:lang="en">Auto Arrange</source>
     </trans-unit>
@@ -4823,6 +4820,9 @@
     </trans-unit>
     <trans-unit id="++CODE++e87dbc12e88933c84d9ccdb30d89a4c9977b80894c26a85504ed7b1b42fda674">
       <source xml:lang="en">Perform checksum before writing to media</source>
+    </trans-unit>
+    <trans-unit id="++CODE++abccc78cc93c07931feccfbd0665c003373b48334fd8d4cf5c6d0c714e68f26e">
+      <source xml:lang="en">Permissions</source>
     </trans-unit>
     <trans-unit id="++CODE++4c09d189302f2506e79be79caf623ccc300816ff936119f9dc5f5bbfd9ee5b0a">
       <source xml:lang="en">Pick from multiple SQL Server versions, including SQL Server 2025 with built-in AI capabilities like vector search and JSON enhancements.</source>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1718,6 +1718,12 @@
     <trans-unit id="++CODE++87a66e3c88ffbca47508d5dcd250ebaa992c772a4b9d260c36216d4695e05475">
       <source xml:lang="en">Currently signed in as:</source>
     </trans-unit>
+    <trans-unit id="++CODE++10e83a09a01b19a7e3094aff3a98451a8413276d7f6266cd15d23ccf5ac6c38e">
+      <source xml:lang="en">Custom GraphQL Plural Type</source>
+    </trans-unit>
+    <trans-unit id="++CODE++561ba11b002a5ba8dea88b4a98186d829c0f8b551c04f331c6985d16c2b2b2e2">
+      <source xml:lang="en">Custom GraphQL Singular Type</source>
+    </trans-unit>
     <trans-unit id="++CODE++c01dcd0e5ceb3a50adfe0ba0d9ab5e70b74daf484cbce1b937f8fa14910f7928">
       <source xml:lang="en">Custom GraphQL Type</source>
     </trans-unit>
@@ -1862,6 +1868,9 @@
     </trans-unit>
     <trans-unit id="++CODE++9912ff507e2f48ad028b400bce2df6d1b4a673fe69fddcacf1cbfd3836275ab1">
       <source xml:lang="en">Define who can access this endpoint</source>
+    </trans-unit>
+    <trans-unit id="++CODE++03477f19d9c2a8d64507c67756d40cf9945e802a3c7f0b52d45a4127ebfd53a2">
+      <source xml:lang="en">Define who can execute this stored procedure</source>
     </trans-unit>
     <trans-unit id="++CODE++9813fafb098c218090536790280a91ee70062a8490eb3615395ee731cdd40023">
       <source xml:lang="en">Definition</source>
@@ -4717,8 +4726,11 @@
     <trans-unit id="++CODE++da53ba1a285ffae9c6528e235b57336fa85b4f05e9fc00a51ee922069c3d9865">
       <source xml:lang="en">Optional (False)</source>
     </trans-unit>
-    <trans-unit id="++CODE++7f528941bf8224f8dd6956f98aa9ae63472375cfaebddbcb78005f15c5f239df">
-      <source xml:lang="en">Optional - Override default GraphQL type name</source>
+    <trans-unit id="++CODE++4458e9d6c19d14a28dfe913b227c80ac7aa74c2a66d830bc962c2e7bbc6350fa">
+      <source xml:lang="en">Optional - Override default GraphQL plural type name</source>
+    </trans-unit>
+    <trans-unit id="++CODE++4109ca63fed7620f568296b7854396c09c0453afd1a5d3e7b1427e88a7e62101">
+      <source xml:lang="en">Optional - Override default GraphQL singular type name</source>
     </trans-unit>
     <trans-unit id="++CODE++88f7acca017a3a274d4c9ee22712b49f567fcadb30287e007c1ac2ea00cb6927">
       <source xml:lang="en">Optional - Override default api/entityName path</source>
@@ -5851,6 +5863,9 @@
     <trans-unit id="++CODE++1fc9a387654d410febd202b81bddbe62d38368260b69b9f73ee6630164536bdf">
       <source xml:lang="en">Select all</source>
     </trans-unit>
+    <trans-unit id="++CODE++958a0500f227e31bede1c2aaac7f01cb586d081a4fa0396928370f797a956bd7">
+      <source xml:lang="en">Select all entities</source>
+    </trans-unit>
     <trans-unit id="++CODE++80a484c3416afd950fcefa87e88b0514e65144c7d45c12bf0bc9809c46837f89">
       <source xml:lang="en">Select all options</source>
     </trans-unit>
@@ -5904,8 +5919,8 @@
     <trans-unit id="++CODE++816fb2b1f45f1228327db6df7e553f728b2074ca7897d2b506a881d6a7e5f6f6">
       <source xml:lang="en">Select the Azure Data Studio settings.json file to scan for connection groups and connections.</source>
     </trans-unit>
-    <trans-unit id="++CODE++c3e908318ac99693f90743c99d94c8d1f123f65564685137a3236da773d4bb9b">
-      <source xml:lang="en">Select the HTTP methods that can execute this stored procedure. DAB defaults to POST.</source>
+    <trans-unit id="++CODE++f51936575cf1dc8077bff593b9237f2ab580f19bf6e25bc409e294768ed1a10c">
+      <source xml:lang="en">Select the HTTP method that can execute this stored procedure. DAB defaults to POST.</source>
     </trans-unit>
     <trans-unit id="++CODE++5c61a29b1d409ff2b70f6fbd1032d7250ac322407dc4b8bbff19eb20af562291">
       <source xml:lang="en">Select the SQL Server Container Image</source>


### PR DESCRIPTION
## Description

Fixes several Data API builder designer regressions found while triaging the JerryNixon/dab-quickstarts issue set:

- Restricts stored procedure REST method selection to a single `GET` or `POST` radio choice and clamps generated config/tool updates to one allowed method.
- Splits custom GraphQL type configuration into singular and plural inputs, emits DAB's supported `graphql.type` object shape when needed, and blocks plural-only values.
- Updates stored procedure authorization hint text to use execute-oriented wording.
- Fixes entity selection behavior for the grid header, schema/type group rows, and manual table deselection while preserving default enablement for compatible entities.
- Keeps DAB Copilot/tool patch handling aligned with the new stored procedure REST and GraphQL type validation.

Related external triage items: JerryNixon/dab-quickstarts#2, JerryNixon/dab-quickstarts#3, JerryNixon/dab-quickstarts#8, JerryNixon/dab-quickstarts#9, JerryNixon/dab-quickstarts#10, JerryNixon/dab-quickstarts#11.

Validation run from `extensions/mssql`:

- `npm run build:webviews`
- `npm run build:extension:typecheck`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)