### PR TITLE
[Port] Use packaged defaults for SQL tools service configuration (#22206)

### DIFF
--- a/extensions/mssql/src/configurations/extConfig.ts
+++ b/extensions/mssql/src/configurations/extConfig.ts
@@ -9,7 +9,7 @@ import * as Constants from "../constants/constants";
 import { IConfigUtils } from "../languageservice/interfaces";
 
 /*
- * ExtConfig class handles getting values from workspace config or config.json.
+ * ExtConfig class handles getting values from VS Code configuration or packaged config.
  */
 export default class ExtConfig implements IConfigUtils {
     constructor(
@@ -51,13 +51,7 @@ export default class ExtConfig implements IConfigUtils {
     }
 
     public getSqlToolsConfigValue(configKey: string): any {
-        let configValue: string = <string>(
-            this.getExtensionConfig(`${Constants.sqlToolsServiceConfigKey}.${configKey}`)
-        );
-        if (!configValue) {
-            configValue = this._config.getSqlToolsConfigValue(configKey);
-        }
-        return configValue;
+        return this._config.getSqlToolsConfigValue(configKey);
     }
 
     public getExtensionConfig(key: string, defaultValue?: any): any {

--- a/extensions/mssql/test/unit/extConfig.test.ts
+++ b/extensions/mssql/test/unit/extConfig.test.ts
@@ -25,9 +25,6 @@ suite("ExtConfig Tests", () => {
     const fromConfig = "fromConfig";
     const fromExtensionConfig = "fromExtensionConfig";
 
-    const toolsKey = (configKey: string): string =>
-        `${Constants.sqlToolsServiceConfigKey}.${configKey}`;
-
     const createExtConfigInstance = (
         configKey: string,
         expectedFromConfig: string | undefined,
@@ -39,7 +36,9 @@ suite("ExtConfig Tests", () => {
         extensionConfigGet.reset();
         extensionConfigGet.returns(undefined);
         if (expectedFromExtension !== undefined) {
-            extensionConfigGet.withArgs(toolsKey(configKey)).returns(expectedFromExtension);
+            extensionConfigGet
+                .withArgs(`${Constants.sqlToolsServiceConfigKey}.${configKey}`)
+                .returns(expectedFromExtension);
         }
 
         return new ExtConfig(config, extensionConfig, workspaceConfig);
@@ -73,32 +72,42 @@ suite("ExtConfig Tests", () => {
         sandbox.restore();
     });
 
-    test("getSqlToolsServiceDownloadUrl should return value from extension config first", () => {
+    test("getSqlToolsServiceDownloadUrl should ignore extension config overrides", () => {
         const configKey = Constants.sqlToolsServiceDownloadUrlConfigKey;
         const extConfig = createExtConfigInstance(configKey, fromConfig, fromExtensionConfig);
         const actual = extConfig.getSqlToolsServiceDownloadUrl();
-        expect(actual).to.equal(fromExtensionConfig);
+        expect(actual).to.equal(fromConfig);
+        expect(extensionConfigGet).to.not.have.been.called;
     });
 
-    test("getSqlToolsServiceDownloadUrl should return value from config.json if not exist in extension config", () => {
+    test("getSqlToolsServiceDownloadUrl should return value from config.json", () => {
         const configKey = Constants.sqlToolsServiceDownloadUrlConfigKey;
         const extConfig = createExtConfigInstance(configKey, fromConfig, undefined);
         const actual = extConfig.getSqlToolsServiceDownloadUrl();
         expect(actual).to.equal(fromConfig);
     });
 
-    test("getSqlToolsConfigValue should return value from extension config first", () => {
+    test("getSqlToolsConfigValue should ignore extension config overrides", () => {
         const configKey = Constants.sqlToolsServiceInstallDirConfigKey;
         const extConfig = createExtConfigInstance(configKey, fromConfig, fromExtensionConfig);
         const actual = extConfig.getSqlToolsConfigValue(configKey);
-        expect(actual).to.equal(fromExtensionConfig);
+        expect(actual).to.equal(fromConfig);
+        expect(extensionConfigGet).to.not.have.been.called;
     });
 
-    test("getSqlToolsConfigValue should return value from config.json if not exist in extension config", () => {
+    test("getSqlToolsConfigValue should return value from config.json", () => {
         const configKey = Constants.sqlToolsServiceInstallDirConfigKey;
         const extConfig = createExtConfigInstance(configKey, fromConfig, undefined);
         const actual = extConfig.getSqlToolsConfigValue(configKey);
         expect(actual).to.equal(fromConfig);
+    });
+
+    test("getSqlToolsConfigValue should not fall back to extension config when config.json has no value", () => {
+        const configKey = Constants.sqlToolsServiceInstallDirConfigKey;
+        const extConfig = createExtConfigInstance(configKey, undefined, fromExtensionConfig);
+        const actual = extConfig.getSqlToolsConfigValue(configKey);
+        expect(actual).to.be.undefined;
+        expect(extensionConfigGet).to.not.have.been.called;
     });
 
     test("getExtensionConfig should return value from extension config", () => {


### PR DESCRIPTION
## Description

Ports the SQL tools service configuration lookup change from main to `release/1.43`.

This keeps SQL tools service package metadata sourced from the shipped extension configuration instead of extension/workspace configuration overrides, matching the behavior merged on main.

Fixes #22205
Main branch PR: #22206

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation performed on `release/1.43`:

- `npm run build:extension:typecheck`
- `npx eslint --quiet src/configurations/extConfig.ts test/unit/extConfig.test.ts`
- `git diff --check origin/release/1.43...HEAD`

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)