### PR TITLE
Add Cloud Deploy diagnostic event bus

### DIFF
--- a/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
+++ b/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
@@ -12,22 +12,30 @@
  *
  * `environments` is `undefined` when no workspace folder is open — Cloud
  * Deploy is a folder-scoped feature, so the rest of the extension still works
- * without it.
+ * without it. `diagnostics` is always present; subscribers can attach at
+ * extension activation regardless of workspace state.
  */
 
 import * as vscode from "vscode";
 
+import { DiagnosticEventBus } from "./diagnostics";
 import { EnvironmentStore } from "./environments/environmentStore";
 
 export class CloudDeployService implements vscode.Disposable {
+    public readonly diagnostics: DiagnosticEventBus;
     public readonly environments: EnvironmentStore | undefined;
 
     public constructor(
         workspaceFolder: vscode.WorkspaceFolder | undefined,
         workspaceState: vscode.Memento,
     ) {
+        this.diagnostics = new DiagnosticEventBus();
         if (workspaceFolder !== undefined) {
-            this.environments = new EnvironmentStore(workspaceFolder, workspaceState);
+            this.environments = new EnvironmentStore(
+                workspaceFolder,
+                workspaceState,
+                this.diagnostics,
+            );
         }
     }
 
@@ -39,6 +47,8 @@ export class CloudDeployService implements vscode.Disposable {
     }
 
     public dispose(): void {
+        // Dispose subsystems first so any final emissions still reach subscribers.
         this.environments?.dispose();
+        this.diagnostics.dispose();
     }
 }

--- a/extensions/mssql/src/cloudDeploy/diagnostics/eventBus.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/eventBus.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — diagnostic event bus.
+ *
+ * In-process, typed publish/subscribe over the closed `DiagnosticEvent`
+ * catalog (`./types`). One instance per `CloudDeployService`; subscribers
+ * reach it as `cloudDeployService.diagnostics`.
+ *
+ * Design properties:
+ *   - **Generic over the catalog.** Every method signature references the
+ *     `DiagnosticEvent` union as a whole — never a specific arm. New events
+ *     are added by extending the union; this file does not change.
+ *   - **Two subscription shapes.** `onDidEmit` is the firehose (telemetry,
+ *     log forwarder, tests); `on(type, handler)` is selective and narrows
+ *     the handler argument to the matching arm.
+ *   - **Bus stamps the envelope.** Callers provide `source`, `type`, and
+ *     `payload`. The bus generates a fresh `id`, stamps `timestampMs`, and
+ *     defaults `severity` to `"info"`.
+ *   - **Synchronous delivery.** Subscribers run inline on `emit()`. A
+ *     subscriber that needs to do async work queues internally.
+ *   - **Per-subscriber error isolation.** Inherited from `vscode.EventEmitter`:
+ *     a thrown subscriber is logged by VS Code and does not stop delivery to
+ *     the rest.
+ */
+
+import { randomUUID } from "crypto";
+import * as vscode from "vscode";
+
+import { DiagnosticEvent, DiagnosticEventInput } from "./types";
+
+export class DiagnosticEventBus implements vscode.Disposable {
+    private readonly _emitter = new vscode.EventEmitter<DiagnosticEvent>();
+    private _disposed = false;
+
+    /**
+     * Firehose subscription — every event the bus emits, in emission order.
+     * Use this for cross-cutting consumers (telemetry, logging, tests).
+     */
+    public readonly onDidEmit: vscode.Event<DiagnosticEvent> = this._emitter.event;
+
+    /**
+     * Selective subscription — fires only for events whose `type` discriminator
+     * matches `type`. The handler's argument is narrowed to the matching arm,
+     * so `event.payload` has the right shape with no manual cast.
+     */
+    public on<T extends DiagnosticEvent["type"]>(
+        type: T,
+        handler: (event: Extract<DiagnosticEvent, { type: T }>) => void,
+    ): vscode.Disposable {
+        return this._emitter.event((event) => {
+            if (event.type === type) {
+                handler(event as Extract<DiagnosticEvent, { type: T }>);
+            }
+        });
+    }
+
+    /**
+     * Publishes an event. The bus stamps `id` and `timestampMs`, and defaults
+     * `severity` to `"info"` when the caller omits it (arms whose severity is
+     * a literal in the catalog — e.g. `"error"` — keep that literal).
+     *
+     * No-ops after `dispose()` so late emissions during extension shutdown
+     * don't throw.
+     */
+    public emit(input: DiagnosticEventInput): void {
+        if (this._disposed) {
+            return;
+        }
+        const stamped = stampEnvelope(input);
+        this._emitter.fire(stamped);
+    }
+
+    public dispose(): void {
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+        this._emitter.dispose();
+    }
+}
+
+/**
+ * Stamps the bus-controlled envelope fields (`id`, `timestampMs`, default
+ * `severity`) onto a producer-provided input and returns a fully-formed
+ * `DiagnosticEvent`. The cast widens because TS can't see that the union
+ * over `DiagnosticEventInput` plus stamped fields reconstructs the original
+ * union exactly — but the runtime shape is correct by construction.
+ */
+function stampEnvelope(input: DiagnosticEventInput): DiagnosticEvent {
+    return {
+        ...input,
+        id: randomUUID(),
+        timestampMs: Date.now(),
+        severity: input.severity ?? "info",
+    } as DiagnosticEvent;
+}

--- a/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { DiagnosticEventBus } from "./eventBus";
+export type {
+    DefaultEnvironmentChangedEvent,
+    DiagnosticEvent,
+    DiagnosticEventEnvelope,
+    DiagnosticEventInput,
+    DiagnosticEventSeverity,
+    DiagnosticEventSource,
+    EnvironmentsChangedEvent,
+    EnvironmentsFileParseFailedEvent,
+    EnvironmentsLoadedEvent,
+    ErrorEvent,
+} from "./types";

--- a/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — diagnostic event catalog.
+ *
+ * Pure type declarations: the vocabulary of "things that can happen in
+ * Cloud Deploy" that subsystems publish through the diagnostic event bus.
+ *
+ * `DiagnosticEvent` is a CLOSED discriminated union. Subscribers narrow by
+ * the `type` discriminator, which gives them the right `payload` shape with
+ * no manual casts. The bus class (`eventBus.ts`) is generic over this union,
+ * so adding a new event in a future deliverable is purely additive — only
+ * this file changes; the bus class and barrel never do.
+ *
+ * Payloads carry ids and counts, not domain objects. Events end up in logs
+ * and (eventually) telemetry; we don't leak full record shapes, and we don't
+ * pin payload size to the size of in-memory state.
+ */
+
+// =============================================================================
+// Source / severity unions (closed, expand additively)
+// =============================================================================
+
+/** Subsystem that produced an event. Closed; expand as new subsystems land. */
+export type DiagnosticEventSource = "environment-store" | "service";
+
+/**
+ * Hint to subscribers, not a gate. The bus delivers all severities; consumers
+ * decide what to do (filter for a UI, forward to telemetry, log at a level).
+ */
+export type DiagnosticEventSeverity = "debug" | "info" | "warn" | "error";
+
+// =============================================================================
+// Envelope
+// =============================================================================
+
+/**
+ * Fields every event carries. `id` and `timestampMs` are stamped by the bus,
+ * not the caller — eliminates forgotten timestamps and duplicate ids.
+ *
+ * `readonly` everywhere: the bus delivers one object to N subscribers; a
+ * subscriber that mutates the event would break the others.
+ */
+export interface DiagnosticEventEnvelope {
+    /** Unique per emission. Stamped by the bus. */
+    readonly id: string;
+    /** `Date.now()` at emission. Stamped by the bus. */
+    readonly timestampMs: number;
+    /** Subsystem that emitted the event. */
+    readonly source: DiagnosticEventSource;
+    /** Severity hint. Defaulted to `"info"` by the bus when the caller omits it. */
+    readonly severity: DiagnosticEventSeverity;
+    /** Optional id tying multi-step flows together. */
+    readonly correlationId?: string;
+}
+
+// =============================================================================
+// Catalog (closed discriminated union)
+// =============================================================================
+
+/**
+ * The complete catalog of events Cloud Deploy can emit. Discriminator: `type`.
+ * Adding a new event = adding a new arm here. Nothing else changes.
+ */
+export type DiagnosticEvent =
+    | EnvironmentsLoadedEvent
+    | EnvironmentsChangedEvent
+    | EnvironmentsFileParseFailedEvent
+    | DefaultEnvironmentChangedEvent
+    | ErrorEvent;
+
+/** Env file was successfully loaded (or determined to be empty/absent). */
+export interface EnvironmentsLoadedEvent extends DiagnosticEventEnvelope {
+    readonly source: "environment-store";
+    readonly type: "environments-loaded";
+    readonly payload: {
+        readonly count: number;
+    };
+}
+
+/** One or more environments were added, updated, or removed in the store. */
+export interface EnvironmentsChangedEvent extends DiagnosticEventEnvelope {
+    readonly source: "environment-store";
+    readonly type: "environments-changed";
+    readonly payload: {
+        readonly addedIds: readonly string[];
+        readonly updatedIds: readonly string[];
+        readonly removedIds: readonly string[];
+    };
+}
+
+/** The env file existed but was malformed; init re-throws after emitting. */
+export interface EnvironmentsFileParseFailedEvent extends DiagnosticEventEnvelope {
+    readonly source: "environment-store";
+    readonly severity: "error";
+    readonly type: "environments-file-parse-failed";
+    readonly payload: {
+        readonly filePath: string;
+        readonly issueCount: number;
+    };
+}
+
+/** The user's default environment selection changed (or was cleared). */
+export interface DefaultEnvironmentChangedEvent extends DiagnosticEventEnvelope {
+    readonly source: "environment-store";
+    readonly type: "default-environment-changed";
+    readonly payload: {
+        readonly id: string | undefined;
+    };
+}
+
+/**
+ * A generic failure surface for the service layer. Used for errors that
+ * don't have a dedicated arm (yet). The catch-all keeps the catalog from
+ * needing a new arm for every one-off failure path.
+ */
+export interface ErrorEvent extends DiagnosticEventEnvelope {
+    readonly source: "service";
+    readonly severity: "error";
+    readonly type: "error";
+    readonly payload: {
+        readonly message: string;
+        /** Serializable shadow of the original `Error` (Error itself doesn't JSON-stringify cleanly). */
+        readonly cause?: {
+            readonly name: string;
+            readonly message: string;
+            readonly stack?: string;
+        };
+    };
+}
+
+// =============================================================================
+// Producer input shape
+// =============================================================================
+
+/**
+ * What producers pass to `bus.emit(...)`. The bus stamps `id` and `timestampMs`,
+ * and defaults `severity` to `"info"` when the caller omits it.
+ */
+export type DiagnosticEventInput = {
+    [E in DiagnosticEvent as E["type"]]: Omit<E, "id" | "timestampMs" | "severity"> & {
+        readonly severity?: E["severity"];
+    };
+}[DiagnosticEvent["type"]];

--- a/extensions/mssql/src/cloudDeploy/environments/environmentStore.ts
+++ b/extensions/mssql/src/cloudDeploy/environments/environmentStore.ts
@@ -84,23 +84,7 @@ export class EnvironmentStore implements vscode.Disposable {
         if (this._initialized) {
             return;
         }
-        let file: EnvironmentsFile;
-        try {
-            file = await loadEnvironmentsFile(this.workspaceFolder);
-        } catch (err) {
-            if (err instanceof EnvironmentsFileParseError) {
-                this._bus.emit({
-                    source: "environment-store",
-                    type: "environments-file-parse-failed",
-                    severity: "error",
-                    payload: {
-                        filePath: err.filePath,
-                        issueCount: err.issues?.length ?? 0,
-                    },
-                });
-            }
-            throw err;
-        }
+        const file = await this.loadFileOrEmitParseError();
         this._envs = [...file.environments];
         this._initialized = true;
         this._bus.emit({
@@ -198,7 +182,7 @@ export class EnvironmentStore implements vscode.Disposable {
     public async reload(): Promise<void> {
         this.assertInitialized();
         await this.runWrite(async () => {
-            const file = await loadEnvironmentsFile(this.workspaceFolder);
+            const file = await this.loadFileOrEmitParseError();
             const before = this._envs;
             const after = file.environments;
             this._envs = [...after];
@@ -285,6 +269,31 @@ export class EnvironmentStore implements vscode.Disposable {
 
     private fireChange(evt: EnvironmentsChangeEvent): void {
         this._onDidChangeEnvironmentsEmitter.fire(evt);
+    }
+
+    /**
+     * Loads the env file; if loading throws a parse error, emits the
+     * `environments-file-parse-failed` diagnostic event before re-throwing.
+     * Shared by `init()` and `reload()` so the bus catalog reflects parse
+     * failures consistently regardless of when they happen.
+     */
+    private async loadFileOrEmitParseError(): Promise<EnvironmentsFile> {
+        try {
+            return await loadEnvironmentsFile(this.workspaceFolder);
+        } catch (err) {
+            if (err instanceof EnvironmentsFileParseError) {
+                this._bus.emit({
+                    source: "environment-store",
+                    type: "environments-file-parse-failed",
+                    severity: "error",
+                    payload: {
+                        filePath: err.filePath,
+                        issueCount: err.issues?.length ?? 0,
+                    },
+                });
+            }
+            throw err;
+        }
     }
 
     private emitEnvironmentsChanged(payload: {

--- a/extensions/mssql/src/cloudDeploy/environments/environmentStore.ts
+++ b/extensions/mssql/src/cloudDeploy/environments/environmentStore.ts
@@ -16,76 +16,62 @@
 
 import * as vscode from "vscode";
 
+import { DiagnosticEventBus } from "../diagnostics";
 import { ENVIRONMENTS_FILE_SCHEMA_VERSION, Environment, EnvironmentsFile } from "./types";
-
 import {
+    EnvironmentsFileParseError,
     getEnvironmentsFileUri,
     loadEnvironmentsFile,
     saveEnvironmentsFile,
 } from "./environmentFile";
-
 import { validateEnvironmentsFile } from "./environmentSchema";
 
 // =============================================================================
-
 // Public types
-
 // =============================================================================
 
 export interface EnvironmentsChangeEvent {
     readonly added: readonly Environment[];
-
     readonly updated: readonly Environment[];
-
     readonly removed: readonly string[];
 }
 
 // =============================================================================
-
 // Constants
-
 // =============================================================================
 
 const DEFAULT_ENV_STATE_KEY = "cloudDeploy.defaultEnvironmentId";
 
 // =============================================================================
-
 // EnvironmentStore
-
 // =============================================================================
 
 export class EnvironmentStore implements vscode.Disposable {
     private _envs: Environment[] = [];
-
     private _initialized = false;
 
     /** Serializes write-through persistence so concurrent mutations don't clobber each other. */
-
     private _writeChain: Promise<void> = Promise.resolve();
 
     private readonly _onDidChangeEnvironmentsEmitter =
         new vscode.EventEmitter<EnvironmentsChangeEvent>();
-
     public readonly onDidChangeEnvironments: vscode.Event<EnvironmentsChangeEvent> =
         this._onDidChangeEnvironmentsEmitter.event;
 
     private readonly _onDidChangeDefaultEnvironmentEmitter = new vscode.EventEmitter<
         string | undefined
     >();
-
     public readonly onDidChangeDefaultEnvironment: vscode.Event<string | undefined> =
         this._onDidChangeDefaultEnvironmentEmitter.event;
 
     public constructor(
         private readonly workspaceFolder: vscode.WorkspaceFolder,
-
         private readonly workspaceState: vscode.Memento,
+        private readonly _bus: DiagnosticEventBus,
     ) {}
 
     // -------------------------------------------------------------------------
-
     // Lifecycle
-
     // -------------------------------------------------------------------------
 
     /**
@@ -94,47 +80,57 @@ export class EnvironmentStore implements vscode.Disposable {
      * are no-ops. Surfaces parse errors to the caller so extension activation
      * can react to a malformed file.
      */
-
     public async init(): Promise<void> {
         if (this._initialized) {
             return;
         }
-
-        const file = await loadEnvironmentsFile(this.workspaceFolder);
-
+        let file: EnvironmentsFile;
+        try {
+            file = await loadEnvironmentsFile(this.workspaceFolder);
+        } catch (err) {
+            if (err instanceof EnvironmentsFileParseError) {
+                this._bus.emit({
+                    source: "environment-store",
+                    type: "environments-file-parse-failed",
+                    severity: "error",
+                    payload: {
+                        filePath: err.filePath,
+                        issueCount: err.issues?.length ?? 0,
+                    },
+                });
+            }
+            throw err;
+        }
         this._envs = [...file.environments];
-
         this._initialized = true;
+        this._bus.emit({
+            source: "environment-store",
+            type: "environments-loaded",
+            payload: { count: this._envs.length },
+        });
     }
 
     public dispose(): void {
         this._onDidChangeEnvironmentsEmitter.dispose();
-
         this._onDidChangeDefaultEnvironmentEmitter.dispose();
     }
 
     // -------------------------------------------------------------------------
-
     // Reads
-
     // -------------------------------------------------------------------------
 
     public list(): readonly Environment[] {
         this.assertInitialized();
-
         return [...this._envs];
     }
 
     public get(id: string): Environment | undefined {
         this.assertInitialized();
-
         return this._envs.find((e) => e.id === id);
     }
 
     // -------------------------------------------------------------------------
-
     // Mutations (write-through)
-
     // -------------------------------------------------------------------------
 
     /**
@@ -142,51 +138,53 @@ export class EnvironmentStore implements vscode.Disposable {
      * shape before writing to disk — defense in depth against in-process bugs
      * passing malformed envs.
      */
-
     public async upsert(env: Environment): Promise<void> {
         this.assertInitialized();
-
         await this.runWrite(async () => {
             const before = this._envs;
-
             const existingIdx = before.findIndex((e) => e.id === env.id);
-
             const next =
                 existingIdx === -1
                     ? [...before, env]
                     : before.map((e, i) => (i === existingIdx ? env : e));
 
             await this.persist(next);
-
             if (existingIdx === -1) {
                 this.fireChange({ added: [env], updated: [], removed: [] });
+                this.emitEnvironmentsChanged({
+                    addedIds: [env.id],
+                    updatedIds: [],
+                    removedIds: [],
+                });
             } else {
                 this.fireChange({ added: [], updated: [env], removed: [] });
+                this.emitEnvironmentsChanged({
+                    addedIds: [],
+                    updatedIds: [env.id],
+                    removedIds: [],
+                });
             }
         });
     }
 
     /** Removes an env by id. No-op if not present. */
-
     public async delete(id: string): Promise<void> {
         this.assertInitialized();
-
         await this.runWrite(async () => {
             const before = this._envs;
-
             if (!before.some((e) => e.id === id)) {
                 return;
             }
-
             const wasDefault = this.getDefaultEnvironmentId() === id;
             const next = before.filter((e) => e.id !== id);
-
             await this.persist(next);
-
             this.fireChange({ added: [], updated: [], removed: [id] });
-
+            this.emitEnvironmentsChanged({
+                addedIds: [],
+                updatedIds: [],
+                removedIds: [id],
+            });
             // If the deleted env was the default, clear the default.
-
             if (wasDefault) {
                 await this.setDefaultEnvironmentId(undefined);
             }
@@ -197,68 +195,60 @@ export class EnvironmentStore implements vscode.Disposable {
      * Re-reads the file from disk, replacing the in-memory cache. Fires a
      * change event with the diff against the previous cache.
      */
-
     public async reload(): Promise<void> {
         this.assertInitialized();
-
         await this.runWrite(async () => {
             const file = await loadEnvironmentsFile(this.workspaceFolder);
-
             const before = this._envs;
-
             const after = file.environments;
-
             this._envs = [...after];
 
             const diff = diffEnvironments(before, after);
-
             if (diff.added.length > 0 || diff.updated.length > 0 || diff.removed.length > 0) {
                 this.fireChange(diff);
+                this.emitEnvironmentsChanged({
+                    addedIds: diff.added.map((e) => e.id),
+                    updatedIds: diff.updated.map((e) => e.id),
+                    removedIds: diff.removed,
+                });
             }
         });
     }
 
     // -------------------------------------------------------------------------
-
     // Default environment (per-user, workspace state)
-
     // -------------------------------------------------------------------------
 
     /**
      * Returns the user's preferred default env id, or undefined if none is set
      * or the previously-set id no longer exists.
      */
-
     public getDefaultEnvironmentId(): string | undefined {
         this.assertInitialized();
-
         const id = this.workspaceState.get<string | undefined>(DEFAULT_ENV_STATE_KEY);
-
         if (id === undefined) {
             return undefined;
         }
-
         return this._envs.some((e) => e.id === id) ? id : undefined;
     }
 
     public async setDefaultEnvironmentId(id: string | undefined): Promise<void> {
         this.assertInitialized();
-
         const current = this.workspaceState.get<string | undefined>(DEFAULT_ENV_STATE_KEY);
-
         if (current === id) {
             return;
         }
-
         await this.workspaceState.update(DEFAULT_ENV_STATE_KEY, id);
-
         this._onDidChangeDefaultEnvironmentEmitter.fire(id);
+        this._bus.emit({
+            source: "environment-store",
+            type: "default-environment-changed",
+            payload: { id },
+        });
     }
 
     // -------------------------------------------------------------------------
-
     // Internal
-
     // -------------------------------------------------------------------------
 
     private assertInitialized(): void {
@@ -271,87 +261,77 @@ export class EnvironmentStore implements vscode.Disposable {
      * Validates `next`, writes the file, and commits the in-memory cache.
      * On any failure, the in-memory state is left untouched.
      */
-
     private async persist(next: Environment[]): Promise<void> {
         const file: EnvironmentsFile = {
             schemaVersion: ENVIRONMENTS_FILE_SCHEMA_VERSION,
-
             environments: next,
         };
-
         // Validate before writing — never persist an invalid shape, even if a
-
         // caller passed something the file validator would later reject.
-
         const filePath = getEnvironmentsFileUri(this.workspaceFolder).fsPath;
-
         validateEnvironmentsFile(file, filePath);
         await saveEnvironmentsFile(this.workspaceFolder, file);
-
         this._envs = next;
     }
 
     /** Serializes a write-style operation behind any in-flight writes. */
-
     private runWrite(op: () => void | Promise<void>): Promise<void> {
         const next = this._writeChain.then(() => op());
-
         // Swallow rejections in the chain so one failure doesn't poison
-
         // subsequent writes — but propagate them to the original caller.
-
         this._writeChain = next.catch(() => undefined);
-
         return next;
     }
 
     private fireChange(evt: EnvironmentsChangeEvent): void {
         this._onDidChangeEnvironmentsEmitter.fire(evt);
     }
+
+    private emitEnvironmentsChanged(payload: {
+        readonly addedIds: readonly string[];
+        readonly updatedIds: readonly string[];
+        readonly removedIds: readonly string[];
+    }): void {
+        this._bus.emit({
+            source: "environment-store",
+            type: "environments-changed",
+            payload,
+        });
+    }
 }
 
 // =============================================================================
-
 // Diff helper
-
 // =============================================================================
 
 function diffEnvironments(
     before: readonly Environment[],
-
     after: readonly Environment[],
 ): EnvironmentsChangeEvent {
     const beforeById = new Map(before.map((e) => [e.id, e]));
-
     const afterById = new Map(after.map((e) => [e.id, e]));
 
     const added: Environment[] = [];
-
     const updated: Environment[] = [];
-
     const removed: string[] = [];
 
     for (const [id, env] of afterById) {
         const prev = beforeById.get(id);
-
         if (prev === undefined) {
             added.push(env);
         } else if (!shallowEqualEnv(prev, env)) {
             updated.push(env);
         }
     }
-
     for (const id of beforeById.keys()) {
         if (!afterById.has(id)) {
             removed.push(id);
         }
     }
-
     return { added, updated, removed };
 }
 
 /** Stringify-equality. Cheap, correct for plain JSON shapes. */
-
 function shallowEqualEnv(a: Environment, b: Environment): boolean {
     return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/extensions/mssql/test/unit/cloudDeployDiagnosticEventBus.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployDiagnosticEventBus.test.ts
@@ -1,0 +1,277 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+
+import {
+    DiagnosticEvent,
+    DiagnosticEventBus,
+    EnvironmentsChangedEvent,
+    EnvironmentsLoadedEvent,
+    ErrorEvent,
+} from "../../src/cloudDeploy/diagnostics";
+import { TestEventCollector } from "./cloudDeployTestEventCollector";
+
+function makeBus(): DiagnosticEventBus {
+    return new DiagnosticEventBus();
+}
+
+/** Reusable minimal `EnvironmentsLoadedEvent` input for tests that don't care about payload specifics. */
+const sampleLoadedInput = {
+    source: "environment-store",
+    type: "environments-loaded",
+    payload: { count: 0 },
+} as const;
+
+/** Reusable minimal `ErrorEvent` input. */
+const sampleErrorInput = {
+    source: "service",
+    type: "error",
+    severity: "error",
+    payload: { message: "boom" },
+} as const;
+
+suite("CloudDeploy DiagnosticEventBus", () => {
+    let bus: DiagnosticEventBus;
+
+    setup(() => {
+        bus = makeBus();
+    });
+
+    teardown(() => {
+        bus.dispose();
+    });
+
+    suite("envelope stamping", () => {
+        test("emit stamps a non-empty string id on the delivered event", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            expect(collector.events).to.have.length(1);
+            expect(collector.events[0].id).to.be.a("string");
+            expect(collector.events[0].id.length).to.be.greaterThan(0);
+            collector.dispose();
+        });
+
+        test("emit stamps a unique id per emission", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            bus.emit(sampleLoadedInput);
+            expect(collector.events).to.have.length(2);
+            expect(collector.events[0].id).to.not.equal(collector.events[1].id);
+            collector.dispose();
+        });
+
+        test("emit stamps timestampMs within a few ms of Date.now()", () => {
+            const collector = new TestEventCollector(bus);
+            const before = Date.now();
+            bus.emit(sampleLoadedInput);
+            const after = Date.now();
+            expect(collector.events[0].timestampMs).to.be.at.least(before);
+            expect(collector.events[0].timestampMs).to.be.at.most(after);
+            collector.dispose();
+        });
+
+        test("emit defaults severity to info when omitted", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            expect(collector.events[0].severity).to.equal("info");
+            collector.dispose();
+        });
+
+        test("emit preserves explicit severity when caller provides it", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit({ ...sampleLoadedInput, severity: "warn" });
+            expect(collector.events[0].severity).to.equal("warn");
+            collector.dispose();
+        });
+    });
+
+    suite("onDidEmit firehose", () => {
+        test("every emitted event reaches a firehose subscriber", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            bus.emit(sampleErrorInput);
+            expect(collector.events).to.have.length(2);
+            expect(collector.events.map((e) => e.type)).to.deep.equal([
+                "environments-loaded",
+                "error",
+            ]);
+            collector.dispose();
+        });
+
+        test("multiple firehose subscribers all receive the same event", () => {
+            const a = new TestEventCollector(bus);
+            const b = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            expect(a.events).to.have.length(1);
+            expect(b.events).to.have.length(1);
+            expect(a.events[0].id).to.equal(b.events[0].id);
+            a.dispose();
+            b.dispose();
+        });
+
+        test("emission order is preserved across multiple emissions", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit({ ...sampleLoadedInput, payload: { count: 1 } });
+            bus.emit({ ...sampleLoadedInput, payload: { count: 2 } });
+            bus.emit({ ...sampleLoadedInput, payload: { count: 3 } });
+            const counts = collector
+                .eventsOfType("environments-loaded")
+                .map((e) => e.payload.count);
+            expect(counts).to.deep.equal([1, 2, 3]);
+            collector.dispose();
+        });
+    });
+
+    suite("on(type, handler) selective subscription", () => {
+        test("handler only fires for matching type", () => {
+            const received: EnvironmentsLoadedEvent[] = [];
+            const sub = bus.on("environments-loaded", (e) => received.push(e));
+            bus.emit(sampleLoadedInput);
+            expect(received).to.have.length(1);
+            expect(received[0].type).to.equal("environments-loaded");
+            sub.dispose();
+        });
+
+        test("handler does NOT fire for non-matching type", () => {
+            const received: EnvironmentsLoadedEvent[] = [];
+            const sub = bus.on("environments-loaded", (e) => received.push(e));
+            bus.emit(sampleErrorInput);
+            expect(received).to.deep.equal([]);
+            sub.dispose();
+        });
+
+        test("multiple handlers on the same type all fire", () => {
+            const a: EnvironmentsLoadedEvent[] = [];
+            const b: EnvironmentsLoadedEvent[] = [];
+            const subA = bus.on("environments-loaded", (e) => a.push(e));
+            const subB = bus.on("environments-loaded", (e) => b.push(e));
+            bus.emit(sampleLoadedInput);
+            expect(a).to.have.length(1);
+            expect(b).to.have.length(1);
+            subA.dispose();
+            subB.dispose();
+        });
+
+        test("handler payload is narrowed to the matching arm", () => {
+            // Compile-time check: inside the handler `e.payload.count` must
+            // be a `number`, not `unknown`. If narrowing broke, this test
+            // file wouldn't compile.
+            const received: number[] = [];
+            const sub = bus.on("environments-loaded", (e) => {
+                received.push(e.payload.count);
+            });
+            bus.emit({ ...sampleLoadedInput, payload: { count: 7 } });
+            expect(received).to.deep.equal([7]);
+            sub.dispose();
+        });
+    });
+
+    suite("disposal", () => {
+        test("disposing a single subscription stops it from firing", () => {
+            const received: DiagnosticEvent[] = [];
+            const sub = bus.onDidEmit((e) => received.push(e));
+            bus.emit(sampleLoadedInput);
+            sub.dispose();
+            bus.emit(sampleLoadedInput);
+            expect(received).to.have.length(1);
+        });
+
+        test("disposing the bus stops all subscriptions", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            bus.dispose();
+            // Subsequent emits are no-ops.
+            bus.emit(sampleLoadedInput);
+            expect(collector.events).to.have.length(1);
+            collector.dispose();
+        });
+
+        test("emit after dispose is a no-op (does not throw)", () => {
+            bus.dispose();
+            expect(() => bus.emit(sampleLoadedInput)).to.not.throw();
+        });
+
+        test("dispose is idempotent", () => {
+            bus.dispose();
+            expect(() => bus.dispose()).to.not.throw();
+        });
+    });
+
+    suite("subscriber error isolation", () => {
+        test("a thrown subscriber does not prevent other subscribers from receiving the event", () => {
+            const received: DiagnosticEvent[] = [];
+            const subA = bus.onDidEmit(() => {
+                throw new Error("subscriber A blew up");
+            });
+            const subB = bus.onDidEmit((e) => received.push(e));
+            bus.emit(sampleLoadedInput);
+            expect(received).to.have.length(1);
+            subA.dispose();
+            subB.dispose();
+        });
+
+        test("subsequent emissions continue to work after a thrown subscriber", () => {
+            const received: DiagnosticEvent[] = [];
+            const subA = bus.onDidEmit(() => {
+                throw new Error("noisy subscriber");
+            });
+            const subB = bus.onDidEmit((e) => received.push(e));
+            bus.emit(sampleLoadedInput);
+            bus.emit(sampleLoadedInput);
+            expect(received).to.have.length(2);
+            subA.dispose();
+            subB.dispose();
+        });
+    });
+
+    suite("correlationId passthrough", () => {
+        test("correlationId is preserved when caller provides it", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit({ ...sampleLoadedInput, correlationId: "flow-123" });
+            expect(collector.events[0].correlationId).to.equal("flow-123");
+            collector.dispose();
+        });
+
+        test("correlationId is undefined on the delivered event when omitted", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleLoadedInput);
+            expect(collector.events[0].correlationId).to.be.undefined;
+            collector.dispose();
+        });
+    });
+
+    suite("catalog-level constraints", () => {
+        test("error-arm events carry severity 'error' (literal in the union)", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit(sampleErrorInput);
+            const errors = collector.eventsOfType("error");
+            expect(errors).to.have.length(1);
+            const errorEvent: ErrorEvent = errors[0];
+            expect(errorEvent.severity).to.equal("error");
+            collector.dispose();
+        });
+
+        test("environments-changed payload carries the diff arrays", () => {
+            const collector = new TestEventCollector(bus);
+            bus.emit({
+                source: "environment-store",
+                type: "environments-changed",
+                payload: {
+                    addedIds: ["a"],
+                    updatedIds: ["b"],
+                    removedIds: ["c"],
+                },
+            });
+            const changes = collector.eventsOfType("environments-changed");
+            expect(changes).to.have.length(1);
+            const ev: EnvironmentsChangedEvent = changes[0];
+            expect(ev.payload.addedIds).to.deep.equal(["a"]);
+            expect(ev.payload.updatedIds).to.deep.equal(["b"]);
+            expect(ev.payload.removedIds).to.deep.equal(["c"]);
+            collector.dispose();
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployEnvironmentStore.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployEnvironmentStore.test.ts
@@ -319,6 +319,29 @@ suite("CloudDeploy EnvironmentStore", () => {
             freshBus.dispose();
         });
 
+        test("reload emits environments-file-parse-failed when the file is corrupted between sessions (and re-throws)", async () => {
+            // Start from a good state, then corrupt the file out-of-band and reload.
+            await store.upsert(makeEnv("a"));
+            const collector = new TestEventCollector(bus);
+            const filePath = path.join(workspaceRoot, ".mssql", "environments.json");
+            await fs.writeFile(filePath, "{ not json");
+
+            let caught: unknown;
+            try {
+                await store.reload();
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught, "expected reload to re-throw the parse error").to.exist;
+
+            const parseFailed = collector.eventsOfType("environments-file-parse-failed");
+            expect(parseFailed).to.have.length(1);
+            expect(parseFailed[0].severity).to.equal("error");
+            expect(parseFailed[0].payload.filePath).to.contain("environments.json");
+
+            collector.dispose();
+        });
+
         test("upsert (add) emits environments-changed with the new id in addedIds", async () => {
             const collector = new TestEventCollector(bus);
             await store.upsert(makeEnv("a"));

--- a/extensions/mssql/test/unit/cloudDeployEnvironmentStore.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployEnvironmentStore.test.ts
@@ -9,6 +9,7 @@ import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
 import {
     Environment,
     SourceOfTruthKind,
@@ -19,6 +20,7 @@ import {
     EnvironmentsChangeEvent,
     EnvironmentStore,
 } from "../../src/cloudDeploy/environments/environmentStore";
+import { TestEventCollector } from "./cloudDeployTestEventCollector";
 
 /**
  * Minimal in-memory `vscode.Memento` for the per-user default-env preference.
@@ -70,18 +72,21 @@ suite("CloudDeploy EnvironmentStore", () => {
     let workspaceRoot: string;
     let folder: vscode.WorkspaceFolder;
     let memento: vscode.Memento;
+    let bus: DiagnosticEventBus;
     let store: EnvironmentStore;
 
     setup(async () => {
         workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mssql-envstore-"));
         folder = makeFolder(workspaceRoot);
         memento = makeMemento();
-        store = new EnvironmentStore(folder, memento);
+        bus = new DiagnosticEventBus();
+        store = new EnvironmentStore(folder, memento, bus);
         await store.init();
     });
 
     teardown(async () => {
         store.dispose();
+        bus.dispose();
         await fs.rm(workspaceRoot, { recursive: true, force: true });
     });
 
@@ -97,7 +102,7 @@ suite("CloudDeploy EnvironmentStore", () => {
         });
 
         test("calling list() before init throws", () => {
-            const s = new EnvironmentStore(folder, makeMemento());
+            const s = new EnvironmentStore(folder, makeMemento(), new DiagnosticEventBus());
             expect(() => s.list()).to.throw(/init/i);
             s.dispose();
         });
@@ -153,7 +158,7 @@ suite("CloudDeploy EnvironmentStore", () => {
         test("persists validations through round-trip", async () => {
             await store.upsert(makeEnv("a", { validations: [unitTestValidation] }));
             // Reload via a fresh store to confirm the file shape survives.
-            const fresh = new EnvironmentStore(folder, makeMemento());
+            const fresh = new EnvironmentStore(folder, makeMemento(), new DiagnosticEventBus());
             await fresh.init();
             const reloaded = fresh.get("a");
             fresh.dispose();
@@ -193,7 +198,11 @@ suite("CloudDeploy EnvironmentStore", () => {
 
     suite("reload", () => {
         test("picks up envs added to the file externally", async () => {
-            const otherStore = new EnvironmentStore(folder, makeMemento());
+            const otherStore = new EnvironmentStore(
+                folder,
+                makeMemento(),
+                new DiagnosticEventBus(),
+            );
             await otherStore.init();
             await otherStore.upsert(makeEnv("external"));
             otherStore.dispose();
@@ -259,6 +268,86 @@ suite("CloudDeploy EnvironmentStore", () => {
                 store.upsert(makeEnv("good")), // valid, queued behind
             ]);
             expect(store.list().map((e) => e.id)).to.deep.equal(["good"]);
+        });
+    });
+
+    suite("diagnostic event emissions", () => {
+        test("init emits environments-loaded with the correct count", async () => {
+            // Seed the file via the setup store, then init a fresh store with
+            // a fresh bus + collector so we observe just that init's emissions.
+            await store.upsert(makeEnv("a"));
+            await store.upsert(makeEnv("b"));
+            const freshBus = new DiagnosticEventBus();
+            const collector = new TestEventCollector(freshBus);
+            const fresh = new EnvironmentStore(folder, makeMemento(), freshBus);
+            await fresh.init();
+
+            const loaded = collector.eventsOfType("environments-loaded");
+            expect(loaded).to.have.length(1);
+            expect(loaded[0].payload.count).to.equal(2);
+            expect(loaded[0].source).to.equal("environment-store");
+
+            collector.dispose();
+            fresh.dispose();
+            freshBus.dispose();
+        });
+
+        test("init emits environments-file-parse-failed on a malformed file (and re-throws)", async () => {
+            const mssqlDir = path.join(workspaceRoot, ".mssql");
+            await fs.mkdir(mssqlDir, { recursive: true });
+            await fs.writeFile(path.join(mssqlDir, "environments.json"), "{ not json");
+
+            const freshBus = new DiagnosticEventBus();
+            const collector = new TestEventCollector(freshBus);
+            const fresh = new EnvironmentStore(folder, makeMemento(), freshBus);
+
+            let caught: unknown;
+            try {
+                await fresh.init();
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught, "expected init to re-throw the parse error").to.exist;
+
+            const parseFailed = collector.eventsOfType("environments-file-parse-failed");
+            expect(parseFailed).to.have.length(1);
+            expect(parseFailed[0].severity).to.equal("error");
+            expect(parseFailed[0].payload.filePath).to.contain("environments.json");
+
+            collector.dispose();
+            fresh.dispose();
+            freshBus.dispose();
+        });
+
+        test("upsert (add) emits environments-changed with the new id in addedIds", async () => {
+            const collector = new TestEventCollector(bus);
+            await store.upsert(makeEnv("a"));
+            const changes = collector.eventsOfType("environments-changed");
+            expect(changes).to.have.length(1);
+            expect(changes[0].payload.addedIds).to.deep.equal(["a"]);
+            expect(changes[0].payload.updatedIds).to.deep.equal([]);
+            expect(changes[0].payload.removedIds).to.deep.equal([]);
+            collector.dispose();
+        });
+
+        test("delete emits environments-changed with the removed id in removedIds", async () => {
+            await store.upsert(makeEnv("a"));
+            const collector = new TestEventCollector(bus);
+            await store.delete("a");
+            const changes = collector.eventsOfType("environments-changed");
+            expect(changes).to.have.length(1);
+            expect(changes[0].payload.removedIds).to.deep.equal(["a"]);
+            collector.dispose();
+        });
+
+        test("setDefaultEnvironmentId emits default-environment-changed with the new id", async () => {
+            await store.upsert(makeEnv("a"));
+            const collector = new TestEventCollector(bus);
+            await store.setDefaultEnvironmentId("a");
+            const changes = collector.eventsOfType("default-environment-changed");
+            expect(changes).to.have.length(1);
+            expect(changes[0].payload.id).to.equal("a");
+            collector.dispose();
         });
     });
 });

--- a/extensions/mssql/test/unit/cloudDeployTestEventCollector.ts
+++ b/extensions/mssql/test/unit/cloudDeployTestEventCollector.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — diagnostic bus test helper.
+ *
+ * Reusable passive observer for tests that need to assert "which events did
+ * the subject emit?". Subscribes to the firehose (`onDidEmit`) and records
+ * every event in order.
+ *
+ * Lives under `test/` because it has no production purpose. Shared across
+ * the diagnostic bus tests, the env-store emission tests, and (eventually)
+ * D2 / D3 emission tests.
+ */
+
+import * as vscode from "vscode";
+
+import { DiagnosticEvent, DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+
+export class TestEventCollector implements vscode.Disposable {
+    public readonly events: DiagnosticEvent[] = [];
+    private readonly _subscription: vscode.Disposable;
+
+    public constructor(bus: DiagnosticEventBus) {
+        this._subscription = bus.onDidEmit((event) => {
+            this.events.push(event);
+        });
+    }
+
+    /** Subset filtered (and type-narrowed) by the `type` discriminator. */
+    public eventsOfType<T extends DiagnosticEvent["type"]>(
+        type: T,
+    ): Array<Extract<DiagnosticEvent, { type: T }>> {
+        return this.events.filter(
+            (e): e is Extract<DiagnosticEvent, { type: T }> => e.type === type,
+        );
+    }
+
+    public clear(): void {
+        this.events.length = 0;
+    }
+
+    public dispose(): void {
+        this._subscription.dispose();
+    }
+}


### PR DESCRIPTION
Builds on #22169 (Cloud Deploy environment model).

**Design:** Full rationale, event catalog, and extension story can be found here: 
[diagnostic-event-bus-design.md](https://github.com/user-attachments/files/28321445/diagnostic-event-bus-design.md).

Introduces an in-process, typed publish/subscribe bus over a closed `DiagnosticEvent` catalog, owned by `CloudDeployService` and exposed as `service.diagnostics`.

### What's new
- **`src/cloudDeploy/diagnostics/`** — new module
  - `types.ts` — `DiagnosticEvent` discriminated union (5 arms), `DiagnosticEventEnvelope`, `DiagnosticEventInput` (mapped-then-distributed so per-arm severity literals like `"error"` are preserved)
  - `eventBus.ts` — `DiagnosticEventBus implements vscode.Disposable`; firehose `onDidEmit` + selective `on<T>(type, handler)` with narrowing; bus stamps `id` / `timestampMs` / default `severity`; emit-after-dispose is a no-op
  - `index.ts` — barrel
- **`cloudDeployService.ts`** — owns the bus, passes it to `EnvironmentStore`, disposes subsystems before the bus so final emissions reach subscribers
- **`environments/environmentStore.ts`** — emits `environments-loaded`, `environments-file-parse-failed` (severity `error`), `environments-changed` (with added/updated/removed id diffs), `default-environment-changed`. Existing `vscode.EventEmitter` channels are preserved — the bus is additive for fan-out subscribers.

### Design properties
- Bus class and barrel never name a specific arm; adding a new event type = adding a new arm to `types.ts`, nothing else changes.
- Per-subscriber error isolation inherited from `vscode.EventEmitter`.
- Synchronous delivery; subscribers needing async work queue internally.

### Tests
- `cloudDeployDiagnosticEventBus.test.ts` — 22 tests across 7 suites (envelope stamping, firehose, selective subscription, disposal, error isolation, correlationId, catalog constraints)
- `cloudDeployEnvironmentStore.test.ts` — 5 new tests in a "diagnostic event emissions" suite
- `cloudDeployTestEventCollector.ts` — passive observer helper, reusable by future deliverable tests

### Validation
- tsgo typecheck: 0 errors
- eslint: 0 errors / 0 warnings on touched files
- 82/82 CloudDeploy unit tests pass
- Full unit suite: 3108 passing