### PR TITLE
Add double-click to auto-resize notebook result grid columns

### DIFF
--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useRef } from "react";
 import { TableDataView, defaultFilter } from "../QueryResult/table/tableDataView";
 import { RowNumberColumn } from "../QueryResult/table/plugins/rowNumberColumn.plugin";
+import { AutoColumnSize } from "../QueryResult/table/plugins/autoColumnSize.plugin";
 import { NotebookHeaderMenu, FilterButtonWidth } from "./notebookHeaderMenu.plugin";
 import { CellSelectionModel } from "../QueryResult/table/plugins/cellSelectionModel.plugin";
 import { CellRangeSelector } from "../QueryResult/table/plugins/cellRangeSelector";
@@ -67,60 +68,6 @@ function computeColumnWidths(columns: IDbColumn[], rows: DbCellValue[][], font: 
         }
         return Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.ceil(maxWidth)));
     });
-}
-
-function computeColumnWidth(
-    column: IDbColumn,
-    columnIndex: number,
-    rows: DbCellValue[][],
-    font: string,
-): number {
-    const sampleRows = rows.slice(0, MAX_SAMPLE_ROWS);
-    return computeColumnWidths(
-        [column],
-        sampleRows.map((row) => [row[columnIndex]]),
-        font,
-    )[0];
-}
-
-function parsePx(value: string): number {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function getOuterWidthWithMargins(element: HTMLElement): number {
-    const style = getComputedStyle(element);
-    return element.offsetWidth + parsePx(style.marginLeft) + parsePx(style.marginRight);
-}
-
-function getMinimumHeaderWidth(headerElement: HTMLElement | null): number {
-    if (!headerElement) {
-        return MIN_COLUMN_WIDTH;
-    }
-
-    const headerStyle = getComputedStyle(headerElement);
-    const horizontalChrome =
-        parsePx(headerStyle.paddingLeft) +
-        parsePx(headerStyle.paddingRight) +
-        parsePx(headerStyle.borderLeftWidth) +
-        parsePx(headerStyle.borderRightWidth);
-
-    const headerName = headerElement.querySelector(".slick-column-name") as HTMLElement | null;
-    const headerTextWidth = headerName ? Math.ceil(headerName.scrollWidth) : 0;
-
-    const sortButton = headerElement.querySelector(
-        ".slick-header-sortbutton",
-    ) as HTMLElement | null;
-    const filterButton = headerElement.querySelector(
-        ".slick-header-filterbutton",
-    ) as HTMLElement | null;
-    const controlsWidth =
-        (sortButton ? getOuterWidthWithMargins(sortButton) : 0) +
-        (filterButton ? getOuterWidthWithMargins(filterButton) : 0);
-
-    // Keep a small visual gap before the resizable handle.
-    const requiredWidth = headerTextWidth + controlsWidth + horizontalChrome + 6;
-    return Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.ceil(requiredWidth)));
 }
 
 /**
@@ -286,60 +233,17 @@ export function NotebookResultGrid({
         const contextMenu = new NotebookContextMenu<Slick.SlickData>();
         grid.registerPlugin(contextMenu);
 
+        // Reuse Query Result auto-size behavior for double-clicking a resize handle.
+        const autoColumnSize = new AutoColumnSize<Slick.SlickData>({
+            maxWidth: MAX_COLUMN_WIDTH,
+            autoSizeOnRender: false,
+            // Notebook headers already include sort/filter button width in-flow.
+            extraColumnHeaderWidth: 0,
+        });
+        grid.registerPlugin(autoColumnSize);
+
         // Now set columns — this triggers header rendering with plugins active
         grid.setColumns(columns);
-
-        const onHeaderClick = (
-            e: Slick.EventData,
-            args: Slick.OnHeaderClickEventArgs<Slick.SlickData>,
-        ) => {
-            const originalEvent = (e as JQuery.TriggeredEvent).originalEvent;
-            if (!(originalEvent instanceof MouseEvent) || originalEvent.detail !== 2) {
-                return;
-            }
-
-            const columnId = args.column?.id;
-            if (!columnId || columnId === "rowNumber") {
-                return;
-            }
-
-            const columnIndex = Number(columnId);
-            if (Number.isNaN(columnIndex) || columnIndex < 0 || columnIndex >= columnInfo.length) {
-                return;
-            }
-
-            const resizedWidth = computeColumnWidth(
-                columnInfo[columnIndex],
-                columnIndex,
-                rows,
-                font,
-            );
-            const headerElement = (originalEvent.target as HTMLElement | null)?.closest(
-                ".slick-header-column",
-            ) as HTMLElement | null;
-            const minHeaderWidth = getMinimumHeaderWidth(headerElement);
-            const targetWidth = Math.max(resizedWidth, minHeaderWidth);
-            const currentColumns = grid.getColumns();
-            const targetColumnIndex = currentColumns.findIndex((col) => col.id === columnId);
-            if (targetColumnIndex < 1) {
-                return;
-            }
-            const targetColumn = currentColumns[targetColumnIndex];
-            const currentWidth = targetColumn?.width ?? 0;
-
-            if (!targetColumn || currentWidth >= targetWidth) {
-                return;
-            }
-
-            currentColumns[targetColumnIndex] = {
-                ...targetColumn,
-                width: targetWidth,
-            };
-            grid.setColumns(currentColumns);
-            grid.resizeCanvas();
-        };
-
-        grid.onHeaderClick.subscribe(onHeaderClick);
 
         // Ctrl+C / Cmd+C copy handler
         gridDiv.addEventListener("keydown", (e: KeyboardEvent) => {
@@ -397,7 +301,6 @@ export function NotebookResultGrid({
 
         // Cleanup
         return () => {
-            grid.onHeaderClick.unsubscribe(onHeaderClick);
             resizeObserver.disconnect();
             grid.destroy();
             tableDataView.dispose();

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -30,6 +30,7 @@ const MAX_COLUMN_WIDTH = 400;
 const MAX_GRID_HEIGHT = 500;
 const HEADER_HEIGHT = 30;
 const HORIZONTAL_SCROLLBAR_HEIGHT = 20;
+const MAX_SAMPLE_ROWS = 50;
 
 /**
  * Measure the pixel width of a string using a canvas context.
@@ -49,8 +50,7 @@ function measureTextWidth(text: string, font: string): number {
  */
 function computeColumnWidths(columns: IDbColumn[], rows: DbCellValue[][], font: string): number[] {
     const padding = 20 + FilterButtonWidth; // cell padding + sort/filter button space
-    const maxSampleRows = 50;
-    const sampleRows = rows.slice(0, maxSampleRows);
+    const sampleRows = rows.slice(0, MAX_SAMPLE_ROWS);
 
     return columns.map((col, colIdx) => {
         let maxWidth = measureTextWidth(col.columnName, font) + padding;
@@ -67,6 +67,19 @@ function computeColumnWidths(columns: IDbColumn[], rows: DbCellValue[][], font: 
         }
         return Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.ceil(maxWidth)));
     });
+}
+
+function computeColumnWidth(
+    column: IDbColumn,
+    columnIndex: number,
+    rows: DbCellValue[][],
+    font: string,
+): number {
+    return computeColumnWidths(
+        [column],
+        rows.map((row) => [row[columnIndex]]),
+        font,
+    )[0];
 }
 
 /**
@@ -235,6 +248,51 @@ export function NotebookResultGrid({
         // Now set columns — this triggers header rendering with plugins active
         grid.setColumns(columns);
 
+        const onHeaderClick = (
+            e: Slick.EventData,
+            args: Slick.OnHeaderClickEventArgs<Slick.SlickData>,
+        ) => {
+            const originalEvent = (e as JQuery.TriggeredEvent).originalEvent;
+            if (!(originalEvent instanceof MouseEvent) || originalEvent.detail !== 2) {
+                return;
+            }
+
+            const columnId = args.column?.id;
+            if (!columnId || columnId === "rowNumber") {
+                return;
+            }
+
+            const columnIndex = Number(columnId);
+            if (Number.isNaN(columnIndex) || columnIndex < 0 || columnIndex >= columnInfo.length) {
+                return;
+            }
+
+            const resizedWidth = computeColumnWidth(
+                columnInfo[columnIndex],
+                columnIndex,
+                rows,
+                font,
+            );
+            const currentColumns = grid.getColumns();
+            const targetColumnIndex = currentColumns.findIndex((col) => col.id === columnId);
+
+            if (
+                targetColumnIndex <= 0 ||
+                currentColumns[targetColumnIndex].width === resizedWidth
+            ) {
+                return;
+            }
+
+            currentColumns[targetColumnIndex] = {
+                ...currentColumns[targetColumnIndex],
+                width: resizedWidth,
+            };
+            grid.setColumns(currentColumns);
+            grid.resizeCanvas();
+        };
+
+        grid.onHeaderClick.subscribe(onHeaderClick);
+
         // Ctrl+C / Cmd+C copy handler
         gridDiv.addEventListener("keydown", (e: KeyboardEvent) => {
             if ((e.ctrlKey || e.metaKey) && e.key === "c") {
@@ -291,6 +349,7 @@ export function NotebookResultGrid({
 
         // Cleanup
         return () => {
+            grid.onHeaderClick.unsubscribe(onHeaderClick);
             resizeObserver.disconnect();
             grid.destroy();
             tableDataView.dispose();

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -321,13 +321,18 @@ export function NotebookResultGrid({
             const targetWidth = Math.max(resizedWidth, minHeaderWidth);
             const currentColumns = grid.getColumns();
             const targetColumnIndex = currentColumns.findIndex((col) => col.id === columnId);
+            if (targetColumnIndex < 1) {
+                return;
+            }
+            const targetColumn = currentColumns[targetColumnIndex];
+            const currentWidth = targetColumn?.width ?? 0;
 
-            if (targetColumnIndex <= 0 || currentColumns[targetColumnIndex].width >= targetWidth) {
+            if (!targetColumn || currentWidth >= targetWidth) {
                 return;
             }
 
             currentColumns[targetColumnIndex] = {
-                ...currentColumns[targetColumnIndex],
+                ...targetColumn,
                 width: targetWidth,
             };
             grid.setColumns(currentColumns);

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -75,11 +75,52 @@ function computeColumnWidth(
     rows: DbCellValue[][],
     font: string,
 ): number {
+    const sampleRows = rows.slice(0, MAX_SAMPLE_ROWS);
     return computeColumnWidths(
         [column],
-        rows.map((row) => [row[columnIndex]]),
+        sampleRows.map((row) => [row[columnIndex]]),
         font,
     )[0];
+}
+
+function parsePx(value: string): number {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getOuterWidthWithMargins(element: HTMLElement): number {
+    const style = getComputedStyle(element);
+    return element.offsetWidth + parsePx(style.marginLeft) + parsePx(style.marginRight);
+}
+
+function getMinimumHeaderWidth(headerElement: HTMLElement | null): number {
+    if (!headerElement) {
+        return MIN_COLUMN_WIDTH;
+    }
+
+    const headerStyle = getComputedStyle(headerElement);
+    const horizontalChrome =
+        parsePx(headerStyle.paddingLeft) +
+        parsePx(headerStyle.paddingRight) +
+        parsePx(headerStyle.borderLeftWidth) +
+        parsePx(headerStyle.borderRightWidth);
+
+    const headerName = headerElement.querySelector(".slick-column-name") as HTMLElement | null;
+    const headerTextWidth = headerName ? Math.ceil(headerName.scrollWidth) : 0;
+
+    const sortButton = headerElement.querySelector(
+        ".slick-header-sortbutton",
+    ) as HTMLElement | null;
+    const filterButton = headerElement.querySelector(
+        ".slick-header-filterbutton",
+    ) as HTMLElement | null;
+    const controlsWidth =
+        (sortButton ? getOuterWidthWithMargins(sortButton) : 0) +
+        (filterButton ? getOuterWidthWithMargins(filterButton) : 0);
+
+    // Keep a small visual gap before the resizable handle.
+    const requiredWidth = headerTextWidth + controlsWidth + horizontalChrome + 6;
+    return Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.ceil(requiredWidth)));
 }
 
 /**
@@ -273,19 +314,21 @@ export function NotebookResultGrid({
                 rows,
                 font,
             );
+            const headerElement = (originalEvent.target as HTMLElement | null)?.closest(
+                ".slick-header-column",
+            ) as HTMLElement | null;
+            const minHeaderWidth = getMinimumHeaderWidth(headerElement);
+            const targetWidth = Math.max(resizedWidth, minHeaderWidth);
             const currentColumns = grid.getColumns();
             const targetColumnIndex = currentColumns.findIndex((col) => col.id === columnId);
 
-            if (
-                targetColumnIndex <= 0 ||
-                currentColumns[targetColumnIndex].width === resizedWidth
-            ) {
+            if (targetColumnIndex <= 0 || currentColumns[targetColumnIndex].width >= targetWidth) {
                 return;
             }
 
             currentColumns[targetColumnIndex] = {
                 ...currentColumns[targetColumnIndex],
-                width: resizedWidth,
+                width: targetWidth,
             };
             grid.setColumns(currentColumns);
             grid.resizeCanvas();

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/autoColumnSize.plugin.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/autoColumnSize.plugin.ts
@@ -8,7 +8,7 @@
 import { TelemetryActions, TelemetryViews } from "../../../../../sharedInterfaces/telemetry";
 import { WebviewTelemetryActionEvent } from "../../../../../sharedInterfaces/webview";
 import { deepClone } from "../../../../common/utils";
-import { QueryResultReactProvider } from "../../queryResultStateProvider";
+import type { QueryResultReactProvider } from "../../queryResultStateProvider";
 import { mixin } from "../objects";
 import { MAX_COLUMN_WIDTH_PX, MIN_COLUMN_WIDTH_PX } from "../table";
 
@@ -39,7 +39,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
 
     constructor(
         options: IAutoColumnSizeOptions = defaultOptions,
-        private _qrContext: QueryResultReactProvider,
+        private _qrContext?: Pick<QueryResultReactProvider, "sendActionEvent">,
     ) {
         this._options = mixin(options, defaultOptions, false);
     }
@@ -383,7 +383,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
                 columns: numColumns,
             },
         };
-        this._qrContext.sendActionEvent(telemetryEvent);
+        this._qrContext?.sendActionEvent(telemetryEvent);
         return maxTemplate!;
     }
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/22208

When a column is too small. A user can double click to auto resize the column
<img width="1522" height="581" alt="auto-resize-columns-with-double-click" src="https://github.com/user-attachments/assets/c8e7685b-af9a-4701-b6ef-10c0662256e8" />

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
