### PR TITLE
[PORT] Add double-click to auto-resize notebook result grid columns (#22216)

### DIFF
--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useRef } from "react";
 import { TableDataView, defaultFilter } from "../QueryResult/table/tableDataView";
 import { RowNumberColumn } from "../QueryResult/table/plugins/rowNumberColumn.plugin";
+import { AutoColumnSize } from "../QueryResult/table/plugins/autoColumnSize.plugin";
 import { NotebookHeaderMenu, FilterButtonWidth } from "./notebookHeaderMenu.plugin";
 import { CellSelectionModel } from "../QueryResult/table/plugins/cellSelectionModel.plugin";
 import { CellRangeSelector } from "../QueryResult/table/plugins/cellRangeSelector";
@@ -30,6 +31,7 @@ const MAX_COLUMN_WIDTH = 400;
 const MAX_GRID_HEIGHT = 500;
 const HEADER_HEIGHT = 30;
 const HORIZONTAL_SCROLLBAR_HEIGHT = 20;
+const MAX_SAMPLE_ROWS = 50;
 
 /**
  * Measure the pixel width of a string using a canvas context.
@@ -49,8 +51,7 @@ function measureTextWidth(text: string, font: string): number {
  */
 function computeColumnWidths(columns: IDbColumn[], rows: DbCellValue[][], font: string): number[] {
     const padding = 20 + FilterButtonWidth; // cell padding + sort/filter button space
-    const maxSampleRows = 50;
-    const sampleRows = rows.slice(0, maxSampleRows);
+    const sampleRows = rows.slice(0, MAX_SAMPLE_ROWS);
 
     return columns.map((col, colIdx) => {
         let maxWidth = measureTextWidth(col.columnName, font) + padding;
@@ -231,6 +232,15 @@ export function NotebookResultGrid({
         // Register context menu (right-click) with copy operations
         const contextMenu = new NotebookContextMenu<Slick.SlickData>();
         grid.registerPlugin(contextMenu);
+
+        // Reuse Query Result auto-size behavior for double-clicking a resize handle.
+        const autoColumnSize = new AutoColumnSize<Slick.SlickData>({
+            maxWidth: MAX_COLUMN_WIDTH,
+            autoSizeOnRender: false,
+            // Notebook headers already include sort/filter button width in-flow.
+            extraColumnHeaderWidth: 0,
+        });
+        grid.registerPlugin(autoColumnSize);
 
         // Now set columns — this triggers header rendering with plugins active
         grid.setColumns(columns);

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/autoColumnSize.plugin.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/autoColumnSize.plugin.ts
@@ -8,7 +8,7 @@
 import { TelemetryActions, TelemetryViews } from "../../../../../sharedInterfaces/telemetry";
 import { WebviewTelemetryActionEvent } from "../../../../../sharedInterfaces/webview";
 import { deepClone } from "../../../../common/utils";
-import { QueryResultReactProvider } from "../../queryResultStateProvider";
+import type { QueryResultReactProvider } from "../../queryResultStateProvider";
 import { mixin } from "../objects";
 import { MAX_COLUMN_WIDTH_PX, MIN_COLUMN_WIDTH_PX } from "../table";
 
@@ -39,7 +39,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
 
     constructor(
         options: IAutoColumnSizeOptions = defaultOptions,
-        private _qrContext: QueryResultReactProvider,
+        private _qrContext?: Pick<QueryResultReactProvider, "sendActionEvent">,
     ) {
         this._options = mixin(options, defaultOptions, false);
     }
@@ -383,7 +383,7 @@ export class AutoColumnSize<T extends Slick.SlickData> implements Slick.Plugin<T
                 columns: numColumns,
             },
         };
-        this._qrContext.sendActionEvent(telemetryEvent);
+        this._qrContext?.sendActionEvent(telemetryEvent);
         return maxTemplate!;
     }
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/vscode-mssql/issues/22208

Original PR: https://github.com/microsoft/vscode-mssql/pull/22216

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
