### PR TITLE
[PORT] Fix: Publish using a saved publish profile does not use stored values for SCLCMD Variables

### DIFF
--- a/extensions/mssql/src/publishProject/projectUtils.ts
+++ b/extensions/mssql/src/publishProject/projectUtils.ts
@@ -9,6 +9,7 @@ import * as constants from "../constants/constants";
 import * as path from "path";
 import { SqlProjectsService } from "../services/sqlProjectsService";
 import { promises as fs } from "fs";
+import * as os from "os";
 import { DOMParser } from "@xmldom/xmldom";
 import { dockerLogger } from "../docker/dockerUtils";
 import { getSqlServerContainerVersions } from "../deployment/sqlServerContainer";
@@ -254,7 +255,14 @@ export function readSqlCmdVariables(profileText: string): { [key: string]: strin
 
     try {
         const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(profileText, "application/xml");
+        // Strip UTF-8 BOM (\uFEFF) if present — xmldom requires the XML declaration to be
+        // at position 0 and throws if a BOM character precedes it.
+        // Also prepend an XML declaration if absent (e.g. hand-authored profiles) to ensure consistent UTF-8 parsing.
+        let normalizedXml = profileText.replace(/^\uFEFF/, "");
+        if (!normalizedXml.trimStart().startsWith("<?xml")) {
+            normalizedXml = '<?xml version="1.0" encoding="utf-8"?>' + os.EOL + normalizedXml;
+        }
+        const xmlDoc = parser.parseFromString(normalizedXml, "application/xml");
 
         // Get all SqlCmdVariable elements
         const sqlCmdVarElements = xmlDoc.documentElement.getElementsByTagName("SqlCmdVariable");

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -42,7 +42,6 @@ import VscodeWrapper from "../controllers/vscodeWrapper";
 import { DiffEntry } from "vscode-mssql";
 import { sendActionEvent, startActivity, sendErrorEvent } from "../telemetry/telemetry";
 import { ActivityStatus, TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
-import { isNullOrUndefined } from "util";
 import * as locConstants from "../constants/locConstants";
 import { IConnectionDialogProfile } from "../sharedInterfaces/connectionDialog";
 import {
@@ -2240,7 +2239,7 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
     }
 
     private formatEntryName(nameParts: string[]): string {
-        if (isNullOrUndefined(nameParts) || nameParts.length === 0) {
+        if (!nameParts || nameParts.length === 0) {
             return "";
         }
         return nameParts.join(".");

--- a/extensions/mssql/test/unit/projectUtils.test.ts
+++ b/extensions/mssql/test/unit/projectUtils.test.ts
@@ -9,6 +9,7 @@ import * as path from "path";
 import {
     parseSqlprojRuleOverrides,
     readProjectProperties,
+    readSqlCmdVariables,
 } from "../../src/publishProject/projectUtils";
 import { SqlProjectsService } from "../../src/services/sqlProjectsService";
 import { GetProjectPropertiesResult } from "vscode-mssql";
@@ -158,6 +159,58 @@ suite("projectUtils Tests", () => {
         expect(result.get("SR0008")).to.equal("Disabled");
         expect(result.get("SR0009")).to.equal("Disabled");
     });
+
+    // #region readSqlCmdVariables Tests
+
+    const SQLCMD_PROFILE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <SqlCmdVariable Include="Var1">
+      <Value>Value1</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="Var2">
+      <Value>Value&amp;2</Value>
+    </SqlCmdVariable>
+  </ItemGroup>
+</Project>`;
+
+    test("readSqlCmdVariables parses SQLCMD variables from normal XML", () => {
+        const result = readSqlCmdVariables(SQLCMD_PROFILE_XML);
+
+        expect(result).to.deep.equal({
+            Var1: "Value1",
+            Var2: "Value&2", // XML entity &amp; decoded to &
+        });
+    });
+
+    test("readSqlCmdVariables parses SQLCMD variables from UTF-8 BOM-prefixed XML", () => {
+        // Visual Studio saves .publish.xml files with a UTF-8 BOM (\uFEFF).
+        // @xmldom/xmldom 0.9.x rejects the XML declaration when
+        // it is not at position 0, causing silent empty-object returns.
+        const bomPrefixedXml = "\uFEFF" + SQLCMD_PROFILE_XML;
+
+        const result = readSqlCmdVariables(bomPrefixedXml);
+
+        expect(result).to.deep.equal({
+            Var1: "Value1",
+            Var2: "Value&2",
+        });
+    });
+
+    test("readSqlCmdVariables parses SQLCMD variables from XML without a declaration", () => {
+        // Hand-authored publish profiles may omit the <?xml ...?> declaration entirely.
+        // The parser should still handle them correctly by prepending one.
+        const xmlWithoutDeclaration = SQLCMD_PROFILE_XML.replace(/^<\?xml.*?\?>\n?/, "");
+
+        const result = readSqlCmdVariables(xmlWithoutDeclaration);
+
+        expect(result).to.deep.equal({
+            Var1: "Value1",
+            Var2: "Value&2",
+        });
+    });
+
+    // #endregion
 
     test("parseSqlprojRuleOverrides handles edge cases", () => {
         // Empty / blank input → empty map

--- a/extensions/mssql/test/unit/publishProjectWebViewController.test.ts
+++ b/extensions/mssql/test/unit/publishProjectWebViewController.test.ts
@@ -385,9 +385,10 @@ suite("PublishProjectWebViewController Tests", () => {
 
         const profilePath = "c:/profiles/TestProfile.publish.xml";
 
-        // Mock file system read
+        // Mock file system read - simulate a file saved by Visual Studio with a UTF-8 BOM (\uFEFF).
+        // @xmldom/xmldom 0.9.x throws when the XML declaration is not at position 0, causing SQLCMD variables to silently return empty.
         const fs = await import("fs");
-        sandbox.stub(fs.promises, "readFile").resolves(SAMPLE_PUBLISH_PROFILE_XML);
+        sandbox.stub(fs.promises, "readFile").resolves("\uFEFF" + SAMPLE_PUBLISH_PROFILE_XML);
 
         // Mock file picker
         sandbox.stub(vscode.window, "showOpenDialog").resolves([vscode.Uri.file(profilePath)]);


### PR DESCRIPTION
## Description

Porting: https://github.com/microsoft/vscode-mssql/pull/22196
Issue: #22030 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
