### PR TITLE
Fix Schema Designer pending changes diff

### DIFF
--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -114,6 +114,7 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
         private treeNode?: TreeNodeInfo,
         private connectionUri?: string,
         isReadOnly: boolean = false,
+        cacheKey?: string,
     ) {
         super(
             context,
@@ -148,7 +149,7 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
             },
         );
 
-        this._key = `${this.connectionString}-${this.databaseName}`;
+        this._key = cacheKey ?? `${this.connectionString}-${this.databaseName}`;
         this._serverName = this.resolveServerName();
         this._sqlServerContainerName = this.resolveSqlServerContainerName();
 

--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewManager.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewManager.ts
@@ -151,6 +151,7 @@ export class SchemaDesignerWebviewManager {
                 treeNode,
                 metadataConnectionUri,
                 isReadOnly,
+                key,
             );
             const viewStateDisposable = schemaDesigner.panel.onDidChangeViewState((event) => {
                 if (event.webviewPanel.visible) {

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/diff/diffUtils.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/diff/diffUtils.ts
@@ -91,6 +91,37 @@ export const FOREIGN_KEY_PROPERTIES: PropertyMetadata[] = [
     { key: "onUpdateAction", displayName: "On Update Action" },
 ];
 
+function isEmptyValue(value: unknown): boolean {
+    return value === null || value === undefined || value === "";
+}
+
+function isLengthBasedType(type: unknown): boolean {
+    return (
+        typeof type === "string" &&
+        ["char", "varchar", "nchar", "nvarchar", "binary", "varbinary", "vector"].includes(type)
+    );
+}
+
+function isPrecisionBasedType(type: unknown): boolean {
+    return typeof type === "string" && ["decimal", "numeric"].includes(type);
+}
+
+function isTimeBasedWithScale(type: unknown): boolean {
+    return typeof type === "string" && ["datetime2", "datetimeoffset", "time"].includes(type);
+}
+
+function normalizeEmptyString(value: unknown): unknown {
+    return isEmptyValue(value) ? "" : value;
+}
+
+function normalizeOptionalNumber(value: unknown): unknown {
+    return value === null || value === undefined || value === "" ? 0 : value;
+}
+
+function normalizeOptionalBoolean(value: unknown): unknown {
+    return value === null || value === undefined ? false : value;
+}
+
 export function diffObject<T extends object>(
     original: T,
     current: T,
@@ -126,6 +157,64 @@ function mapById<T extends { id: string }>(items: T[]): Map<string, T> {
     return map;
 }
 
+export function normalizeColumnForDiff(column: sd.SchemaDesigner.Column): sd.SchemaDesigner.Column {
+    const normalized: sd.SchemaDesigner.Column = {
+        ...column,
+        maxLength: isLengthBasedType(column.dataType)
+            ? (normalizeEmptyString(column.maxLength) as string)
+            : "",
+        precision: isPrecisionBasedType(column.dataType)
+            ? (normalizeOptionalNumber(column.precision) as number)
+            : 0,
+        scale:
+            isPrecisionBasedType(column.dataType) || isTimeBasedWithScale(column.dataType)
+                ? (normalizeOptionalNumber(column.scale) as number)
+                : 0,
+        identitySeed: column.isIdentity
+            ? (normalizeOptionalNumber(column.identitySeed) as number)
+            : 0,
+        identityIncrement: column.isIdentity
+            ? (normalizeOptionalNumber(column.identityIncrement) as number)
+            : 0,
+        defaultValue: normalizeEmptyString(column.defaultValue) as string,
+        computedFormula: column.isComputed
+            ? (normalizeEmptyString(column.computedFormula) as string)
+            : "",
+        computedPersisted: column.isComputed
+            ? (normalizeOptionalBoolean(column.computedPersisted) as boolean)
+            : false,
+    };
+
+    return normalized;
+}
+
+export function normalizeForeignKeyForDiff(
+    foreignKey: sd.SchemaDesigner.ForeignKey,
+): sd.SchemaDesigner.ForeignKey {
+    return {
+        ...foreignKey,
+        columnsIds: Array.isArray(foreignKey.columnsIds) ? [...foreignKey.columnsIds] : [],
+        referencedTableId: foreignKey.referencedTableId ?? "",
+        referencedColumnsIds: Array.isArray(foreignKey.referencedColumnsIds)
+            ? [...foreignKey.referencedColumnsIds]
+            : [],
+    };
+}
+
+export function normalizeTableForDiff(table: sd.SchemaDesigner.Table): sd.SchemaDesigner.Table {
+    return {
+        ...table,
+        columns: (table.columns ?? []).map(normalizeColumnForDiff),
+        foreignKeys: (table.foreignKeys ?? []).map(normalizeForeignKeyForDiff),
+    };
+}
+
+export function normalizeSchemaForDiff(schema: sd.SchemaDesigner.Schema): sd.SchemaDesigner.Schema {
+    return {
+        tables: (schema.tables ?? []).map(normalizeTableForDiff),
+    };
+}
+
 /**
  * Compares two schemas and returns changes grouped by table.
  *
@@ -152,8 +241,11 @@ export function calculateSchemaDiff(
     oldSchema: sd.SchemaDesigner.Schema,
     newSchema: sd.SchemaDesigner.Schema,
 ): SchemaChangesSummary {
-    const oldTablesById = mapById(oldSchema.tables ?? []);
-    const newTablesById = mapById(newSchema.tables ?? []);
+    const normalizedOldSchema = normalizeSchemaForDiff(oldSchema);
+    const normalizedNewSchema = normalizeSchemaForDiff(newSchema);
+
+    const oldTablesById = mapById(normalizedOldSchema.tables ?? []);
+    const newTablesById = mapById(normalizedNewSchema.tables ?? []);
 
     const allTableIds = new Set<string>([...oldTablesById.keys(), ...newTablesById.keys()]);
     const groupsByTableId = new Map<string, TableChangeGroup>();
@@ -384,10 +476,10 @@ export function calculateSchemaDiff(
             const oldReferencedTableId = oldFk.referencedTableId ?? "";
             const newReferencedTableId = newFk.referencedTableId ?? "";
 
-            const oldReferencedTable = oldSchema.tables.find(
+            const oldReferencedTable = normalizedOldSchema.tables.find(
                 (table) => table.id === oldReferencedTableId,
             );
-            const newReferencedTable = newSchema.tables.find(
+            const newReferencedTable = normalizedNewSchema.tables.find(
                 (table) => table.id === newReferencedTableId,
             );
 
@@ -468,8 +560,14 @@ export function calculateSchemaDiff(
                     case "referencedTableId":
                         return {
                             ...propertyChange,
-                            oldValue: getTableDisplayName(propertyChange.oldValue, oldSchema),
-                            newValue: getTableDisplayName(propertyChange.newValue, newSchema),
+                            oldValue: getTableDisplayName(
+                                propertyChange.oldValue,
+                                normalizedOldSchema,
+                            ),
+                            newValue: getTableDisplayName(
+                                propertyChange.newValue,
+                                normalizedNewSchema,
+                            ),
                         };
                     case "referencedColumnIds":
                         return {

--- a/extensions/mssql/test/unit/schemaDesignerDiff.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerDiff.test.ts
@@ -11,11 +11,16 @@ import {
     calculateSchemaDiff,
     ChangeAction,
     ChangeCategory,
+    normalizeSchemaForDiff,
     type SchemaChange,
     type SchemaChangesSummary,
     type TableChangeGroup,
 } from "../../src/webviews/pages/SchemaDesigner/diff/diffUtils";
 import { describeChange } from "../../src/webviews/pages/SchemaDesigner/diff/schemaDiff";
+import {
+    buildFlowComponentsFromSchema,
+    buildSchemaFromFlowState,
+} from "../../src/webviews/pages/SchemaDesigner/model";
 import {
     canRevertChange,
     computeRevertedSchema,
@@ -234,6 +239,65 @@ suite("SchemaDesigner diff utils", () => {
 
     test("returns no changes for identical schemas", () => {
         const summary = calculateSchemaDiff(sampleSchema, sampleSchema);
+        expect(summary.hasChanges).to.equal(false);
+        expect(summary.totalChanges).to.equal(0);
+        expect(summary.groups).to.have.length(0);
+    });
+
+    test("ignores webview defaults for non-applicable column properties", () => {
+        const updated = deepClone(sampleSchema);
+
+        for (const table of updated.tables) {
+            for (const column of table.columns) {
+                if (
+                    !["char", "varchar", "nchar", "nvarchar", "binary", "varbinary"].includes(
+                        column.dataType,
+                    )
+                ) {
+                    column.maxLength = "";
+                }
+
+                if (!["decimal", "numeric"].includes(column.dataType)) {
+                    column.precision = 0;
+                }
+
+                if (
+                    !["decimal", "numeric", "datetime2", "datetimeoffset", "time"].includes(
+                        column.dataType,
+                    )
+                ) {
+                    column.scale = 0;
+                }
+
+                if (!column.isIdentity) {
+                    column.identitySeed = 0;
+                    column.identityIncrement = 0;
+                }
+
+                column.defaultValue = "";
+
+                if (!column.isComputed) {
+                    column.computedFormula = "";
+                    column.computedPersisted = false;
+                }
+            }
+        }
+
+        const summary = calculateSchemaDiff(sampleSchema, updated);
+        expect(summary.hasChanges).to.equal(false);
+        expect(summary.totalChanges).to.equal(0);
+        expect(summary.groups).to.have.length(0);
+    });
+
+    test("normalizes schemas before diffing flow-extracted schema", () => {
+        const flow = buildFlowComponentsFromSchema(sampleSchema);
+        const extractedSchema = buildSchemaFromFlowState(flow.nodes, flow.edges);
+
+        const summary = calculateSchemaDiff(sampleSchema, extractedSchema);
+
+        expect(normalizeSchemaForDiff(extractedSchema)).to.deep.equal(
+            normalizeSchemaForDiff(sampleSchema),
+        );
         expect(summary.hasChanges).to.equal(false);
         expect(summary.totalChanges).to.equal(0);
         expect(summary.groups).to.have.length(0);

--- a/extensions/mssql/test/unit/schemaDesignerWebviewManager.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerWebviewManager.test.ts
@@ -155,6 +155,20 @@ suite("SchemaDesignerWebviewManager tests", () => {
                 .calledOnce;
         });
 
+        test("should give controller the mode-qualified cache key", async () => {
+            const designer = await manager.getSchemaDesigner(
+                mockContext,
+                mockVscodeWrapper,
+                mockMainController,
+                mockSchemaDesignerService,
+                databaseName,
+                treeNode,
+                undefined,
+            );
+
+            expect(designer.designerKey).to.equal(`${connectionString}-${databaseName}-rw`);
+        });
+
         test("should update connection profile with database name", async () => {
             await manager.getSchemaDesigner(
                 mockContext,


### PR DESCRIPTION
## Description

Fixes #22226.

Schema Designer could show pending changes even when the user had not made meaningful edits. The diff was comparing the service baseline schema directly against a schema extracted from React Flow, where non-applicable column fields can be represented differently (`null` vs `""`, `0`, or `false`). This PR adds a diff-only schema normalizer so baseline and extracted schemas are compared in the same semantic shape.

This also fixes Schema Designer cache key handling so the manager and controller use the same mode-qualified cache key (`rw`/`ro`), preventing stale dirty sessions from being read or cleaned up under different keys.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Verification:
- `npm run build:extension:typecheck`
- `npm run build:extension:emit`
- `npx mocha out/test/unit/schemaDesignerDiff.test.js --ui tdd --timeout 30000`

Note: full `npm run test` was not run. A targeted VS Code-hosted test run timed out locally; direct Mocha cannot run the manager test because it depends on the `vscode` module.
