### PR TITLE
Fixing issue where Warehouses weren't setting connection props in Fabric Browse

### DIFF
--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
@@ -78,6 +78,13 @@ export const FabricBrowsePage = () => {
                 setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
 
                 return;
+            case SqlArtifactTypes.Warehouse:
+                setConnectionProperty("server", database.server);
+                setConnectionProperty("database", database.displayName);
+                setConnectionProperty("profileName", generateProfileName(database));
+                setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
+
+                return;
             default:
                 context!.log("Unknown server type selected.", "error");
         }


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/22056

Fabric warehouse connection properties weren't getting set, resulting in an error when trying to use the browser to connect

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
