### PR TITLE
Bumping YAUZL to 3.3.1, pinning Node

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -17,7 +17,7 @@ runs:
       if: ${{ inputs.cache != '' }}
       uses: actions/setup-node@v6
       with:
-        node-version: "24"
+        node-version: "24.15.0" # pinning due to https://github.com/nodejs/node/issues/63487
         cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs['cache-dependency-path'] }}
 
@@ -25,4 +25,4 @@ runs:
       if: ${{ inputs.cache == '' }}
       uses: actions/setup-node@v6
       with:
-        node-version: "24"
+        node-version: "24.15.0" # pinning due to https://github.com/nodejs/node/issues/63487

--- a/extensions/mssql/package-lock.json
+++ b/extensions/mssql/package-lock.json
@@ -45,7 +45,7 @@
                 "vscode-languageclient": "5.2.1",
                 "xml-formatter": "^3.6.7",
                 "yallist": "^5.0.0",
-                "yauzl": "^3.2.1"
+                "yauzl": "^3.3.1"
             },
             "devDependencies": {
                 "@azure/core-paging": "^1.6.2",
@@ -14026,7 +14026,9 @@
             }
         },
         "node_modules/yauzl": {
-            "version": "3.2.1",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+            "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
             "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -180,7 +180,7 @@
         "vscode-languageclient": "5.2.1",
         "xml-formatter": "^3.6.7",
         "yallist": "^5.0.0",
-        "yauzl": "^3.2.1"
+        "yauzl": "^3.3.1"
     },
     "capabilities": {
         "untrustedWorkspaces": {


### PR DESCRIPTION
## Description

Bumping YAUZL to 3.3.1 fix an issue with packaging
Pins node to 24.15.0 to avoid https://github.com/nodejs/node/issues/63487 (same yauzl issue)

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
