### PR TITLE
Cloud Deploy: D3-Part-1 — RunRecord schema + writer/reader

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3895,6 +3895,38 @@
     },
     "View known issues": "View known issues",
     "Service installation failed.": "Service installation failed.",
+    "Run artifact at {0} is not a valid zip archive./{0} is the absolute file path of the run artifact": {
+        "message": "Run artifact at {0} is not a valid zip archive.",
+        "comment": ["{0} is the absolute file path of the run artifact"]
+    },
+    "Run artifact at {0} declares schema version {1}, which this version of the extension does not understand. Update the extension to read it./{0} is the absolute file path of the run artifact{1} is the unsupported schema version number": {
+        "message": "Run artifact at {0} declares schema version {1}, which this version of the extension does not understand. Update the extension to read it.",
+        "comment": [
+            "{0} is the absolute file path of the run artifact",
+            "{1} is the unsupported schema version number"
+        ]
+    },
+    "Run artifact at {0} is missing the required entry '{1}'./{0} is the absolute file path of the run artifact{1} is the name of the missing entry inside the zip": {
+        "message": "Run artifact at {0} is missing the required entry '{1}'.",
+        "comment": [
+            "{0} is the absolute file path of the run artifact",
+            "{1} is the name of the missing entry inside the zip"
+        ]
+    },
+    "Run artifact at {0} failed schema validation with {1} issue(s)./{0} is the absolute file path of the run artifact{1} is the count of validation issues": {
+        "message": "Run artifact at {0} failed schema validation with {1} issue(s).",
+        "comment": [
+            "{0} is the absolute file path of the run artifact",
+            "{1} is the count of validation issues"
+        ]
+    },
+    "Failed to read run artifact at {0}: {1}/{0} is the absolute file path of the run artifact{1} is the underlying I/O error message": {
+        "message": "Failed to read run artifact at {0}: {1}",
+        "comment": [
+            "{0} is the absolute file path of the run artifact",
+            "{1} is the underlying I/O error message"
+        ]
+    },
     "Azure sign in failed.": "Azure sign in failed.",
     "Select subscriptions": "Select subscriptions",
     "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/extensions/mssql/package-lock.json
+++ b/extensions/mssql/package-lock.json
@@ -46,6 +46,7 @@
                 "xml-formatter": "^3.6.7",
                 "yallist": "^5.0.0",
                 "yauzl": "^3.2.1",
+                "yazl": "^2.5.1",
                 "zod": "^3.25.0"
             },
             "devDependencies": {
@@ -76,6 +77,8 @@
                 "@types/vscode": "1.98.0",
                 "@types/vscode-webview": "^1.57.5",
                 "@types/xmldom": "^0.1.34",
+                "@types/yauzl": "^2.10.3",
+                "@types/yazl": "^2.4.6",
                 "@typescript/native-preview": "^7.0.0-dev.20260507.1",
                 "@vscode/l10n": "^0.0.18",
                 "@vscode/l10n-dev": "^0.0.35",
@@ -4236,6 +4239,26 @@
             "version": "0.1.34",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/yauzl": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/yazl": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.6.tgz",
+            "integrity": "sha512-/ifFjQtcKaoZOjl5NNCQRR0fAKafB3Foxd7J/WvFPTMea46zekapcR30uzkwIkKAAuq5T6d0dkwz754RFH27hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript/native-preview": {
             "version": "7.0.0-dev.20260507.1",
@@ -14039,7 +14062,6 @@
         },
         "node_modules/yazl": {
             "version": "2.5.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3"

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -106,6 +106,8 @@
         "@types/tmp": "0.0.28",
         "@types/tunnel": "0.0.1",
         "@types/vscode": "1.98.0",
+        "@types/yauzl": "^2.10.3",
+        "@types/yazl": "^2.4.6",
         "@types/vscode-webview": "^1.57.5",
         "@types/xmldom": "^0.1.34",
         "@typescript/native-preview": "^7.0.0-dev.20260507.1",
@@ -181,6 +183,7 @@
         "xml-formatter": "^3.6.7",
         "yallist": "^5.0.0",
         "yauzl": "^3.2.1",
+        "yazl": "^2.5.1",
         "zod": "^3.25.0"
     },
     "capabilities": {

--- a/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
+++ b/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
@@ -12,18 +12,32 @@
  *
  * `environments` is `undefined` when no workspace folder is open — Cloud
  * Deploy is a folder-scoped feature, so the rest of the extension still works
- * without it. `diagnostics` is always present; subscribers can attach at
- * extension activation regardless of workspace state.
+ * without it. `diagnostics` and `runs` are always present; run artifacts
+ * live at absolute paths, not under `.mssql/`, so they don't depend on a
+ * workspace folder to be readable or writable.
  */
 
 import * as vscode from "vscode";
 
 import { DiagnosticEventBus } from "./diagnostics";
 import { EnvironmentStore } from "./environments/environmentStore";
+import { LocalFileProvider } from "./providers";
+import { RunArtifactReader, RunArtifactWriter } from "./runs";
+
+/**
+ * Run-artifact I/O surface attached to the service. Both members share the
+ * same `FileProvider`; the writer also shares the service's diagnostic bus
+ * so success / failure events reach existing subscribers automatically.
+ */
+export interface CloudDeployRunsApi {
+    readonly writer: RunArtifactWriter;
+    readonly reader: RunArtifactReader;
+}
 
 export class CloudDeployService implements vscode.Disposable {
     public readonly diagnostics: DiagnosticEventBus;
     public readonly environments: EnvironmentStore | undefined;
+    public readonly runs: CloudDeployRunsApi;
 
     public constructor(
         workspaceFolder: vscode.WorkspaceFolder | undefined,
@@ -37,6 +51,11 @@ export class CloudDeployService implements vscode.Disposable {
                 this.diagnostics,
             );
         }
+        const fileProvider = new LocalFileProvider();
+        this.runs = {
+            writer: new RunArtifactWriter(fileProvider, this.diagnostics),
+            reader: new RunArtifactReader(fileProvider),
+        };
     }
 
     /** Loads on-disk state. Safe to call when no folder is open (resolves immediately). */

--- a/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
@@ -15,4 +15,6 @@ export type {
     EnvironmentsFileParseFailedEvent,
     EnvironmentsLoadedEvent,
     ErrorEvent,
+    RunPersistedEvent,
+    RunPersistFailedEvent,
 } from "./types";

--- a/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
@@ -25,7 +25,7 @@
 // =============================================================================
 
 /** Subsystem that produced an event. Closed; expand as new subsystems land. */
-export type DiagnosticEventSource = "environment-store" | "service";
+export type DiagnosticEventSource = "environment-store" | "run-store" | "service";
 
 /**
  * Hint to subscribers, not a gate. The bus delivers all severities; consumers
@@ -70,6 +70,8 @@ export type DiagnosticEvent =
     | EnvironmentsChangedEvent
     | EnvironmentsFileParseFailedEvent
     | DefaultEnvironmentChangedEvent
+    | RunPersistedEvent
+    | RunPersistFailedEvent
     | ErrorEvent;
 
 /** Env file was successfully loaded (or determined to be empty/absent). */
@@ -109,6 +111,30 @@ export interface DefaultEnvironmentChangedEvent extends DiagnosticEventEnvelope 
     readonly type: "default-environment-changed";
     readonly payload: {
         readonly id: string | undefined;
+    };
+}
+
+/** A run artifact was successfully persisted to its final on-disk location. */
+export interface RunPersistedEvent extends DiagnosticEventEnvelope {
+    readonly source: "run-store";
+    readonly type: "run-persisted";
+    readonly payload: {
+        readonly runId: string;
+        readonly path: string;
+        readonly sizeBytes: number;
+    };
+}
+
+/** Writing a run artifact failed; the writer re-throws after emitting. */
+export interface RunPersistFailedEvent extends DiagnosticEventEnvelope {
+    readonly source: "run-store";
+    readonly severity: "error";
+    readonly type: "run-persist-failed";
+    readonly payload: {
+        readonly runId: string;
+        readonly path: string;
+        /** Stringified error message; the full error object is not retained. */
+        readonly cause: string;
     };
 }
 

--- a/extensions/mssql/src/cloudDeploy/providers.ts
+++ b/extensions/mssql/src/cloudDeploy/providers.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — host-agnostic file providers.
+ *
+ * Phase 3 introduces a narrow `FileProvider` interface so the run-artifact
+ * writer and reader can be exercised against an in-memory fake without ever
+ * touching disk. The local Node.js implementation lives here (`LocalFileProvider`)
+ * and gives the production code path real fs semantics, including an atomic
+ * `writeFileAtomic` (temp + rename) that mirrors the pattern already used by
+ * the environments file layer.
+ *
+ * The interface is intentionally small: just the few operations the writer
+ * and reader need. Later phases (notably D2's Local + GitHub artifact
+ * providers and Phase 4a's broader store wiring) will expand it as required;
+ * additive growth keeps the contract honest.
+ */
+
+import { promises as fs } from "fs";
+import * as path from "path";
+
+// =============================================================================
+// Public interface
+// =============================================================================
+
+/**
+ * Narrow host abstraction the run-artifact writer and reader depend on.
+ *
+ * The choice to operate on whole-file `Buffer`s — rather than streams — is
+ * deliberate: run artifacts are bounded (a single user's single run), the
+ * zip layout demands a complete buffer for `yauzl.fromBuffer`, and a buffer
+ * surface is trivial to fake for unit tests.
+ */
+export interface FileProvider {
+    /**
+     * Reads the entire contents of a file as a `Buffer`. Implementations
+     * MUST throw with `code === "ENOENT"` when the file does not exist so
+     * callers can distinguish "missing" from other I/O failures.
+     */
+    readFileBuffer(filePath: string): Promise<Buffer>;
+
+    /**
+     * Atomically writes `data` to `filePath`. Implementations MUST guarantee
+     * that callers never observe a half-written file at `filePath`: either
+     * the previous version is intact, or the new version is fully present.
+     * The parent directory is created on demand.
+     */
+    writeFileAtomic(filePath: string, data: Buffer): Promise<void>;
+
+    /** Returns `true` iff `filePath` exists and is reachable for read. */
+    fileExists(filePath: string): Promise<boolean>;
+}
+
+// =============================================================================
+// LocalFileProvider
+// =============================================================================
+
+/**
+ * Production `FileProvider` implementation backed by `node:fs/promises`.
+ *
+ * `writeFileAtomic` writes the payload to a sibling temp file then renames
+ * it onto the destination. The temp filename is namespaced by pid + hi-res
+ * timestamp + a small random suffix so concurrent writers within the same
+ * process do not collide on the temp path.
+ */
+export class LocalFileProvider implements FileProvider {
+    public async readFileBuffer(filePath: string): Promise<Buffer> {
+        return fs.readFile(filePath);
+    }
+
+    public async writeFileAtomic(filePath: string, data: Buffer): Promise<void> {
+        const dirPath = path.dirname(filePath);
+        await fs.mkdir(dirPath, { recursive: true });
+
+        const tempPath = path.join(
+            dirPath,
+            `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomSuffix()}.tmp`,
+        );
+        await fs.writeFile(tempPath, data);
+        try {
+            await fs.rename(tempPath, filePath);
+        } catch (err) {
+            // Best-effort cleanup; surface the rename failure as the cause.
+            await fs.unlink(tempPath).catch(() => undefined);
+            throw err;
+        }
+    }
+
+    public async fileExists(filePath: string): Promise<boolean> {
+        try {
+            await fs.access(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Short alphanumeric suffix used to defuse temp-file collisions when many
+ * writes happen within the same millisecond on the same pid. Not security
+ * sensitive; `Math.random()` is plenty for collision avoidance.
+ */
+function randomSuffix(): string {
+    return Math.random().toString(36).slice(2, 10);
+}

--- a/extensions/mssql/src/cloudDeploy/runs/index.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/index.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export * from "./types";
+export {
+    RUN_EVENTS_ENTRY,
+    RUN_MANIFEST_ENTRY,
+    RunArtifactWriter,
+    type RunArtifactWriteResult,
+} from "./runArtifactWriter";
+export { RunArtifactReader } from "./runArtifactReader";
+export {
+    RunArtifactParseError,
+    type RunArtifactIssue,
+    type RunArtifactParseErrorKind,
+    validateRunRecord,
+    validateValidationResult,
+} from "./runArtifactSchema";

--- a/extensions/mssql/src/cloudDeploy/runs/runArtifactReader.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/runArtifactReader.ts
@@ -1,0 +1,249 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — run-artifact reader.
+ *
+ * Symmetric counterpart to `RunArtifactWriter`. Loads a `.cdrun.zip` through
+ * a `FileProvider`, parses it with `yauzl.fromBuffer`, and surfaces the
+ * `RunRecord` via `read()` and the optional event log via `readEvents()`.
+ *
+ * Failure handling is fail-closed and typed:
+ *   * Any non-zip bytes → `RunArtifactParseError { kind: "malformed-zip" }`.
+ *   * Missing `manifest.json` → `kind: "missing-entry"`.
+ *   * `schemaVersion` we don't recognize → `kind: "unknown-schema-version"`.
+ *   * Anything else schema-wise → `kind: "schema-validation"` with `issues`.
+ *   * Provider I/O failure → `kind: "io"`.
+ *
+ * Diagnostic events in `events.jsonl` are best-effort: malformed lines are
+ * skipped rather than aborting the read, since events are advisory and
+ * losing one event must never make a run unreadable.
+ */
+
+import * as yauzl from "yauzl";
+
+import { DiagnosticEvent } from "../diagnostics/types";
+import { FileProvider } from "../providers";
+import { RUN_EVENTS_ENTRY, RUN_MANIFEST_ENTRY } from "./runArtifactWriter";
+import { RunRecord } from "./types";
+import { RunArtifactParseError, validateRunRecord } from "./runArtifactSchema";
+
+// =============================================================================
+// RunArtifactReader
+// =============================================================================
+
+export class RunArtifactReader {
+    public constructor(private readonly _fileProvider: FileProvider) {}
+
+    /**
+     * Reads, parses, and validates the run artifact at `artifactPath`.
+     * Throws `RunArtifactParseError` for every recoverable failure mode;
+     * inspect `.kind` to differentiate.
+     */
+    public async read(artifactPath: string): Promise<RunRecord> {
+        const buffer = await this.readBuffer(artifactPath);
+        const entries = await readZipEntries(buffer, artifactPath);
+
+        const manifestEntry = entries.get(RUN_MANIFEST_ENTRY);
+        if (manifestEntry === undefined) {
+            throw new RunArtifactParseError(
+                artifactPath,
+                "missing-entry",
+                `Run artifact at ${artifactPath} is missing the required entry '${RUN_MANIFEST_ENTRY}'.`,
+            );
+        }
+
+        let raw: unknown;
+        try {
+            raw = JSON.parse(manifestEntry.toString("utf8"));
+        } catch (err) {
+            throw new RunArtifactParseError(
+                artifactPath,
+                "schema-validation",
+                `Run artifact at ${artifactPath} has a malformed '${RUN_MANIFEST_ENTRY}' (invalid JSON).`,
+                undefined,
+                undefined,
+                err,
+            );
+        }
+
+        return validateRunRecord(raw, artifactPath);
+    }
+
+    /**
+     * Lazily yields diagnostic events from the optional `events.jsonl`
+     * entry. Returns an empty stream when the entry is absent. Malformed
+     * lines are skipped silently (events are advisory).
+     */
+    public async *readEvents(artifactPath: string): AsyncIterable<DiagnosticEvent> {
+        const buffer = await this.readBuffer(artifactPath);
+        const entries = await readZipEntries(buffer, artifactPath);
+
+        const eventsEntry = entries.get(RUN_EVENTS_ENTRY);
+        if (eventsEntry === undefined) {
+            return;
+        }
+
+        const text = eventsEntry.toString("utf8");
+        for (const line of text.split("\n")) {
+            if (line.length === 0) {
+                continue;
+            }
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(line);
+            } catch {
+                // Bad line — events are advisory, so we silently skip
+                // rather than poisoning the whole iteration.
+                continue;
+            }
+            // We trust the line shape minimally: an object with a string
+            // `type`. Full Zod validation of every event would couple this
+            // reader to the bus catalog; events are read-only history.
+            if (isLikelyEvent(parsed)) {
+                yield parsed as DiagnosticEvent;
+            }
+        }
+    }
+
+    /**
+     * Centralized read so both `read()` and `readEvents()` use the same
+     * I/O-failure mapping. ENOENT is rewrapped as `kind: "io"` (the file
+     * the caller named doesn't exist).
+     */
+    private async readBuffer(artifactPath: string): Promise<Buffer> {
+        try {
+            return await this._fileProvider.readFileBuffer(artifactPath);
+        } catch (err) {
+            throw new RunArtifactParseError(
+                artifactPath,
+                "io",
+                `Failed to read run artifact at ${artifactPath}: ${errorToMessage(err)}`,
+                undefined,
+                undefined,
+                err,
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Parses the zip buffer into a map of `entryName -> entry contents`.
+ *
+ * The Phase-3 artifact layout is small (manifest + optional events.jsonl)
+ * so buffering all entries upfront is fine; it also keeps the public
+ * surface simple — neither `read()` nor `readEvents()` has to thread a
+ * live zip handle around. If artifacts grow in a future deliverable (e.g.
+ * per-validation files), this is the obvious extraction point for
+ * a streaming entry iterator.
+ */
+function readZipEntries(buffer: Buffer, artifactPath: string): Promise<Map<string, Buffer>> {
+    return new Promise<Map<string, Buffer>>((resolve, reject) => {
+        yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zipfile) => {
+            if (err || !zipfile) {
+                reject(
+                    new RunArtifactParseError(
+                        artifactPath,
+                        "malformed-zip",
+                        `Run artifact at ${artifactPath} is not a valid zip archive.`,
+                        undefined,
+                        undefined,
+                        err ?? undefined,
+                    ),
+                );
+                return;
+            }
+
+            const entries = new Map<string, Buffer>();
+            zipfile.on("error", (zipErr) =>
+                reject(
+                    new RunArtifactParseError(
+                        artifactPath,
+                        "malformed-zip",
+                        `Run artifact at ${artifactPath} could not be parsed: ${errorToMessage(zipErr)}`,
+                        undefined,
+                        undefined,
+                        zipErr,
+                    ),
+                ),
+            );
+            zipfile.on("end", () => resolve(entries));
+
+            zipfile.on("entry", (entry: yauzl.Entry) => {
+                // Skip directories — Phase 3 layout is flat, and a stray
+                // directory entry in a malformed artifact must not stall
+                // the reader.
+                if (/\/$/.test(entry.fileName)) {
+                    zipfile.readEntry();
+                    return;
+                }
+
+                zipfile.openReadStream(entry, (streamErr, stream) => {
+                    if (streamErr || !stream) {
+                        reject(
+                            new RunArtifactParseError(
+                                artifactPath,
+                                "malformed-zip",
+                                `Run artifact at ${artifactPath} entry '${entry.fileName}' could not be opened: ${errorToMessage(streamErr)}`,
+                                undefined,
+                                undefined,
+                                streamErr ?? undefined,
+                            ),
+                        );
+                        return;
+                    }
+                    const chunks: Buffer[] = [];
+                    stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+                    stream.on("end", () => {
+                        entries.set(entry.fileName, Buffer.concat(chunks));
+                        zipfile.readEntry();
+                    });
+                    stream.on("error", (streamReadErr) =>
+                        reject(
+                            new RunArtifactParseError(
+                                artifactPath,
+                                "malformed-zip",
+                                `Run artifact at ${artifactPath} entry '${entry.fileName}' failed mid-read: ${errorToMessage(streamReadErr)}`,
+                                undefined,
+                                undefined,
+                                streamReadErr,
+                            ),
+                        ),
+                    );
+                });
+            });
+
+            zipfile.readEntry();
+        });
+    });
+}
+
+/** Lightweight shape check — an object with a non-empty string `type`. */
+function isLikelyEvent(value: unknown): boolean {
+    if (value === null || typeof value !== "object") {
+        return false;
+    }
+    const t = (value as { type?: unknown }).type;
+    return typeof t === "string" && t.length > 0;
+}
+
+/** Mirror of writer's helper; kept local to avoid cross-file coupling. */
+function errorToMessage(err: unknown): string {
+    if (err instanceof Error) {
+        return err.message;
+    }
+    if (typeof err === "string") {
+        return err;
+    }
+    try {
+        return JSON.stringify(err);
+    } catch {
+        return String(err);
+    }
+}

--- a/extensions/mssql/src/cloudDeploy/runs/runArtifactSchema.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/runArtifactSchema.ts
@@ -1,0 +1,333 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — run-artifact Zod validator.
+ *
+ * Validates the parsed JSON entries inside a `.cdrun.zip` against the
+ * `RunRecord` model. The same `passthrough()` / collect-all / jq-path
+ * conventions used by the environments validator apply here, so issues
+ * surface in a familiar shape for callers and tests.
+ *
+ * Forward compatibility is enforced at the entry point: any `schemaVersion`
+ * we don't recognize throws `RunArtifactParseError` with
+ * `kind: "unknown-schema-version"` — fail-closed so an older reader never
+ * silently mis-interprets a newer artifact.
+ */
+
+import { z } from "zod";
+
+import { ValidationType } from "../environments/types";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunRecord,
+    RunStatus,
+    ValidationResult,
+    ValidationStatus,
+} from "./types";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/** Single validation problem within a run artifact. Mirrors `EnvironmentsFileIssue`. */
+export interface RunArtifactIssue {
+    readonly path: string;
+    readonly message: string;
+    readonly severity: "error";
+}
+
+/**
+ * Kinds of failures the reader can surface. Exhaustive so callers can switch
+ * on `error.kind` for differentiated UI ("update the extension" vs.
+ * "delete the corrupt file" vs. "open it and fix this issue").
+ */
+export type RunArtifactParseErrorKind =
+    | "malformed-zip"
+    | "unknown-schema-version"
+    | "missing-entry"
+    | "schema-validation"
+    | "io";
+
+/**
+ * Thrown by the run-artifact reader for every recoverable failure path.
+ * `kind` is always populated; `issues` and `schemaVersion` are present only
+ * for the kinds that produce them.
+ */
+export class RunArtifactParseError extends Error {
+    public constructor(
+        public readonly filePath: string,
+        public readonly kind: RunArtifactParseErrorKind,
+        message: string,
+        public readonly issues?: readonly RunArtifactIssue[],
+        public readonly schemaVersion?: number,
+        public readonly cause?: unknown,
+    ) {
+        super(message);
+        this.name = "RunArtifactParseError";
+    }
+}
+
+// =============================================================================
+// Building-block schemas
+// =============================================================================
+
+/**
+ * Loose env-snapshot validator: we know the env was valid at write time
+ * (the store validates before persisting), so re-validating its full shape
+ * on read would couple us to whatever the env schema looked like at write
+ * time. Just enforce the core shape and preserve the rest verbatim.
+ */
+const EnvironmentSnapshotSchema = z
+    .object({
+        id: z.string().min(1),
+        name: z.string().min(1),
+        sourceOfTruth: z.object({ kind: z.string().min(1) }).passthrough(),
+        validations: z.array(z.unknown()),
+    })
+    .passthrough();
+
+const RunnerIdentitySchema = z
+    .object({
+        userId: z.string().min(1),
+        displayName: z.string().min(1),
+        hostKind: z.enum(["vscode", "codespaces", "github-actions"]),
+    })
+    .passthrough();
+
+const RunStatusSchema = z.nativeEnum(RunStatus);
+const ValidationStatusSchema = z.nativeEnum(ValidationStatus);
+
+// -----------------------------------------------------------------------------
+// Finding schemas
+// -----------------------------------------------------------------------------
+
+const StaticAnalysisFindingSchema = z
+    .object({
+        kind: z.literal("static-analysis"),
+        ruleId: z.string().min(1),
+        severity: z.enum(["info", "warning", "error"]),
+        message: z.string(),
+        location: z
+            .object({
+                file: z.string().min(1),
+                line: z.number().int().nonnegative().optional(),
+                column: z.number().int().nonnegative().optional(),
+            })
+            .passthrough()
+            .optional(),
+    })
+    .passthrough();
+
+const UnitTestFindingSchema = z
+    .object({
+        kind: z.literal("unit-tests"),
+        testName: z.string().min(1),
+        outcome: z.enum(["passed", "failed", "skipped", "errored"]),
+        message: z.string().optional(),
+        durationMs: z.number().nonnegative().optional(),
+    })
+    .passthrough();
+
+const WorkloadRegressionFindingSchema = z
+    .object({
+        kind: z.literal("workload-playback"),
+        stepId: z.string().min(1),
+        regression: z.enum(["throughput", "latency", "error-rate", "plan-change"]),
+        delta: z.number(),
+        message: z.string(),
+    })
+    .passthrough();
+
+// -----------------------------------------------------------------------------
+// Payload schemas
+// -----------------------------------------------------------------------------
+
+const StaticAnalysisPayloadSchema = z
+    .object({
+        validationType: z.literal(ValidationType.StaticAnalysis),
+        findings: z.array(StaticAnalysisFindingSchema),
+        summary: z
+            .object({
+                info: z.number().int().nonnegative(),
+                warning: z.number().int().nonnegative(),
+                error: z.number().int().nonnegative(),
+            })
+            .passthrough(),
+    })
+    .passthrough();
+
+const UnitTestsPayloadSchema = z
+    .object({
+        validationType: z.literal(ValidationType.UnitTests),
+        findings: z.array(UnitTestFindingSchema),
+        summary: z
+            .object({
+                total: z.number().int().nonnegative(),
+                passed: z.number().int().nonnegative(),
+                failed: z.number().int().nonnegative(),
+                skipped: z.number().int().nonnegative(),
+                errored: z.number().int().nonnegative(),
+            })
+            .passthrough(),
+    })
+    .passthrough();
+
+const WorkloadPlaybackPayloadSchema = z
+    .object({
+        validationType: z.literal(ValidationType.WorkloadPlayback),
+        findings: z.array(WorkloadRegressionFindingSchema),
+        summary: z
+            .object({
+                steps: z.number().int().nonnegative(),
+                regressions: z.number().int().nonnegative(),
+            })
+            .passthrough(),
+    })
+    .passthrough();
+
+const ValidationPayloadSchema = z.discriminatedUnion("validationType", [
+    StaticAnalysisPayloadSchema,
+    UnitTestsPayloadSchema,
+    WorkloadPlaybackPayloadSchema,
+]);
+
+// -----------------------------------------------------------------------------
+// ValidationResult & RunRecord
+// -----------------------------------------------------------------------------
+
+const ValidationResultSchema = z
+    .object({
+        validationId: z.string().min(1),
+        displayName: z.string().min(1),
+        status: ValidationStatusSchema,
+        startedAtMs: z.number().int().nonnegative(),
+        endedAtMs: z.number().int().nonnegative(),
+        payload: ValidationPayloadSchema,
+        errorMessage: z.string().optional(),
+    })
+    .passthrough();
+
+const RunRecordSchema = z
+    .object({
+        schemaVersion: z.literal(RUN_RECORD_SCHEMA_VERSION),
+        runId: z.string().min(1),
+        environmentId: z.string().min(1),
+        environmentSnapshot: EnvironmentSnapshotSchema,
+        runner: RunnerIdentitySchema,
+        startedAtMs: z.number().int().nonnegative(),
+        endedAtMs: z.number().int().nonnegative(),
+        status: RunStatusSchema,
+        validations: z.array(ValidationResultSchema),
+    })
+    .passthrough()
+    .superRefine((rec, ctx) => {
+        if (rec.environmentSnapshot.id !== rec.environmentId) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `environmentSnapshot.id (${rec.environmentSnapshot.id}) does not match environmentId (${rec.environmentId}).`,
+                path: ["environmentSnapshot", "id"],
+            });
+        }
+        if (rec.endedAtMs < rec.startedAtMs) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "endedAtMs must be >= startedAtMs.",
+                path: ["endedAtMs"],
+            });
+        }
+    });
+
+// =============================================================================
+// Public entry points
+// =============================================================================
+
+/**
+ * Validates a single parsed `ValidationResult` JSON entry. Throws
+ * `RunArtifactParseError` with `kind: "schema-validation"` on any issue.
+ *
+ * Exposed so the reader can stream validations one-at-a-time without
+ * materializing the full `RunRecord` upfront.
+ */
+export function validateValidationResult(raw: unknown, filePath: string): ValidationResult {
+    const result = ValidationResultSchema.safeParse(raw);
+    if (result.success) {
+        return result.data as unknown as ValidationResult;
+    }
+    throw buildSchemaError(result.error, filePath);
+}
+
+/**
+ * Validates a parsed `RunRecord` (the assembled manifest + validations).
+ * Forward-version detection happens BEFORE Zod parsing: we peek at
+ * `schemaVersion` and reject anything we don't understand with a typed
+ * `unknown-schema-version` error so callers can prompt the user to upgrade.
+ */
+export function validateRunRecord(raw: unknown, filePath: string): RunRecord {
+    const versionPeek = peekSchemaVersion(raw);
+    if (versionPeek !== undefined && versionPeek !== RUN_RECORD_SCHEMA_VERSION) {
+        throw new RunArtifactParseError(
+            filePath,
+            "unknown-schema-version",
+            `Run artifact at ${filePath} declares schemaVersion ${versionPeek}, expected ${RUN_RECORD_SCHEMA_VERSION}.`,
+            undefined,
+            versionPeek,
+        );
+    }
+    const result = RunRecordSchema.safeParse(raw);
+    if (result.success) {
+        return result.data as unknown as RunRecord;
+    }
+    throw buildSchemaError(result.error, filePath);
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Pulls `schemaVersion` off a raw value without committing to the full shape.
+ * Returns `undefined` if the value isn't an object or the field isn't numeric;
+ * the full validator will surface the real complaint in that case.
+ */
+function peekSchemaVersion(raw: unknown): number | undefined {
+    if (raw === null || typeof raw !== "object") {
+        return undefined;
+    }
+    const v = (raw as { schemaVersion?: unknown }).schemaVersion;
+    return typeof v === "number" ? v : undefined;
+}
+
+function buildSchemaError(error: z.ZodError, filePath: string): RunArtifactParseError {
+    const issues = mapZodErrorToIssues(error);
+    const summary = issues.map((i) => `  • ${i.path}: ${i.message}`).join("\n");
+    return new RunArtifactParseError(
+        filePath,
+        "schema-validation",
+        `Run artifact at ${filePath} has ${issues.length} issue${issues.length === 1 ? "" : "s"}:\n${summary}`,
+        issues,
+    );
+}
+
+function mapZodErrorToIssues(error: z.ZodError): RunArtifactIssue[] {
+    return error.issues.map((issue) => ({
+        path: zodPathToJqPath(issue.path),
+        message: issue.message,
+        severity: "error" as const,
+    }));
+}
+
+/** `["validations", 0, "validationId"]` -> `"$.validations[0].validationId"`. `[]` -> `"$"`. */
+function zodPathToJqPath(path: (string | number)[]): string {
+    let out = "$";
+    for (const segment of path) {
+        if (typeof segment === "number") {
+            out += `[${segment}]`;
+        } else {
+            out += `.${segment}`;
+        }
+    }
+    return out;
+}

--- a/extensions/mssql/src/cloudDeploy/runs/runArtifactWriter.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/runArtifactWriter.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — run-artifact writer.
+ *
+ * Builds a `.cdrun.zip` from a `RunRecord` plus an optional stream of
+ * diagnostic events, then persists it atomically through a `FileProvider`.
+ *
+ * Layout (locked, additive only):
+ *   * `manifest.json`        — pretty-printed `RunRecord` (authoritative).
+ *   * `events.jsonl`         — one `DiagnosticEvent` per line, NDJSON
+ *                              (omitted entirely when no events were emitted).
+ *
+ * The writer pre-validates the record against the Zod schema before it
+ * writes anything, so a buggy producer never lands a malformed artifact on
+ * disk. Success / failure is announced on the diagnostic bus when one is
+ * supplied; the bus is optional so callers can write artifacts without a
+ * bus configured (tests, future headless flows).
+ */
+
+import * as yazl from "yazl";
+
+import { DiagnosticEventBus } from "../diagnostics";
+import { DiagnosticEvent } from "../diagnostics/types";
+import { FileProvider } from "../providers";
+import { RunRecord } from "./types";
+import { validateRunRecord } from "./runArtifactSchema";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Entry name of the authoritative run-record manifest inside the zip. */
+export const RUN_MANIFEST_ENTRY = "manifest.json";
+/** Entry name of the optional diagnostic event log inside the zip. */
+export const RUN_EVENTS_ENTRY = "events.jsonl";
+
+// =============================================================================
+// RunArtifactWriter
+// =============================================================================
+
+/**
+ * Result of a successful write. `path` is the absolute destination the
+ * caller passed in; `sizeBytes` is the final zip size, which the bus also
+ * reports in the `run-persisted` event.
+ */
+export interface RunArtifactWriteResult {
+    readonly path: string;
+    readonly sizeBytes: number;
+}
+
+export class RunArtifactWriter {
+    public constructor(
+        private readonly _fileProvider: FileProvider,
+        private readonly _bus?: DiagnosticEventBus,
+    ) {}
+
+    /**
+     * Builds and persists a run artifact at `destPath`. Drains `events`
+     * synchronously (i.e. waits for the iterator to complete) before
+     * writing, so the on-disk event log is final by the time the file
+     * appears at its final path.
+     *
+     * Throws the underlying error on failure after emitting
+     * `run-persist-failed`; the partial temp file (if any) is cleaned up
+     * by `FileProvider.writeFileAtomic`.
+     */
+    public async write(
+        record: RunRecord,
+        events: AsyncIterable<DiagnosticEvent> | undefined,
+        destPath: string,
+    ): Promise<RunArtifactWriteResult> {
+        try {
+            // Pre-validate — never persist a malformed record. `safeParse`
+            // is invoked internally; this throws `RunArtifactParseError`
+            // on shape problems so the caller learns about its own bug
+            // before the artifact lands on disk.
+            validateRunRecord(record, destPath);
+
+            const eventLines = await collectEvents(events);
+            const zipBuffer = await buildZip(record, eventLines);
+
+            await this._fileProvider.writeFileAtomic(destPath, zipBuffer);
+
+            this._bus?.emit({
+                source: "run-store",
+                type: "run-persisted",
+                payload: {
+                    runId: record.runId,
+                    path: destPath,
+                    sizeBytes: zipBuffer.length,
+                },
+            });
+
+            return { path: destPath, sizeBytes: zipBuffer.length };
+        } catch (err) {
+            this._bus?.emit({
+                source: "run-store",
+                severity: "error",
+                type: "run-persist-failed",
+                payload: {
+                    runId: record.runId,
+                    path: destPath,
+                    cause: errorToMessage(err),
+                },
+            });
+            throw err;
+        }
+    }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Drains an async iterable of events into NDJSON lines. Returns an empty
+ * array when `events` is undefined so the writer can skip the entry
+ * entirely (omitting an empty events.jsonl keeps trivial artifacts smaller).
+ */
+async function collectEvents(
+    events: AsyncIterable<DiagnosticEvent> | undefined,
+): Promise<string[]> {
+    if (events === undefined) {
+        return [];
+    }
+    const lines: string[] = [];
+    for await (const event of events) {
+        lines.push(JSON.stringify(event));
+    }
+    return lines;
+}
+
+/**
+ * Builds the zip buffer in memory. We use `'data'` / `'end'` events on
+ * yazl's output stream rather than `for await`-of so this stays portable
+ * across `NodeJS.ReadableStream` typings, which don't always advertise
+ * async-iterable surface.
+ */
+function buildZip(record: RunRecord, eventLines: readonly string[]): Promise<Buffer> {
+    const zip = new yazl.ZipFile();
+    const manifestBuf = Buffer.from(JSON.stringify(record, null, 2) + "\n", "utf8");
+    zip.addBuffer(manifestBuf, RUN_MANIFEST_ENTRY);
+    if (eventLines.length > 0) {
+        const eventsBuf = Buffer.from(eventLines.join("\n") + "\n", "utf8");
+        zip.addBuffer(eventsBuf, RUN_EVENTS_ENTRY);
+    }
+    zip.end();
+
+    return new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        zip.outputStream
+            .on("data", (chunk: Buffer) => chunks.push(chunk))
+            .on("end", () => resolve(Buffer.concat(chunks)))
+            .on("error", reject);
+    });
+}
+
+/** Best-effort stringification of an unknown error, safe for the bus payload. */
+function errorToMessage(err: unknown): string {
+    if (err instanceof Error) {
+        return err.message;
+    }
+    if (typeof err === "string") {
+        return err;
+    }
+    try {
+        return JSON.stringify(err);
+    } catch {
+        return String(err);
+    }
+}

--- a/extensions/mssql/src/cloudDeploy/runs/types.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/types.ts
@@ -1,0 +1,245 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — run-record domain types.
+ *
+ * The `RunRecord` is the in-memory shape that round-trips through a
+ * persisted run artifact (`.cdrun.zip`). It captures everything we need to
+ * later render a run in the UI without re-executing validations: which
+ * environment was targeted, who ran what at what time, the aggregate
+ * status, and one `ValidationResult` per executed validation.
+ *
+ * Schema rules:
+ *   * `RUN_RECORD_SCHEMA_VERSION` is bumped only on breaking changes; readers
+ *     reject any forward version they don't understand.
+ *   * `passthrough()` everywhere in the Zod mirror (see `runArtifactSchema.ts`)
+ *     so additive forward-compatible fields don't break older readers.
+ *   * All fields are `readonly`: a `RunRecord` is a snapshot.
+ *
+ * Validation payload shapes live in this file as a discriminated union keyed
+ * on `validationType`, so the writer/reader can rely on Zod to narrow without
+ * any manual instanceof / typeof gymnastics.
+ */
+
+import { Environment, ValidationType } from "../environments/types";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Bumped on breaking changes to the on-disk run artifact format. */
+export const RUN_RECORD_SCHEMA_VERSION = 1 as const;
+
+// =============================================================================
+// Enums
+// =============================================================================
+
+/**
+ * Overall status of a run, computed by collapsing all per-validation statuses
+ * via `RUN_STATUS_PRIORITY` (worst wins). Listed least- to most-severe.
+ */
+export enum RunStatus {
+    Passed = "passed",
+    Skipped = "skipped",
+    Warning = "warning",
+    Failed = "failed",
+    Errored = "errored",
+}
+
+/**
+ * Per-status severity rank. Higher value = worse outcome. Aggregation picks
+ * the validation with the highest rank as the run-level `RunStatus`.
+ *
+ * `Object.freeze` prevents accidental mutation of shared module-level state
+ * by callers (a real bug class once the store starts copying these constants
+ * into telemetry payloads).
+ */
+export const RUN_STATUS_PRIORITY: Readonly<Record<RunStatus, number>> = Object.freeze({
+    [RunStatus.Passed]: 0,
+    [RunStatus.Skipped]: 1,
+    [RunStatus.Warning]: 2,
+    [RunStatus.Failed]: 3,
+    [RunStatus.Errored]: 4,
+});
+
+/** Status of a single validation execution. Mirrors `RunStatus` semantics. */
+export enum ValidationStatus {
+    Passed = "passed",
+    Skipped = "skipped",
+    Warning = "warning",
+    Failed = "failed",
+    Errored = "errored",
+}
+
+// =============================================================================
+// Runner identity
+// =============================================================================
+
+/**
+ * Identifies who/what initiated a run. `userId` is a stable, non-PII handle
+ * (e.g. the VS Code `machineId` or a hashed account id); `displayName` is
+ * what the UI surfaces. `hostKind` exists so future Codespaces / GitHub
+ * Actions launches can be distinguished from a local VS Code workspace.
+ */
+export interface RunnerIdentity {
+    readonly userId: string;
+    readonly displayName: string;
+    readonly hostKind: "vscode" | "codespaces" | "github-actions";
+}
+
+// =============================================================================
+// Findings
+// =============================================================================
+
+/**
+ * Closed discriminated union of every finding the UI can render. The
+ * discriminator is `kind`, matching the corresponding `ValidationType`.
+ *
+ * Findings are validation-shaped, not test-runner-shaped: a "test failure"
+ * inside a unit-test run is `UnitTestFinding`, not a generic message blob.
+ * That gives the renderer a typed surface without inspecting magic strings.
+ */
+export type Finding = StaticAnalysisFinding | UnitTestFinding | WorkloadRegressionFinding;
+
+export interface StaticAnalysisFinding {
+    readonly kind: "static-analysis";
+    /** Rule identifier (e.g. an SQL linter rule code). */
+    readonly ruleId: string;
+    /** Severity within the rule's vocabulary. */
+    readonly severity: "info" | "warning" | "error";
+    /** Human-readable description; not localized — emitted by the analyzer. */
+    readonly message: string;
+    /** Optional source location for navigation. */
+    readonly location?: {
+        readonly file: string;
+        readonly line?: number;
+        readonly column?: number;
+    };
+}
+
+export interface UnitTestFinding {
+    readonly kind: "unit-tests";
+    /** Fully-qualified test name (suite + test). */
+    readonly testName: string;
+    readonly outcome: "passed" | "failed" | "skipped" | "errored";
+    /** Failure message when `outcome !== "passed"`. */
+    readonly message?: string;
+    /** Wall-clock duration; useful for perf regressions but not authoritative. */
+    readonly durationMs?: number;
+}
+
+export interface WorkloadRegressionFinding {
+    readonly kind: "workload-playback";
+    /** Workload step / query identifier. */
+    readonly stepId: string;
+    /** What changed vs. baseline. */
+    readonly regression: "throughput" | "latency" | "error-rate" | "plan-change";
+    /** Numeric delta (interpretation depends on `regression`). */
+    readonly delta: number;
+    /** Free-form description for the UI; emitted by the workload runner. */
+    readonly message: string;
+}
+
+// =============================================================================
+// Validation payloads
+// =============================================================================
+
+/**
+ * Discriminated union of per-validation payloads. The discriminator is
+ * `validationType`, matching `ValidationType` from the env model. This lets
+ * a single `ValidationResult.payload` be exhaustively narrowed without
+ * runtime type checks.
+ */
+export type ValidationPayload = StaticAnalysisPayload | UnitTestsPayload | WorkloadPlaybackPayload;
+
+export interface StaticAnalysisPayload {
+    readonly validationType: ValidationType.StaticAnalysis;
+    readonly findings: readonly StaticAnalysisFinding[];
+    /** Aggregate counts; pre-computed so the UI doesn't recount. */
+    readonly summary: {
+        readonly info: number;
+        readonly warning: number;
+        readonly error: number;
+    };
+}
+
+export interface UnitTestsPayload {
+    readonly validationType: ValidationType.UnitTests;
+    readonly findings: readonly UnitTestFinding[];
+    readonly summary: {
+        readonly total: number;
+        readonly passed: number;
+        readonly failed: number;
+        readonly skipped: number;
+        readonly errored: number;
+    };
+}
+
+export interface WorkloadPlaybackPayload {
+    readonly validationType: ValidationType.WorkloadPlayback;
+    readonly findings: readonly WorkloadRegressionFinding[];
+    /** Aggregate counts; pre-computed for fast UI rendering. */
+    readonly summary: {
+        readonly steps: number;
+        readonly regressions: number;
+    };
+}
+
+// =============================================================================
+// ValidationResult
+// =============================================================================
+
+/**
+ * One executed validation within a run. Owns its own status, timestamps,
+ * and payload. Persisted as a separate entry inside the run artifact zip
+ * (`validations/{validationId}.json`) so partial reads — e.g. "show me only
+ * the static-analysis result" — are cheap.
+ */
+export interface ValidationResult {
+    /** Stable id within the run (typically the validation's id from the env config). */
+    readonly validationId: string;
+    /** Human-friendly label, copied from the env at run-start time. */
+    readonly displayName: string;
+    readonly status: ValidationStatus;
+    readonly startedAtMs: number;
+    readonly endedAtMs: number;
+    readonly payload: ValidationPayload;
+    /**
+     * Optional terse error message when `status === "errored"`. Distinct from
+     * `payload.findings`: this is "the validation runner itself crashed",
+     * not "the validation found N problems".
+     */
+    readonly errorMessage?: string;
+}
+
+// =============================================================================
+// RunRecord
+// =============================================================================
+
+/**
+ * Top-level run-record shape: one of these per persisted run artifact.
+ *
+ * `environmentSnapshot` is the FULL env value at the moment the run started,
+ * captured by deep-copy. The env may have been edited or deleted since;
+ * the snapshot preserves the historical context the run was executed in.
+ */
+export interface RunRecord {
+    /** Always equals `RUN_RECORD_SCHEMA_VERSION` at write time. */
+    readonly schemaVersion: typeof RUN_RECORD_SCHEMA_VERSION;
+    /** Stable, globally-unique run id (UUID). */
+    readonly runId: string;
+    /** The env id this run targeted. Matches `environmentSnapshot.id`. */
+    readonly environmentId: string;
+    /** Frozen copy of the targeted env at run-start time. */
+    readonly environmentSnapshot: Environment;
+    readonly runner: RunnerIdentity;
+    readonly startedAtMs: number;
+    readonly endedAtMs: number;
+    /** Aggregate status across all `validations`. */
+    readonly status: RunStatus;
+    /** One entry per validation that executed. May be empty for an aborted run. */
+    readonly validations: readonly ValidationResult[];
+}

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -3852,3 +3852,58 @@ export class ServiceClient {
 
     public static installFailedStatusText = l10n.t("Service installation failed.");
 }
+
+export class CloudDeployRuns {
+    public static malformedZip(filePath: string): string {
+        return l10n.t({
+            message: "Run artifact at {0} is not a valid zip archive.",
+            args: [filePath],
+            comment: ["{0} is the absolute file path of the run artifact"],
+        });
+    }
+
+    public static unknownSchemaVersion(filePath: string, version: number): string {
+        return l10n.t({
+            message:
+                "Run artifact at {0} declares schema version {1}, which this version of the extension does not understand. Update the extension to read it.",
+            args: [filePath, version],
+            comment: [
+                "{0} is the absolute file path of the run artifact",
+                "{1} is the unsupported schema version number",
+            ],
+        });
+    }
+
+    public static missingEntry(filePath: string, entryName: string): string {
+        return l10n.t({
+            message: "Run artifact at {0} is missing the required entry '{1}'.",
+            args: [filePath, entryName],
+            comment: [
+                "{0} is the absolute file path of the run artifact",
+                "{1} is the name of the missing entry inside the zip",
+            ],
+        });
+    }
+
+    public static schemaValidationFailed(filePath: string, issueCount: number): string {
+        return l10n.t({
+            message: "Run artifact at {0} failed schema validation with {1} issue(s).",
+            args: [filePath, issueCount],
+            comment: [
+                "{0} is the absolute file path of the run artifact",
+                "{1} is the count of validation issues",
+            ],
+        });
+    }
+
+    public static ioError(filePath: string, message: string): string {
+        return l10n.t({
+            message: "Failed to read run artifact at {0}: {1}",
+            args: [filePath, message],
+            comment: [
+                "{0} is the absolute file path of the run artifact",
+                "{1} is the underlying I/O error message",
+            ],
+        });
+    }
+}

--- a/extensions/mssql/test/unit/cloudDeployProviders.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployProviders.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { LocalFileProvider } from "../../src/cloudDeploy/providers";
+
+suite("CloudDeploy LocalFileProvider", () => {
+    let root: string;
+    let provider: LocalFileProvider;
+
+    setup(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), "mssql-fileprov-"));
+        provider = new LocalFileProvider();
+    });
+
+    teardown(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    suite("readFileBuffer", () => {
+        test("returns the file contents as a Buffer", async () => {
+            const filePath = path.join(root, "a.bin");
+            await fs.writeFile(filePath, Buffer.from([1, 2, 3]));
+            const data = await provider.readFileBuffer(filePath);
+            expect(Buffer.isBuffer(data)).to.be.true;
+            expect(Array.from(data)).to.deep.equal([1, 2, 3]);
+        });
+
+        test("throws ENOENT-shaped error when the file is missing", async () => {
+            let caught: NodeJS.ErrnoException | undefined;
+            try {
+                await provider.readFileBuffer(path.join(root, "missing.bin"));
+            } catch (err) {
+                caught = err as NodeJS.ErrnoException;
+            }
+            expect(caught).to.exist;
+            expect(caught!.code).to.equal("ENOENT");
+        });
+    });
+
+    suite("writeFileAtomic", () => {
+        test("creates the parent directory on demand", async () => {
+            const target = path.join(root, "nested", "deep", "out.bin");
+            await provider.writeFileAtomic(target, Buffer.from("hi"));
+            const stat = await fs.stat(target);
+            expect(stat.isFile()).to.be.true;
+        });
+
+        test("leaves no temp files behind on success", async () => {
+            const target = path.join(root, "out.bin");
+            await provider.writeFileAtomic(target, Buffer.from("hi"));
+            const entries = await fs.readdir(root);
+            expect(entries).to.deep.equal(["out.bin"]);
+        });
+
+        test("overwrites prior contents fully (no partial state)", async () => {
+            const target = path.join(root, "out.bin");
+            await provider.writeFileAtomic(target, Buffer.from("first"));
+            await provider.writeFileAtomic(target, Buffer.from("second"));
+            const back = await fs.readFile(target, { encoding: "utf8" });
+            expect(back).to.equal("second");
+        });
+    });
+
+    suite("fileExists", () => {
+        test("returns true for a present file", async () => {
+            const target = path.join(root, "x");
+            await fs.writeFile(target, "x");
+            expect(await provider.fileExists(target)).to.be.true;
+        });
+
+        test("returns false for a missing file (no throw)", async () => {
+            expect(await provider.fileExists(path.join(root, "nope"))).to.be.false;
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunArtifactReader.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunArtifactReader.test.ts
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as yazl from "yazl";
+
+import { DiagnosticEvent } from "../../src/cloudDeploy/diagnostics/types";
+import { RunArtifactReader } from "../../src/cloudDeploy/runs/runArtifactReader";
+import {
+    RUN_EVENTS_ENTRY,
+    RUN_MANIFEST_ENTRY,
+    RunArtifactWriter,
+} from "../../src/cloudDeploy/runs/runArtifactWriter";
+import { RunArtifactParseError } from "../../src/cloudDeploy/runs/runArtifactSchema";
+import { RUN_RECORD_SCHEMA_VERSION } from "../../src/cloudDeploy/runs/types";
+import { FakeFileProvider, makeValidRunRecord } from "./cloudDeployRunsTestHelpers";
+
+const ARTIFACT_PATH = "/artifacts/run.cdrun.zip";
+
+/** Build a zip in memory and seed it into a FakeFileProvider at `ARTIFACT_PATH`. */
+async function seedZip(
+    provider: FakeFileProvider,
+    entries: Array<{ name: string; data: Buffer }>,
+): Promise<void> {
+    const zip = new yazl.ZipFile();
+    for (const e of entries) {
+        zip.addBuffer(e.data, e.name);
+    }
+    zip.end();
+    const buf = await new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        zip.outputStream
+            .on("data", (c: Buffer) => chunks.push(c))
+            .on("end", () => resolve(Buffer.concat(chunks)))
+            .on("error", reject);
+    });
+    provider.files.set(ARTIFACT_PATH, buf);
+}
+
+async function readErr<T>(p: Promise<T>): Promise<RunArtifactParseError> {
+    try {
+        await p;
+    } catch (err) {
+        if (err instanceof RunArtifactParseError) {
+            return err;
+        }
+        throw err;
+    }
+    throw new Error("Expected RunArtifactParseError but no error was thrown.");
+}
+
+suite("CloudDeploy RunArtifactReader", () => {
+    let provider: FakeFileProvider;
+    let reader: RunArtifactReader;
+
+    setup(() => {
+        provider = new FakeFileProvider();
+        reader = new RunArtifactReader(provider);
+    });
+
+    suite("read() — happy path", () => {
+        test("reads a writer-produced artifact end-to-end", async () => {
+            const writer = new RunArtifactWriter(provider);
+            const record = makeValidRunRecord({ runId: "happy-1" });
+            await writer.write(record, undefined, ARTIFACT_PATH);
+
+            const back = await reader.read(ARTIFACT_PATH);
+            expect(back.runId).to.equal("happy-1");
+            expect(back.environmentSnapshot.id).to.equal(record.environmentSnapshot.id);
+        });
+
+        test("preserves passthrough fields in the manifest", async () => {
+            const record = { ...makeValidRunRecord(), futureField: "v2" };
+            const manifest = Buffer.from(JSON.stringify(record));
+            await seedZip(provider, [{ name: RUN_MANIFEST_ENTRY, data: manifest }]);
+
+            const back = await reader.read(ARTIFACT_PATH);
+            expect((back as unknown as { futureField: string }).futureField).to.equal("v2");
+        });
+    });
+
+    suite("read() — failure modes (kind exhaustive)", () => {
+        test("kind=io when the file does not exist", async () => {
+            const err = await readErr(reader.read("/missing.cdrun.zip"));
+            expect(err.kind).to.equal("io");
+            expect(err.filePath).to.equal("/missing.cdrun.zip");
+        });
+
+        test("kind=malformed-zip when the bytes are not a zip", async () => {
+            provider.files.set(ARTIFACT_PATH, Buffer.from("not a zip"));
+            const err = await readErr(reader.read(ARTIFACT_PATH));
+            expect(err.kind).to.equal("malformed-zip");
+        });
+
+        test("kind=missing-entry when manifest.json is absent", async () => {
+            await seedZip(provider, [{ name: RUN_EVENTS_ENTRY, data: Buffer.from("{}\n") }]);
+            const err = await readErr(reader.read(ARTIFACT_PATH));
+            expect(err.kind).to.equal("missing-entry");
+        });
+
+        test("kind=schema-validation when manifest.json is invalid JSON", async () => {
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from("{ not json") },
+            ]);
+            const err = await readErr(reader.read(ARTIFACT_PATH));
+            expect(err.kind).to.equal("schema-validation");
+        });
+
+        test("kind=unknown-schema-version when schemaVersion is forward", async () => {
+            const record = { ...makeValidRunRecord(), schemaVersion: 99 };
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+            ]);
+            const err = await readErr(reader.read(ARTIFACT_PATH));
+            expect(err.kind).to.equal("unknown-schema-version");
+            expect(err.schemaVersion).to.equal(99);
+        });
+
+        test("kind=schema-validation populates issues[] with jq paths", async () => {
+            const record = { ...makeValidRunRecord(), runId: "" };
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+            ]);
+            const err = await readErr(reader.read(ARTIFACT_PATH));
+            expect(err.kind).to.equal("schema-validation");
+            expect(err.issues).to.exist;
+            expect(err.issues!.some((i) => i.path === "$.runId")).to.be.true;
+        });
+
+        test("sanity: RUN_RECORD_SCHEMA_VERSION is 1 (gate for forward-version test)", () => {
+            expect(RUN_RECORD_SCHEMA_VERSION).to.equal(1);
+        });
+    });
+
+    suite("readEvents()", () => {
+        test("yields nothing when events.jsonl is absent", async () => {
+            const record = makeValidRunRecord();
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+            ]);
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents(ARTIFACT_PATH)) {
+                collected.push(ev);
+            }
+            expect(collected).to.deep.equal([]);
+        });
+
+        test("yields one event per NDJSON line", async () => {
+            const record = makeValidRunRecord();
+            const events = [
+                {
+                    id: "e-1",
+                    timestampMs: 1,
+                    source: "environment-store",
+                    severity: "info",
+                    type: "environments-loaded",
+                    payload: { count: 0 },
+                },
+                {
+                    id: "e-2",
+                    timestampMs: 2,
+                    source: "run-store",
+                    severity: "info",
+                    type: "run-persisted",
+                    payload: { runId: "r", path: "/p", sizeBytes: 1 },
+                },
+            ];
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+                {
+                    name: RUN_EVENTS_ENTRY,
+                    data: Buffer.from(events.map((e) => JSON.stringify(e)).join("\n") + "\n"),
+                },
+            ]);
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents(ARTIFACT_PATH)) {
+                collected.push(ev);
+            }
+            expect(collected.map((e) => e.type)).to.deep.equal([
+                "environments-loaded",
+                "run-persisted",
+            ]);
+        });
+
+        test("skips malformed lines silently (events are advisory)", async () => {
+            const record = makeValidRunRecord();
+            const goodLine = JSON.stringify({
+                id: "ok",
+                timestampMs: 1,
+                source: "environment-store",
+                severity: "info",
+                type: "environments-loaded",
+                payload: { count: 0 },
+            });
+            const events = `${goodLine}\n{not json\n${goodLine}\n`;
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+                { name: RUN_EVENTS_ENTRY, data: Buffer.from(events) },
+            ]);
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents(ARTIFACT_PATH)) {
+                collected.push(ev);
+            }
+            expect(collected).to.have.lengthOf(2);
+        });
+
+        test("skips non-object event lines (best-effort shape check)", async () => {
+            const record = makeValidRunRecord();
+            const events = `"a string"\n123\nnull\n`;
+            await seedZip(provider, [
+                { name: RUN_MANIFEST_ENTRY, data: Buffer.from(JSON.stringify(record)) },
+                { name: RUN_EVENTS_ENTRY, data: Buffer.from(events) },
+            ]);
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents(ARTIFACT_PATH)) {
+                collected.push(ev);
+            }
+            expect(collected).to.deep.equal([]);
+        });
+
+        test("rewraps I/O failures as kind=io", async () => {
+            const err = await readErr(
+                (async () => {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    for await (const _ev of reader.readEvents("/missing.cdrun.zip")) {
+                        // unreachable
+                    }
+                })(),
+            );
+            expect(err.kind).to.equal("io");
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunArtifactSchema.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunArtifactSchema.test.ts
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunStatus,
+    ValidationStatus,
+} from "../../src/cloudDeploy/runs/types";
+import {
+    RunArtifactParseError,
+    validateRunRecord,
+    validateValidationResult,
+} from "../../src/cloudDeploy/runs/runArtifactSchema";
+import { makeUnitTestsValidation, makeValidRunRecord } from "./cloudDeployRunsTestHelpers";
+
+const FILE_PATH = "/tmp/run.cdrun.zip";
+
+function expectThrows(raw: unknown, assert: (err: RunArtifactParseError) => void): void {
+    let caught: unknown;
+    try {
+        validateRunRecord(raw, FILE_PATH);
+    } catch (err) {
+        caught = err;
+    }
+    expect(caught).to.be.instanceOf(RunArtifactParseError);
+    assert(caught as RunArtifactParseError);
+}
+
+suite("CloudDeploy RunArtifactSchema", () => {
+    suite("validateRunRecord — happy path", () => {
+        test("accepts a minimal valid record", () => {
+            const record = makeValidRunRecord();
+            const validated = validateRunRecord(record, FILE_PATH);
+            expect(validated.runId).to.equal("run-1");
+            expect(validated.status).to.equal(RunStatus.Passed);
+            expect(validated.validations).to.have.lengthOf(1);
+        });
+
+        test("preserves unknown top-level fields (forward-compat passthrough)", () => {
+            const raw = { ...makeValidRunRecord(), futureField: "keep me" };
+            const validated = validateRunRecord(raw, FILE_PATH) as unknown as Record<
+                string,
+                unknown
+            >;
+            expect(validated.futureField).to.equal("keep me");
+        });
+
+        test("accepts an empty validations array", () => {
+            const record = makeValidRunRecord({ validations: [] });
+            const validated = validateRunRecord(record, FILE_PATH);
+            expect(validated.validations).to.deep.equal([]);
+        });
+    });
+
+    suite("validateRunRecord — schemaVersion gate", () => {
+        test("rejects an unknown forward schemaVersion with kind 'unknown-schema-version'", () => {
+            const raw = { ...makeValidRunRecord(), schemaVersion: 99 };
+            expectThrows(raw, (err) => {
+                expect(err.kind).to.equal("unknown-schema-version");
+                expect(err.schemaVersion).to.equal(99);
+                expect(err.issues).to.be.undefined;
+            });
+        });
+
+        test("rejects a missing schemaVersion via schema-validation, not version gate", () => {
+            const raw = { ...makeValidRunRecord() } as Record<string, unknown>;
+            delete raw.schemaVersion;
+            expectThrows(raw, (err) => {
+                expect(err.kind).to.equal("schema-validation");
+                expect(err.issues).to.exist;
+                expect(err.issues!.some((i) => i.path === "$.schemaVersion")).to.be.true;
+            });
+        });
+    });
+
+    suite("validateRunRecord — shape errors collect every issue", () => {
+        test("rejects non-object root", () => {
+            expectThrows("not an object", (err) => {
+                expect(err.kind).to.equal("schema-validation");
+                expect(err.issues!.some((i) => i.path === "$")).to.be.true;
+            });
+        });
+
+        test("flags every missing required top-level field at once", () => {
+            expectThrows({ schemaVersion: RUN_RECORD_SCHEMA_VERSION }, (err) => {
+                const paths = new Set((err.issues ?? []).map((i) => i.path));
+                expect(paths).to.include("$.runId");
+                expect(paths).to.include("$.environmentId");
+                expect(paths).to.include("$.environmentSnapshot");
+                expect(paths).to.include("$.runner");
+                expect(paths).to.include("$.startedAtMs");
+                expect(paths).to.include("$.endedAtMs");
+                expect(paths).to.include("$.status");
+                expect(paths).to.include("$.validations");
+            });
+        });
+
+        test("rejects environmentSnapshot.id mismatching environmentId", () => {
+            const record = makeValidRunRecord({ environmentId: "different" });
+            expectThrows(record, (err) => {
+                expect(err.kind).to.equal("schema-validation");
+                expect(err.issues!.some((i) => i.path === "$.environmentSnapshot.id")).to.be.true;
+            });
+        });
+
+        test("rejects endedAtMs < startedAtMs", () => {
+            const record = makeValidRunRecord({ startedAtMs: 5_000, endedAtMs: 1_000 });
+            expectThrows(record, (err) => {
+                expect(err.issues!.some((i) => i.path === "$.endedAtMs")).to.be.true;
+            });
+        });
+
+        test("rejects an unknown run status", () => {
+            const record = { ...makeValidRunRecord(), status: "not-a-status" };
+            expectThrows(record, (err) => {
+                expect(err.issues!.some((i) => i.path === "$.status")).to.be.true;
+            });
+        });
+    });
+
+    suite("validateRunRecord — validation payload discrimination", () => {
+        test("narrows by validationType (UnitTests payload accepted)", () => {
+            const record = makeValidRunRecord({
+                validations: [
+                    makeUnitTestsValidation({
+                        payload: {
+                            validationType: ValidationType.UnitTests,
+                            findings: [
+                                {
+                                    kind: "unit-tests",
+                                    testName: "suite.it works",
+                                    outcome: "passed",
+                                },
+                            ],
+                            summary: {
+                                total: 1,
+                                passed: 1,
+                                failed: 0,
+                                skipped: 0,
+                                errored: 0,
+                            },
+                        },
+                    }),
+                ],
+            });
+            const validated = validateRunRecord(record, FILE_PATH);
+            expect(validated.validations[0].payload.validationType).to.equal(
+                ValidationType.UnitTests,
+            );
+        });
+
+        test("rejects a payload whose finding kind doesn't match validationType", () => {
+            const record = makeValidRunRecord({
+                validations: [
+                    makeUnitTestsValidation({
+                        payload: {
+                            validationType: ValidationType.UnitTests,
+                            // wrong finding kind for this payload
+                            findings: [
+                                {
+                                    kind: "static-analysis",
+                                    ruleId: "rule-1",
+                                    severity: "error",
+                                    message: "oops",
+                                } as never,
+                            ],
+                            summary: {
+                                total: 0,
+                                passed: 0,
+                                failed: 0,
+                                skipped: 0,
+                                errored: 0,
+                            },
+                        },
+                    }),
+                ],
+            });
+            expectThrows(record, (err) => {
+                expect(err.kind).to.equal("schema-validation");
+                // Reports under the validation's findings array.
+                expect(
+                    err.issues!.some((i) =>
+                        i.path.startsWith("$.validations[0].payload.findings[0]"),
+                    ),
+                ).to.be.true;
+            });
+        });
+
+        test("rejects an unknown validationType discriminator", () => {
+            const record = makeValidRunRecord({
+                validations: [
+                    {
+                        validationId: "v",
+                        displayName: "v",
+                        status: ValidationStatus.Passed,
+                        startedAtMs: 0,
+                        endedAtMs: 0,
+                        payload: {
+                            validationType: "bogus",
+                            findings: [],
+                            summary: {},
+                        } as never,
+                    },
+                ],
+            });
+            expectThrows(record, (err) => {
+                expect(err.issues!.some((i) => i.path.startsWith("$.validations[0].payload"))).to.be
+                    .true;
+            });
+        });
+    });
+
+    suite("validateValidationResult", () => {
+        test("accepts a valid single result", () => {
+            const result = validateValidationResult(makeUnitTestsValidation(), FILE_PATH);
+            expect(result.validationId).to.equal("unit-tests-1");
+        });
+
+        test("throws schema-validation error on a malformed result", () => {
+            let caught: unknown;
+            try {
+                validateValidationResult({ validationId: 1 }, FILE_PATH);
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught).to.be.instanceOf(RunArtifactParseError);
+            expect((caught as RunArtifactParseError).kind).to.equal("schema-validation");
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunArtifactWriter.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunArtifactWriter.test.ts
@@ -1,0 +1,203 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+import { DiagnosticEvent } from "../../src/cloudDeploy/diagnostics/types";
+import { LocalFileProvider } from "../../src/cloudDeploy/providers";
+import {
+    RUN_EVENTS_ENTRY,
+    RUN_MANIFEST_ENTRY,
+    RunArtifactWriter,
+} from "../../src/cloudDeploy/runs/runArtifactWriter";
+import { RunArtifactReader } from "../../src/cloudDeploy/runs/runArtifactReader";
+import { RunArtifactParseError } from "../../src/cloudDeploy/runs/runArtifactSchema";
+import { FakeFileProvider, makeValidRunRecord } from "./cloudDeployRunsTestHelpers";
+import { TestEventCollector } from "./cloudDeployTestEventCollector";
+
+async function* emptyEvents(): AsyncIterable<DiagnosticEvent> {
+    // empty
+}
+
+async function* fixedEvents(...events: DiagnosticEvent[]): AsyncIterable<DiagnosticEvent> {
+    for (const e of events) {
+        yield e;
+    }
+}
+
+suite("CloudDeploy RunArtifactWriter", () => {
+    suite("in-memory writes (FakeFileProvider)", () => {
+        let provider: FakeFileProvider;
+        let writer: RunArtifactWriter;
+        let bus: DiagnosticEventBus;
+        let collector: TestEventCollector;
+
+        setup(() => {
+            provider = new FakeFileProvider();
+            bus = new DiagnosticEventBus();
+            collector = new TestEventCollector(bus);
+            writer = new RunArtifactWriter(provider, bus);
+        });
+
+        teardown(() => {
+            collector.dispose();
+            bus.dispose();
+        });
+
+        test("persists a single zip file at destPath", async () => {
+            const record = makeValidRunRecord();
+            const result = await writer.write(record, undefined, "/artifacts/run-1.cdrun.zip");
+            expect(result.path).to.equal("/artifacts/run-1.cdrun.zip");
+            expect(result.sizeBytes).to.be.greaterThan(0);
+            expect(provider.files.has("/artifacts/run-1.cdrun.zip")).to.be.true;
+            expect(provider.files.get("/artifacts/run-1.cdrun.zip")!.length).to.equal(
+                result.sizeBytes,
+            );
+        });
+
+        test("emits run-persisted with runId, path, and sizeBytes", async () => {
+            const record = makeValidRunRecord({ runId: "abc" });
+            const result = await writer.write(record, emptyEvents(), "/out.cdrun.zip");
+            const emitted = collector.eventsOfType("run-persisted");
+            expect(emitted).to.have.lengthOf(1);
+            expect(emitted[0].payload.runId).to.equal("abc");
+            expect(emitted[0].payload.path).to.equal("/out.cdrun.zip");
+            expect(emitted[0].payload.sizeBytes).to.equal(result.sizeBytes);
+        });
+
+        test("round-trips through the reader (record body matches)", async () => {
+            const record = makeValidRunRecord({ runId: "rt-1" });
+            await writer.write(record, undefined, "/out.cdrun.zip");
+            const reader = new RunArtifactReader(provider);
+            const readBack = await reader.read("/out.cdrun.zip");
+            expect(readBack.runId).to.equal("rt-1");
+            expect(readBack.environmentSnapshot.id).to.equal(record.environmentSnapshot.id);
+        });
+
+        test("round-trips drained events through readEvents()", async () => {
+            const record = makeValidRunRecord();
+            const stamped: DiagnosticEvent = {
+                id: "e-1",
+                timestampMs: 1234,
+                source: "environment-store",
+                severity: "info",
+                type: "environments-loaded",
+                payload: { count: 0 },
+            };
+            await writer.write(record, fixedEvents(stamped), "/out.cdrun.zip");
+
+            const reader = new RunArtifactReader(provider);
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents("/out.cdrun.zip")) {
+                collected.push(ev);
+            }
+            expect(collected).to.have.lengthOf(1);
+            expect(collected[0].type).to.equal("environments-loaded");
+        });
+
+        test("omits events.jsonl entirely when no events were drained", async () => {
+            const record = makeValidRunRecord();
+            await writer.write(record, undefined, "/out.cdrun.zip");
+            const reader = new RunArtifactReader(provider);
+            // readEvents() yields nothing when the entry is absent.
+            const collected: DiagnosticEvent[] = [];
+            for await (const ev of reader.readEvents("/out.cdrun.zip")) {
+                collected.push(ev);
+            }
+            expect(collected).to.deep.equal([]);
+        });
+
+        test("entry names are exactly manifest.json (and events.jsonl when present)", async () => {
+            // Sanity: writer is the only place these constants are produced.
+            expect(RUN_MANIFEST_ENTRY).to.equal("manifest.json");
+            expect(RUN_EVENTS_ENTRY).to.equal("events.jsonl");
+        });
+
+        test("emits run-persist-failed and throws on a malformed record", async () => {
+            // Pre-validation should reject and emit the failure event.
+            const bad = { ...makeValidRunRecord(), runId: "" };
+            let caught: unknown;
+            try {
+                await writer.write(bad as never, undefined, "/out.cdrun.zip");
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught).to.be.instanceOf(RunArtifactParseError);
+            const failed = collector.eventsOfType("run-persist-failed");
+            expect(failed).to.have.lengthOf(1);
+            expect(failed[0].payload.path).to.equal("/out.cdrun.zip");
+        });
+
+        test("emits run-persist-failed when the provider write throws", async () => {
+            const throwingProvider: FakeFileProvider = new FakeFileProvider();
+            // Stub writeFileAtomic to fail.
+            throwingProvider.writeFileAtomic = async () => {
+                throw new Error("disk full");
+            };
+            const failingWriter = new RunArtifactWriter(throwingProvider, bus);
+
+            let caught: unknown;
+            try {
+                await failingWriter.write(makeValidRunRecord(), undefined, "/out.cdrun.zip");
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught).to.be.instanceOf(Error);
+            expect((caught as Error).message).to.equal("disk full");
+            const failed = collector.eventsOfType("run-persist-failed");
+            expect(failed).to.have.lengthOf(1);
+            expect(failed[0].payload.cause).to.equal("disk full");
+        });
+
+        test("works with no bus configured (optional dep)", async () => {
+            const noBusWriter = new RunArtifactWriter(provider);
+            const result = await noBusWriter.write(
+                makeValidRunRecord(),
+                undefined,
+                "/no-bus.cdrun.zip",
+            );
+            expect(result.sizeBytes).to.be.greaterThan(0);
+        });
+    });
+
+    suite("disk writes (LocalFileProvider)", () => {
+        let workspaceRoot: string;
+
+        setup(async () => {
+            workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mssql-runwriter-"));
+        });
+
+        teardown(async () => {
+            await fs.rm(workspaceRoot, { recursive: true, force: true });
+        });
+
+        test("writes a single .cdrun.zip with no leftover temp files", async () => {
+            const writer = new RunArtifactWriter(new LocalFileProvider());
+            const dest = path.join(workspaceRoot, "nested", "run-1.cdrun.zip");
+            await writer.write(makeValidRunRecord(), undefined, dest);
+
+            const stat = await fs.stat(dest);
+            expect(stat.isFile()).to.be.true;
+            expect(stat.size).to.be.greaterThan(0);
+
+            const entries = await fs.readdir(path.dirname(dest));
+            expect(entries).to.deep.equal(["run-1.cdrun.zip"]);
+        });
+
+        test("the written file is a real zip (yauzl can parse it)", async () => {
+            const writer = new RunArtifactWriter(new LocalFileProvider());
+            const dest = path.join(workspaceRoot, "run.cdrun.zip");
+            await writer.write(makeValidRunRecord({ runId: "real-1" }), undefined, dest);
+
+            const reader = new RunArtifactReader(new LocalFileProvider());
+            const record = await reader.read(dest);
+            expect(record.runId).to.equal("real-1");
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunsTestHelpers.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunsTestHelpers.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — run-tests shared helpers.
+ *
+ * Reusable plumbing for D3 unit tests:
+ *   * `FakeFileProvider`: in-memory `FileProvider` so writer/reader round
+ *     trips happen with zero disk I/O. Mirrors `LocalFileProvider` semantics
+ *     (ENOENT shape on missing reads; "atomic" writes are trivially atomic
+ *     in memory).
+ *   * `makeValidRunRecord`: tiny builder for a passing `RunRecord` that
+ *     satisfies the Zod schema. Tests override only the fields they care
+ *     about so the noise stays out of each individual test.
+ */
+
+import { FileProvider } from "../../src/cloudDeploy/providers";
+import {
+    SourceOfTruthKind,
+    ValidationType,
+    Environment,
+} from "../../src/cloudDeploy/environments/types";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunRecord,
+    RunStatus,
+    ValidationResult,
+    ValidationStatus,
+} from "../../src/cloudDeploy/runs/types";
+
+// =============================================================================
+// FakeFileProvider
+// =============================================================================
+
+/**
+ * In-memory `FileProvider`. Exposes the raw `files` map so tests can seed
+ * arbitrary bytes (e.g. corrupt zip content) without going through the
+ * write API.
+ */
+export class FakeFileProvider implements FileProvider {
+    public readonly files: Map<string, Buffer> = new Map();
+
+    public async readFileBuffer(filePath: string): Promise<Buffer> {
+        const data = this.files.get(filePath);
+        if (data === undefined) {
+            const err: NodeJS.ErrnoException = new Error(
+                `ENOENT: no such file or directory, open '${filePath}'`,
+            );
+            err.code = "ENOENT";
+            throw err;
+        }
+        // Return a copy so callers can't mutate the seeded buffer.
+        return Buffer.from(data);
+    }
+
+    public async writeFileAtomic(filePath: string, data: Buffer): Promise<void> {
+        // Copy on write so callers reusing the buffer don't mutate stored state.
+        this.files.set(filePath, Buffer.from(data));
+    }
+
+    public async fileExists(filePath: string): Promise<boolean> {
+        return this.files.has(filePath);
+    }
+}
+
+// =============================================================================
+// Builders
+// =============================================================================
+
+export function makeEnvironment(overrides: Partial<Environment> = {}): Environment {
+    return {
+        id: "env-1",
+        name: "Env 1",
+        sourceOfTruth: { kind: SourceOfTruthKind.Container, connectionProfileId: "conn-1" },
+        validations: [],
+        ...overrides,
+    };
+}
+
+export function makeUnitTestsValidation(
+    overrides: Partial<ValidationResult> = {},
+): ValidationResult {
+    return {
+        validationId: "unit-tests-1",
+        displayName: "Unit Tests",
+        status: ValidationStatus.Passed,
+        startedAtMs: 1_000,
+        endedAtMs: 2_000,
+        payload: {
+            validationType: ValidationType.UnitTests,
+            findings: [],
+            summary: { total: 0, passed: 0, failed: 0, skipped: 0, errored: 0 },
+        },
+        ...overrides,
+    };
+}
+
+/**
+ * Builds a minimal valid `RunRecord`. Override only the fields you need;
+ * the defaults satisfy the Zod schema as-is.
+ */
+export function makeValidRunRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+    const env = overrides.environmentSnapshot ?? makeEnvironment();
+    return {
+        schemaVersion: RUN_RECORD_SCHEMA_VERSION,
+        runId: "run-1",
+        environmentId: env.id,
+        environmentSnapshot: env,
+        runner: {
+            userId: "user-1",
+            displayName: "Test User",
+            hostKind: "vscode",
+        },
+        startedAtMs: 1_000,
+        endedAtMs: 5_000,
+        status: RunStatus.Passed,
+        validations: [makeUnitTestsValidation()],
+        ...overrides,
+    };
+}

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3085,6 +3085,11 @@
     <trans-unit id="++CODE++644046a988c76e759d05ee90c400f545f6fee393f6c75a23495c621fe9e27b5d">
       <source xml:lang="en">Failed to pull SQL Server image. Please check your network connection and try again.</source>
     </trans-unit>
+    <trans-unit id="++CODE++9599ebfe0eee2c9dafdea1bd6d3bd596784d316c0ae71750531bd88ce8d51404">
+      <source xml:lang="en">Failed to read run artifact at {0}: {1}</source>
+      <note>{0} is the absolute file path of the run artifact
+{1} is the underlying I/O error message</note>
+    </trans-unit>
     <trans-unit id="++CODE++496b6f97ebcac961581d18dc0885f8d7a6b2a71fc701642e7a36ea762139e99d">
       <source xml:lang="en">Failed to read saved rule overrides from project</source>
     </trans-unit>
@@ -5740,6 +5745,25 @@
     </trans-unit>
     <trans-unit id="++CODE++ac94961d65d453caddfb9b5cdcf79c96671b85462f0c7b9ff25e2a316c6dfa86">
       <source xml:lang="en">Run a query in the current editor, or switch to an editor that has results.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++713e435be57c0f00fbf66c38ff5c27cb64c06929dcf3edc439270793855a07ee">
+      <source xml:lang="en">Run artifact at {0} declares schema version {1}, which this version of the extension does not understand. Update the extension to read it.</source>
+      <note>{0} is the absolute file path of the run artifact
+{1} is the unsupported schema version number</note>
+    </trans-unit>
+    <trans-unit id="++CODE++0721de38841184ea64cd03b1c715d4a0fad3b61a13fc0a105521f22d2f57bd29">
+      <source xml:lang="en">Run artifact at {0} failed schema validation with {1} issue(s).</source>
+      <note>{0} is the absolute file path of the run artifact
+{1} is the count of validation issues</note>
+    </trans-unit>
+    <trans-unit id="++CODE++9e74f764cac35fb177574af4e80bd423b73026f39aa84f7fb590080ad95412c6">
+      <source xml:lang="en">Run artifact at {0} is missing the required entry &apos;{1}&apos;.</source>
+      <note>{0} is the absolute file path of the run artifact
+{1} is the name of the missing entry inside the zip</note>
+    </trans-unit>
+    <trans-unit id="++CODE++3bf830086726c849b1cd7f85038064ee4076aa4cfe3a676407ffa6c327227215">
+      <source xml:lang="en">Run artifact at {0} is not a valid zip archive.</source>
+      <note>{0} is the absolute file path of the run artifact</note>
     </trans-unit>
     <trans-unit id="++CODE++2c757183a36d594602187e88cad67e8e38ab92dd5c9c01ca69eb4c67f465b8e3">
       <source xml:lang="en">Run query on connection &apos;{0}&apos; (ID: {1})?&#10;&#10;Query: {2}</source>


### PR DESCRIPTION
## Summary

Pins the canonical `RunRecord` shape and the on-disk `.cdrun.zip` artifact format, plus the minimal I/O primitives (writer, reader, Zod validator) that produce and consume them. This is the **schema-only slice** of D3 (Run Records & Viewer); the `RunStore`, viewer, diff, MCP wrapping, retention, and GitHub ingestion all land in Part 2 and consume this contract without modifying it.

Built per the corrective resequence published in `deliverables-5-19.md`: D3-schema lands **before** the D2 runner is rebuilt, so the runner returns the canonical `RunRecord` from line one instead of inventing ad-hoc per-validation result shapes (which is what the parked D2 WIP at `fe9d0723e` did).

## What's in this PR

### New source (`extensions/mssql/src/cloudDeploy/`)
| File | Bucket | Role |
|---|---|---|
| `runs/types.ts` | A (pure types) | `RunRecord`, `ValidationResult`, `ValidationPayload` + `Finding` closed unions, `RunStatus` / `ValidationStatus` 5-arm enums, `RUN_STATUS_PRIORITY`, `RUN_RECORD_SCHEMA_VERSION` (`as const`), `RunnerIdentity`. Embeds D1's `Environment` verbatim as `environmentSnapshot`. |
| `runs/runArtifactSchema.ts` | C (trust boundary) | Zod mirror. `validateRunRecord` **peeks `schemaVersion` before `safeParse`** so a forward-version artifact returns `kind: "unknown-schema-version"` instead of 50 phantom shape issues. Collect-all errors with jq-paths; cross-field invariants (`envSnapshot.id === environmentId`, `endedAtMs >= startedAtMs`) via `superRefine`. Typed `RunArtifactParseError` with 5 exhaustive `kind`s. |
| `runs/runArtifactWriter.ts` | B (I/O) | `yazl`-backed. Pre-validates → drains `AsyncIterable<DiagnosticEvent>` to NDJSON → builds zip in memory → atomic persist via `FileProvider` → emits `run-persisted` / `run-persist-failed` on bus (bus optional). |
| `runs/runArtifactReader.ts` | B (I/O) | `yauzl`-backed. Each step rewraps underlying errors as typed `RunArtifactParseError`. `readEvents()` returns `AsyncIterable<DiagnosticEvent>`; skips malformed lines silently (events are advisory, not authoritative). |
| `runs/index.ts` | F | Curated barrel. |
| `providers.ts` | shared | `FileProvider` interface (host-agnostic) + `LocalFileProvider`. `writeFileAtomic` = temp + rename (mirrors D1's `environmentFile.ts`). `readFileBuffer` preserves `code === "ENOENT"`. Lives at the top level (not under `runs/`) because D2's rebuild will share the same interface. |

### Wiring (additive edits)
- `cloudDeployService.ts` — `+runs: CloudDeployRunsApi { writer, reader }`. Always present (folder-agnostic), unlike `environments` which is folder-scoped.
- `diagnostics/types.ts` (D4) — `+RunPersistedEvent`, `+RunPersistFailedEvent`, `+"run-store"` source literal. **Third consecutive deliverable to verify D4's catalog-additive property** (`eventBus.ts` untouched).
- `diagnostics/index.ts` — `+2 type re-exports`.
- `constants/locConstants.ts` — `+class CloudDeployRuns` (5 entries: `malformedZip`, `unknownSchemaVersion`, `missingEntry`, `schemaValidationFailed`, `ioError`). R2 lesson from Phase 1 applied from line one.
- `package.json` — `+yazl ^2.5.1`, `+@types/yazl ^2.4.6`, `+@types/yauzl ^2.10.3` (`yauzl 3.2.1` was already present).

### Tests (~50 new)
| File | Tests | Coverage |
|---|---|---|
| `cloudDeployRunsTestHelpers.ts` | (helpers) | `FakeFileProvider` (in-memory, ENOENT-shaped error on miss, copy-on-read/write); record builders. |
| `cloudDeployProviders.test.ts` | 8 | `LocalFileProvider`: read success + ENOENT preserved; atomic write creates parents, no stray `.tmp`, overwrite atomic; `fileExists` true/false. |
| `cloudDeployRunArtifactSchema.test.ts` | 17 | Happy path; forward-version short-circuit; jq-path issues; cross-field invariants; payload discrimination across all 3 arms; `validateValidationResult` standalone. |
| `cloudDeployRunArtifactWriter.test.ts` | 10 | In-memory round-trip; `run-persisted` w/ `sizeBytes`; pre-validate emits `run-persist-failed`; no-bus construction; **disk suite** round-tripping through real `LocalFileProvider` + real reader. |
| `cloudDeployRunArtifactReader.test.ts` | ~15 | **Kind-exhaustive** failure modes (`io` / `malformed-zip` / `missing-entry` / two `schema-validation` paths / `unknown-schema-version`); `readEvents` absent / NDJSON / skip malformed / skip non-object / I/O rewrap. |

## Validation

- `tsgo` typecheck clean
- `tsc --noCheck` emit clean
- ESLint 0 errors, 0 warnings
- **130 CloudDeploy-scoped tests passing, 0 failing**
- Full extension suite 3157/3159 (the 2 failures are pre-existing flakes — `SchemaDesignerWebviewCopilotChatEntry` and `SchemaCompareWebViewController` — that pass in isolation and reproduce on `dev/cloud-deploy` head before any D3 changes)

## Load-bearing properties

1. **One type, both in-memory and on-disk.** The (future) runner returns a `RunRecord`; the writer serializes it; the reader returns it. No translation layer.
2. **Host-agnostic `FileProvider`.** Writer/reader compile against the abstraction; future `GitHubArtifactProvider` (Scope 2) slots in with zero changes.
3. **Fail-closed forward-version handling.** Reader peeks `schemaVersion` *before* full schema validation.
4. **Typed exhaustive failure modes.** Callers `switch` on `error.kind` for differentiated UI.
5. **Atomic writes.** Mid-zip crashes leave only a `.tmp` file behind; the real path is either complete or absent.
6. **Diagnostic events are advisory.** Reader skips malformed event lines silently — losing one event must never make a run unreadable.
7. **Every reader-surfaced string is localized** via `locConstants.CloudDeployRuns`.

## Not in this PR (Part 2 / later phases)

`RunStore`, viewer, diff, MCP wrapping, retention/GC, run-listing UI, GitHub artifact ingestion, the D2 runner rebuild itself.

## Reviewer notes

- Base branch is `dev/cloud-deploy`.
- Companion design doc (as-built): `planning/design_docs/run-records-part1-as-built-design.md` (lives in the planning workspace, attached separately if needed).
- The 2 auto-generated localization files (`l10n/bundle.l10n.json`, `localization/xliff/vscode-mssql.xlf`) were updated by the standard pre-commit extract script.