### PR TITLE
Add Query Results export notification actions

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3,6 +3,10 @@
     "Remind Me Later": "Remind Me Later",
     "Don't Show Again": "Don't Show Again",
     "Learn More": "Learn More",
+    "Open File": "Open File",
+    "Reveal in Explorer": "Reveal in Explorer",
+    "Reveal in Finder": "Reveal in Finder",
+    "Open Containing Folder": "Open Containing Folder",
     "Delete": "Delete",
     "Cancel": "Cancel",
     "Are you sure?": "Are you sure?",
@@ -157,9 +161,18 @@
     "Save Password? If 'No', password will be required each time you connect": "Save Password? If 'No', password will be required each time you connect",
     "Profile Name": "Profile Name",
     "Error occurred opening content in editor.": "Error occurred opening content in editor.",
-    "Started saving results to ": "Started saving results to ",
-    "Failed to save results. ": "Failed to save results. ",
-    "Successfully saved results to ": "Successfully saved results to ",
+    "Started saving results to {0}/{0} is the file path": {
+        "message": "Started saving results to {0}",
+        "comment": ["{0} is the file path"]
+    },
+    "Failed to save results. {0}/{0} is the error message": {
+        "message": "Failed to save results. {0}",
+        "comment": ["{0} is the error message"]
+    },
+    "Successfully saved results to {0}/{0} is the file path": {
+        "message": "Successfully saved results to {0}",
+        "comment": ["{0} is the file path"]
+    },
     "Select profile to remove": "Select profile to remove",
     "Select profile to edit": "Select profile to edit",
     "Confirm to remove this profile.": "Confirm to remove this profile.",
@@ -1669,9 +1682,6 @@
     "Deploy": "Deploy",
     "Files": "Files",
     "Application version must be in format n.n.n.n where n is a number (e.g., 1.0.0.0)": "Application version must be in format n.n.n.n where n is a number (e.g., 1.0.0.0)",
-    "Reveal in Explorer": "Reveal in Explorer",
-    "Reveal in Finder": "Reveal in Finder",
-    "Open Containing Folder": "Open Containing Folder",
     "Unable to retrieve the list of databases. You may not have permission to list databases on this server.": "Unable to retrieve the list of databases. You may not have permission to list databases on this server.",
     "DACPAC deployed successfully to database '{0}'/{0} is the database name": {
         "message": "DACPAC deployed successfully to database '{0}'",
@@ -1963,7 +1973,6 @@
         "message": "Profiler events exported successfully to {0}",
         "comment": ["{0} is the file path"]
     },
-    "Open File": "Open File",
     "Failed to export profiler events: {0}/{0} is the error message": {
         "message": "Failed to export profiler events: {0}",
         "comment": ["{0} is the error message"]

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -11,6 +11,10 @@ export class Common {
     public static remindMeLater = l10n.t("Remind Me Later");
     public static dontShowAgain = l10n.t("Don't Show Again");
     public static learnMore = l10n.t("Learn More");
+    public static openFile = l10n.t("Open File");
+    public static revealInExplorer = l10n.t("Reveal in Explorer");
+    public static revealInFinder = l10n.t("Reveal in Finder");
+    public static openContainingFolder = l10n.t("Open Containing Folder");
     public static delete = l10n.t("Delete");
     public static cancel = l10n.t("Cancel");
     public static areYouSure = l10n.t("Are you sure?");
@@ -262,9 +266,27 @@ export let msgSavePassword = l10n.t(
 );
 export let profileNamePrompt = l10n.t("Profile Name");
 export let msgCannotOpenContent = l10n.t("Error occurred opening content in editor.");
-export let msgSaveStarted = l10n.t("Started saving results to ");
-export let msgSaveFailed = l10n.t("Failed to save results. ");
-export let msgSaveSucceeded = l10n.t("Successfully saved results to ");
+export function msgSaveStarted(filePath: string) {
+    return l10n.t({
+        message: "Started saving results to {0}",
+        args: [filePath],
+        comment: ["{0} is the file path"],
+    });
+}
+export function msgSaveFailed(error: string) {
+    return l10n.t({
+        message: "Failed to save results. {0}",
+        args: [error],
+        comment: ["{0} is the error message"],
+    });
+}
+export function msgSaveSucceeded(filePath: string) {
+    return l10n.t({
+        message: "Successfully saved results to {0}",
+        args: [filePath],
+        comment: ["{0} is the file path"],
+    });
+}
 export let msgSelectProfileToRemove = l10n.t("Select profile to remove");
 export let msgSelectProfileToEdit = l10n.t("Select profile to edit");
 export let confirmRemoveProfilePrompt = l10n.t("Confirm to remove this profile.");
@@ -3069,9 +3091,9 @@ export class DacpacDialog {
     public static InvalidApplicationVersion = l10n.t(
         "Application version must be in format n.n.n.n where n is a number (e.g., 1.0.0.0)",
     );
-    public static RevealInExplorer = l10n.t("Reveal in Explorer");
-    public static RevealInFinder = l10n.t("Reveal in Finder");
-    public static OpenContainingFolder = l10n.t("Open Containing Folder");
+    public static RevealInExplorer = Common.revealInExplorer;
+    public static RevealInFinder = Common.revealInFinder;
+    public static OpenContainingFolder = Common.openContainingFolder;
     public static FailedToListDatabases = l10n.t(
         "Unable to retrieve the list of databases. You may not have permission to list databases on this server.",
     );
@@ -3612,7 +3634,7 @@ export class Profiler {
             args: [filePath],
             comment: ["{0} is the file path"],
         });
-    public static openFile = l10n.t("Open File");
+    public static openFile = Common.openFile;
     public static exportFailed = (error: string) =>
         l10n.t({
             message: "Failed to export profiler events: {0}",

--- a/extensions/mssql/src/models/resultsSerializer.ts
+++ b/extensions/mssql/src/models/resultsSerializer.ts
@@ -209,6 +209,37 @@ export default class ResultsSerializer {
         return config.get<boolean>(Constants.configResultsOpenAfterSave, true);
     }
 
+    private getRevealFileActionLabel(): string {
+        if (process.platform === "darwin") {
+            return LocalizedConstants.Common.revealInFinder;
+        }
+        if (process.platform === "win32") {
+            return LocalizedConstants.Common.revealInExplorer;
+        }
+        return LocalizedConstants.Common.openContainingFolder;
+    }
+
+    private showSaveSucceededNotification(filePath: string, format: string): void {
+        const openFileAction = LocalizedConstants.Common.openFile;
+        const revealFileAction = this.getRevealFileActionLabel();
+        void this._vscodeWrapper
+            .showInformationMessage(
+                LocalizedConstants.msgSaveSucceeded(filePath),
+                openFileAction,
+                revealFileAction,
+            )
+            .then((action) => {
+                if (action === openFileAction) {
+                    this.openSavedFile(filePath, format);
+                } else if (action === revealFileAction) {
+                    void this._vscodeWrapper.executeCommand(
+                        "revealFileInOS",
+                        vscode.Uri.file(filePath),
+                    );
+                }
+            });
+    }
+
     /**
      * Send request to sql tools service to save a result set
      */
@@ -243,24 +274,22 @@ export default class ResultsSerializer {
             type = Contracts.SaveResultsAsInsertRequest.type;
         }
 
-        self._vscodeWrapper.logToOutputChannel(LocalizedConstants.msgSaveStarted + this._filePath);
+        self._vscodeWrapper.logToOutputChannel(LocalizedConstants.msgSaveStarted(this._filePath));
 
         // send message to the sqlserverclient for converting results to the requested format and saving to filepath
         return self._client.sendRequest(type, saveResultsParams).then(
             (result) => {
                 if (result.messages) {
                     self._vscodeWrapper.showErrorMessage(
-                        LocalizedConstants.msgSaveFailed + result.messages,
+                        LocalizedConstants.msgSaveFailed(result.messages),
                     );
                     self._vscodeWrapper.logToOutputChannel(
-                        LocalizedConstants.msgSaveFailed + result.messages,
+                        LocalizedConstants.msgSaveFailed(result.messages),
                     );
                 } else {
-                    self._vscodeWrapper.showInformationMessage(
-                        LocalizedConstants.msgSaveSucceeded + this._filePath,
-                    );
+                    self.showSaveSucceededNotification(this._filePath, format);
                     self._vscodeWrapper.logToOutputChannel(
-                        LocalizedConstants.msgSaveSucceeded + filePath,
+                        LocalizedConstants.msgSaveSucceeded(filePath),
                     );
                     if (self.shouldOpenSavedFile()) {
                         self.openSavedFile(self._filePath, format);
@@ -269,10 +298,10 @@ export default class ResultsSerializer {
             },
             (error) => {
                 self._vscodeWrapper.showErrorMessage(
-                    LocalizedConstants.msgSaveFailed + error.message,
+                    LocalizedConstants.msgSaveFailed(error.message),
                 );
                 self._vscodeWrapper.logToOutputChannel(
-                    LocalizedConstants.msgSaveFailed + error.message,
+                    LocalizedConstants.msgSaveFailed(error.message),
                 );
             },
         );

--- a/extensions/mssql/test/unit/saveResults.test.ts
+++ b/extensions/mssql/test/unit/saveResults.test.ts
@@ -17,6 +17,7 @@ import SqlToolsServerClient from "../../src/languageservice/serviceclient";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 import * as Contracts from "../../src/models/contracts";
 import { stubVscodeWrapper } from "./utils";
+import * as LocalizedConstants from "../../src/constants/locConstants";
 
 chai.use(sinonChai);
 
@@ -62,7 +63,7 @@ suite("save results tests", () => {
         (vscodeWrapper.showTextDocument as sinon.SinonStub).resolves(
             undefined as unknown as vscode.TextEditor,
         );
-        (vscodeWrapper.showInformationMessage as sinon.SinonStub).returns(undefined);
+        (vscodeWrapper.showInformationMessage as sinon.SinonStub).resolves(undefined);
         serverClient.sendRequest.resolves({ messages: undefined, ...response });
     }
 
@@ -70,6 +71,10 @@ suite("save results tests", () => {
         (vscodeWrapper.showSaveDialog as sinon.SinonStub).resolves(fileUri);
         (vscodeWrapper.showErrorMessage as sinon.SinonStub).returns(undefined);
         serverClient.sendRequest.resolves({ messages: message });
+    }
+
+    async function waitForPendingPromises(): Promise<void> {
+        await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
     test("check if filepath prompt displays and right value is set", (done) => {
@@ -155,6 +160,48 @@ suite("save results tests", () => {
             expect(vscodeWrapper.showInformationMessage).to.have.been.calledOnce;
             expect(openSavedFileStub).to.not.have.been.called;
         });
+    });
+
+    test("Save as CSV - opens saved file when notification action is selected", async () => {
+        configureSuccess();
+        (vscodeWrapper.getConfiguration as sinon.SinonStub).returns({
+            get: (key: string) => (key === "results.openAfterSave" ? false : undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+        (vscodeWrapper.showInformationMessage as sinon.SinonStub).resolves(
+            LocalizedConstants.Common.openFile,
+        );
+        const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
+
+        await saveResults.onSaveResults(testFile, 0, 0, "csv", undefined);
+        await waitForPendingPromises();
+
+        expect(openSavedFileStub).to.have.been.calledOnceWith(fileUri.fsPath, "csv");
+    });
+
+    test("Save as CSV - reveals saved file when notification action is selected", async () => {
+        configureSuccess();
+        const revealFileAction =
+            os.platform() === "darwin"
+                ? LocalizedConstants.Common.revealInFinder
+                : os.platform() === "win32"
+                  ? LocalizedConstants.Common.revealInExplorer
+                  : LocalizedConstants.Common.openContainingFolder;
+        (vscodeWrapper.getConfiguration as sinon.SinonStub).returns({
+            get: (key: string) => (key === "results.openAfterSave" ? false : undefined),
+        } as unknown as vscode.WorkspaceConfiguration);
+        (vscodeWrapper.showInformationMessage as sinon.SinonStub).resolves(revealFileAction);
+        const saveResults = createSerializer();
+        const openSavedFileStub = sandbox.stub(saveResults, "openSavedFile");
+
+        await saveResults.onSaveResults(testFile, 0, 0, "csv", undefined);
+        await waitForPendingPromises();
+
+        expect(openSavedFileStub).to.not.have.been.called;
+        expect(vscodeWrapper.executeCommand).to.have.been.calledOnceWith(
+            "revealFileInOS",
+            sinon.match.has("fsPath", fileUri.fsPath),
+        );
     });
 
     test("Save as Excel - does not open saved file when openAfterSave is disabled", () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3140,8 +3140,9 @@
     <trans-unit id="++CODE++656e30cd5a427ecbf935f88a531699c67f2edc2f0cfa7ef8cbec340a88c0c423">
       <source xml:lang="en">Failed to save publish profile</source>
     </trans-unit>
-    <trans-unit id="++CODE++283dc9bd4f27ff0efed1b3ac27910746f64f860e2e0c2240f9723ff02c1dc29c">
-      <source xml:lang="en">Failed to save results. </source>
+    <trans-unit id="++CODE++11167e57bf77932c07f42c4b2a08ba8428726757beb2f754ece1786e81ed0447">
+      <source xml:lang="en">Failed to save results. {0}</source>
+      <note>{0} is the error message</note>
     </trans-unit>
     <trans-unit id="++CODE++295dc600027d16c46d0596df1afe12f2c8db841203c77f15207d06851c0d50ec">
       <source xml:lang="en">Failed to save results: {0}</source>
@@ -6618,8 +6619,9 @@
       <source xml:lang="en">Started query execution for document &quot;{0}&quot;</source>
       <note>{0} is the document name</note>
     </trans-unit>
-    <trans-unit id="++CODE++47d62b3ce92021fa331252ba82176c2a4ccb592c2264bd58ec74e5d1b722c98e">
-      <source xml:lang="en">Started saving results to </source>
+    <trans-unit id="++CODE++b10574f779b09047bedf3228566923bf6ba89edd4f6f08ff15e9a9c0314cfbdb">
+      <source xml:lang="en">Started saving results to {0}</source>
+      <note>{0} is the file path</note>
     </trans-unit>
     <trans-unit id="++CODE++7db6cebea8c95ec1db665d9ce39b1798388767fb2481b3f02548f4f008012631">
       <source xml:lang="en">Starting &apos;{0}&apos;...</source>
@@ -6730,8 +6732,9 @@
 {1} is the uri
 {2} is the message</note>
     </trans-unit>
-    <trans-unit id="++CODE++9c85106af25fd7656e977d5453607973955ae5d79fce0a78264cd714a628e981">
-      <source xml:lang="en">Successfully saved results to </source>
+    <trans-unit id="++CODE++c36cade68fea2c699e5795c527fd1daf085d0b76a5a5bc35526765a1b5d5b974">
+      <source xml:lang="en">Successfully saved results to {0}</source>
+      <note>{0} is the file path</note>
     </trans-unit>
     <trans-unit id="++CODE++da099a63ce9b5fe688c4f5219cdd8614a27faa324bdd5c612dfab086630b346c">
       <source xml:lang="en">Sum: {0}</source>


### PR DESCRIPTION
## Description

Fixes #22210

Adds action buttons to Query Results export success notifications so users can open the exported file directly or reveal it in Finder/Explorer/the containing folder. The existing `mssql.results.openAfterSave` setting behavior is preserved.

Validation run:

- `npm --prefix extensions/mssql run build:extension:typecheck`
- `npm --prefix extensions/mssql run lint`
- `npx prettier --check extensions/mssql/src/models/resultsSerializer.ts extensions/mssql/test/unit/saveResults.test.ts`
- `npx vscode-test --coverage --grep "save results tests" --reporter spec`

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)