### PR TITLE
Add setting to hide results copied notification

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2096,6 +2096,12 @@
                     "default": true,
                     "scope": "resource"
                 },
+                "mssql.results.showCopyNotification": {
+                    "type": "boolean",
+                    "description": "%mssql.results.showCopyNotification%",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "mssql.saveAsCsv.includeHeaders": {
                     "type": "boolean",
                     "description": "%mssql.saveAsCsv.includeHeaders%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -128,6 +128,7 @@
     "mssql.resultsFontFamily": "Set the font family for the results grid; set to blank to use the editor font",
     "mssql.resultsFontSize": "Set the font size for the results grid; set to blank to use the editor size",
     "mssql.results.openAfterSave": "When enabled, saved query result exports are opened after export. Excel exports open with the system file handler; text exports open in VS Code.",
+    "mssql.results.showCopyNotification": "When enabled, show a notification after query results are copied to the clipboard.",
     "mssql.saveAsCsv.includeHeaders": "[Optional] When true, column headers are included when saving results as CSV",
     "mssql.saveAsCsv.delimiter": "[Optional] Delimiter for separating data items when saving results as CSV. Choose from common separators like comma (,), tab (\\t), semicolon (;), or pipe (|)",
     "mssql.saveAsCsv.lineSeparator": "[Optional] Character(s) used for separating rows when saving results as CSV",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -269,6 +269,7 @@ export const configSaveAsCsv = "saveAsCsv";
 export const configSaveAsJson = "saveAsJson";
 export const configSaveAsExcel = "saveAsExcel";
 export const configResultsOpenAfterSave = "results.openAfterSave";
+export const configResultsShowCopyNotification = "results.showCopyNotification";
 export const configRecentConnections = "recentConnections";
 export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -844,9 +844,11 @@ export default class QueryRunner {
                         await this.writeStringToClipboard(result.content);
                     }
 
-                    vscode.window.showInformationMessage(
-                        LocalizedConstants.resultsCopiedToClipboard,
-                    );
+                    if (this.shouldShowCopyNotification()) {
+                        vscode.window.showInformationMessage(
+                            LocalizedConstants.resultsCopiedToClipboard,
+                        );
+                    }
                     resolve();
                 } catch (error) {
                     // Don't show error if cancelled
@@ -992,6 +994,15 @@ export default class QueryRunner {
 
     private _requestID: string;
     private _cancelConfirmation: Deferred<void>;
+
+    private shouldShowCopyNotification(): boolean {
+        const config = this._vscodeWrapper.getConfiguration(
+            Constants.extensionConfigSectionName,
+            this.uri,
+        );
+        return config.get<boolean>(Constants.configResultsShowCopyNotification, true);
+    }
+
     public async generateSelectionSummaryData(
         selections: ISlickRange[],
         batchId: number,

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -23,6 +23,7 @@ import {
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
 import StatusView from "../../src/views/statusView";
 import * as Constants from "../../src/constants/constants";
+import * as LocalizedConstants from "../../src/constants/locConstants";
 import * as QueryExecuteContracts from "../../src/models/contracts/queryExecute";
 import * as QueryDisposeContracts from "../../src/models/contracts/queryDispose";
 import { ISelectionData } from "../../src/models/interfaces";
@@ -81,6 +82,9 @@ suite("Query Runner tests", () => {
         (testVscodeWrapper.logToOutputChannel as sinon.SinonStub).returns(undefined);
         (testVscodeWrapper.openTextDocument as sinon.SinonStub).resolves({} as vscode.TextDocument);
         (testVscodeWrapper.showTextDocument as sinon.SinonStub).resolves({} as vscode.TextEditor);
+        (testVscodeWrapper.getConfiguration as sinon.SinonStub).returns(
+            stubs.createWorkspaceConfiguration({}),
+        );
     });
 
     teardown(() => {
@@ -753,6 +757,7 @@ suite("Query Runner tests", () => {
                 const tokenSource = new vscode.CancellationTokenSource();
                 await task(progress, tokenSource.token);
             });
+            sandbox.stub(vscode.window, "showInformationMessage").resolves(undefined);
         });
 
         test("copyResults calls copyResults2 with correct CopyType", async () => {
@@ -789,6 +794,39 @@ suite("Query Runner tests", () => {
             await queryRunner.copyResults(selection, 0, 0, false);
 
             expect(testVscodeWrapper.clipboardWriteText).to.have.been.calledWith(expectedContent);
+        });
+
+        test("copyResults shows notification by default", async () => {
+            const queryRunner = createQueryRunner();
+            const selection = [{ fromRow: 0, toRow: 1, fromCell: 0, toCell: 1 }];
+
+            testSqlToolsServerClient.sendRequest
+                .withArgs(CopyResults2Request.type, sinon.match.object)
+                .resolves({ content: "copied" });
+
+            await queryRunner.copyResults(selection, 0, 0, false);
+
+            expect(vscode.window.showInformationMessage).to.have.been.calledOnceWith(
+                LocalizedConstants.resultsCopiedToClipboard,
+            );
+        });
+
+        test("copyResults does not show notification when setting is disabled", async () => {
+            const queryRunner = createQueryRunner();
+            const selection = [{ fromRow: 0, toRow: 1, fromCell: 0, toCell: 1 }];
+            (testVscodeWrapper.getConfiguration as sinon.SinonStub).returns(
+                stubs.createWorkspaceConfiguration({
+                    [Constants.configResultsShowCopyNotification]: false,
+                }),
+            );
+
+            testSqlToolsServerClient.sendRequest
+                .withArgs(CopyResults2Request.type, sinon.match.object)
+                .resolves({ content: "copied" });
+
+            await queryRunner.copyResults(selection, 0, 0, false);
+
+            expect(vscode.window.showInformationMessage).to.not.have.been.called;
         });
 
         test("copyResults does not call clipboard fallback when content is not returned", async () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -8770,6 +8770,9 @@
     <trans-unit id="mssql.results.openAfterSave">
       <source xml:lang="en">When enabled, saved query result exports are opened after export. Excel exports open with the system file handler; text exports open in VS Code.</source>
     </trans-unit>
+    <trans-unit id="mssql.results.showCopyNotification">
+      <source xml:lang="en">When enabled, show a notification after query results are copied to the clipboard.</source>
+    </trans-unit>
     <trans-unit id="mssql.objectExplorer.groupBySchema">
       <source xml:lang="en">When enabled, the database objects in Object Explorer will be categorized by schema.</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Fixes #22227

Adds `mssql.results.showCopyNotification` so users can disable the `Results copied to clipboard` information toast while preserving the current default behavior.

Validation run:

- `npm --prefix extensions/mssql run build:extension:typecheck`
- `npm --prefix extensions/mssql run lint`
- `npx prettier --check extensions/mssql/package.json extensions/mssql/package.nls.json extensions/mssql/src/constants/constants.ts extensions/mssql/src/controllers/queryRunner.ts extensions/mssql/test/unit/queryRunner.test.ts localization/xliff/vscode-mssql.xlf`
- `npx vscode-test --coverage --grep "Query Runner tests" --reporter spec`

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)