### PR TITLE
Add Messages Copy All timestamp option

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2074,6 +2074,12 @@
                     "default": true,
                     "scope": "resource"
                 },
+                "mssql.messages.copyIncludeTimestamps": {
+                    "type": "boolean",
+                    "description": "%mssql.messages.copyIncludeTimestamps%",
+                    "default": false,
+                    "scope": "resource"
+                },
                 "mssql.resultsFontFamily": {
                     "type": "string",
                     "description": "%mssql.resultsFontFamily%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -125,6 +125,7 @@
     "mssql.statusBar.enableConnectionColor": "When enabled, colorizes the connection status bar item with the color of the connection group. This setting is disabled by default.  This uses the connection group folder's color directly, and does not alter it in order to ensure contrast with the current VS Code theme. Users should choose connection group colors that work well with their theme.",
     "mssql.shortcuts": "Shortcuts related to the results window",
     "mssql.messagesDefaultOpen": "True for the messages pane to be open by default; false for closed",
+    "mssql.messages.copyIncludeTimestamps": "When enabled, Copy All in the query result Messages pane includes message timestamps.",
     "mssql.resultsFontFamily": "Set the font family for the results grid; set to blank to use the editor font",
     "mssql.resultsFontSize": "Set the font size for the results grid; set to blank to use the editor size",
     "mssql.results.openAfterSave": "When enabled, saved query result exports are opened after export. Excel exports open with the system file handler; text exports open in VS Code.",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -274,6 +274,7 @@ export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";
 export const configSplitPaneSelection = "splitPaneSelection";
 export const configShowBatchTime = "showBatchTime";
+export const configMessagesCopyIncludeTimestamps = "messages.copyIncludeTimestamps";
 export const configPreventAutoExecuteScript = "mssql.query.preventAutoExecuteScript";
 export enum extConfigResultKeys {
     Shortcuts = "shortcuts",

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -635,6 +635,7 @@ export class SqlOutputContentProvider {
                 resultWebviewState.messages.push({
                     message: LocalizedConstants.elapsedTimeLabel(totalMilliseconds),
                     isError: false, // Elapsed time messages are never displayed as errors
+                    time: new Date().toLocaleTimeString(),
                 });
                 // if there is an error, show the error message and set the tab to the messages tab
                 let tabState: QueryResultPaneTabs;

--- a/extensions/mssql/src/queryResult/queryResultWebViewController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebViewController.ts
@@ -552,10 +552,19 @@ export class QueryResultWebviewController extends WebviewViewController<
         return this._sqlDocumentService;
     }
 
+    private shouldCopyMessageTimestamps(uri?: string): boolean {
+        return this.vscodeWrapper
+            .getConfiguration(Constants.extensionConfigSectionName, uri)
+            .get<boolean>(Constants.configMessagesCopyIncludeTimestamps, false);
+    }
+
     public async copyAllMessagesToClipboard(uri: string): Promise<void> {
+        const includeTimestamps = this.shouldCopyMessageTimestamps(uri ?? this.state?.uri);
         const messages = uri
-            ? this.getQueryResultState(uri)?.messages?.map((message) => messageToString(message))
-            : this.state?.messages?.map((message) => messageToString(message));
+            ? this.getQueryResultState(uri)?.messages?.map((message) =>
+                  messageToString(message, includeTimestamps),
+              )
+            : this.state?.messages?.map((message) => messageToString(message, includeTimestamps));
 
         if (!messages) {
             return;

--- a/extensions/mssql/src/queryResult/utils.ts
+++ b/extensions/mssql/src/queryResult/utils.ts
@@ -388,11 +388,16 @@ export function recordLength(record: any): number {
     return Object.keys(record).length;
 }
 
-export function messageToString(message: qr.IMessage): string {
-    if (message.link?.text) {
-        return `${message.message}${message.link.text}`;
+export function messageToString(message: qr.IMessage, includeTimestamp: boolean = false): string {
+    const text = message.link?.text ? `${message.message}${message.link.text}` : message.message;
+    if (!includeTimestamp || !message.time) {
+        return text;
     }
-    return message.message;
+
+    return text
+        .split(/\r?\n/)
+        .map((line) => `${message.time}\t${line}`)
+        .join("\n");
 }
 
 /**

--- a/extensions/mssql/test/unit/queryResultUtils.test.ts
+++ b/extensions/mssql/test/unit/queryResultUtils.test.ts
@@ -8,6 +8,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import * as queryResultUtils from "../../src/queryResult/utils";
 import * as Constants from "../../src/constants/constants";
+import * as qr from "../../src/sharedInterfaces/queryResult";
 
 suite("QueryResult Utils Tests", () => {
     let sandbox: sinon.SinonSandbox;
@@ -84,6 +85,12 @@ suite("QueryResult Utils Tests", () => {
             expect(Constants.configResultsGridRowPadding).to.equal("resultsGrid.rowPadding");
         });
 
+        test("messages copy timestamp config key has correct path", () => {
+            expect(Constants.configMessagesCopyIncludeTimestamps).to.equal(
+                "messages.copyIncludeTimestamps",
+            );
+        });
+
         test("default gridSettings returns rowPadding=undefined when config is undefined", () => {
             const mockConfig = {
                 get: sandbox.stub().returns(undefined),
@@ -117,5 +124,46 @@ suite("QueryResult Utils Tests", () => {
                 expect(queryResultUtils.bucketizeRowCount(value)).to.equal(expected);
             });
         }
+    });
+
+    suite("messageToString", () => {
+        test("returns message text without timestamp by default", () => {
+            const message: qr.IMessage = {
+                message: "Started executing query at ",
+                isError: false,
+                time: "12:34:56 PM",
+                link: {
+                    text: "Line 1",
+                },
+            };
+
+            expect(queryResultUtils.messageToString(message)).to.equal(
+                "Started executing query at Line 1",
+            );
+        });
+
+        test("prefixes timestamp when requested", () => {
+            const message: qr.IMessage = {
+                message: "Rows affected",
+                isError: false,
+                time: "12:34:56 PM",
+            };
+
+            expect(queryResultUtils.messageToString(message, true)).to.equal(
+                "12:34:56 PM\tRows affected",
+            );
+        });
+
+        test("prefixes each message line with timestamp when requested", () => {
+            const message: qr.IMessage = {
+                message: "First line\nSecond line",
+                isError: false,
+                time: "12:34:56 PM",
+            };
+
+            expect(queryResultUtils.messageToString(message, true)).to.equal(
+                "12:34:56 PM\tFirst line\n12:34:56 PM\tSecond line",
+            );
+        });
     });
 });

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -8758,6 +8758,9 @@
     <trans-unit id="mssql.schemaDesigner">
       <source xml:lang="en">Visualize and Design Schema...</source>
     </trans-unit>
+    <trans-unit id="mssql.messages.copyIncludeTimestamps">
+      <source xml:lang="en">When enabled, Copy All in the query result Messages pane includes message timestamps.</source>
+    </trans-unit>
     <trans-unit id="mssql.transferActiveEditorConnections.description">
       <source xml:lang="en">When enabled, automatically transfer the active connection to newly opened SQL files. When disabled, you must explicitly connect to a database for each SQL file.</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Fixes #22245

Adds `mssql.messages.copyIncludeTimestamps` so Messages `Copy All` can include the timestamps already shown in the Messages pane. Also adds a timestamp to the completion/elapsed-time message so copied logs include when execution completed.

Validation run:

- `npm --prefix extensions/mssql run build:extension:typecheck`
- `npm --prefix extensions/mssql run lint`
- `npx prettier --check extensions/mssql/package.json extensions/mssql/package.nls.json extensions/mssql/src/constants/constants.ts extensions/mssql/src/queryResult/utils.ts extensions/mssql/src/queryResult/queryResultWebViewController.ts extensions/mssql/src/models/sqlOutputContentProvider.ts extensions/mssql/test/unit/queryResultUtils.test.ts localization/xliff/vscode-mssql.xlf`
- `npx vscode-test --coverage --grep "QueryResult Utils Tests" --reporter spec`

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)