### PR TITLE
Fix Edit Data Column Header Focus Outline

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentSlickGrid/fluentSlickGrid.css
+++ b/extensions/mssql/src/webviews/common/FluentSlickGrid/fluentSlickGrid.css
@@ -133,6 +133,7 @@ body {
     --slick-icon-sort-position-top: 5px;
     --slick-icon-sort-color: var(--vscode-editor-foreground);
     --slick-header-column-background-active: var(--vscode-editor-background);
+    --slick-focus-outline-color: var(--vscode-focusBorder);
 }
 
 .slick-context-menu,


### PR DESCRIPTION
## Description

This PR fixes the focus border color that appears in the Edit Data column headers with keyboard navigation.
Before:
<img width="548" height="46" alt="image" src="https://github.com/user-attachments/assets/fd063ae3-fc99-4c12-92b7-f9017048ad34" />
<img width="553" height="40" alt="image" src="https://github.com/user-attachments/assets/2e8d6d41-edfb-44ff-9623-552eedd79ed4" />


After:
<img width="548" height="45" alt="image" src="https://github.com/user-attachments/assets/ac170fcf-e576-4f54-b16e-0b19ecc09f51" />

<img width="554" height="48" alt="image" src="https://github.com/user-attachments/assets/e8b4414d-90cc-440c-a4e6-bbca13eb66ce" />



_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
