### PR TITLE
Remove deprecated isNullOrUndefined from sql-database-projects

### DIFF
--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -8,7 +8,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
-import { isNullOrUndefined } from "util";
 import * as vscode from "vscode";
 import {
     DoNotAskAgain,
@@ -141,8 +140,7 @@ export class NetCoreTool extends ShellExecutionHelper {
 
     private get isNetCoreInstallationPresent(): boolean {
         const netCoreInstallationPresent =
-            !isNullOrUndefined(this.netcoreInstallLocation) &&
-            fs.existsSync(this.netcoreInstallLocation);
+            !!this.netcoreInstallLocation && fs.existsSync(this.netcoreInstallLocation);
         if (!netCoreInstallationPresent) {
             this.netCoreInstallState = netCoreInstallState.netCoreNotPresent;
         }
@@ -195,7 +193,7 @@ export class NetCoreTool extends ShellExecutionHelper {
     }
 
     private getDotnetPathIfPresent(folderPath: string | undefined): string | undefined {
-        if (!isNullOrUndefined(folderPath) && fs.existsSync(path.join(folderPath, "dotnet"))) {
+        if (folderPath && fs.existsSync(path.join(folderPath, "dotnet"))) {
             return path.join(folderPath, "dotnet");
         }
         return undefined;


### PR DESCRIPTION
## Summary

PR #22238 removed all usages of the deprecated `isNullOrUndefined` function from `node:util`, but missed the reference in `extensions/sql-database-projects/src/tools/netcoreTool.ts`, which was causing the SQL Database Projects build feature to fail completely.

## Changes

- Removed `import { isNullOrUndefined } from "util"` from `netcoreTool.ts`
- Replaced `!isNullOrUndefined(this.netcoreInstallLocation)` with `!!this.netcoreInstallLocation`
- Replaced `!isNullOrUndefined(folderPath)` with `folderPath` (plain truthy check, parameter is typed `string | undefined`)

## Related

Follow-up to #22238