### PR TITLE
Hotfix: version bump sqlproj extension for 1.6.1

### DIFF
--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -6,6 +6,10 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-03
+
+- Fixed an issue where SQL Database projects would fail when being built into a dacpac
+
 ## [1.6.0] - 2026-06-02
 
 - Improved Publish Project dialog performance for faster initial loading, and improved port number validation in Publish Project dialog to correctly show available port.

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
     "name": "sql-database-projects-vscode",
     "displayName": "SQL Database Projects",
     "description": "Enables users to develop and publish database schemas for MSSQL Databases",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "publisher": "ms-mssql",
     "preview": false,
     "homepage": "https://github.com/Microsoft/vscode-mssql/blob/main/extensions/sql-database-projects/README.md",


### PR DESCRIPTION
## Summary

Hotfix for the `release/1.43` branch — version bump for the SQL Database Projects extension to `1.6.1` with changelog entry.

## Changes

- Bumped `sql-database-projects` extension version to `1.6.1`
- Added changelog entry for `1.6.1`:
  - Fixed an issue where the SQL Database Projects build feature was completely broken due to a missed removal of the deprecated `isNullOrUndefined` function from Node's `util` module (follow-up to #22238)

## Related

- Fix PR: #22285
- Original removal PR: #22238