### PR TITLE
Update GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Download baseline sizes
         if: env.should_compare_baseline == 'true'
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: publish-baseline.yml
           branch: ${{ github.event.pull_request.base.ref }}
@@ -87,25 +87,25 @@ jobs:
           npm run package
 
       - name: MSSQL - Upload VSIX files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mssql-vsix
           path: ./extensions/mssql/*.vsix
 
       - name: SqlProj - Upload VSIX files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: sql-database-projects-vsix
           path: ./extensions/sql-database-projects/*.vsix
 
       - name: DataWorkspace - Upload VSIX files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: data-workspace-vsix
           path: ./extensions/data-workspace/*.vsix
 
       - name: Keymap - Upload VSIX files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: keymap-vsix
           path: ./extensions/database-management-keymap/*.vsix
@@ -286,7 +286,7 @@ jobs:
           echo "mssql_unit_tests_pr_exit_code=$UNIT_EXIT_CODE" >> $GITHUB_ENV
 
       - name: MSSQL - Unit Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: success() || failure()
         with:
           name: "Unit Test Report"
@@ -348,14 +348,14 @@ jobs:
           echo "mssql_smoke_tests_pr_exit_code=$SMOKE_EXIT_CODE" >> $GITHUB_ENV
 
       - name: Upload Smoke Test Screenshots and Videos
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-failure-screenshots
           path: ./extensions/mssql/test-results/**/
           retention-days: 7
 
       - name: Smoke Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: success() || failure()
         with:
           name: "Smoke Test Report"
@@ -374,7 +374,7 @@ jobs:
           fi
 
       - name: Generate Coverage Report
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.4.4
+        uses: danielpalme/ReportGenerator-GitHub-Action@v5
         with:
           reports: "./extensions/mssql/coverage/cobertura-coverage.xml"
           targetdir: "coveragereport"
@@ -382,13 +382,13 @@ jobs:
           toolpath: "reportgeneratortool"
 
       - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: CoverageReport
           path: coveragereport
 
       - name: MSSQL - Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./extensions/mssql/coverage/cobertura-coverage.xml
@@ -406,7 +406,7 @@ jobs:
           echo "| keymap VSIX                 | ${{ env.keymap_target_vsix_size }} KB | ${{ env.keymap_pr_vsix_size }} KB | ${{ env.keymap_vsix_change_icon }} ${{ env.keymap_vsix_size_diff }} KB ( ${{ env.keymap_vsix_percentage_change }}% ) |" >> results.md
 
       - name: Find comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         if: env.should_compare_baseline == 'true'
         id: fc
         with:
@@ -416,7 +416,7 @@ jobs:
             ### PR Changes
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         if: env.should_compare_baseline == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -434,7 +434,7 @@ jobs:
           echo "sqlproj_unit_tests_pr_exit_code=$UNIT_EXIT_CODE" >> $GITHUB_ENV
 
       - name: SqlProj - Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./extensions/sql-database-projects/coverage/cobertura-coverage.xml
@@ -449,7 +449,7 @@ jobs:
           echo "dataworkspace_unit_tests_pr_exit_code=$UNIT_EXIT_CODE" >> $GITHUB_ENV
 
       - name: DataWorkspace - Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./extensions/data-workspace/coverage/cobertura-coverage.xml
@@ -502,7 +502,7 @@ jobs:
           fi
 
       - name: Find comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         if: github.event_name == 'pull_request'
         id: loc-comment
         with:
@@ -513,7 +513,7 @@ jobs:
 
       - name: Create or update comment
         if: github.event_name == 'pull_request' && env.loc_update_required == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.loc-comment.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mssql-vsix-launch.yml
+++ b/.github/workflows/mssql-vsix-launch.yml
@@ -69,7 +69,7 @@ jobs:
           find ./extensions/mssql -maxdepth 1 -name "*.vsix" -print | sort
 
       - name: MSSQL - Upload VSIX files
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mssql-offline-vsix
           path: ./extensions/mssql/*.vsix
@@ -115,7 +115,7 @@ jobs:
         run: npm ci
 
       - name: Download MSSQL VSIX files
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mssql-offline-vsix
           path: ./extensions/mssql
@@ -157,7 +157,7 @@ jobs:
 
       - name: MSSQL - Upload launch test artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mssql-vsix-launch-test-artifacts-${{ matrix.platform }}
           path: |

--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -83,7 +83,7 @@ jobs:
           cat baseline-sizes.json
 
       - name: Upload baseline sizes
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: baseline-sizes
           path: baseline-sizes.json


### PR DESCRIPTION
## Description

Updates GitHub Actions workflow dependencies to current major versions across build/test, baseline publishing, and MSSQL VSIX launch verification workflows. This keeps CI on supported action majors while using major-only `@vX` refs as requested.

Validation performed locally:
- Confirmed no stale lower-major or exact `@vX.Y` action refs remain under `.github`
- Parsed edited workflow YAML successfully
- Ran `git diff --check`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
