### PR TITLE
[PORT] Fix macOS CI EINVAL error in sql-database-projects tests (#22289)

### DIFF
--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -11,7 +11,7 @@ const mocha = createMochaConfig({
 // TODO: Workaround for macOS CI EINVAL error — revert once the upstream VS Code issue is fixed.
 // A recent VS Code build changed the socket filename format (e.g. "1.12-main.sock"), pushing the
 // default .vscode-test/user-data/ path over macOS's hard 103-char Unix socket path limit.
-// Tracked in: https://github.com/microsoft/vscode-mssql/issues/22294
+// Tracked in: https://github.com/microsoft/vscode/issues/319752
 // Use a short temp user-data-dir to avoid macOS's 103-char Unix socket path limit.
 // The "sql-database-projects" directory name makes the default path too long on CI.
 const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();

--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -8,6 +8,10 @@ const mocha = createMochaConfig({
     timeout: 30_000,
 });
 
+// TODO: Workaround for macOS CI EINVAL error — revert once the upstream VS Code issue is fixed.
+// A recent VS Code build changed the socket filename format (e.g. "1.12-main.sock"), pushing the
+// default .vscode-test/user-data/ path over macOS's hard 103-char Unix socket path limit.
+// Tracked in: https://github.com/microsoft/vscode-mssql/issues/22294
 // Use a short temp user-data-dir to avoid macOS's 103-char Unix socket path limit.
 // The "sql-database-projects" directory name makes the default path too long on CI.
 const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();

--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -1,15 +1,27 @@
 import { defineConfig } from "@vscode/test-cli";
 import { createMochaConfig, defaultCoverageConfig } from "../../scripts/vscode-test-config.mjs";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 const mocha = createMochaConfig({
     timeout: 30_000,
+});
+
+// Use a short temp user-data-dir to avoid macOS's 103-char Unix socket path limit.
+// The "sql-database-projects" directory name makes the default path too long on CI.
+const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();
+const userDataDir = fs.mkdtempSync(path.join(tmpBaseDir, "vsc-sqlproj-"));
+process.on("exit", () => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
 });
 
 export default defineConfig({
     tests: [
         {
             files: "out/test/**/*.test.js",
-            launchArgs: ["--disable-gpu"],
+            version: "insiders",
+            launchArgs: ["--disable-gpu", "--user-data-dir", userDataDir],
             env: {
                 SQLPROJ_TEST_MODE: "1",
                 VSCODE_LOG_LEVEL: "error",


### PR DESCRIPTION
- vscode-mssql Issue: #22294 
- vscode Issue: https://github.com/microsoft/vscode/issues/319752 
- PR:  Fix macOS CI EINVAL error in sql-database-projects tests (#22291 )

The 'sql-database-projects' extension directory name causes the VS Code Unix socket path to exceed macOS's 103-char limit on CI runners:
  .vscode-test/user-data/X.XX-main.sock → 107 chars → EINVAL on listen

Fix by:
1. Adding version: 'insiders' to match mssql extension pattern
2. Redirecting --user-data-dir to a short OS temp path via mkdtempSync

* Potential fix for pull request finding



---------

## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
