### PR TITLE
macOS CI EINVAL error fix - adding TODO comment for workaround removal

### DIFF
--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -11,7 +11,7 @@ const mocha = createMochaConfig({
 // TODO: Workaround for macOS CI EINVAL error — revert once the upstream VS Code issue is fixed.
 // A recent VS Code build changed the socket filename format (e.g. "1.12-main.sock"), pushing the
 // default .vscode-test/user-data/ path over macOS's hard 103-char Unix socket path limit.
-// Tracked in: https://github.com/microsoft/vscode-mssql/issues/22294
+// Tracked in: https://github.com/microsoft/vscode/issues/319752
 // Use a short temp user-data-dir to avoid macOS's 103-char Unix socket path limit.
 // The "sql-database-projects" directory name makes the default path too long on CI.
 const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();

--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -8,6 +8,10 @@ const mocha = createMochaConfig({
     timeout: 30_000,
 });
 
+// TODO: Workaround for macOS CI EINVAL error — revert once the upstream VS Code issue is fixed.
+// A recent VS Code build changed the socket filename format (e.g. "1.12-main.sock"), pushing the
+// default .vscode-test/user-data/ path over macOS's hard 103-char Unix socket path limit.
+// Tracked in: https://github.com/microsoft/vscode-mssql/issues/22294
 // Use a short temp user-data-dir to avoid macOS's 103-char Unix socket path limit.
 // The "sql-database-projects" directory name makes the default path too long on CI.
 const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();


### PR DESCRIPTION
## Description

This PR, updates the todo comment to keep tracking of the issue and remove the workaround once the vscode level issue is resolved.

vscode-mssql Issue: https://github.com/microsoft/vscode-mssql/issues/22294
vscode Issue: https://github.com/microsoft/vscode/issues/319752

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
