### PR TITLE
Fix macOS VSIX launch EINVAL by shortening user-data-dir path

### DIFF
--- a/extensions/mssql/test/e2e/utils/launchVscodeWithMsSqlExt.ts
+++ b/extensions/mssql/test/e2e/utils/launchVscodeWithMsSqlExt.ts
@@ -77,7 +77,15 @@ export async function launchVsCodeWithMssqlExtension(
     const [cliPath] = resolveCliArgsFromVSCodeExecutablePath(vscodePath);
     const devExtensionPath = findExtensionRoot(__dirname);
 
-    const tmpRoot = path.join(os.tmpdir(), `vscode-mssql-test-${Date.now()}`);
+    // TODO: Workaround for macOS CI EINVAL error — revert once the upstream VS Code issue is fixed.
+    // A recent VS Code build changed the socket filename format (e.g. "1.12-main.sock"), pushing the
+    // default user-data-dir path over macOS's hard 103-char Unix socket path limit. On macOS,
+    // os.tmpdir() returns a long "/var/folders/.../T" path which, combined with the nested
+    // "vscode-mssql-test-<timestamp>/user-data" directories, exceeds the limit and fails to launch.
+    // Use a short "/tmp" base on macOS to keep the resulting socket path under the limit.
+    // Tracked in: https://github.com/microsoft/vscode/issues/319752
+    const tmpBaseDir = process.platform === "darwin" ? "/tmp" : os.tmpdir();
+    const tmpRoot = path.join(tmpBaseDir, `vscode-mssql-test-${Date.now()}`);
     const userDataDir = path.join(tmpRoot, "user-data");
     const extensionsDir = path.join(tmpRoot, "extensions");
     const videoDir = path.join(


### PR DESCRIPTION
## Description

The `osx` / `osx-arm64` legs of the **MSSQL VSIX Launch Verification** workflow were failing to launch VS Code with an `EINVAL` error.

Root cause: the launch utility built the user-data directory from `os.tmpdir()`, which on macOS returns a long `/var/folders/.../T` path. Combined with the nested `vscode-mssql-test-<timestamp>/user-data` directories and VS Code's recently changed IPC socket filename (e.g. `1.12-main.sock`), the resulting Unix domain socket path was **105 chars**, exceeding macOS's hard **103-char socket path limit** — so VS Code could not create its IPC socket and Electron failed to launch.

Fix: on macOS, use a short `/tmp` base instead of `os.tmpdir()` for the test's user-data/extensions directories, keeping the socket path well under the limit. Linux/Windows continue to use `os.tmpdir()`.

This mirrors the same workaround already applied to `sql-database-projects` in #22295, tracked in [vscode#319752](https://github.com/microsoft/vscode/issues/319752).

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)