### PR TITLE
Cloud Deploy: validation runner (D2) — engine, validators, providers

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3927,6 +3927,46 @@
             "{1} is the underlying I/O error message"
         ]
     },
+    "Cloud Deploy: Validate environment": "Cloud Deploy: Validate environment",
+    "No Cloud Deploy environments are declared in this workspace. Add one to .mssql/environments.json before running validation.": "No Cloud Deploy environments are declared in this workspace. Add one to .mssql/environments.json before running validation.",
+    "Cloud Deploy validation requires an open workspace folder.": "Cloud Deploy validation requires an open workspace folder.",
+    "Select an environment to validate": "Select an environment to validate",
+    "Validating environment '{0}'/{0} is the user-facing environment name": {
+        "message": "Validating environment '{0}'",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "Validation passed for '{0}'./{0} is the user-facing environment name": {
+        "message": "Validation passed for '{0}'.",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "Validation finished with warnings for '{0}'./{0} is the user-facing environment name": {
+        "message": "Validation finished with warnings for '{0}'.",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "Validation failed for '{0}'./{0} is the user-facing environment name": {
+        "message": "Validation failed for '{0}'.",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "Validation runner crashed for '{0}': {1}/{0} is the user-facing environment name{1} is the underlying error message": {
+        "message": "Validation runner crashed for '{0}': {1}",
+        "comment": [
+            "{0} is the user-facing environment name",
+            "{1} is the underlying error message"
+        ]
+    },
+    "Validation cancelled for '{0}'./{0} is the user-facing environment name": {
+        "message": "Validation cancelled for '{0}'.",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "No validations were declared on '{0}'./{0} is the user-facing environment name": {
+        "message": "No validations were declared on '{0}'.",
+        "comment": ["{0} is the user-facing environment name"]
+    },
+    "Show output": "Show output",
+    "Validation finished but the run artifact could not be saved: {0}/{0} is the underlying I/O error message": {
+        "message": "Validation finished but the run artifact could not be saved: {0}",
+        "comment": ["{0} is the underlying I/O error message"]
+    },
     "Azure sign in failed.": "Azure sign in failed.",
     "Select subscriptions": "Select subscriptions",
     "Error loading Azure subscriptions.": "Error loading Azure subscriptions.",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1565,6 +1565,11 @@
                 }
             },
             {
+                "command": "mssql.cloudDeploy.validateEnvironment",
+                "title": "%mssql.cloudDeploy.validateEnvironment%",
+                "category": "MS SQL"
+            },
+            {
                 "command": "mssql.stopContainer",
                 "title": "%mssql.stopContainer%",
                 "category": "MS SQL"

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -250,6 +250,7 @@
     "mssql.schemaDesigner": "Visualize and Design Schema...",
     "mssql.buildDataApi": "Build Data API...",
     "mssql.newDeployment": "New Deployment",
+    "mssql.cloudDeploy.validateEnvironment": "Cloud Deploy: Validate environment",
     "mssql.stopContainer": "Stop SQL Container",
     "mssql.deleteContainer": "Delete SQL Container",
     "mssql.startContainer": "Start SQL Container",

--- a/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
+++ b/extensions/mssql/src/cloudDeploy/cloudDeployService.ts
@@ -15,6 +15,12 @@
  * without it. `diagnostics` and `runs` are always present; run artifacts
  * live at absolute paths, not under `.mssql/`, so they don't depend on a
  * workspace folder to be readable or writable.
+ *
+ * `validation` is the D2 surface: `service.validation.run(envId, opts)`
+ * dispatches every enabled validation declared on the env and returns the
+ * produced `RunRecord`. The service owns the registry, the runner, and
+ * the output channel subscription so callers don't reconstruct any of it
+ * per call.
  */
 
 import * as vscode from "vscode";
@@ -23,6 +29,18 @@ import { DiagnosticEventBus } from "./diagnostics";
 import { EnvironmentStore } from "./environments/environmentStore";
 import { LocalFileProvider } from "./providers";
 import { RunArtifactReader, RunArtifactWriter } from "./runs";
+import {
+    CloudDeployValidationApi,
+    ConnectionError,
+    ConnectionHandle,
+    LiveArtifactProvider,
+    LiveConnectionProvider,
+    LiveConnectionStrategy,
+    LiveProcessProvider,
+    OutputChannelSubscriber,
+    ValidationService,
+    createDefaultRegistry,
+} from "./validation";
 
 /**
  * Run-artifact I/O surface attached to the service. Both members share the
@@ -34,14 +52,34 @@ export interface CloudDeployRunsApi {
     readonly reader: RunArtifactReader;
 }
 
+/**
+ * Optional per-construction injection points. Production wiring (in
+ * `mainController`) supplies `connectionStrategy` once vscode-mssql's
+ * `ConnectionManager` is available; tests substitute their own. When
+ * omitted, the service installs a stub strategy that throws
+ * `ConnectionError("unknown")` with a clear "not configured" message —
+ * connectivity validations against `Container` envs surface as
+ * `Failed`, but the rest of the pipeline still functions.
+ */
+export interface CloudDeployServiceOptions {
+    readonly connectionStrategy?: LiveConnectionStrategy;
+}
+
+const OUTPUT_CHANNEL_NAME = "Cloud Deploy";
+
 export class CloudDeployService implements vscode.Disposable {
     public readonly diagnostics: DiagnosticEventBus;
     public readonly environments: EnvironmentStore | undefined;
     public readonly runs: CloudDeployRunsApi;
+    public readonly validation: CloudDeployValidationApi;
+    public readonly outputChannel: vscode.OutputChannel;
+
+    private readonly _outputSubscriber: OutputChannelSubscriber;
 
     public constructor(
         workspaceFolder: vscode.WorkspaceFolder | undefined,
         workspaceState: vscode.Memento,
+        options: CloudDeployServiceOptions = {},
     ) {
         this.diagnostics = new DiagnosticEventBus();
         if (workspaceFolder !== undefined) {
@@ -52,10 +90,28 @@ export class CloudDeployService implements vscode.Disposable {
             );
         }
         const fileProvider = new LocalFileProvider();
+        const writer = new RunArtifactWriter(fileProvider, this.diagnostics);
         this.runs = {
-            writer: new RunArtifactWriter(fileProvider, this.diagnostics),
+            writer,
             reader: new RunArtifactReader(fileProvider),
         };
+
+        const registry = createDefaultRegistry({
+            connection: new LiveConnectionProvider(
+                options.connectionStrategy ?? new UnconfiguredConnectionStrategy(),
+            ),
+            process: new LiveProcessProvider(),
+            artifact: new LiveArtifactProvider(fileProvider),
+        });
+        this.validation = new ValidationService(
+            registry,
+            this.diagnostics,
+            this.environments,
+            writer,
+        );
+
+        this.outputChannel = vscode.window.createOutputChannel(OUTPUT_CHANNEL_NAME);
+        this._outputSubscriber = new OutputChannelSubscriber(this.outputChannel, this.diagnostics);
     }
 
     /** Loads on-disk state. Safe to call when no folder is open (resolves immediately). */
@@ -68,6 +124,34 @@ export class CloudDeployService implements vscode.Disposable {
     public dispose(): void {
         // Dispose subsystems first so any final emissions still reach subscribers.
         this.environments?.dispose();
+        this._outputSubscriber.dispose();
+        this.outputChannel.dispose();
         this.diagnostics.dispose();
+    }
+}
+
+// =============================================================================
+// Stub strategy for the un-wired connectivity path
+// =============================================================================
+
+/**
+ * Placeholder `LiveConnectionStrategy` used when the host has not yet
+ * supplied a real one. Throws `ConnectionError("unknown")` with a
+ * deterministic message so the connectivity validator surfaces a `Failed`
+ * result — the rest of the pipeline keeps running unimpeded.
+ *
+ * The real strategy (binding `vscode-mssql`'s `ConnectionManager`) lands
+ * as a follow-up; the service constructor accepts an injected strategy
+ * for that wiring.
+ */
+class UnconfiguredConnectionStrategy implements LiveConnectionStrategy {
+    public async connectByProfileId(
+        _profileId: string,
+        _signal: AbortSignal,
+    ): Promise<ConnectionHandle> {
+        throw new ConnectionError(
+            "unknown",
+            "Live connection strategy is not configured. The Cloud Deploy validation runner cannot open a live SQL connection in this build.",
+        );
     }
 }

--- a/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/index.ts
@@ -17,4 +17,9 @@ export type {
     ErrorEvent,
     RunPersistedEvent,
     RunPersistFailedEvent,
+    ValidationFinishedEvent,
+    ValidationProgressEvent,
+    ValidationRunFinishedEvent,
+    ValidationRunStartedEvent,
+    ValidationStartedEvent,
 } from "./types";

--- a/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
+++ b/extensions/mssql/src/cloudDeploy/diagnostics/types.ts
@@ -20,12 +20,20 @@
  * pin payload size to the size of in-memory state.
  */
 
+import type { ValidationType } from "../environments/types";
+import type { CancellationReason, RunStatus, ValidationStatus } from "../runs/types";
+
 // =============================================================================
 // Source / severity unions (closed, expand additively)
 // =============================================================================
 
 /** Subsystem that produced an event. Closed; expand as new subsystems land. */
-export type DiagnosticEventSource = "environment-store" | "run-store" | "service";
+export type DiagnosticEventSource =
+    | "environment-store"
+    | "run-store"
+    | "runner"
+    | "service"
+    | "validation";
 
 /**
  * Hint to subscribers, not a gate. The bus delivers all severities; consumers
@@ -72,6 +80,11 @@ export type DiagnosticEvent =
     | DefaultEnvironmentChangedEvent
     | RunPersistedEvent
     | RunPersistFailedEvent
+    | ValidationRunStartedEvent
+    | ValidationStartedEvent
+    | ValidationProgressEvent
+    | ValidationFinishedEvent
+    | ValidationRunFinishedEvent
     | ErrorEvent;
 
 /** Env file was successfully loaded (or determined to be empty/absent). */
@@ -155,6 +168,94 @@ export interface ErrorEvent extends DiagnosticEventEnvelope {
             readonly message: string;
             readonly stack?: string;
         };
+    };
+}
+
+// =============================================================================
+// Validation runner lifecycle (D2)
+// =============================================================================
+
+/**
+ * D2's validation runner emits run- and validation-level lifecycle events so
+ * the output channel, progress UI, and future telemetry can observe a run
+ * without polling. `correlationId` on every arm carries the `runId` so a
+ * subscriber can stitch events from a single run together.
+ *
+ * Severity rule: lifecycle events default to `"info"`; `validation-progress`
+ * defaults to `"debug"` because it can be high-volume. The finish events
+ * (`validation-finished` and `validation-run-finished`) do NOT carry a
+ * literal severity — the runner stamps `"warn"` or `"error"` based on the
+ * resulting status so subscribers can filter at the bus level.
+ */
+
+/** A validation run is starting. Emitted by the runner before any per-validation event. */
+export interface ValidationRunStartedEvent extends DiagnosticEventEnvelope {
+    readonly source: "runner";
+    readonly type: "validation-run-started";
+    readonly payload: {
+        readonly runId: string;
+        readonly environmentId: string;
+        /** The validation types about to be dispatched, in dispatch order. */
+        readonly validationTypes: readonly ValidationType[];
+    };
+}
+
+/** A single validation is starting. Emitted by the validator (or runner on skip) immediately before `run()`. */
+export interface ValidationStartedEvent extends DiagnosticEventEnvelope {
+    readonly source: "validation";
+    readonly type: "validation-started";
+    readonly payload: {
+        readonly runId: string;
+        readonly validationType: ValidationType;
+    };
+}
+
+/**
+ * Optional progress update from inside a long-running validation. High-volume;
+ * defaulted to `"debug"` so the output channel can elide it by default.
+ */
+export interface ValidationProgressEvent extends DiagnosticEventEnvelope {
+    readonly source: "validation";
+    readonly type: "validation-progress";
+    readonly payload: {
+        readonly runId: string;
+        readonly validationType: ValidationType;
+        readonly message: string;
+        /** Optional 0-100 progress percentage. */
+        readonly percent?: number;
+    };
+}
+
+/**
+ * A single validation has finished. Severity tracks `status` so subscribers
+ * can filter without inspecting payload (the runner stamps `"warn"` for
+ * `Warning`, `"error"` for `Failed` / `Errored`, `"info"` otherwise).
+ */
+export interface ValidationFinishedEvent extends DiagnosticEventEnvelope {
+    readonly source: "validation";
+    readonly type: "validation-finished";
+    readonly payload: {
+        readonly runId: string;
+        readonly validationType: ValidationType;
+        readonly status: ValidationStatus;
+        readonly findingsCount: number;
+        readonly durationMs: number;
+        readonly cancellationReason?: CancellationReason;
+    };
+}
+
+/**
+ * The whole validation run has finished. Severity tracks `status` per the
+ * same rule as `ValidationFinishedEvent`.
+ */
+export interface ValidationRunFinishedEvent extends DiagnosticEventEnvelope {
+    readonly source: "runner";
+    readonly type: "validation-run-finished";
+    readonly payload: {
+        readonly runId: string;
+        readonly status: RunStatus;
+        readonly durationMs: number;
+        readonly validationCount: number;
     };
 }
 

--- a/extensions/mssql/src/cloudDeploy/environments/environmentSchema.ts
+++ b/extensions/mssql/src/cloudDeploy/environments/environmentSchema.ts
@@ -78,6 +78,13 @@ const SourceOfTruthSchema = z.discriminatedUnion("kind", [
 const ValidationConfigSchema = z.discriminatedUnion("type", [
     z
         .object({
+            type: z.literal(ValidationType.Connectivity),
+            enabled: z.boolean(),
+            settings: SettingsSchema.default({}),
+        })
+        .passthrough(),
+    z
+        .object({
             type: z.literal(ValidationType.StaticAnalysis),
             enabled: z.boolean(),
             settings: SettingsSchema.default({}),

--- a/extensions/mssql/src/cloudDeploy/environments/types.ts
+++ b/extensions/mssql/src/cloudDeploy/environments/types.ts
@@ -30,6 +30,7 @@
  * surface small without precluding that.
  */
 export enum ValidationType {
+    Connectivity = "connectivity",
     StaticAnalysis = "static-analysis",
     UnitTests = "unit-tests",
     WorkloadPlayback = "workload-playback",
@@ -67,6 +68,10 @@ export type SourceOfTruth =
  * each validation is implemented. Keeping them as named interfaces (rather
  * than `Record<string, unknown>`) gives us type-safety as soon as fields land.
  */
+export interface ConnectivitySettings {
+    // populated when connectivity gains real options (e.g., custom probe query, retry policy)
+}
+
 export interface StaticAnalysisSettings {
     // populated when static analysis is implemented (e.g., enabled rule ids, severity overrides)
 }
@@ -84,6 +89,7 @@ export interface WorkloadPlaybackSettings {
  * validation's `settings` is correctly typed.
  */
 export type ValidationConfig =
+    | { type: ValidationType.Connectivity; enabled: boolean; settings: ConnectivitySettings }
     | { type: ValidationType.StaticAnalysis; enabled: boolean; settings: StaticAnalysisSettings }
     | { type: ValidationType.UnitTests; enabled: boolean; settings: UnitTestsSettings }
     | {

--- a/extensions/mssql/src/cloudDeploy/environments/types.ts
+++ b/extensions/mssql/src/cloudDeploy/environments/types.ts
@@ -81,7 +81,42 @@ export interface UnitTestsSettings {
 }
 
 export interface WorkloadPlaybackSettings {
-    // populated when workload playback is implemented (e.g., baseline artifact ref, regression threshold)
+    /**
+     * Captured-workload artifact location consumed by the replay tool.
+     * In Scope 1 this is an absolute or workspace-relative local file path
+     * (resolved by the host); a future `GitHubArtifactProvider` reuses the
+     * same field with a `gh://` URI.
+     */
+    workloadUri?: string;
+    /**
+     * Baseline-metrics artifact the replay's observed metrics are compared
+     * against. Same uri semantics as `workloadUri`.
+     */
+    baselineUri?: string;
+    /**
+     * Replay tool command. Defaults to `"sql-workload-replay"` when omitted;
+     * the service layer may pin an absolute path the same way it does for
+     * `sqlpackage`.
+     */
+    replayCommand?: string;
+    /**
+     * Latency-regression threshold expressed as a fraction of the baseline
+     * (e.g. `0.25` flags any step whose observed latency is more than 25 %
+     * higher than baseline). Defaults applied by the validator.
+     */
+    latencyRegressionThreshold?: number;
+    /**
+     * Throughput-regression threshold expressed as a fraction of the baseline
+     * (e.g. `0.25` flags any step whose observed throughput drops by more
+     * than 25 %).
+     */
+    throughputRegressionThreshold?: number;
+    /**
+     * Error-rate-increase threshold expressed as an absolute delta (e.g.
+     * `0.05` flags any step whose observed error rate is more than five
+     * percentage points above baseline).
+     */
+    errorRateThreshold?: number;
 }
 
 /**

--- a/extensions/mssql/src/cloudDeploy/runs/runArtifactSchema.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/runArtifactSchema.ts
@@ -104,6 +104,22 @@ const ValidationStatusSchema = z.nativeEnum(ValidationStatus);
 // Finding schemas
 // -----------------------------------------------------------------------------
 
+const ConnectivityFindingSchema = z
+    .object({
+        kind: z.literal("connectivity"),
+        outcome: z.enum([
+            "reachable",
+            "connection-refused",
+            "auth-failed",
+            "host-unreachable",
+            "timeout",
+            "unknown",
+        ]),
+        severity: z.enum(["info", "warning", "error"]),
+        message: z.string(),
+    })
+    .passthrough();
+
 const StaticAnalysisFindingSchema = z
     .object({
         kind: z.literal("static-analysis"),
@@ -144,6 +160,19 @@ const WorkloadRegressionFindingSchema = z
 // -----------------------------------------------------------------------------
 // Payload schemas
 // -----------------------------------------------------------------------------
+
+const ConnectivityPayloadSchema = z
+    .object({
+        validationType: z.literal(ValidationType.Connectivity),
+        findings: z.array(ConnectivityFindingSchema),
+        summary: z
+            .object({
+                reachable: z.boolean(),
+                serverVersion: z.string().min(1).optional(),
+            })
+            .passthrough(),
+    })
+    .passthrough();
 
 const StaticAnalysisPayloadSchema = z
     .object({
@@ -189,6 +218,7 @@ const WorkloadPlaybackPayloadSchema = z
     .passthrough();
 
 const ValidationPayloadSchema = z.discriminatedUnion("validationType", [
+    ConnectivityPayloadSchema,
     StaticAnalysisPayloadSchema,
     UnitTestsPayloadSchema,
     WorkloadPlaybackPayloadSchema,
@@ -207,8 +237,25 @@ const ValidationResultSchema = z
         endedAtMs: z.number().int().nonnegative(),
         payload: ValidationPayloadSchema,
         errorMessage: z.string().optional(),
+        cancellationReason: z.enum(["user", "timeout"]).optional(),
     })
-    .passthrough();
+    .passthrough()
+    .superRefine((res, ctx) => {
+        if (res.status === ValidationStatus.Cancelled && res.cancellationReason === undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "cancellationReason is required when status is 'cancelled'.",
+                path: ["cancellationReason"],
+            });
+        }
+        if (res.status !== ValidationStatus.Cancelled && res.cancellationReason !== undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "cancellationReason must be omitted unless status is 'cancelled'.",
+                path: ["cancellationReason"],
+            });
+        }
+    });
 
 const RunRecordSchema = z
     .object({

--- a/extensions/mssql/src/cloudDeploy/runs/types.ts
+++ b/extensions/mssql/src/cloudDeploy/runs/types.ts
@@ -40,10 +40,16 @@ export const RUN_RECORD_SCHEMA_VERSION = 1 as const;
 /**
  * Overall status of a run, computed by collapsing all per-validation statuses
  * via `RUN_STATUS_PRIORITY` (worst wins). Listed least- to most-severe.
+ *
+ * `Cancelled` was added in D2: user-cancelled and timed-out runs surface a
+ * real status arm instead of a string-matched `errorMessage`. Ranked between
+ * `Skipped` and `Warning` — worse than skipping intentionally, better than
+ * finding a real warning.
  */
 export enum RunStatus {
     Passed = "passed",
     Skipped = "skipped",
+    Cancelled = "cancelled",
     Warning = "warning",
     Failed = "failed",
     Errored = "errored",
@@ -60,19 +66,29 @@ export enum RunStatus {
 export const RUN_STATUS_PRIORITY: Readonly<Record<RunStatus, number>> = Object.freeze({
     [RunStatus.Passed]: 0,
     [RunStatus.Skipped]: 1,
-    [RunStatus.Warning]: 2,
-    [RunStatus.Failed]: 3,
-    [RunStatus.Errored]: 4,
+    [RunStatus.Cancelled]: 2,
+    [RunStatus.Warning]: 3,
+    [RunStatus.Failed]: 4,
+    [RunStatus.Errored]: 5,
 });
 
 /** Status of a single validation execution. Mirrors `RunStatus` semantics. */
 export enum ValidationStatus {
     Passed = "passed",
     Skipped = "skipped",
+    Cancelled = "cancelled",
     Warning = "warning",
     Failed = "failed",
     Errored = "errored",
 }
+
+/**
+ * Why a validation (or run) was cancelled. `"user"` covers explicit
+ * user-initiated cancellation; `"timeout"` covers runner-level deadline
+ * expiry. Stored on `ValidationResult.cancellationReason` and required
+ * whenever the corresponding status is `Cancelled` (enforced in Zod).
+ */
+export type CancellationReason = "user" | "timeout";
 
 // =============================================================================
 // Runner identity
@@ -102,7 +118,31 @@ export interface RunnerIdentity {
  * inside a unit-test run is `UnitTestFinding`, not a generic message blob.
  * That gives the renderer a typed surface without inspecting magic strings.
  */
-export type Finding = StaticAnalysisFinding | UnitTestFinding | WorkloadRegressionFinding;
+export type Finding =
+    | ConnectivityFinding
+    | StaticAnalysisFinding
+    | UnitTestFinding
+    | WorkloadRegressionFinding;
+
+export interface ConnectivityFinding {
+    readonly kind: "connectivity";
+    /**
+     * Closed enum of the connection failure modes the connectivity validator
+     * surfaces. New modes ride the same arm — additive. `"reachable"` is the
+     * success marker (the one finding emitted on a green connection).
+     */
+    readonly outcome:
+        | "reachable"
+        | "connection-refused"
+        | "auth-failed"
+        | "host-unreachable"
+        | "timeout"
+        | "unknown";
+    /** Severity within the validator's vocabulary. `"reachable"` is `"info"`; failures are `"error"`. */
+    readonly severity: "info" | "warning" | "error";
+    /** Human-readable description; not localized — emitted by the validator. */
+    readonly message: string;
+}
 
 export interface StaticAnalysisFinding {
     readonly kind: "static-analysis";
@@ -153,7 +193,25 @@ export interface WorkloadRegressionFinding {
  * a single `ValidationResult.payload` be exhaustively narrowed without
  * runtime type checks.
  */
-export type ValidationPayload = StaticAnalysisPayload | UnitTestsPayload | WorkloadPlaybackPayload;
+export type ValidationPayload =
+    | ConnectivityPayload
+    | StaticAnalysisPayload
+    | UnitTestsPayload
+    | WorkloadPlaybackPayload;
+
+export interface ConnectivityPayload {
+    readonly validationType: ValidationType.Connectivity;
+    readonly findings: readonly ConnectivityFinding[];
+    /**
+     * `serverVersion` is captured on a successful probe so the UI can render
+     * "connected to SQL Server 2022 (16.0.x)" without re-querying. Absent on
+     * failure paths.
+     */
+    readonly summary: {
+        readonly reachable: boolean;
+        readonly serverVersion?: string;
+    };
+}
 
 export interface StaticAnalysisPayload {
     readonly validationType: ValidationType.StaticAnalysis;
@@ -213,6 +271,12 @@ export interface ValidationResult {
      * not "the validation found N problems".
      */
     readonly errorMessage?: string;
+    /**
+     * Why this validation was cancelled. Required whenever
+     * `status === ValidationStatus.Cancelled` and forbidden otherwise
+     * (enforced by the Zod schema's `superRefine` cross-field check).
+     */
+    readonly cancellationReason?: CancellationReason;
 }
 
 // =============================================================================

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -6,6 +6,7 @@
 export { Runner } from "./runner";
 export type { RunnerRunOptions } from "./runner";
 export { createDefaultRegistry } from "./registry";
+export type { RegistryProviders } from "./registry";
 export {
     CancellationError,
     assertNeverValidationType,
@@ -13,3 +14,18 @@ export {
     throwIfCancelled,
 } from "./types";
 export type { SettingsFor, Validator, ValidatorRegistry, ValidatorRunOptions } from "./types";
+export {
+    ConnectionError,
+    FakeConnectionHandle,
+    FakeConnectionProvider,
+    LiveConnectionProvider,
+} from "./providers/connectionProvider";
+export type {
+    ConnectionFailureKind,
+    ConnectionHandle,
+    ConnectionProvider,
+    FakeConnectionBehavior,
+    FakeConnectionHandleConfig,
+    LiveConnectionStrategy,
+} from "./providers/connectionProvider";
+export { ConnectivityValidator } from "./validators/connectivityValidator";

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { Runner } from "./runner";
+export type { RunnerRunOptions } from "./runner";
+export { createDefaultRegistry } from "./registry";
+export {
+    CancellationError,
+    assertNeverValidationType,
+    defineRegistry,
+    throwIfCancelled,
+} from "./types";
+export type { SettingsFor, Validator, ValidatorRegistry, ValidatorRunOptions } from "./types";

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -29,3 +29,12 @@ export type {
     LiveConnectionStrategy,
 } from "./providers/connectionProvider";
 export { ConnectivityValidator } from "./validators/connectivityValidator";
+export { FakeProcessProvider, LiveProcessProvider } from "./providers/processProvider";
+export type {
+    FakeProcessResponse,
+    FakeSpawnInvocation,
+    ProcessProvider,
+    ProcessResult,
+    ProcessSpawnOptions,
+} from "./providers/processProvider";
+export { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -39,3 +39,10 @@ export type {
 } from "./providers/processProvider";
 export { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";
 export { UnitTestsValidator } from "./validators/unitTestsValidator";
+export { WorkloadPlaybackValidator } from "./validators/workloadPlaybackValidator";
+export {
+    ArtifactNotFoundError,
+    FakeArtifactProvider,
+    LiveArtifactProvider,
+} from "./providers/artifactProvider";
+export type { ArtifactProvider, FakeArtifactRead } from "./providers/artifactProvider";

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -46,3 +46,11 @@ export {
     LiveArtifactProvider,
 } from "./providers/artifactProvider";
 export type { ArtifactProvider, FakeArtifactRead } from "./providers/artifactProvider";
+export { ValidationService } from "./validationApi";
+export type {
+    CloudDeployValidationApi,
+    CloudDeployValidationRunOptions,
+    CloudDeployValidationRunResult,
+} from "./validationApi";
+export { OutputChannelSubscriber, formatEvent } from "./outputChannelSubscriber";
+export type { OutputChannelLike } from "./outputChannelSubscriber";

--- a/extensions/mssql/src/cloudDeploy/validation/index.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/index.ts
@@ -38,3 +38,4 @@ export type {
     ProcessSpawnOptions,
 } from "./providers/processProvider";
 export { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";
+export { UnitTestsValidator } from "./validators/unitTestsValidator";

--- a/extensions/mssql/src/cloudDeploy/validation/outputChannelSubscriber.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/outputChannelSubscriber.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — output-channel subscriber.
+ *
+ * Wraps a `vscode.OutputChannel` (or any `OutputChannelLike` for tests) and
+ * subscribes to a `DiagnosticEventBus`, formatting every event into a
+ * single line. The shape mirrors the design doc's example:
+ *
+ *   `[12:34:56.789] [info] [runner] validation-run-started: runId=abc env=my-env validations=[connectivity,...]`
+ *
+ * The subscriber owns the bus subscription only; it does NOT own the
+ * channel. Callers (the service layer) construct the channel and pass it
+ * in so the channel's lifetime can match the service's, not the
+ * subscriber's, and so tests can substitute a recording stub.
+ */
+
+import type * as vscode from "vscode";
+
+import type { DiagnosticEvent, DiagnosticEventBus } from "../diagnostics";
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Minimal shape from `vscode.OutputChannel` we depend on. Lets unit tests
+ * pass a recording stub without faking the full VS Code API.
+ */
+export interface OutputChannelLike {
+    appendLine(value: string): void;
+}
+
+/**
+ * Subscribes a channel-like sink to a bus. Returns a `Disposable`; callers
+ * dispose to unsubscribe. The subscriber drops the high-volume `debug`
+ * arms (currently `validation-progress`) by default — tracing those is a
+ * separate developer-mode concern.
+ */
+export class OutputChannelSubscriber implements vscode.Disposable {
+    private readonly _subscription: vscode.Disposable;
+
+    public constructor(
+        private readonly _channel: OutputChannelLike,
+        bus: DiagnosticEventBus,
+        private readonly _options: { readonly includeDebug?: boolean } = {},
+    ) {
+        this._subscription = bus.onDidEmit((e) => this._onEvent(e));
+    }
+
+    public dispose(): void {
+        this._subscription.dispose();
+    }
+
+    private _onEvent(event: DiagnosticEvent): void {
+        if (event.severity === "debug" && !this._options.includeDebug) {
+            return;
+        }
+        this._channel.appendLine(formatEvent(event));
+    }
+}
+
+// =============================================================================
+// Formatting
+// =============================================================================
+
+/**
+ * Formats a single event onto one line. The payload is rendered with a
+ * shallow `key=value` projection so common cases (run-id, env-id, status)
+ * land on a single line; nested fields are JSON-stringified inline.
+ *
+ * Exported for unit tests that exercise the formatter directly without
+ * spinning up a bus.
+ */
+export function formatEvent(event: DiagnosticEvent): string {
+    const stamp = formatTimestamp(event.timestampMs);
+    const payloadStr = formatPayload(event);
+    return `[${stamp}] [${event.severity}] [${event.source}] ${event.type}${payloadStr}`;
+}
+
+function formatTimestamp(timestampMs: number): string {
+    const d = new Date(timestampMs);
+    const hh = pad2(d.getHours());
+    const mm = pad2(d.getMinutes());
+    const ss = pad2(d.getSeconds());
+    const ms = pad3(d.getMilliseconds());
+    return `${hh}:${mm}:${ss}.${ms}`;
+}
+
+function pad2(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+}
+
+function pad3(n: number): string {
+    if (n < 10) {
+        return `00${n}`;
+    }
+    if (n < 100) {
+        return `0${n}`;
+    }
+    return `${n}`;
+}
+
+function formatPayload(event: DiagnosticEvent): string {
+    const payload = (event as { payload?: Record<string, unknown> }).payload;
+    if (payload === undefined) {
+        return "";
+    }
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(payload)) {
+        parts.push(`${key}=${formatValue(value)}`);
+    }
+    return parts.length === 0 ? "" : `: ${parts.join(" ")}`;
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined || value === null) {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => formatValue(v)).join(",")}]`;
+    }
+    if (typeof value === "object") {
+        return JSON.stringify(value);
+    }
+    return String(value);
+}

--- a/extensions/mssql/src/cloudDeploy/validation/providers/artifactProvider.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/providers/artifactProvider.ts
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `ArtifactProvider` abstraction.
+ *
+ * Host-agnostic seam for "read a captured-workload file or a baseline-metrics
+ * artifact from somewhere." `WorkloadPlaybackValidator` consumes it to load
+ * the workload it's about to replay and the baseline it compares against;
+ * any future validator that needs to consult an external blob (e.g. a
+ * pre-computed plan-store snapshot) reuses the same interface.
+ *
+ * The contract is intentionally minimal — `read(uri)` returns the entire
+ * artifact as a `Buffer`, `exists(uri)` is a cheap pre-flight. There is no
+ * write path: validators consume artifacts, they do not produce them. The
+ * production implementation (`LiveArtifactProvider`) delegates to the same
+ * `FileProvider` abstraction that backs D3's run-artifact reader / writer,
+ * so the slice has a single I/O abstraction shared by every consumer.
+ *
+ * The `uri` parameter is a string-typed local file path in Scope 1. A future
+ * Scope-2 `GitHubArtifactProvider` slots into the same interface and parses
+ * `gh://owner/repo/run/{id}/artifacts/{name}`-style URIs without any change
+ * to the consumer (`WorkloadPlaybackValidator`) or the contract.
+ *
+ * Errors:
+ *   * `ArtifactNotFoundError` — `read()` was called for a uri that does not
+ *     exist. Distinct error class so validators can react with a typed
+ *     `Skipped` result instead of bubbling a generic `Error`.
+ *   * Any other I/O failure surfaces as a plain `Error`; validators re-throw
+ *     so the runner classifies the result as `Errored`.
+ */
+
+import type { FileProvider } from "../../providers";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Provider interface. Two methods, both async, no streaming. Validators that
+ * need richer access (range reads, partial decompression) can extend the
+ * interface additively when a concrete need lands.
+ */
+export interface ArtifactProvider {
+    /**
+     * Reads the full artifact at `uri` as a `Buffer`. Throws
+     * `ArtifactNotFoundError` when the artifact does not exist; any other
+     * failure surfaces as a generic `Error`.
+     */
+    read(uri: string): Promise<Buffer>;
+
+    /** Cheap pre-flight; never throws on a missing artifact. */
+    exists(uri: string): Promise<boolean>;
+}
+
+/**
+ * Thrown by `read()` when the artifact is not present. Carries the original
+ * `uri` so callers can build a useful skipped-finding message without
+ * needing to reconstruct it.
+ */
+export class ArtifactNotFoundError extends Error {
+    public constructor(
+        public readonly uri: string,
+        message?: string,
+    ) {
+        super(message ?? `Artifact not found: ${uri}`);
+        this.name = "ArtifactNotFoundError";
+    }
+}
+
+// =============================================================================
+// LiveArtifactProvider
+// =============================================================================
+
+/**
+ * Production implementation. Treats `uri` as an absolute or workspace-relative
+ * local file path and delegates I/O to the injected `FileProvider`. The
+ * `FileProvider` is the same interface D3's run-artifact writer/reader uses,
+ * so the production stack has a single fs seam.
+ */
+export class LiveArtifactProvider implements ArtifactProvider {
+    public constructor(private readonly _files: FileProvider) {}
+
+    public async read(uri: string): Promise<Buffer> {
+        try {
+            return await this._files.readFileBuffer(uri);
+        } catch (err) {
+            if (isEnoent(err)) {
+                throw new ArtifactNotFoundError(uri);
+            }
+            throw err;
+        }
+    }
+
+    public exists(uri: string): Promise<boolean> {
+        return this._files.fileExists(uri);
+    }
+}
+
+function isEnoent(err: unknown): boolean {
+    return (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code?: unknown }).code === "ENOENT"
+    );
+}
+
+// =============================================================================
+// FakeArtifactProvider (test double)
+// =============================================================================
+
+/** Records every read so tests can assert which URIs were consulted. */
+export interface FakeArtifactRead {
+    readonly uri: string;
+    readonly hit: boolean;
+}
+
+/**
+ * In-memory implementation for unit tests. Tests `set()` artifacts up-front;
+ * `read()` returns the stored `Buffer` (or throws `ArtifactNotFoundError`
+ * for unset URIs); `exists()` returns whether a uri has been `set`. Every
+ * `read` (hit or miss) is captured in `reads` so tests can assert which
+ * artifacts the validator actually consulted, in order.
+ */
+export class FakeArtifactProvider implements ArtifactProvider {
+    public readonly reads: FakeArtifactRead[] = [];
+    private readonly _store = new Map<string, Buffer>();
+
+    /**
+     * Seeds an artifact at `uri`. Strings are stored as UTF-8 Buffers for
+     * convenience (the workload-playback validator consumes JSON payloads,
+     * which are easier to seed as strings).
+     */
+    public set(uri: string, contents: Buffer | string): void {
+        const buf = typeof contents === "string" ? Buffer.from(contents, "utf-8") : contents;
+        this._store.set(uri, buf);
+    }
+
+    public async read(uri: string): Promise<Buffer> {
+        const buf = this._store.get(uri);
+        this.reads.push({ uri, hit: buf !== undefined });
+        if (buf === undefined) {
+            throw new ArtifactNotFoundError(uri);
+        }
+        return buf;
+    }
+
+    public async exists(uri: string): Promise<boolean> {
+        return this._store.has(uri);
+    }
+}

--- a/extensions/mssql/src/cloudDeploy/validation/providers/connectionProvider.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/providers/connectionProvider.ts
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `ConnectionProvider` abstraction.
+ *
+ * Host-agnostic seam for "open a SQL connection from an `Environment` and
+ * execute a probe query." Validators that need a live connection
+ * (`ConnectivityValidator`, `UnitTestsValidator`) take a `ConnectionProvider`
+ * by injection so they can run against `FakeConnectionProvider` in unit
+ * tests and against `LiveConnectionProvider` (wired by the service layer)
+ * in production.
+ *
+ * The interface is deliberately narrow: `connect(env, signal)` returns a
+ * `ConnectionHandle`; the handle exposes `execute(sql, signal)` for probe
+ * queries and `dispose()` for cleanup. No transactions, no parameterized
+ * queries, no result-set metadata — those live behind a wider abstraction
+ * if a validator ever needs them.
+ *
+ * Failure modes are a closed `ConnectionFailureKind` union surfaced via
+ * `ConnectionError`. Callers (validators) map that union onto
+ * `ConnectivityFinding.outcome` directly.
+ */
+
+import { type Environment, SourceOfTruthKind } from "../../environments/types";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Closed enum of connection-failure modes. New modes ride the same union —
+ * additive. Validators map these 1:1 onto `ConnectivityFinding.outcome`.
+ */
+export type ConnectionFailureKind =
+    | "connection-refused"
+    | "auth-failed"
+    | "host-unreachable"
+    | "timeout"
+    | "unknown";
+
+/**
+ * Typed error thrown by `ConnectionProvider.connect()` and
+ * `ConnectionHandle.execute()` on failure. The `kind` is the closed-union
+ * discriminator the validator surfaces; `message` is a free-form human
+ * description (not localized — consumed by the validator and stamped onto
+ * the `ConnectivityFinding`).
+ */
+export class ConnectionError extends Error {
+    public constructor(
+        public readonly kind: ConnectionFailureKind,
+        message?: string,
+    ) {
+        super(message ?? `Connection failed (${kind}).`);
+        this.name = "ConnectionError";
+    }
+}
+
+/**
+ * An open connection. Validators call `execute()` to run probe queries and
+ * `dispose()` (or rely on auto-disposal) when done. `dispose()` MUST be
+ * idempotent — validators may call it on both success and failure paths.
+ */
+export interface ConnectionHandle {
+    /**
+     * Execute a probe query. Returns the raw row array; validators inspect
+     * shape (e.g. read `row[0][0]` for a single scalar). Throws
+     * `ConnectionError` on transport / auth / timeout failures.
+     */
+    execute(sql: string, signal: AbortSignal): Promise<unknown[][]>;
+    /** Closes the underlying connection. Idempotent. */
+    dispose(): Promise<void>;
+}
+
+/**
+ * The provider contract. `connect()` opens a connection against the env's
+ * target and returns a `ConnectionHandle`, or throws `ConnectionError`.
+ *
+ * Implementations MUST honor `signal`: if it aborts during the connect
+ * attempt, the provider abandons the attempt and throws `ConnectionError`
+ * with `kind: "timeout"`.
+ */
+export interface ConnectionProvider {
+    connect(env: Environment, signal: AbortSignal): Promise<ConnectionHandle>;
+}
+
+// =============================================================================
+// LiveConnectionProvider — strategy wrapper
+// =============================================================================
+
+/**
+ * Strategy bundle injected into `LiveConnectionProvider`. The service layer
+ * (commit 6) constructs the real strategy by wiring vscode-mssql's
+ * `ConnectionManager` (or whatever the production connection surface is)
+ * into a callable `connectFn`. Keeping the strategy injectable here means
+ * commit 2 ships a real, functional `LiveConnectionProvider` class without
+ * coupling D2 to the wider extension's connection plumbing.
+ */
+export interface LiveConnectionStrategy {
+    /**
+     * Open a live connection given a connection-profile id and a cancellation
+     * signal. Implementations MUST throw `ConnectionError` (with the right
+     * `kind`) on failure rather than letting other error shapes leak.
+     */
+    connectByProfileId(profileId: string, signal: AbortSignal): Promise<ConnectionHandle>;
+}
+
+/**
+ * Production `ConnectionProvider`. Reads `env.sourceOfTruth`; for the
+ * `Container` arm it delegates to the injected strategy. For non-container
+ * envs (`SqlProj`, `Dacpac`) there is no live target — `connect()` throws
+ * `ConnectionError("unknown")` with a deterministic message so the
+ * connectivity validator surfaces it as a `Failed` result with
+ * `outcome: "unknown"`.
+ */
+export class LiveConnectionProvider implements ConnectionProvider {
+    public constructor(private readonly _strategy: LiveConnectionStrategy) {}
+
+    public async connect(env: Environment, signal: AbortSignal): Promise<ConnectionHandle> {
+        if (env.sourceOfTruth.kind !== SourceOfTruthKind.Container) {
+            throw new ConnectionError(
+                "unknown",
+                `Environment "${env.id}" has no connection profile (source-of-truth kind is "${env.sourceOfTruth.kind}").`,
+            );
+        }
+        return this._strategy.connectByProfileId(env.sourceOfTruth.connectionProfileId, signal);
+    }
+}
+
+// =============================================================================
+// FakeConnectionProvider — test double
+// =============================================================================
+
+/**
+ * Per-env behavior selector for `FakeConnectionProvider`. Test files configure
+ * one of these per env id before invoking the validator.
+ *
+ *   * `"success"` — `connect()` resolves to a configurable `FakeConnectionHandle`.
+ *   * `"failure"` — `connect()` throws `ConnectionError(kind, message?)`.
+ *   * `"timeout"` — `connect()` waits for `signal.aborted`, then throws
+ *     `ConnectionError("timeout")`. Used to test cancellation mid-connect.
+ */
+export type FakeConnectionBehavior =
+    | { mode: "success"; handle?: FakeConnectionHandleConfig }
+    | { mode: "failure"; kind: ConnectionFailureKind; message?: string }
+    | { mode: "timeout" };
+
+/** Optional canned configuration for a `FakeConnectionHandle`. */
+export interface FakeConnectionHandleConfig {
+    /**
+     * Canned responses keyed by SQL string (exact match). When `execute()`
+     * is called with an unknown SQL, the handle returns `[[]]` (one empty
+     * row) by default.
+     */
+    readonly executeResponses?: Readonly<Record<string, unknown[][]>>;
+    /** If set, `execute()` throws this `ConnectionError` instead of returning. */
+    readonly executeError?: ConnectionError;
+}
+
+/**
+ * Test double. Records every `connect()` invocation and every per-handle
+ * `execute()` invocation for assertion. Configurable per env id; envs
+ * without configuration default to `{ mode: "success" }`.
+ */
+export class FakeConnectionProvider implements ConnectionProvider {
+    public readonly invocations: Array<{ envId: string; signalAborted: boolean }> = [];
+    /**
+     * Handles created by `connect()`. Tests inspect the latest handle's
+     * `executions` array to assert which probe queries ran.
+     */
+    public readonly handles: FakeConnectionHandle[] = [];
+
+    private readonly _behaviors = new Map<string, FakeConnectionBehavior>();
+
+    /** Registers a per-env behavior. Subsequent `connect()` calls honor it. */
+    public configure(envId: string, behavior: FakeConnectionBehavior): void {
+        this._behaviors.set(envId, behavior);
+    }
+
+    public async connect(env: Environment, signal: AbortSignal): Promise<ConnectionHandle> {
+        this.invocations.push({ envId: env.id, signalAborted: signal.aborted });
+
+        const behavior = this._behaviors.get(env.id) ?? { mode: "success" };
+
+        switch (behavior.mode) {
+            case "success": {
+                const handle = new FakeConnectionHandle(behavior.handle);
+                this.handles.push(handle);
+                return handle;
+            }
+            case "failure":
+                throw new ConnectionError(behavior.kind, behavior.message);
+            case "timeout":
+                await waitForAbort(signal);
+                throw new ConnectionError("timeout", "Fake connection aborted before opening.");
+        }
+    }
+}
+
+/**
+ * Test-double `ConnectionHandle`. Records every `execute()` call; returns
+ * canned responses by exact SQL match or `[[]]` for unknown SQL.
+ */
+export class FakeConnectionHandle implements ConnectionHandle {
+    public readonly executions: Array<{ sql: string; signalAborted: boolean }> = [];
+    public disposed = false;
+
+    public constructor(private readonly _config?: FakeConnectionHandleConfig) {}
+
+    public async execute(sql: string, signal: AbortSignal): Promise<unknown[][]> {
+        this.executions.push({ sql, signalAborted: signal.aborted });
+        if (this._config?.executeError) {
+            throw this._config.executeError;
+        }
+        const canned = this._config?.executeResponses?.[sql];
+        return canned ?? [[]];
+    }
+
+    public async dispose(): Promise<void> {
+        this.disposed = true;
+    }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
+        if (signal.aborted) {
+            resolve();
+            return;
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+}

--- a/extensions/mssql/src/cloudDeploy/validation/providers/processProvider.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/providers/processProvider.ts
@@ -1,0 +1,348 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `ProcessProvider` abstraction.
+ *
+ * Host-agnostic seam for "spawn a subprocess, feed it args, capture stdout
+ * and stderr, get an exit code, forward an `AbortSignal` to kill it."
+ * Validators that shell out to external CLIs (`StaticAnalysisValidator` runs
+ * `sqlpackage`, `WorkloadPlaybackValidator` runs the replay tool) take a
+ * `ProcessProvider` by injection so unit tests can drive them with
+ * `FakeProcessProvider` and production wires up `LiveProcessProvider`.
+ *
+ * The contract is deliberately small: one `spawn()` method, no streaming
+ * stdout API, no interactive stdin past the initial buffer. If a future
+ * validator needs streaming or richer IPC, that's a wider abstraction —
+ * not a change to this surface.
+ *
+ * Cancellation is `AbortSignal`-based to match the rest of D2 (the runner,
+ * the connection provider, every validator). On abort, `LiveProcessProvider`
+ * sends `SIGTERM`, then `SIGKILL` after a short grace window. The resulting
+ * `ProcessResult.exitCode` is `null` when the child was killed by signal;
+ * `ProcessResult.signal` carries the signal name in that case.
+ */
+
+import { ChildProcess, spawn as nodeSpawn, type SpawnOptionsWithoutStdio } from "child_process";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Options for a single `spawn()` call. `signal` is required because every
+ * call site already has one from the runner; making it optional would
+ * encourage validators to skip cancellation plumbing.
+ */
+export interface ProcessSpawnOptions {
+    /** Working directory. Defaults to the parent process's `cwd`. */
+    readonly cwd?: string;
+    /**
+     * Environment variables. When provided, replaces (does not merge with)
+     * the parent's `process.env`. Callers that want to inherit should spread
+     * `process.env` themselves so the inheritance is explicit at the call site.
+     */
+    readonly env?: Record<string, string>;
+    /** Cancellation signal. Required. */
+    readonly signal: AbortSignal;
+    /** Optional stdin payload. Written once at spawn, then closed. */
+    readonly stdin?: string;
+    /**
+     * Hard cap on the captured stdout / stderr byte count (each stream
+     * counted independently). When the cap is reached, further bytes are
+     * dropped and a `[output truncated]` marker is appended to the captured
+     * string. Defaults to 5 MiB.
+     */
+    readonly maxOutputBytes?: number;
+}
+
+/**
+ * Outcome of a single `spawn()` call. `exitCode` is `null` when the child
+ * was terminated by a signal (in which case `signal` carries the signal
+ * name); otherwise it's the numeric exit code from the OS.
+ */
+export interface ProcessResult {
+    readonly exitCode: number | null;
+    readonly stdout: string;
+    readonly stderr: string;
+    /**
+     * Set when the child was terminated by signal (e.g. `"SIGTERM"` after an
+     * abort). Mutually exclusive with a numeric `exitCode` in practice.
+     */
+    readonly signal?: NodeJS.Signals;
+    /** True when the abort signal fired before the child exited naturally. */
+    readonly aborted: boolean;
+    /** True when at least one of stdout / stderr hit the byte cap. */
+    readonly truncated: boolean;
+}
+
+/**
+ * Provider interface. One method, one promise.
+ */
+export interface ProcessProvider {
+    spawn(
+        command: string,
+        args: readonly string[],
+        opts: ProcessSpawnOptions,
+    ): Promise<ProcessResult>;
+}
+
+// =============================================================================
+// LiveProcessProvider
+// =============================================================================
+
+const DEFAULT_MAX_OUTPUT_BYTES = 5 * 1024 * 1024; // 5 MiB per stream
+const SIGKILL_GRACE_MS = 250; // SIGTERM → SIGKILL grace window after abort
+
+/**
+ * Real implementation backed by Node's `child_process.spawn`. `shell: false`
+ * — `command` is resolved exactly as given, no shell quoting, no PATHEXT
+ * magic. Callers are responsible for resolving the binary path (the service
+ * layer wires up `sqlpackage` discovery; this provider doesn't try to be
+ * clever).
+ */
+export class LiveProcessProvider implements ProcessProvider {
+    public spawn(
+        command: string,
+        args: readonly string[],
+        opts: ProcessSpawnOptions,
+    ): Promise<ProcessResult> {
+        return new Promise<ProcessResult>((resolve, reject) => {
+            const max = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+            const stdoutBuf = new BoundedBuffer(max);
+            const stderrBuf = new BoundedBuffer(max);
+            let aborted = false;
+            let killTimer: NodeJS.Timeout | undefined;
+
+            const spawnOpts: SpawnOptionsWithoutStdio = {
+                cwd: opts.cwd,
+                env: opts.env,
+                shell: false,
+                windowsHide: true,
+            };
+
+            let child: ChildProcess;
+            try {
+                child = nodeSpawn(command, [...args], spawnOpts);
+            } catch (err) {
+                reject(err);
+                return;
+            }
+
+            child.stdout?.on("data", (chunk: Buffer) => stdoutBuf.append(chunk));
+            child.stderr?.on("data", (chunk: Buffer) => stderrBuf.append(chunk));
+
+            const onAbort = () => {
+                aborted = true;
+                terminate(child);
+                killTimer = setTimeout(() => {
+                    if (child.exitCode === null && child.signalCode === null) {
+                        try {
+                            child.kill("SIGKILL");
+                        } catch {
+                            // Already gone.
+                        }
+                    }
+                }, SIGKILL_GRACE_MS);
+            };
+
+            if (opts.signal.aborted) {
+                onAbort();
+            } else {
+                opts.signal.addEventListener("abort", onAbort, { once: true });
+            }
+
+            if (opts.stdin !== undefined) {
+                child.stdin?.end(opts.stdin);
+            } else {
+                child.stdin?.end();
+            }
+
+            child.on("error", (err) => {
+                opts.signal.removeEventListener("abort", onAbort);
+                if (killTimer) {
+                    clearTimeout(killTimer);
+                }
+                reject(err);
+            });
+
+            child.on("close", (code, signal) => {
+                opts.signal.removeEventListener("abort", onAbort);
+                if (killTimer) {
+                    clearTimeout(killTimer);
+                }
+                resolve({
+                    exitCode: code,
+                    stdout: stdoutBuf.toString(),
+                    stderr: stderrBuf.toString(),
+                    signal: signal ?? undefined,
+                    aborted,
+                    truncated: stdoutBuf.overflowed || stderrBuf.overflowed,
+                });
+            });
+        });
+    }
+}
+
+/**
+ * Fixed-budget rolling buffer. When the byte cap is hit we stop appending —
+ * we don't slide a window because callers parse from the start of the
+ * stream (e.g., sqlpackage prints diagnostics top-down). Truncation is
+ * signalled by a trailing marker so callers can detect it without changing
+ * the public API.
+ */
+class BoundedBuffer {
+    private readonly _chunks: Buffer[] = [];
+    private _size = 0;
+    private _overflowed = false;
+
+    public constructor(private readonly cap: number) {}
+
+    public get overflowed(): boolean {
+        return this._overflowed;
+    }
+
+    public append(chunk: Buffer): void {
+        if (this._size >= this.cap) {
+            this._overflowed = true;
+            return;
+        }
+        const room = this.cap - this._size;
+        if (chunk.length <= room) {
+            this._chunks.push(chunk);
+            this._size += chunk.length;
+            return;
+        }
+        this._chunks.push(chunk.subarray(0, room));
+        this._size = this.cap;
+        this._overflowed = true;
+    }
+
+    public toString(): string {
+        const joined = Buffer.concat(this._chunks, this._size).toString("utf-8");
+        return this._overflowed ? joined + "\n[output truncated]" : joined;
+    }
+}
+
+function terminate(child: ChildProcess): void {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+    try {
+        child.kill("SIGTERM");
+    } catch {
+        // Process may already have exited between the check and the kill.
+    }
+}
+
+// =============================================================================
+// FakeProcessProvider (test double)
+// =============================================================================
+
+/**
+ * Canned response for a `(command, firstArg)` key. `cancelled` simulates a
+ * subprocess that didn't exit before the abort signal fired.
+ */
+export type FakeProcessResponse =
+    | {
+          readonly mode: "exit";
+          readonly exitCode: number;
+          readonly stdout?: string;
+          readonly stderr?: string;
+      }
+    | { readonly mode: "throw"; readonly error: Error }
+    | { readonly mode: "hang" }; // resolves only when signal aborts
+
+export interface FakeSpawnInvocation {
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly cwd?: string;
+    readonly env?: Record<string, string>;
+    readonly stdin?: string;
+}
+
+/**
+ * Records invocations and replays canned responses keyed on
+ * `(command, args[0])`. Tests configure expectations up-front via
+ * `respond()`; unmatched calls fall through to a default `exit 0` so simple
+ * happy-path setups don't need a `respond()` call per spawn.
+ */
+export class FakeProcessProvider implements ProcessProvider {
+    public readonly invocations: FakeSpawnInvocation[] = [];
+    private readonly _responses = new Map<string, FakeProcessResponse>();
+
+    /**
+     * Configure the canned response for a given `(command, firstArg)` pair.
+     * The matcher is intentionally crude — most validator tests dispatch on
+     * the first arg (e.g. `/Action:DeployReport`), and richer matching can
+     * be added when a test actually needs it.
+     */
+    public respond(command: string, firstArg: string, response: FakeProcessResponse): void {
+        this._responses.set(keyOf(command, firstArg), response);
+    }
+
+    public spawn(
+        command: string,
+        args: readonly string[],
+        opts: ProcessSpawnOptions,
+    ): Promise<ProcessResult> {
+        this.invocations.push({
+            command,
+            args: [...args],
+            cwd: opts.cwd,
+            env: opts.env,
+            stdin: opts.stdin,
+        });
+
+        const response = this._responses.get(keyOf(command, args[0] ?? "")) ?? {
+            mode: "exit" as const,
+            exitCode: 0,
+        };
+
+        if (response.mode === "throw") {
+            return Promise.reject(response.error);
+        }
+
+        if (opts.signal.aborted) {
+            return Promise.resolve({
+                exitCode: null,
+                stdout: "",
+                stderr: "",
+                signal: "SIGTERM" as NodeJS.Signals,
+                aborted: true,
+                truncated: false,
+            });
+        }
+
+        if (response.mode === "hang") {
+            return new Promise<ProcessResult>((resolve) => {
+                const onAbort = () => {
+                    opts.signal.removeEventListener("abort", onAbort);
+                    resolve({
+                        exitCode: null,
+                        stdout: "",
+                        stderr: "",
+                        signal: "SIGTERM" as NodeJS.Signals,
+                        aborted: true,
+                        truncated: false,
+                    });
+                };
+                opts.signal.addEventListener("abort", onAbort, { once: true });
+            });
+        }
+
+        return Promise.resolve({
+            exitCode: response.exitCode,
+            stdout: response.stdout ?? "",
+            stderr: response.stderr ?? "",
+            aborted: false,
+            truncated: false,
+        });
+    }
+}
+
+function keyOf(command: string, firstArg: string): string {
+    return `${command}\u0000${firstArg}`;
+}

--- a/extensions/mssql/src/cloudDeploy/validation/registry.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/registry.ts
@@ -25,6 +25,7 @@ import type { ProcessProvider } from "./providers/processProvider";
 import { defineRegistry, Validator, ValidatorRegistry } from "./types";
 import { ConnectivityValidator } from "./validators/connectivityValidator";
 import { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";
+import { UnitTestsValidator } from "./validators/unitTestsValidator";
 
 /**
  * Provider bundle injected into `createDefaultRegistry`. Each subsequent
@@ -68,7 +69,7 @@ export function createDefaultRegistry(providers: RegistryProviders): ValidatorRe
     return defineRegistry({
         [ValidationType.Connectivity]: new ConnectivityValidator(providers.connection),
         [ValidationType.StaticAnalysis]: new StaticAnalysisValidator(providers.process),
-        [ValidationType.UnitTests]: new NotYetWiredValidator(ValidationType.UnitTests),
+        [ValidationType.UnitTests]: new UnitTestsValidator(providers.connection),
         [ValidationType.WorkloadPlayback]: new NotYetWiredValidator(
             ValidationType.WorkloadPlayback,
         ),

--- a/extensions/mssql/src/cloudDeploy/validation/registry.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/registry.ts
@@ -20,7 +20,19 @@
  */
 
 import { ValidationType } from "../environments/types";
+import type { ConnectionProvider } from "./providers/connectionProvider";
 import { defineRegistry, Validator, ValidatorRegistry } from "./types";
+import { ConnectivityValidator } from "./validators/connectivityValidator";
+
+/**
+ * Provider bundle injected into `createDefaultRegistry`. Each subsequent
+ * commit adds one field as its provider lands (commit 3: `process`, commit
+ * 5: `artifact`). Service layer (commit 6) constructs the bundle once and
+ * hands it to `createDefaultRegistry` to build the registry.
+ */
+export interface RegistryProviders {
+    readonly connection: ConnectionProvider;
+}
 
 /**
  * Placeholder validator used by `createDefaultRegistry` until each real
@@ -49,9 +61,9 @@ class NotYetWiredValidator<T extends ValidationType> implements Validator<T> {
  * Service layer constructs this once per `CloudDeployService` and hands
  * the result to the runner.
  */
-export function createDefaultRegistry(): ValidatorRegistry {
+export function createDefaultRegistry(providers: RegistryProviders): ValidatorRegistry {
     return defineRegistry({
-        [ValidationType.Connectivity]: new NotYetWiredValidator(ValidationType.Connectivity),
+        [ValidationType.Connectivity]: new ConnectivityValidator(providers.connection),
         [ValidationType.StaticAnalysis]: new NotYetWiredValidator(ValidationType.StaticAnalysis),
         [ValidationType.UnitTests]: new NotYetWiredValidator(ValidationType.UnitTests),
         [ValidationType.WorkloadPlayback]: new NotYetWiredValidator(

--- a/extensions/mssql/src/cloudDeploy/validation/registry.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/registry.ts
@@ -20,47 +20,31 @@
  */
 
 import { ValidationType } from "../environments/types";
+import type { ArtifactProvider } from "./providers/artifactProvider";
 import type { ConnectionProvider } from "./providers/connectionProvider";
 import type { ProcessProvider } from "./providers/processProvider";
-import { defineRegistry, Validator, ValidatorRegistry } from "./types";
+import { defineRegistry, ValidatorRegistry } from "./types";
 import { ConnectivityValidator } from "./validators/connectivityValidator";
 import { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";
 import { UnitTestsValidator } from "./validators/unitTestsValidator";
+import { WorkloadPlaybackValidator } from "./validators/workloadPlaybackValidator";
 
 /**
- * Provider bundle injected into `createDefaultRegistry`. Each subsequent
- * commit adds one field as its provider lands (commit 3: `process`, commit
- * 5: `artifact`). Service layer (commit 6) constructs the bundle once and
- * hands it to `createDefaultRegistry` to build the registry.
+ * Provider bundle injected into `createDefaultRegistry`. Commit 5 added
+ * `artifact` (the workload-playback validator's artifact seam); the bundle
+ * is now complete for Scope 1. The service layer (commit 6) constructs the
+ * bundle once and hands it to `createDefaultRegistry` to build the registry.
  */
 export interface RegistryProviders {
     readonly connection: ConnectionProvider;
     readonly process: ProcessProvider;
+    readonly artifact: ArtifactProvider;
 }
 
 /**
- * Placeholder validator used by `createDefaultRegistry` until each real
- * validator lands in its own commit. Throws on `run()` so an accidental
- * invocation surfaces immediately rather than silently producing a
- * "passed" result.
- *
- * Not exported: tests should build their own registries via
- * `defineRegistry({ ... fakes })`, not reach for the placeholder.
- */
-class NotYetWiredValidator<T extends ValidationType> implements Validator<T> {
-    public constructor(public readonly type: T) {}
-
-    public run(): never {
-        throw new Error(
-            `Validator for "${this.type}" is not wired yet (added in a later D2 commit).`,
-        );
-    }
-}
-
-/**
- * Builds the default production registry. Wires each `ValidationType` arm
- * to its concrete validator; entries that haven't landed yet point at
- * `NotYetWiredValidator` so calling `run()` is loud instead of silent.
+ * Builds the default production registry. Every `ValidationType` arm is
+ * wired to its concrete validator as of commit 5; there is no longer a
+ * placeholder slot.
  *
  * Service layer constructs this once per `CloudDeployService` and hands
  * the result to the runner.
@@ -70,8 +54,9 @@ export function createDefaultRegistry(providers: RegistryProviders): ValidatorRe
         [ValidationType.Connectivity]: new ConnectivityValidator(providers.connection),
         [ValidationType.StaticAnalysis]: new StaticAnalysisValidator(providers.process),
         [ValidationType.UnitTests]: new UnitTestsValidator(providers.connection),
-        [ValidationType.WorkloadPlayback]: new NotYetWiredValidator(
-            ValidationType.WorkloadPlayback,
+        [ValidationType.WorkloadPlayback]: new WorkloadPlaybackValidator(
+            providers.artifact,
+            providers.process,
         ),
     });
 }

--- a/extensions/mssql/src/cloudDeploy/validation/registry.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/registry.ts
@@ -21,8 +21,10 @@
 
 import { ValidationType } from "../environments/types";
 import type { ConnectionProvider } from "./providers/connectionProvider";
+import type { ProcessProvider } from "./providers/processProvider";
 import { defineRegistry, Validator, ValidatorRegistry } from "./types";
 import { ConnectivityValidator } from "./validators/connectivityValidator";
+import { StaticAnalysisValidator } from "./validators/staticAnalysisValidator";
 
 /**
  * Provider bundle injected into `createDefaultRegistry`. Each subsequent
@@ -32,6 +34,7 @@ import { ConnectivityValidator } from "./validators/connectivityValidator";
  */
 export interface RegistryProviders {
     readonly connection: ConnectionProvider;
+    readonly process: ProcessProvider;
 }
 
 /**
@@ -64,7 +67,7 @@ class NotYetWiredValidator<T extends ValidationType> implements Validator<T> {
 export function createDefaultRegistry(providers: RegistryProviders): ValidatorRegistry {
     return defineRegistry({
         [ValidationType.Connectivity]: new ConnectivityValidator(providers.connection),
-        [ValidationType.StaticAnalysis]: new NotYetWiredValidator(ValidationType.StaticAnalysis),
+        [ValidationType.StaticAnalysis]: new StaticAnalysisValidator(providers.process),
         [ValidationType.UnitTests]: new NotYetWiredValidator(ValidationType.UnitTests),
         [ValidationType.WorkloadPlayback]: new NotYetWiredValidator(
             ValidationType.WorkloadPlayback,

--- a/extensions/mssql/src/cloudDeploy/validation/registry.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/registry.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — default validator registry construction.
+ *
+ * `createDefaultRegistry` wires the four shipping validators against
+ * production providers. Construction is centralized here so the service
+ * layer (and any future entry point) builds the same registry; tests
+ * substitute by constructing their own `ValidatorRegistry` from fakes
+ * via `defineRegistry({ ... })`.
+ *
+ * Per-commit growth: commit 1 ships the surface and an empty default that
+ * throws on `run()`. Each subsequent commit replaces one arm with the
+ * concrete validator + provider it adds (commit 2 wires connectivity,
+ * commit 3 wires static analysis, etc.). Commit 5 leaves the registry
+ * fully populated; commit 6 is the service-side wiring that calls this.
+ */
+
+import { ValidationType } from "../environments/types";
+import { defineRegistry, Validator, ValidatorRegistry } from "./types";
+
+/**
+ * Placeholder validator used by `createDefaultRegistry` until each real
+ * validator lands in its own commit. Throws on `run()` so an accidental
+ * invocation surfaces immediately rather than silently producing a
+ * "passed" result.
+ *
+ * Not exported: tests should build their own registries via
+ * `defineRegistry({ ... fakes })`, not reach for the placeholder.
+ */
+class NotYetWiredValidator<T extends ValidationType> implements Validator<T> {
+    public constructor(public readonly type: T) {}
+
+    public run(): never {
+        throw new Error(
+            `Validator for "${this.type}" is not wired yet (added in a later D2 commit).`,
+        );
+    }
+}
+
+/**
+ * Builds the default production registry. Wires each `ValidationType` arm
+ * to its concrete validator; entries that haven't landed yet point at
+ * `NotYetWiredValidator` so calling `run()` is loud instead of silent.
+ *
+ * Service layer constructs this once per `CloudDeployService` and hands
+ * the result to the runner.
+ */
+export function createDefaultRegistry(): ValidatorRegistry {
+    return defineRegistry({
+        [ValidationType.Connectivity]: new NotYetWiredValidator(ValidationType.Connectivity),
+        [ValidationType.StaticAnalysis]: new NotYetWiredValidator(ValidationType.StaticAnalysis),
+        [ValidationType.UnitTests]: new NotYetWiredValidator(ValidationType.UnitTests),
+        [ValidationType.WorkloadPlayback]: new NotYetWiredValidator(
+            ValidationType.WorkloadPlayback,
+        ),
+    });
+}

--- a/extensions/mssql/src/cloudDeploy/validation/runner.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/runner.ts
@@ -1,0 +1,585 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — validation runner.
+ *
+ * Takes an `Environment`, dispatches each declared (and enabled) validation
+ * through the `ValidatorRegistry`, aggregates the results into a canonical
+ * `RunRecord`, and emits run-lifecycle events on the diagnostic bus along
+ * the way. Returns the produced `RunRecord` to the caller.
+ *
+ * Design properties:
+ *   - **Sequential dispatch.** Order: connectivity first (when declared),
+ *     then the rest in declaration order. Keeps cancellation, status
+ *     rollup, and bus-event interleaving trivial. A future `parallel`
+ *     option can be added additively if perf data justifies it.
+ *   - **Connectivity gates the rest.** If a connectivity validation fails
+ *     (Failed / Errored / Cancelled), remaining non-connectivity
+ *     validations short-circuit to `Skipped` with a deterministic
+ *     `connectivity` finding. The runner emits a `validation-started` and
+ *     `validation-finished` for each skipped arm so subscribers see a
+ *     complete lifecycle.
+ *   - **Cancellation is a status, not a string.** `CancellationError`
+ *     thrown by a validator becomes a `ValidationStatus.Cancelled` result
+ *     carrying `cancellationReason`. Cancellation also cascades to all
+ *     remaining validations.
+ *   - **Bus is best-effort.** When `bus` is undefined the runner still
+ *     produces the correct `RunRecord` \u2014 the bus is the announcement
+ *     channel, not the contract.
+ *   - **No persistence.** The runner does not call the run-artifact writer.
+ *     The service layer (commit 6) writes the returned `RunRecord` through
+ *     D3's writer when the caller opts in.
+ */
+
+import { randomUUID } from "crypto";
+
+import type { DiagnosticEventBus } from "../diagnostics";
+import { Environment, ValidationConfig, ValidationType } from "../environments/types";
+import {
+    CancellationReason,
+    RUN_STATUS_PRIORITY,
+    RunRecord,
+    RunStatus,
+    RUN_RECORD_SCHEMA_VERSION,
+    RunnerIdentity,
+    ValidationPayload,
+    ValidationResult,
+    ValidationStatus,
+} from "../runs/types";
+
+import { CancellationError, ValidatorRegistry, ValidatorRunOptions } from "./types";
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Per-call options for `Runner.run()`. All fields optional; sensible defaults
+ * are applied when omitted (`runId` becomes a fresh UUID, `runner` becomes
+ * a local-vscode identity, no timeout).
+ */
+export interface RunnerRunOptions {
+    /** Caller-supplied cancellation. Merged with the timeout signal (if any). */
+    readonly signal?: AbortSignal;
+    /** Overall run timeout in ms. Triggers a `"timeout"`-flavored cancellation. */
+    readonly timeoutMs?: number;
+    /** Stable run identifier; defaults to a fresh UUID per call. */
+    readonly runId?: string;
+    /** Runner identity stamped on the `RunRecord`; defaults to a local-vscode marker. */
+    readonly runner?: RunnerIdentity;
+}
+
+/**
+ * Orchestrates a single validation run. Stateless across calls: each
+ * `run()` constructs its own ids, signal, and aggregation state.
+ *
+ * Bus and providers are dependency-injected so tests substitute fakes
+ * without monkey-patching imports.
+ */
+export class Runner {
+    public constructor(
+        private readonly _registry: ValidatorRegistry,
+        private readonly _bus?: DiagnosticEventBus,
+    ) {}
+
+    public async run(env: Environment, opts: RunnerRunOptions = {}): Promise<RunRecord> {
+        const runId = opts.runId ?? randomUUID();
+        const runner = opts.runner ?? DEFAULT_RUNNER_IDENTITY;
+        const startedAtMs = Date.now();
+
+        const { signal, dispose: disposeSignal } = buildEffectiveSignal(
+            opts.signal,
+            opts.timeoutMs,
+        );
+
+        // Dispatch order: connectivity first (if enabled), then rest in declaration order.
+        const dispatchOrder = orderForDispatch(env.validations);
+
+        this._emitRunStarted(runId, env, dispatchOrder);
+
+        const results: ValidationResult[] = [];
+        let connectivityFailed = false;
+        let cascadeCancellation: CancellationReason | undefined;
+
+        try {
+            for (const config of dispatchOrder) {
+                if (!config.enabled) {
+                    continue;
+                }
+
+                if (cascadeCancellation !== undefined) {
+                    const cancelledResult = makeCancelledResult(
+                        config,
+                        Date.now(),
+                        cascadeCancellation,
+                    );
+                    results.push(cancelledResult);
+                    this._emitValidationStarted(runId, config.type);
+                    this._emitValidationFinished(runId, cancelledResult);
+                    continue;
+                }
+
+                if (signal.aborted) {
+                    cascadeCancellation = currentCancellationReason(signal);
+                    const cancelledResult = makeCancelledResult(
+                        config,
+                        Date.now(),
+                        cascadeCancellation,
+                    );
+                    results.push(cancelledResult);
+                    this._emitValidationStarted(runId, config.type);
+                    this._emitValidationFinished(runId, cancelledResult);
+                    continue;
+                }
+
+                if (connectivityFailed && config.type !== ValidationType.Connectivity) {
+                    const skipped = makeGatedSkipResult(config, Date.now());
+                    results.push(skipped);
+                    this._emitValidationStarted(runId, config.type);
+                    this._emitValidationFinished(runId, skipped);
+                    continue;
+                }
+
+                const result = await this._dispatchOne(env, config, runId, signal);
+                results.push(result);
+
+                if (config.type === ValidationType.Connectivity && !isPass(result.status)) {
+                    connectivityFailed = true;
+                }
+
+                if (result.status === ValidationStatus.Cancelled) {
+                    cascadeCancellation = result.cancellationReason ?? "user";
+                }
+            }
+        } finally {
+            disposeSignal();
+        }
+
+        const endedAtMs = Date.now();
+        const status = rollupRunStatus(results);
+
+        const record: RunRecord = {
+            schemaVersion: RUN_RECORD_SCHEMA_VERSION,
+            runId,
+            environmentId: env.id,
+            environmentSnapshot: env,
+            runner,
+            startedAtMs,
+            endedAtMs,
+            status,
+            validations: results,
+        };
+
+        this._emitRunFinished(record);
+
+        return record;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    private async _dispatchOne(
+        env: Environment,
+        config: ValidationConfig,
+        runId: string,
+        signal: AbortSignal,
+    ): Promise<ValidationResult> {
+        const validator = this._registry[config.type];
+        const opts: ValidatorRunOptions = { runId, signal, bus: this._bus };
+        const startedAtMs = Date.now();
+
+        // Per-validator start/finish events are emitted by the validator itself
+        // when a bus is wired. The runner only emits run-level events here so
+        // we don't double-fire the per-validation arm.
+        try {
+            const result = await (validator as { run: typeof validator.run }).run(
+                env,
+                config.settings as never,
+                opts,
+            );
+            return result;
+        } catch (err) {
+            const endedAtMs = Date.now();
+            if (err instanceof CancellationError) {
+                // The signal is the source of truth for the cancellation
+                // reason: a validator that calls `throwIfCancelled(signal)`
+                // can't tell `"user"` from `"timeout"` without inspecting the
+                // sentinel, so the runner reconciles here.
+                const reason = signal.aborted ? currentCancellationReason(signal) : err.reason;
+                const cancelled = buildCancelledResultFromError(
+                    config,
+                    startedAtMs,
+                    endedAtMs,
+                    reason,
+                );
+                this._emitValidationStarted(runId, config.type);
+                this._emitValidationFinished(runId, cancelled);
+                return cancelled;
+            }
+            const errored = buildErroredResultFromException(config, startedAtMs, endedAtMs, err);
+            this._emitValidationStarted(runId, config.type);
+            this._emitValidationFinished(runId, errored);
+            return errored;
+        }
+    }
+
+    private _emitRunStarted(
+        runId: string,
+        env: Environment,
+        dispatchOrder: readonly ValidationConfig[],
+    ): void {
+        this._bus?.emit({
+            source: "runner",
+            type: "validation-run-started",
+            correlationId: runId,
+            payload: {
+                runId,
+                environmentId: env.id,
+                validationTypes: dispatchOrder.filter((c) => c.enabled).map((c) => c.type),
+            },
+        });
+    }
+
+    private _emitValidationStarted(runId: string, validationType: ValidationType): void {
+        this._bus?.emit({
+            source: "validation",
+            type: "validation-started",
+            correlationId: runId,
+            payload: { runId, validationType },
+        });
+    }
+
+    private _emitValidationFinished(runId: string, result: ValidationResult): void {
+        this._bus?.emit({
+            source: "validation",
+            type: "validation-finished",
+            severity: severityForStatus(result.status),
+            correlationId: runId,
+            payload: {
+                runId,
+                validationType: result.payload.validationType,
+                status: result.status,
+                findingsCount: result.payload.findings.length,
+                durationMs: result.endedAtMs - result.startedAtMs,
+                cancellationReason: result.cancellationReason,
+            },
+        });
+    }
+
+    private _emitRunFinished(record: RunRecord): void {
+        this._bus?.emit({
+            source: "runner",
+            type: "validation-run-finished",
+            severity: severityForStatus(record.status),
+            correlationId: record.runId,
+            payload: {
+                runId: record.runId,
+                status: record.status,
+                durationMs: record.endedAtMs - record.startedAtMs,
+                validationCount: record.validations.length,
+            },
+        });
+    }
+}
+
+// =============================================================================
+// Dispatch ordering
+// =============================================================================
+
+/**
+ * Returns the dispatch order: connectivity first (if declared), then the
+ * remaining configs in their original declaration order. Stable; does not
+ * mutate the input.
+ */
+function orderForDispatch(configs: readonly ValidationConfig[]): readonly ValidationConfig[] {
+    const connectivity = configs.filter((c) => c.type === ValidationType.Connectivity);
+    const rest = configs.filter((c) => c.type !== ValidationType.Connectivity);
+    return [...connectivity, ...rest];
+}
+
+// =============================================================================
+// Status rollup
+// =============================================================================
+
+/**
+ * Worst-case rollup: picks the result with the highest `RUN_STATUS_PRIORITY`
+ * rank and uses its status as the run-level status. An empty results list
+ * collapses to `Passed` (nothing ran, nothing failed).
+ *
+ * `ValidationStatus` and `RunStatus` share string values, so the lookup
+ * via `RUN_STATUS_PRIORITY` is safe.
+ */
+function rollupRunStatus(results: readonly ValidationResult[]): RunStatus {
+    if (results.length === 0) {
+        return RunStatus.Passed;
+    }
+    let worst: RunStatus = RunStatus.Passed;
+    let worstRank = RUN_STATUS_PRIORITY[worst];
+    for (const r of results) {
+        const asRun = r.status as unknown as RunStatus;
+        const rank = RUN_STATUS_PRIORITY[asRun];
+        if (rank > worstRank) {
+            worst = asRun;
+            worstRank = rank;
+        }
+    }
+    return worst;
+}
+
+function isPass(status: ValidationStatus): boolean {
+    return status === ValidationStatus.Passed;
+}
+
+// =============================================================================
+// Severity mapping
+// =============================================================================
+
+/**
+ * Maps a `RunStatus` / `ValidationStatus` to a `DiagnosticEventSeverity` so
+ * subscribers can filter `validation-finished` and `validation-run-finished`
+ * events at the bus level without inspecting payload.
+ *
+ *   Passed / Skipped / Cancelled -> info
+ *   Warning                      -> warn
+ *   Failed  / Errored            -> error
+ */
+function severityForStatus(status: RunStatus | ValidationStatus): "info" | "warn" | "error" {
+    switch (status) {
+        case ValidationStatus.Warning:
+            return "warn";
+        case ValidationStatus.Failed:
+        case ValidationStatus.Errored:
+            return "error";
+        default:
+            return "info";
+    }
+}
+
+// =============================================================================
+// Result builders (cancellation, gating, error capture)
+// =============================================================================
+
+const GATED_BY_CONNECTIVITY_MESSAGE = "Skipped because the connectivity validation did not pass.";
+
+function makeCancelledResult(
+    config: ValidationConfig,
+    nowMs: number,
+    reason: CancellationReason,
+): ValidationResult {
+    return {
+        validationId: validationIdFor(config),
+        displayName: displayNameFor(config.type),
+        status: ValidationStatus.Cancelled,
+        startedAtMs: nowMs,
+        endedAtMs: nowMs,
+        payload: emptyPayloadFor(config.type),
+        cancellationReason: reason,
+    };
+}
+
+function buildCancelledResultFromError(
+    config: ValidationConfig,
+    startedAtMs: number,
+    endedAtMs: number,
+    reason: CancellationReason,
+): ValidationResult {
+    return {
+        validationId: validationIdFor(config),
+        displayName: displayNameFor(config.type),
+        status: ValidationStatus.Cancelled,
+        startedAtMs,
+        endedAtMs,
+        payload: emptyPayloadFor(config.type),
+        cancellationReason: reason,
+    };
+}
+
+function buildErroredResultFromException(
+    config: ValidationConfig,
+    startedAtMs: number,
+    endedAtMs: number,
+    err: unknown,
+): ValidationResult {
+    return {
+        validationId: validationIdFor(config),
+        displayName: displayNameFor(config.type),
+        status: ValidationStatus.Errored,
+        startedAtMs,
+        endedAtMs,
+        payload: emptyPayloadFor(config.type),
+        errorMessage: err instanceof Error ? err.message : String(err),
+    };
+}
+
+function makeGatedSkipResult(config: ValidationConfig, nowMs: number): ValidationResult {
+    // Skipped result with a single `connectivity` finding when the rest of
+    // the run was gated. For non-connectivity arms the finding still lives
+    // under the validation's own payload so the result shape is consistent.
+    const payload = emptyPayloadFor(config.type);
+    return {
+        validationId: validationIdFor(config),
+        displayName: displayNameFor(config.type),
+        status: ValidationStatus.Skipped,
+        startedAtMs: nowMs,
+        endedAtMs: nowMs,
+        payload,
+        errorMessage: GATED_BY_CONNECTIVITY_MESSAGE,
+    };
+}
+
+/**
+ * Validation id, stable within a run. Derived from `ValidationType`'s string
+ * value so consumers can locate the result by type without separately tracking
+ * id assignment. If multiple validations of the same type are ever supported,
+ * this is the place to change.
+ */
+function validationIdFor(config: ValidationConfig): string {
+    return config.type;
+}
+
+function displayNameFor(type: ValidationType): string {
+    switch (type) {
+        case ValidationType.Connectivity:
+            return "Connectivity";
+        case ValidationType.StaticAnalysis:
+            return "Static Analysis";
+        case ValidationType.UnitTests:
+            return "Unit Tests";
+        case ValidationType.WorkloadPlayback:
+            return "Workload Playback";
+    }
+}
+
+function emptyPayloadFor(type: ValidationType): ValidationPayload {
+    switch (type) {
+        case ValidationType.Connectivity:
+            return {
+                validationType: ValidationType.Connectivity,
+                findings: [],
+                summary: { reachable: false },
+            };
+        case ValidationType.StaticAnalysis:
+            return {
+                validationType: ValidationType.StaticAnalysis,
+                findings: [],
+                summary: { info: 0, warning: 0, error: 0 },
+            };
+        case ValidationType.UnitTests:
+            return {
+                validationType: ValidationType.UnitTests,
+                findings: [],
+                summary: { total: 0, passed: 0, failed: 0, skipped: 0, errored: 0 },
+            };
+        case ValidationType.WorkloadPlayback:
+            return {
+                validationType: ValidationType.WorkloadPlayback,
+                findings: [],
+                summary: { steps: 0, regressions: 0 },
+            };
+    }
+}
+
+// =============================================================================
+// Signal composition (caller signal + timeout)
+// =============================================================================
+
+/**
+ * Builds the *effective* `AbortSignal` the runner threads through every
+ * validator: the caller-supplied signal (if any) combined with an internal
+ * timeout signal (if `timeoutMs` is provided).
+ *
+ * Returns a `dispose` function to clear the timeout in the success path so
+ * Node.js doesn't keep a stray timer alive after the run.
+ *
+ * The internal timeout controller tags itself with a sentinel reason
+ * (`"runner-timeout"`) so we can tell timeout-aborts apart from
+ * user-aborts when stamping `cancellationReason`.
+ */
+function buildEffectiveSignal(
+    callerSignal: AbortSignal | undefined,
+    timeoutMs: number | undefined,
+): { signal: AbortSignal; dispose: () => void } {
+    const controllers: AbortController[] = [];
+    const sources: AbortSignal[] = [];
+
+    if (callerSignal !== undefined) {
+        sources.push(callerSignal);
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+        const timeoutCtrl = new AbortController();
+        controllers.push(timeoutCtrl);
+        sources.push(timeoutCtrl.signal);
+        timeoutHandle = setTimeout(() => {
+            timeoutCtrl.abort(RUNNER_TIMEOUT_REASON);
+        }, timeoutMs);
+    }
+
+    if (sources.length === 0) {
+        // No caller signal, no timeout. Return a fresh never-aborted controller.
+        return { signal: new AbortController().signal, dispose: () => undefined };
+    }
+
+    const merged = anySignal(sources);
+    return {
+        signal: merged,
+        dispose: () => {
+            if (timeoutHandle !== undefined) {
+                clearTimeout(timeoutHandle);
+            }
+        },
+    };
+}
+
+const RUNNER_TIMEOUT_REASON = Symbol("runner-timeout");
+
+/**
+ * Returns a single `AbortSignal` that aborts when any of `sources` aborts.
+ * Forwards the abort reason from the first triggering source so callers can
+ * distinguish timeout-vs-user via `currentCancellationReason`.
+ *
+ * `AbortSignal.any` is available in modern Node, but VS Code's minimum still
+ * spans versions without it; a small polyfill keeps us compatible without a
+ * runtime check at every call site.
+ */
+function anySignal(sources: readonly AbortSignal[]): AbortSignal {
+    const ctrl = new AbortController();
+    const onAbort = (src: AbortSignal) => {
+        if (!ctrl.signal.aborted) {
+            ctrl.abort((src as { reason?: unknown }).reason);
+        }
+    };
+    for (const s of sources) {
+        if (s.aborted) {
+            onAbort(s);
+            break;
+        }
+        s.addEventListener("abort", () => onAbort(s), { once: true });
+    }
+    return ctrl.signal;
+}
+
+/**
+ * Maps an aborted signal's `reason` to a `CancellationReason`. The runner's
+ * own timeout controller aborts with a sentinel `Symbol`; everything else
+ * is treated as user-initiated cancellation.
+ */
+function currentCancellationReason(signal: AbortSignal): CancellationReason {
+    const reason = (signal as { reason?: unknown }).reason;
+    return reason === RUNNER_TIMEOUT_REASON ? "timeout" : "user";
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+const DEFAULT_RUNNER_IDENTITY: RunnerIdentity = Object.freeze({
+    userId: "local",
+    displayName: "Local",
+    hostKind: "vscode",
+});

--- a/extensions/mssql/src/cloudDeploy/validation/types.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/types.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — validation runner vocabulary.
+ *
+ * Pure type declarations. The contract every validator implements, the
+ * registry shape the runner dispatches through, the cancellation marker the
+ * runner catches, and the exhaustiveness helper validators reach for when
+ * switching over `ValidationType`.
+ *
+ * No runtime, no I/O. Implementations live in `validation/validators/` and
+ * `validation/runner.ts`.
+ */
+
+import type { DiagnosticEventBus } from "../diagnostics";
+import type {
+    Environment,
+    ConnectivitySettings,
+    StaticAnalysisSettings,
+    UnitTestsSettings,
+    ValidationConfig,
+    ValidationType,
+    WorkloadPlaybackSettings,
+} from "../environments/types";
+import type { CancellationReason, ValidationResult } from "../runs/types";
+
+// =============================================================================
+// Per-type settings narrowing
+// =============================================================================
+
+/**
+ * Picks the settings shape corresponding to a `ValidationType` arm. Lets the
+ * `Validator<T>` interface narrow its `config` parameter to the right
+ * `*Settings` shape per implementation, so a validator never has to widen
+ * its config to `unknown` and re-narrow.
+ */
+export type SettingsFor<T extends ValidationType> = Extract<
+    ValidationConfig,
+    { type: T }
+>["settings"];
+
+// Light sanity wiring (not exported): if a new ValidationType arm lands without
+// a settings interface, this conditional fails to typecheck. Forces the
+// environments/types.ts author to add the matching ConnectivitySettings-shaped
+// arm before the build is green.
+type _SettingsExhaustivenessCheck =
+    SettingsFor<ValidationType> extends
+        | ConnectivitySettings
+        | StaticAnalysisSettings
+        | UnitTestsSettings
+        | WorkloadPlaybackSettings
+        ? true
+        : never;
+// Reference the alias so unused-type lint doesn't flag it; the check runs at
+// type-resolution time regardless.
+export type _ValidationSettingsExhaustiveness = _SettingsExhaustivenessCheck;
+
+// =============================================================================
+// Validator contract
+// =============================================================================
+
+/**
+ * The contract every validation implements. Generic over the `ValidationType`
+ * arm so `config` and (eventually) finding shapes narrow correctly per
+ * validator implementation.
+ *
+ * Implementations MUST:
+ *   * Return a `ValidationResult` whose `payload.validationType` matches `this.type`.
+ *   * Poll `opts.signal` at safe checkpoints and throw `CancellationError`
+ *     when cancellation is observed mid-flight.
+ *   * Stamp accurate `startedAtMs` and `endedAtMs` on the result.
+ *
+ * Implementations MUST NOT:
+ *   * Persist anything (the runner / service layer owns artifact writing).
+ *   * Retry; failed validations stay failed.
+ *   * Mutate the input `env` or `config`.
+ */
+export interface Validator<TType extends ValidationType = ValidationType> {
+    /** The `ValidationType` arm this validator handles. Used as the registry key. */
+    readonly type: TType;
+
+    /**
+     * Run the validation against the given environment. The returned
+     * `ValidationResult` is in D3's canonical shape and is appended verbatim
+     * to the run's `validations` array by the runner.
+     */
+    run(
+        env: Environment,
+        config: SettingsFor<TType>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult>;
+}
+
+/**
+ * What the runner passes into every `validator.run()` invocation.
+ *
+ * `signal` is the *effective* signal: caller-supplied cancellation merged
+ * with the runner's overall timeout (if any). Validators only ever see this
+ * combined signal, never the raw caller-supplied one.
+ *
+ * `bus` is optional so a validator can run in a CLI / test harness context
+ * with no bus wired and still produce a correct `ValidationResult`. When
+ * present, validators emit `validation-started` / `validation-progress` /
+ * `validation-finished` lifecycle events themselves.
+ */
+export interface ValidatorRunOptions {
+    readonly runId: string;
+    readonly signal: AbortSignal;
+    readonly bus?: DiagnosticEventBus;
+}
+
+// =============================================================================
+// Cancellation
+// =============================================================================
+
+/**
+ * Thrown by validators when `signal.aborted` is observed at a safe checkpoint.
+ * The runner catches this specifically and maps it to a
+ * `ValidationStatus.Cancelled` result with the matching `cancellationReason`.
+ *
+ * Implementations call `throwIfCancelled(signal, reason)` rather than
+ * instantiating `CancellationError` directly — the helper hides the message
+ * formatting and keeps the call sites short.
+ */
+export class CancellationError extends Error {
+    public constructor(
+        public readonly reason: CancellationReason,
+        message?: string,
+    ) {
+        super(message ?? `Validation cancelled (reason: ${reason}).`);
+        this.name = "CancellationError";
+    }
+}
+
+/**
+ * Throws `CancellationError` if `signal.aborted` is true. Reason defaults to
+ * `"user"`; callers running under a timeout-derived signal pass `"timeout"`
+ * explicitly.
+ */
+export function throwIfCancelled(signal: AbortSignal, reason: CancellationReason = "user"): void {
+    if (signal.aborted) {
+        throw new CancellationError(reason);
+    }
+}
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+/**
+ * Closed map of `ValidationType -> Validator`. Compile-time exhaustive:
+ * every `ValidationType` arm MUST have an entry, and each entry's value is
+ * narrowed to the matching `Validator<TType>` generic.
+ *
+ * Adding a new `ValidationType` enum value without adding a registry entry
+ * is a type error at every `defineRegistry({ ... })` call site.
+ */
+export type ValidatorRegistry = {
+    readonly [K in ValidationType]: Validator<K>;
+};
+
+/**
+ * Helper for constructing a `ValidatorRegistry`. Pass an object literal with
+ * every `ValidationType` arm wired to its `Validator`; TypeScript enforces
+ * exhaustiveness. The returned object is frozen so post-construction
+ * mutation is impossible.
+ */
+export function defineRegistry(entries: ValidatorRegistry): ValidatorRegistry {
+    return Object.freeze({ ...entries });
+}
+
+// =============================================================================
+// Exhaustiveness helper
+// =============================================================================
+
+/**
+ * Reached only when a switch over `ValidationType` is missing an arm. The
+ * compiler will narrow `x` to `never` only if every other arm is handled;
+ * if a new arm is added without updating the switch, the call site fails to
+ * compile because `x` is no longer `never`.
+ */
+export function assertNeverValidationType(x: never): never {
+    throw new Error(`Unhandled validation type: ${JSON.stringify(x)}`);
+}

--- a/extensions/mssql/src/cloudDeploy/validation/validationApi.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/validationApi.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — validation service surface.
+ *
+ * `CloudDeployValidationApi` is the single seam between the rest of the
+ * extension (commands, MCP tools, future webviews) and the validation
+ * pipeline. The service constructs `Runner` once over the supplied
+ * registry + bus and exposes a single `run(envId, opts)` method that:
+ *
+ *   1. Looks the env up by id. Returns a synthesized `Errored` `RunRecord`
+ *      when the env is missing rather than throwing — callers route the
+ *      record into the same UI flow as a normal failure, no special-case
+ *      branching at the call site.
+ *   2. Dispatches the run via the runner. Cancellation, timeouts, and bus
+ *      events are the runner's job; this layer only hands the env in.
+ *   3. Optionally persists the produced `RunRecord` via D3's
+ *      `RunArtifactWriter`. Persistence failures are surfaced via the
+ *      `runArtifactPath?` field on the result; the run's own status is
+ *      not downgraded — a successful validation that fails to persist is
+ *      still a successful validation.
+ *
+ * The service does NOT register any commands, build any UI, or subscribe
+ * to the bus on its own. Those concerns live one layer up
+ * (`CloudDeployService` wires this against the host bus + registry, and
+ * `mainController` registers the command). Keeping the service free of
+ * `vscode.*` calls makes it unit-testable without an extension host.
+ */
+
+import * as path from "path";
+
+import type { DiagnosticEventBus } from "../diagnostics";
+import type { EnvironmentStore } from "../environments/environmentStore";
+import { Environment, SourceOfTruthKind, ValidationType } from "../environments/types";
+import type { RunArtifactWriter } from "../runs";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunStatus,
+    RunRecord,
+    RunnerIdentity,
+    ValidationStatus,
+} from "../runs/types";
+
+import { Runner, RunnerRunOptions } from "./runner";
+import type { ValidatorRegistry } from "./types";
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Result of `CloudDeployValidationApi.run()`. The `record` is always
+ * present (even on env-not-found, a synthesized `Errored` record is
+ * returned). `runArtifactPath` is set when persistence was requested and
+ * succeeded; absent when persistence wasn't requested or failed.
+ *
+ * `persistError` carries the I/O error message when persistence was
+ * requested but failed. The `record.status` is NOT downgraded in that
+ * case — a green run that failed to persist is still a green run.
+ */
+export interface CloudDeployValidationRunResult {
+    readonly record: RunRecord;
+    readonly runArtifactPath?: string;
+    readonly persistError?: string;
+}
+
+/** Options accepted by `CloudDeployValidationApi.run()`. */
+export interface CloudDeployValidationRunOptions {
+    /** Caller-supplied cancellation. Passed through to the runner. */
+    readonly signal?: AbortSignal;
+    /** Hard cap on the run in milliseconds. Passed through to the runner. */
+    readonly timeoutMs?: number;
+    /**
+     * When `true`, the produced `RunRecord` is written through the run-artifact
+     * writer at the supplied directory. Defaults to `false` so callers that
+     * just want the record in-memory don't pay for I/O they didn't ask for.
+     */
+    readonly persist?: boolean;
+    /**
+     * Absolute directory to write the artifact under when `persist === true`.
+     * The artifact filename is derived from `runId`. Required when
+     * `persist === true`; ignored otherwise.
+     */
+    readonly artifactDir?: string;
+    /** Stable runner identity stamped on the record. Defaults applied when omitted. */
+    readonly runner?: RunnerIdentity;
+}
+
+/**
+ * Service surface exposed on `CloudDeployService.validation`. Single
+ * method; everything else (event subscription, output channel, command
+ * registration) is layered above this.
+ */
+export interface CloudDeployValidationApi {
+    /**
+     * Runs every enabled validation declared on the env identified by `envId`.
+     * Returns a `CloudDeployValidationRunResult` — never throws, never returns
+     * `undefined`. Missing envs surface as a synthesized `Errored` record so
+     * callers can route them through the same UI path as a real failure.
+     */
+    run(
+        envId: string,
+        opts?: CloudDeployValidationRunOptions,
+    ): Promise<CloudDeployValidationRunResult>;
+}
+
+// =============================================================================
+// ValidationService
+// =============================================================================
+
+const ENV_NOT_FOUND_MESSAGE = (envId: string): string =>
+    `No Cloud Deploy environment with id "${envId}" was found in this workspace.`;
+const PERSIST_DIR_REQUIRED_MESSAGE =
+    "persist=true requires an artifactDir. The validation ran successfully; only the artifact was not written.";
+const RUN_ARTIFACT_FILENAME = (runId: string): string => `${runId}.cdrun.zip`;
+
+const DEFAULT_RUNNER_IDENTITY: RunnerIdentity = {
+    userId: "local-vscode",
+    displayName: "Local VS Code",
+    hostKind: "vscode",
+};
+
+/**
+ * Concrete `CloudDeployValidationApi` implementation. Composed once by
+ * `CloudDeployService` from a registry, an event bus, an env store, and
+ * an optional run-artifact writer; reused for every `run()` call.
+ *
+ * The service is intentionally state-light: no caching, no batching, no
+ * "in-flight runs" tracking. Each `run()` call is independent. Callers
+ * that need to coordinate multiple runs (e.g. queueing) layer that above.
+ */
+export class ValidationService implements CloudDeployValidationApi {
+    private readonly _runner: Runner;
+
+    public constructor(
+        private readonly _registry: ValidatorRegistry,
+        private readonly _bus: DiagnosticEventBus,
+        private readonly _environments: EnvironmentStore | undefined,
+        private readonly _writer?: RunArtifactWriter,
+    ) {
+        this._runner = new Runner(this._registry, this._bus);
+    }
+
+    public async run(
+        envId: string,
+        opts: CloudDeployValidationRunOptions = {},
+    ): Promise<CloudDeployValidationRunResult> {
+        const env = this._environments?.get(envId);
+        if (env === undefined) {
+            return { record: synthesizeEnvNotFoundRecord(envId, opts.runner) };
+        }
+
+        const runnerOpts: RunnerRunOptions = {
+            signal: opts.signal,
+            timeoutMs: opts.timeoutMs,
+            runner: opts.runner,
+        };
+
+        const record = await this._runner.run(env, runnerOpts);
+
+        if (!opts.persist) {
+            return { record };
+        }
+
+        if (this._writer === undefined || opts.artifactDir === undefined) {
+            return { record, persistError: PERSIST_DIR_REQUIRED_MESSAGE };
+        }
+
+        const destPath = path.join(opts.artifactDir, RUN_ARTIFACT_FILENAME(record.runId));
+        try {
+            const result = await this._writer.write(record, undefined, destPath);
+            return { record, runArtifactPath: result.path };
+        } catch (err) {
+            return {
+                record,
+                persistError: err instanceof Error ? err.message : String(err),
+            };
+        }
+    }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Builds an `Errored` `RunRecord` for the "env not found" path. Allows
+ * callers to handle the "asked for an env that doesn't exist" case through
+ * the same `RunRecord`-shaped UI flow as a real validation failure, with
+ * no thrown exceptions to route around.
+ */
+function synthesizeEnvNotFoundRecord(envId: string, runner?: RunnerIdentity): RunRecord {
+    const now = Date.now();
+    const placeholderEnv: Environment = {
+        id: envId,
+        name: envId,
+        sourceOfTruth: { kind: SourceOfTruthKind.Container, connectionProfileId: "" },
+        validations: [],
+    };
+    return {
+        schemaVersion: RUN_RECORD_SCHEMA_VERSION,
+        runId: `missing-env-${envId}-${now}`,
+        environmentId: envId,
+        environmentSnapshot: placeholderEnv,
+        runner: runner ?? DEFAULT_RUNNER_IDENTITY,
+        startedAtMs: now,
+        endedAtMs: now,
+        status: RunStatus.Errored,
+        validations: [
+            {
+                validationId: "env-not-found",
+                displayName: "Environment lookup",
+                status: ValidationStatus.Errored,
+                startedAtMs: now,
+                endedAtMs: now,
+                payload: {
+                    validationType: ValidationType.Connectivity,
+                    findings: [],
+                    summary: { reachable: false },
+                },
+                errorMessage: ENV_NOT_FOUND_MESSAGE(envId),
+            },
+        ],
+    };
+}

--- a/extensions/mssql/src/cloudDeploy/validation/validators/connectivityValidator.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/validators/connectivityValidator.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `ConnectivityValidator`.
+ *
+ * The first real validator. Opens a connection via the injected
+ * `ConnectionProvider`, runs a `SELECT @@VERSION` probe, closes the
+ * connection, and produces a `ValidationResult` whose `payload` is a
+ * `ConnectivityPayload`.
+ *
+ * Behavior summary:
+ *   * Success → status `Passed`. Payload carries one `info` finding
+ *     (`outcome: "reachable"`) plus the server-version string in
+ *     `summary.serverVersion`.
+ *   * `ConnectionError` from connect/execute → status `Failed`. Payload
+ *     carries one `error` finding whose `outcome` mirrors the error's
+ *     `kind`.
+ *   * `CancellationError` (or `signal.aborted` observed at a checkpoint) →
+ *     re-thrown so the runner reconciles the reason against the signal
+ *     and produces a `Cancelled` result.
+ *   * Any other thrown error → re-thrown so the runner maps it to
+ *     `Errored` (not `Failed`). The runner draws the line: connection
+ *     transport failures are `Failed`; the validator itself crashing is
+ *     `Errored`.
+ *
+ * Connectivity gates the rest of the run (`Runner` short-circuits the
+ * remaining validations to `Skipped` whenever this validator's result is
+ * not `Passed`). That rule lives in the runner; the validator's only job
+ * is to produce an accurate result.
+ */
+
+import { type Environment, ValidationType } from "../../environments/types";
+import {
+    type ConnectivityFinding,
+    type ConnectivityPayload,
+    type ValidationResult,
+    ValidationStatus,
+} from "../../runs/types";
+import {
+    CancellationError,
+    type SettingsFor,
+    throwIfCancelled,
+    type Validator,
+    type ValidatorRunOptions,
+} from "../types";
+import {
+    ConnectionError,
+    type ConnectionHandle,
+    type ConnectionProvider,
+} from "../providers/connectionProvider";
+
+/**
+ * The probe query. `@@VERSION` is preferred over `SELECT 1` because the
+ * server-version string is itself a useful artifact (rendered by the UI as
+ * "connected to SQL Server 2022 (16.0.x)") and the latency cost is small
+ * (~50ms vs ~10ms — see deliverable2.md TBD-10).
+ */
+const PROBE_SQL = "SELECT @@VERSION";
+
+/**
+ * Shape returned by the probe. SQL Server returns a single row, single
+ * column with the version banner. Defensive against odd shapes:
+ * non-string scalars are stringified; missing rows produce `undefined`
+ * which the validator treats as a `Passed` result with no version.
+ */
+function extractServerVersion(rows: unknown[][]): string | undefined {
+    const first = rows[0]?.[0];
+    if (first === undefined || first === null) {
+        return undefined;
+    }
+    return typeof first === "string" ? first : String(first);
+}
+
+export class ConnectivityValidator implements Validator<ValidationType.Connectivity> {
+    public readonly type = ValidationType.Connectivity;
+
+    public constructor(private readonly _connections: ConnectionProvider) {}
+
+    public async run(
+        env: Environment,
+        _config: SettingsFor<ValidationType.Connectivity>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult> {
+        const startedAtMs = Date.now();
+
+        // Cheap pre-check so a caller-cancelled run never opens a socket.
+        throwIfCancelled(opts.signal);
+
+        let handle: ConnectionHandle | undefined;
+        try {
+            handle = await this._connections.connect(env, opts.signal);
+            throwIfCancelled(opts.signal);
+
+            const rows = await handle.execute(PROBE_SQL, opts.signal);
+            throwIfCancelled(opts.signal);
+
+            const serverVersion = extractServerVersion(rows);
+            return buildPassedResult(startedAtMs, Date.now(), serverVersion);
+        } catch (err) {
+            // Cancellation propagates to the runner unchanged so the runner
+            // can stamp the right reason from the (possibly timeout-derived)
+            // signal. Aborted signal during connect/execute also yields a
+            // ConnectionError("timeout") which we translate to cancellation
+            // when the signal is the cause.
+            if (err instanceof CancellationError) {
+                throw err;
+            }
+            if (opts.signal.aborted) {
+                throw new CancellationError("user");
+            }
+            if (err instanceof ConnectionError) {
+                return buildFailedResult(startedAtMs, Date.now(), err);
+            }
+            // Any other error: re-throw so the runner classifies as Errored.
+            throw err;
+        } finally {
+            if (handle) {
+                try {
+                    await handle.dispose();
+                } catch {
+                    // Disposal failures are not surfaced — the validator's
+                    // job is the probe result, not connection-pool hygiene.
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function buildPassedResult(
+    startedAtMs: number,
+    endedAtMs: number,
+    serverVersion: string | undefined,
+): ValidationResult {
+    const finding: ConnectivityFinding = {
+        kind: "connectivity",
+        outcome: "reachable",
+        severity: "info",
+        message: serverVersion ? `Connected. Server version: ${serverVersion}` : "Connected.",
+    };
+    const payload: ConnectivityPayload = {
+        validationType: ValidationType.Connectivity,
+        findings: [finding],
+        summary:
+            serverVersion !== undefined ? { reachable: true, serverVersion } : { reachable: true },
+    };
+    return {
+        validationId: ValidationType.Connectivity,
+        displayName: "Connectivity",
+        status: ValidationStatus.Passed,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}
+
+function buildFailedResult(
+    startedAtMs: number,
+    endedAtMs: number,
+    err: ConnectionError,
+): ValidationResult {
+    const finding: ConnectivityFinding = {
+        kind: "connectivity",
+        outcome: err.kind,
+        severity: "error",
+        message: err.message,
+    };
+    const payload: ConnectivityPayload = {
+        validationType: ValidationType.Connectivity,
+        findings: [finding],
+        summary: { reachable: false },
+    };
+    return {
+        validationId: ValidationType.Connectivity,
+        displayName: "Connectivity",
+        status: ValidationStatus.Failed,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}

--- a/extensions/mssql/src/cloudDeploy/validation/validators/staticAnalysisValidator.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/validators/staticAnalysisValidator.ts
@@ -1,0 +1,294 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `StaticAnalysisValidator`.
+ *
+ * Shells out to `sqlpackage /Action:DeployReport` via the injected
+ * `ProcessProvider`, parses the diagnostics it prints to stderr, and
+ * produces a `ValidationResult` whose `payload` is a `StaticAnalysisPayload`.
+ *
+ * Source-of-truth requirements:
+ *   * `SqlProj` and `Dacpac` envs run analysis against `sourceOfTruth.path`.
+ *   * `Container` envs have no project file — analysis is `Skipped` with a
+ *     single `info` finding directing the user to attach a sqlproj/dacpac.
+ *
+ * Outcome mapping:
+ *   * sqlpackage exits 0 with no warnings/errors → `Passed`, zero findings.
+ *   * sqlpackage exits 0 with warnings only → `Passed` (no `failOn`
+ *     promotion in this PR; `failOn: "warning"` is TBD-7, deferred).
+ *     Warning findings still appear in the payload so the UI can render them.
+ *   * sqlpackage exits non-zero → `Failed`. Findings are populated from
+ *     parsed diagnostics; if no diagnostics could be parsed, a single
+ *     synthesized `error` finding carries a stderr excerpt.
+ *   * `CancellationError` (or `signal.aborted` observed at a checkpoint, or
+ *     `ProcessResult.aborted === true`) → re-thrown as `CancellationError`
+ *     so the runner reconciles `"user"` vs `"timeout"`.
+ *   * `Error` from `processProvider.spawn()` itself (binary not found, OS
+ *     refused to spawn) → re-thrown so the runner maps it to `Errored`.
+ *
+ * Diagnostic parsing is line-based. sqlpackage prints lines of the form
+ * `Warning SQL71558: ...` and `Error SQL70001: ...` to stderr; we extract
+ * `(severity, ruleId, message)` per match. Anything we can't parse is
+ * preserved in the payload only when sqlpackage failed (so the UI surfaces
+ * the raw output instead of an empty Failed result). Successful runs with
+ * un-parseable stderr lines produce zero findings.
+ */
+
+import { type Environment, SourceOfTruthKind, ValidationType } from "../../environments/types";
+import {
+    type StaticAnalysisFinding,
+    type StaticAnalysisPayload,
+    type ValidationResult,
+    ValidationStatus,
+} from "../../runs/types";
+import {
+    CancellationError,
+    type SettingsFor,
+    throwIfCancelled,
+    type Validator,
+    type ValidatorRunOptions,
+} from "../types";
+import { type ProcessProvider, type ProcessResult } from "../providers/processProvider";
+
+// =============================================================================
+// Defaults & constants
+// =============================================================================
+
+/** Command name. The service layer is responsible for resolving an absolute
+ * path before commit 6 wires up production. Defaulting to the bare name lets
+ * unit tests (which inject `FakeProcessProvider`) ignore path resolution. */
+const DEFAULT_SQLPACKAGE_COMMAND = "sqlpackage";
+
+/** sqlpackage's diagnostic line shape. Captures severity ("Warning" or
+ * "Error"), the rule id ("SQL71558"), and the trailing message. */
+const DIAGNOSTIC_LINE = /^\s*(Warning|Error)\s+([A-Z]+\d+):\s*(.+?)\s*$/;
+
+/** When sqlpackage fails but emits no parseable diagnostics, surface this
+ * many leading bytes of stderr in the synthesized finding so the user has
+ * something to act on. */
+const STDERR_EXCERPT_BYTES = 1024;
+
+const SKIPPED_NEEDS_PROJECT_MESSAGE =
+    "Static analysis requires a sqlproj or dacpac source of truth.";
+
+const PARSE_FAILURE_RULE_ID = "SQLPACKAGE_FAILED";
+
+// =============================================================================
+// Validator
+// =============================================================================
+
+/**
+ * Static-analysis validator. Constructor takes a `ProcessProvider` and an
+ * optional command override (lets tests pass `"sqlpackage-test"` and lets
+ * the service layer supply an absolute path).
+ */
+export class StaticAnalysisValidator implements Validator<ValidationType.StaticAnalysis> {
+    public readonly type = ValidationType.StaticAnalysis;
+
+    public constructor(
+        private readonly _processes: ProcessProvider,
+        private readonly _opts: { readonly sqlpackageCommand?: string } = {},
+    ) {}
+
+    public async run(
+        env: Environment,
+        _config: SettingsFor<ValidationType.StaticAnalysis>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult> {
+        const startedAtMs = Date.now();
+        throwIfCancelled(opts.signal);
+
+        const projectPath = projectPathFor(env);
+        if (projectPath === undefined) {
+            return buildSkippedResult(startedAtMs);
+        }
+
+        const command = this._opts.sqlpackageCommand ?? DEFAULT_SQLPACKAGE_COMMAND;
+        const args = buildSqlpackageArgs(projectPath);
+
+        let result: ProcessResult;
+        try {
+            result = await this._processes.spawn(command, args, { signal: opts.signal });
+        } catch (err) {
+            if (err instanceof CancellationError) {
+                throw err;
+            }
+            if (opts.signal.aborted) {
+                throw new CancellationError("user");
+            }
+            // Spawn-time failures (binary not found, OS error) bubble up to
+            // the runner, which classifies them as Errored.
+            throw err;
+        }
+
+        throwIfCancelled(opts.signal);
+
+        if (result.aborted) {
+            // Subprocess was killed by our abort handler; treat as cancellation.
+            throw new CancellationError("user");
+        }
+
+        const findings = parseDiagnostics(result.stdout, result.stderr);
+        const succeeded = result.exitCode === 0;
+
+        if (succeeded) {
+            return buildPassedResult(findings, startedAtMs);
+        }
+
+        // sqlpackage exited non-zero. If we parsed real diagnostics, use
+        // them; otherwise synthesize a single error from the stderr excerpt
+        // so the UI has something concrete.
+        const failureFindings: readonly StaticAnalysisFinding[] =
+            findings.length > 0 ? findings : [synthesizeFailureFinding(result)];
+        return buildFailedResult(failureFindings, startedAtMs);
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function projectPathFor(env: Environment): string | undefined {
+    const sot = env.sourceOfTruth;
+    if (sot.kind === SourceOfTruthKind.SqlProj || sot.kind === SourceOfTruthKind.Dacpac) {
+        return sot.path;
+    }
+    return undefined;
+}
+
+/**
+ * Builds the sqlpackage CLI args for a deploy-report run against `path`.
+ * Kept narrow: no profile, no target, no variables. Future settings (e.g.
+ * `StaticAnalysisSettings.ruleSet`) extend this once they land.
+ */
+function buildSqlpackageArgs(path: string): readonly string[] {
+    return ["/Action:DeployReport", `/SourceFile:${path}`];
+}
+
+/**
+ * Walks stdout + stderr for `Warning SQLnnnnn: ...` / `Error SQLnnnnn: ...`
+ * lines and emits one `StaticAnalysisFinding` per match. sqlpackage prints
+ * to both streams depending on subcommand; we scan both and dedupe by the
+ * literal line. Order is preserved (stdout first, then stderr).
+ */
+function parseDiagnostics(stdout: string, stderr: string): readonly StaticAnalysisFinding[] {
+    const seen = new Set<string>();
+    const findings: StaticAnalysisFinding[] = [];
+    for (const stream of [stdout, stderr]) {
+        for (const rawLine of stream.split(/\r?\n/)) {
+            if (seen.has(rawLine)) {
+                continue;
+            }
+            const match = DIAGNOSTIC_LINE.exec(rawLine);
+            if (match === null) {
+                continue;
+            }
+            seen.add(rawLine);
+            const [, severityWord, ruleId, message] = match;
+            findings.push({
+                kind: "static-analysis",
+                ruleId,
+                severity: severityWord === "Error" ? "error" : "warning",
+                message,
+            });
+        }
+    }
+    return findings;
+}
+
+function synthesizeFailureFinding(result: ProcessResult): StaticAnalysisFinding {
+    const excerpt = (result.stderr || result.stdout).slice(0, STDERR_EXCERPT_BYTES).trim();
+    const message =
+        excerpt.length > 0
+            ? `sqlpackage exited with code ${result.exitCode}: ${excerpt}`
+            : `sqlpackage exited with code ${result.exitCode} (no diagnostics on stderr).`;
+    return {
+        kind: "static-analysis",
+        ruleId: PARSE_FAILURE_RULE_ID,
+        severity: "error",
+        message,
+    };
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function summarize(findings: readonly StaticAnalysisFinding[]): StaticAnalysisPayload["summary"] {
+    let info = 0;
+    let warning = 0;
+    let error = 0;
+    for (const f of findings) {
+        if (f.severity === "info") {
+            info += 1;
+        } else if (f.severity === "warning") {
+            warning += 1;
+        } else {
+            error += 1;
+        }
+    }
+    return { info, warning, error };
+}
+
+function buildPassedResult(
+    findings: readonly StaticAnalysisFinding[],
+    startedAtMs: number,
+): ValidationResult {
+    const payload: StaticAnalysisPayload = {
+        validationType: ValidationType.StaticAnalysis,
+        findings,
+        summary: summarize(findings),
+    };
+    return {
+        validationId: ValidationType.StaticAnalysis,
+        displayName: "Static Analysis",
+        status: ValidationStatus.Passed,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}
+
+function buildFailedResult(
+    findings: readonly StaticAnalysisFinding[],
+    startedAtMs: number,
+): ValidationResult {
+    const payload: StaticAnalysisPayload = {
+        validationType: ValidationType.StaticAnalysis,
+        findings,
+        summary: summarize(findings),
+    };
+    return {
+        validationId: ValidationType.StaticAnalysis,
+        displayName: "Static Analysis",
+        status: ValidationStatus.Failed,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}
+
+function buildSkippedResult(startedAtMs: number): ValidationResult {
+    const finding: StaticAnalysisFinding = {
+        kind: "static-analysis",
+        ruleId: "SOURCE_OF_TRUTH_UNSUPPORTED",
+        severity: "info",
+        message: SKIPPED_NEEDS_PROJECT_MESSAGE,
+    };
+    const payload: StaticAnalysisPayload = {
+        validationType: ValidationType.StaticAnalysis,
+        findings: [finding],
+        summary: summarize([finding]),
+    };
+    return {
+        validationId: ValidationType.StaticAnalysis,
+        displayName: "Static Analysis",
+        status: ValidationStatus.Skipped,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}

--- a/extensions/mssql/src/cloudDeploy/validation/validators/unitTestsValidator.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/validators/unitTestsValidator.ts
@@ -1,0 +1,311 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `UnitTestsValidator`.
+ *
+ * Runs the tSQLt test framework against the env's live target and produces
+ * a `ValidationResult` whose `payload` is a `UnitTestsPayload`. Reuses the
+ * `ConnectionProvider` abstraction shipped in commit 2 — no new provider
+ * surface lands here.
+ *
+ * Behavior summary:
+ *   * Source-of-truth gate: only `Container` envs have a live target to
+ *     run tSQLt against. `SqlProj` / `Dacpac` envs short-circuit to
+ *     `Skipped` with one `info` finding (no spawn / no connection).
+ *   * tSQLt-installed probe: `SELECT 1 FROM sys.schemas WHERE name = 'tSQLt'`.
+ *     Zero rows → `Skipped` with one `info` finding directing the user to
+ *     install tSQLt. We invoke, we don't install.
+ *   * Connection failure (`ConnectionError` from connect or any of the
+ *     SQL probes) → `Skipped` with one `info` finding carrying the
+ *     `ConnectionFailureKind` and message. Rationale: the runner already
+ *     gates the run on `ConnectivityValidator`; a connection error here
+ *     is a transient retry candidate, not a unit-test failure.
+ *   * `EXEC tSQLt.RunAll` followed by
+ *     `SELECT Class, TestCase, Result, Msg FROM tSQLt.TestResult` parses
+ *     each row into a `UnitTestFinding`. tSQLt's `Result` column values
+ *     are `"Success" | "Failure" | "Error"`; we map to
+ *     `"passed" | "failed" | "errored"` (skipped is not a tSQLt concept,
+ *     so the count stays 0 unless future tooling surfaces it).
+ *   * Outcome: `Passed` when zero failed + zero errored; `Failed` when any
+ *     failed or errored row is present.
+ *   * Cancellation: re-thrown `CancellationError` propagates so the runner
+ *     reconciles the reason.
+ *   * Validator-itself crash: re-thrown so the runner classifies as
+ *     `Errored`.
+ */
+
+import { type Environment, SourceOfTruthKind, ValidationType } from "../../environments/types";
+import {
+    type UnitTestFinding,
+    type UnitTestsPayload,
+    type ValidationResult,
+    ValidationStatus,
+} from "../../runs/types";
+import {
+    CancellationError,
+    type SettingsFor,
+    throwIfCancelled,
+    type Validator,
+    type ValidatorRunOptions,
+} from "../types";
+import {
+    ConnectionError,
+    type ConnectionHandle,
+    type ConnectionProvider,
+} from "../providers/connectionProvider";
+
+const DISPLAY_NAME = "Unit Tests";
+
+/**
+ * Probes whether tSQLt is installed in the target DB. Empty result set
+ * means "not installed". `sys.schemas` is the canonical detection point —
+ * `tSQLt.RunAll` would error with a helpful message anyway, but probing
+ * first lets us produce a `Skipped` result instead of a noisy `Failed`.
+ */
+const TSQLT_PROBE_SQL = "SELECT 1 FROM sys.schemas WHERE name = 'tSQLt'";
+
+/** Runs every test class / case registered with tSQLt. */
+const TSQLT_RUN_ALL_SQL = "EXEC tSQLt.RunAll";
+
+/**
+ * Pulls the populated result table after `RunAll` returns. `Id` ascending
+ * preserves test execution order. `Result` is `'Success' | 'Failure' | 'Error'`.
+ * `Msg` is the failure / error message (empty for successes).
+ */
+const TSQLT_RESULTS_SQL = "SELECT Class, TestCase, Result, Msg FROM tSQLt.TestResult ORDER BY Id";
+
+export class UnitTestsValidator implements Validator<ValidationType.UnitTests> {
+    public readonly type = ValidationType.UnitTests;
+
+    public constructor(private readonly _connections: ConnectionProvider) {}
+
+    public async run(
+        env: Environment,
+        _config: SettingsFor<ValidationType.UnitTests>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult> {
+        const startedAtMs = Date.now();
+
+        // Cheap pre-check so a caller-cancelled run never opens a socket.
+        throwIfCancelled(opts.signal);
+
+        if (env.sourceOfTruth.kind !== SourceOfTruthKind.Container) {
+            return buildSkippedNoLiveTarget(startedAtMs, Date.now(), env.sourceOfTruth.kind);
+        }
+
+        let handle: ConnectionHandle | undefined;
+        try {
+            handle = await this._connections.connect(env, opts.signal);
+            throwIfCancelled(opts.signal);
+
+            // tSQLt installed?
+            const probeRows = await handle.execute(TSQLT_PROBE_SQL, opts.signal);
+            throwIfCancelled(opts.signal);
+            if (probeRows.length === 0) {
+                return buildSkippedTsqltMissing(startedAtMs, Date.now());
+            }
+
+            // Run all tests + collect results.
+            await handle.execute(TSQLT_RUN_ALL_SQL, opts.signal);
+            throwIfCancelled(opts.signal);
+            const resultRows = await handle.execute(TSQLT_RESULTS_SQL, opts.signal);
+            throwIfCancelled(opts.signal);
+
+            const findings = parseResultRows(resultRows);
+            return buildResultFromFindings(startedAtMs, Date.now(), findings);
+        } catch (err) {
+            if (err instanceof CancellationError) {
+                throw err;
+            }
+            if (opts.signal.aborted) {
+                throw new CancellationError("user");
+            }
+            if (err instanceof ConnectionError) {
+                return buildSkippedConnectionFailure(startedAtMs, Date.now(), err);
+            }
+            // Any other error: re-throw so the runner classifies as Errored.
+            throw err;
+        } finally {
+            if (handle) {
+                try {
+                    await handle.dispose();
+                } catch {
+                    // Disposal failures are not surfaced — the validator's
+                    // job is the test outcomes, not connection-pool hygiene.
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Row parsing
+// =============================================================================
+
+/**
+ * Maps a single `tSQLt.TestResult` row to a `UnitTestFinding`. Defensive
+ * against unexpected scalar shapes: any non-string value is stringified;
+ * an unrecognized `Result` value is treated as `"errored"` so a typo or a
+ * future tSQLt status surfaces visibly rather than being silently dropped.
+ */
+function parseResultRows(rows: unknown[][]): UnitTestFinding[] {
+    const findings: UnitTestFinding[] = [];
+    for (const row of rows) {
+        const className = stringOrEmpty(row[0]);
+        const testCase = stringOrEmpty(row[1]);
+        const result = stringOrEmpty(row[2]);
+        const msg = stringOrEmpty(row[3]);
+
+        const testName =
+            className && testCase
+                ? `${className}.${testCase}`
+                : testCase || className || "(unknown)";
+        const outcome = mapTsqltResult(result);
+        const finding: UnitTestFinding = {
+            kind: "unit-tests",
+            testName,
+            outcome,
+            ...(outcome === "passed" || msg.length === 0 ? {} : { message: msg }),
+        };
+        findings.push(finding);
+    }
+    return findings;
+}
+
+function mapTsqltResult(raw: string): UnitTestFinding["outcome"] {
+    switch (raw) {
+        case "Success":
+            return "passed";
+        case "Failure":
+            return "failed";
+        case "Error":
+            return "errored";
+        default:
+            // Unknown status — treat as errored so it surfaces visibly.
+            return "errored";
+    }
+}
+
+function stringOrEmpty(value: unknown): string {
+    if (value === null || value === undefined) {
+        return "";
+    }
+    return typeof value === "string" ? value : String(value);
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function buildResultFromFindings(
+    startedAtMs: number,
+    endedAtMs: number,
+    findings: UnitTestFinding[],
+): ValidationResult {
+    let passed = 0;
+    let failed = 0;
+    let errored = 0;
+    for (const f of findings) {
+        if (f.outcome === "passed") {
+            passed++;
+        } else if (f.outcome === "failed") {
+            failed++;
+        } else if (f.outcome === "errored") {
+            errored++;
+        }
+    }
+    const total = findings.length;
+    const status =
+        failed === 0 && errored === 0 ? ValidationStatus.Passed : ValidationStatus.Failed;
+    const payload: UnitTestsPayload = {
+        validationType: ValidationType.UnitTests,
+        findings,
+        summary: { total, passed, failed, skipped: 0, errored },
+    };
+    return {
+        validationId: ValidationType.UnitTests,
+        displayName: DISPLAY_NAME,
+        status,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}
+
+function buildSkippedNoLiveTarget(
+    startedAtMs: number,
+    endedAtMs: number,
+    kind: SourceOfTruthKind,
+): ValidationResult {
+    const finding: UnitTestFinding = {
+        kind: "unit-tests",
+        testName: "(skipped)",
+        outcome: "skipped",
+        message: `Unit tests require a live database target; this environment's source of truth is "${kind}". Attach a Container connection profile to enable tSQLt.`,
+    };
+    const payload: UnitTestsPayload = {
+        validationType: ValidationType.UnitTests,
+        findings: [finding],
+        summary: { total: 0, passed: 0, failed: 0, skipped: 1, errored: 0 },
+    };
+    return {
+        validationId: ValidationType.UnitTests,
+        displayName: DISPLAY_NAME,
+        status: ValidationStatus.Skipped,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}
+
+function buildSkippedTsqltMissing(startedAtMs: number, endedAtMs: number): ValidationResult {
+    const finding: UnitTestFinding = {
+        kind: "unit-tests",
+        testName: "(skipped)",
+        outcome: "skipped",
+        message:
+            "tSQLt is not installed on the target database. Install tSQLt (https://tsqlt.org/) and rerun to execute unit tests.",
+    };
+    const payload: UnitTestsPayload = {
+        validationType: ValidationType.UnitTests,
+        findings: [finding],
+        summary: { total: 0, passed: 0, failed: 0, skipped: 1, errored: 0 },
+    };
+    return {
+        validationId: ValidationType.UnitTests,
+        displayName: DISPLAY_NAME,
+        status: ValidationStatus.Skipped,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}
+
+function buildSkippedConnectionFailure(
+    startedAtMs: number,
+    endedAtMs: number,
+    err: ConnectionError,
+): ValidationResult {
+    const finding: UnitTestFinding = {
+        kind: "unit-tests",
+        testName: "(skipped)",
+        outcome: "skipped",
+        message: `Could not connect to the target database (${err.kind}): ${err.message}`,
+    };
+    const payload: UnitTestsPayload = {
+        validationType: ValidationType.UnitTests,
+        findings: [finding],
+        summary: { total: 0, passed: 0, failed: 0, skipped: 1, errored: 0 },
+    };
+    return {
+        validationId: ValidationType.UnitTests,
+        displayName: DISPLAY_NAME,
+        status: ValidationStatus.Skipped,
+        startedAtMs,
+        endedAtMs,
+        payload,
+    };
+}

--- a/extensions/mssql/src/cloudDeploy/validation/validators/workloadPlaybackValidator.ts
+++ b/extensions/mssql/src/cloudDeploy/validation/validators/workloadPlaybackValidator.ts
@@ -1,0 +1,527 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — `WorkloadPlaybackValidator`.
+ *
+ * Loads a captured workload via the injected `ArtifactProvider`, replays it
+ * via the injected `ProcessProvider`, parses observed per-step metrics from
+ * the replay tool's stdout, then compares them to a baseline (also loaded
+ * via `ArtifactProvider`) and emits one finding per significant regression.
+ *
+ * The shape of both the workload artifact and the baseline artifact is a
+ * permissive JSON object with a `steps` array; per step we read the metric
+ * fields the comparator needs and ignore the rest. Forward-compat is
+ * deliberately built into the parser so future capture formats (Query Store
+ * extracts, Distributed Replay capture files) only need to project into the
+ * `WorkloadStep` shape — the validator itself does not need to understand
+ * the source-of-truth.
+ *
+ * Source-of-truth gating mirrors `UnitTestsValidator`: replay needs a live
+ * target, so non-`Container` envs are `Skipped` with a directing finding. A
+ * missing `workloadUri` or `baselineUri` in `WorkloadPlaybackSettings` is
+ * also `Skipped` (with config-pointing findings) — the env was declared
+ * intent-wise but isn't yet wired up.
+ *
+ * Outcome mapping:
+ *   * Source-of-truth not Container → `Skipped` with a config finding.
+ *   * `workloadUri` or `baselineUri` missing in settings → `Skipped` with
+ *     a config finding naming the missing field.
+ *   * Workload or baseline artifact missing on disk
+ *     (`ArtifactNotFoundError`) → `Skipped` with a finding directing the
+ *     user to populate the artifact.
+ *   * Replay tool exits non-zero → `Failed` with a synthesized regression
+ *     finding carrying a stderr excerpt.
+ *   * Replay tool exits zero → parse stdout JSON, compare to baseline,
+ *     emit one regression finding per matched step that exceeded its
+ *     threshold. Status is `Passed` if zero regressions, `Failed`
+ *     otherwise.
+ *   * `CancellationError` (entry / artifact-read / spawn / post-spawn) →
+ *     re-thrown so the runner reconciles `"user"` vs `"timeout"`.
+ *   * Spawn-time `Error` (binary not found, OS refused) → re-thrown so the
+ *     runner classifies as `Errored`.
+ *
+ * Threshold defaults are deliberately conservative (25 % latency / 25 %
+ * throughput / 5pp error-rate) so first-time users see the validator behave
+ * sanely without any tuning. `WorkloadPlaybackSettings` overrides each
+ * threshold individually.
+ */
+
+import { type Environment, SourceOfTruthKind, ValidationType } from "../../environments/types";
+import {
+    type ValidationResult,
+    ValidationStatus,
+    type WorkloadPlaybackPayload,
+    type WorkloadRegressionFinding,
+} from "../../runs/types";
+import { ArtifactNotFoundError, type ArtifactProvider } from "../providers/artifactProvider";
+import { type ProcessProvider, type ProcessResult } from "../providers/processProvider";
+import {
+    CancellationError,
+    type SettingsFor,
+    throwIfCancelled,
+    type Validator,
+    type ValidatorRunOptions,
+} from "../types";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DISPLAY_NAME = "Workload Playback";
+
+/** Replay tool command name when settings don't override. The service layer
+ * may resolve an absolute path before commit 6 wires production. */
+const DEFAULT_REPLAY_COMMAND = "sql-workload-replay";
+
+/** Latency regression flagged when observed exceeds baseline by this fraction. */
+const DEFAULT_LATENCY_THRESHOLD = 0.25;
+/** Throughput regression flagged when observed drops below baseline by this fraction. */
+const DEFAULT_THROUGHPUT_THRESHOLD = 0.25;
+/** Error-rate regression flagged when (observed − baseline) exceeds this absolute delta. */
+const DEFAULT_ERROR_RATE_THRESHOLD = 0.05;
+
+/** Bytes of stderr surfaced in a synthesized regression finding when the
+ * replay tool exits non-zero with no parseable observations. */
+const STDERR_EXCERPT_BYTES = 1024;
+
+const SKIPPED_NEEDS_CONTAINER_MESSAGE =
+    "Workload playback requires a Container source of truth (a live target to replay against).";
+const SKIPPED_MISSING_WORKLOAD_URI_MESSAGE =
+    "WorkloadPlaybackSettings.workloadUri is not configured.";
+const SKIPPED_MISSING_BASELINE_URI_MESSAGE =
+    "WorkloadPlaybackSettings.baselineUri is not configured.";
+
+const SYNTHETIC_STEP_ID_REPLAY_FAILED = "__replay_failed__";
+const SYNTHETIC_STEP_ID_NOT_CONFIGURED = "__not_configured__";
+const SYNTHETIC_STEP_ID_ARTIFACT_MISSING = "__artifact_missing__";
+
+// =============================================================================
+// Internal shapes
+// =============================================================================
+
+/**
+ * Per-step metrics shape. All metric fields are optional so partial captures
+ * (e.g. a workload that didn't record plan hashes) compare cleanly without
+ * synthesizing missing data.
+ */
+interface WorkloadStep {
+    readonly id: string;
+    readonly latencyMs?: number;
+    readonly throughputQps?: number;
+    readonly errorRate?: number;
+    readonly planHash?: string;
+}
+
+interface ResolvedThresholds {
+    readonly latency: number;
+    readonly throughput: number;
+    readonly errorRate: number;
+}
+
+// =============================================================================
+// Validator
+// =============================================================================
+
+/**
+ * Workload-playback validator. Constructor takes an `ArtifactProvider`
+ * (artifacts) and a `ProcessProvider` (replay tool spawner); production
+ * wires `LiveArtifactProvider` + `LiveProcessProvider`, tests substitute
+ * `FakeArtifactProvider` + `FakeProcessProvider`.
+ */
+export class WorkloadPlaybackValidator implements Validator<ValidationType.WorkloadPlayback> {
+    public readonly type = ValidationType.WorkloadPlayback;
+
+    public constructor(
+        private readonly _artifacts: ArtifactProvider,
+        private readonly _processes: ProcessProvider,
+    ) {}
+
+    public async run(
+        env: Environment,
+        config: SettingsFor<ValidationType.WorkloadPlayback>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult> {
+        const startedAtMs = Date.now();
+        throwIfCancelled(opts.signal);
+
+        if (env.sourceOfTruth.kind !== SourceOfTruthKind.Container) {
+            return buildSkippedResult(
+                SYNTHETIC_STEP_ID_NOT_CONFIGURED,
+                SKIPPED_NEEDS_CONTAINER_MESSAGE,
+                startedAtMs,
+            );
+        }
+
+        const workloadUri = config.workloadUri;
+        if (workloadUri === undefined || workloadUri.length === 0) {
+            return buildSkippedResult(
+                SYNTHETIC_STEP_ID_NOT_CONFIGURED,
+                SKIPPED_MISSING_WORKLOAD_URI_MESSAGE,
+                startedAtMs,
+            );
+        }
+
+        const baselineUri = config.baselineUri;
+        if (baselineUri === undefined || baselineUri.length === 0) {
+            return buildSkippedResult(
+                SYNTHETIC_STEP_ID_NOT_CONFIGURED,
+                SKIPPED_MISSING_BASELINE_URI_MESSAGE,
+                startedAtMs,
+            );
+        }
+
+        let workloadBuf: Buffer;
+        let baselineBuf: Buffer;
+        try {
+            workloadBuf = await this._artifacts.read(workloadUri);
+        } catch (err) {
+            if (err instanceof ArtifactNotFoundError) {
+                return buildSkippedResult(
+                    SYNTHETIC_STEP_ID_ARTIFACT_MISSING,
+                    `Captured workload artifact not found at ${err.uri}.`,
+                    startedAtMs,
+                );
+            }
+            throw err;
+        }
+        throwIfCancelled(opts.signal);
+
+        try {
+            baselineBuf = await this._artifacts.read(baselineUri);
+        } catch (err) {
+            if (err instanceof ArtifactNotFoundError) {
+                return buildSkippedResult(
+                    SYNTHETIC_STEP_ID_ARTIFACT_MISSING,
+                    `Baseline artifact not found at ${err.uri}.`,
+                    startedAtMs,
+                );
+            }
+            throw err;
+        }
+        throwIfCancelled(opts.signal);
+
+        // Parse the baseline now so a malformed baseline file fails the run
+        // before we burn time on a replay we can't interpret. Workload bytes
+        // are forwarded to the replay tool verbatim via stdin so we don't
+        // parse them here.
+        const baselineSteps = parseSteps(baselineBuf, "baseline");
+        const command = config.replayCommand ?? DEFAULT_REPLAY_COMMAND;
+
+        let result: ProcessResult;
+        try {
+            result = await this._processes.spawn(command, [], {
+                signal: opts.signal,
+                stdin: workloadBuf.toString("utf-8"),
+            });
+        } catch (err) {
+            if (err instanceof CancellationError) {
+                throw err;
+            }
+            if (opts.signal.aborted) {
+                throw new CancellationError("user");
+            }
+            throw err;
+        }
+        throwIfCancelled(opts.signal);
+
+        if (result.aborted) {
+            throw new CancellationError("user");
+        }
+
+        if (result.exitCode !== 0) {
+            return buildFailedReplayResult(result, startedAtMs);
+        }
+
+        const observedSteps = parseSteps(Buffer.from(result.stdout, "utf-8"), "replay output");
+        const thresholds = resolveThresholds(config);
+        const findings = compareSteps(baselineSteps, observedSteps, thresholds);
+
+        return buildComparisonResult(findings, baselineSteps.length, startedAtMs);
+    }
+}
+
+// =============================================================================
+// Parsing
+// =============================================================================
+
+/**
+ * Decodes a `{ steps: [...] }` JSON document into our internal `WorkloadStep`
+ * shape. Unknown step fields are dropped; missing metric fields are left
+ * `undefined` so the comparator skips them rather than synthesizing zero.
+ *
+ * Throws a plain `Error` on JSON-parse failure or top-level shape mismatch
+ * (validators bubble these as `Errored` via the runner).
+ */
+function parseSteps(buf: Buffer, label: string): readonly WorkloadStep[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(buf.toString("utf-8"));
+    } catch (err) {
+        throw new Error(
+            `Failed to parse ${label} JSON: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+    if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        !("steps" in parsed) ||
+        !Array.isArray((parsed as { steps: unknown }).steps)
+    ) {
+        throw new Error(`${label} document is missing the required "steps" array.`);
+    }
+    const out: WorkloadStep[] = [];
+    for (const raw of (parsed as { steps: unknown[] }).steps) {
+        if (typeof raw !== "object" || raw === null) {
+            continue;
+        }
+        const obj = raw as Record<string, unknown>;
+        if (typeof obj.id !== "string" || obj.id.length === 0) {
+            continue;
+        }
+        out.push({
+            id: obj.id,
+            latencyMs: numberOrUndefined(obj.latencyMs),
+            throughputQps: numberOrUndefined(obj.throughputQps),
+            errorRate: numberOrUndefined(obj.errorRate),
+            planHash: typeof obj.planHash === "string" ? obj.planHash : undefined,
+        });
+    }
+    return out;
+}
+
+function numberOrUndefined(v: unknown): number | undefined {
+    return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+// =============================================================================
+// Comparison
+// =============================================================================
+
+function resolveThresholds(
+    config: SettingsFor<ValidationType.WorkloadPlayback>,
+): ResolvedThresholds {
+    return {
+        latency: config.latencyRegressionThreshold ?? DEFAULT_LATENCY_THRESHOLD,
+        throughput: config.throughputRegressionThreshold ?? DEFAULT_THROUGHPUT_THRESHOLD,
+        errorRate: config.errorRateThreshold ?? DEFAULT_ERROR_RATE_THRESHOLD,
+    };
+}
+
+/**
+ * Walks baseline steps in order; for each one, looks up the matching observed
+ * step by `id`. Steps in baseline that are missing from observed and steps
+ * in observed that aren't in baseline are intentionally not emitted as
+ * findings — this validator surfaces *regressions*, not coverage gaps. A
+ * future commit can add a separate "missing-step" finding kind if there's
+ * demand.
+ */
+function compareSteps(
+    baseline: readonly WorkloadStep[],
+    observed: readonly WorkloadStep[],
+    thresholds: ResolvedThresholds,
+): readonly WorkloadRegressionFinding[] {
+    const observedById = new Map<string, WorkloadStep>();
+    for (const step of observed) {
+        observedById.set(step.id, step);
+    }
+    const findings: WorkloadRegressionFinding[] = [];
+    for (const base of baseline) {
+        const obs = observedById.get(base.id);
+        if (obs === undefined) {
+            continue;
+        }
+        const latencyFinding = compareLatency(base, obs, thresholds.latency);
+        if (latencyFinding !== undefined) {
+            findings.push(latencyFinding);
+        }
+        const throughputFinding = compareThroughput(base, obs, thresholds.throughput);
+        if (throughputFinding !== undefined) {
+            findings.push(throughputFinding);
+        }
+        const errorFinding = compareErrorRate(base, obs, thresholds.errorRate);
+        if (errorFinding !== undefined) {
+            findings.push(errorFinding);
+        }
+        const planFinding = comparePlanHash(base, obs);
+        if (planFinding !== undefined) {
+            findings.push(planFinding);
+        }
+    }
+    return findings;
+}
+
+function compareLatency(
+    base: WorkloadStep,
+    obs: WorkloadStep,
+    threshold: number,
+): WorkloadRegressionFinding | undefined {
+    if (base.latencyMs === undefined || obs.latencyMs === undefined || base.latencyMs <= 0) {
+        return undefined;
+    }
+    const ratio = (obs.latencyMs - base.latencyMs) / base.latencyMs;
+    if (ratio <= threshold) {
+        return undefined;
+    }
+    return {
+        kind: "workload-playback",
+        stepId: base.id,
+        regression: "latency",
+        delta: ratio,
+        message: `Latency regression: ${formatPercent(ratio)} (baseline ${base.latencyMs} ms, observed ${obs.latencyMs} ms).`,
+    };
+}
+
+function compareThroughput(
+    base: WorkloadStep,
+    obs: WorkloadStep,
+    threshold: number,
+): WorkloadRegressionFinding | undefined {
+    if (
+        base.throughputQps === undefined ||
+        obs.throughputQps === undefined ||
+        base.throughputQps <= 0
+    ) {
+        return undefined;
+    }
+    // Negative ratio = drop. We flag drops larger (in magnitude) than threshold.
+    const ratio = (obs.throughputQps - base.throughputQps) / base.throughputQps;
+    if (ratio >= -threshold) {
+        return undefined;
+    }
+    return {
+        kind: "workload-playback",
+        stepId: base.id,
+        regression: "throughput",
+        delta: ratio,
+        message: `Throughput regression: ${formatPercent(ratio)} (baseline ${base.throughputQps} qps, observed ${obs.throughputQps} qps).`,
+    };
+}
+
+function compareErrorRate(
+    base: WorkloadStep,
+    obs: WorkloadStep,
+    threshold: number,
+): WorkloadRegressionFinding | undefined {
+    if (base.errorRate === undefined || obs.errorRate === undefined) {
+        return undefined;
+    }
+    const delta = obs.errorRate - base.errorRate;
+    if (delta <= threshold) {
+        return undefined;
+    }
+    return {
+        kind: "workload-playback",
+        stepId: base.id,
+        regression: "error-rate",
+        delta,
+        message: `Error rate regression: +${formatPercent(delta)} (baseline ${formatPercent(base.errorRate)}, observed ${formatPercent(obs.errorRate)}).`,
+    };
+}
+
+function comparePlanHash(
+    base: WorkloadStep,
+    obs: WorkloadStep,
+): WorkloadRegressionFinding | undefined {
+    if (base.planHash === undefined || obs.planHash === undefined) {
+        return undefined;
+    }
+    if (base.planHash === obs.planHash) {
+        return undefined;
+    }
+    return {
+        kind: "workload-playback",
+        stepId: base.id,
+        regression: "plan-change",
+        delta: 0,
+        message: `Plan change: baseline ${base.planHash}, observed ${obs.planHash}.`,
+    };
+}
+
+function formatPercent(ratio: number): string {
+    return `${(ratio * 100).toFixed(1)}%`;
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function buildComparisonResult(
+    findings: readonly WorkloadRegressionFinding[],
+    baselineStepCount: number,
+    startedAtMs: number,
+): ValidationResult {
+    const payload: WorkloadPlaybackPayload = {
+        validationType: ValidationType.WorkloadPlayback,
+        findings,
+        summary: {
+            steps: baselineStepCount,
+            regressions: findings.length,
+        },
+    };
+    return {
+        validationId: ValidationType.WorkloadPlayback,
+        displayName: DISPLAY_NAME,
+        status: findings.length === 0 ? ValidationStatus.Passed : ValidationStatus.Failed,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}
+
+function buildFailedReplayResult(result: ProcessResult, startedAtMs: number): ValidationResult {
+    const excerpt = (result.stderr || result.stdout).slice(0, STDERR_EXCERPT_BYTES).trim();
+    const message =
+        excerpt.length > 0
+            ? `Replay tool exited with code ${result.exitCode}: ${excerpt}`
+            : `Replay tool exited with code ${result.exitCode} (no diagnostics on stderr).`;
+    const finding: WorkloadRegressionFinding = {
+        kind: "workload-playback",
+        stepId: SYNTHETIC_STEP_ID_REPLAY_FAILED,
+        regression: "error-rate",
+        delta: 0,
+        message,
+    };
+    const payload: WorkloadPlaybackPayload = {
+        validationType: ValidationType.WorkloadPlayback,
+        findings: [finding],
+        summary: { steps: 0, regressions: 1 },
+    };
+    return {
+        validationId: ValidationType.WorkloadPlayback,
+        displayName: DISPLAY_NAME,
+        status: ValidationStatus.Failed,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}
+
+function buildSkippedResult(
+    syntheticStepId: string,
+    message: string,
+    startedAtMs: number,
+): ValidationResult {
+    const finding: WorkloadRegressionFinding = {
+        kind: "workload-playback",
+        stepId: syntheticStepId,
+        regression: "plan-change",
+        delta: 0,
+        message,
+    };
+    const payload: WorkloadPlaybackPayload = {
+        validationType: ValidationType.WorkloadPlayback,
+        findings: [finding],
+        summary: { steps: 0, regressions: 0 },
+    };
+    return {
+        validationId: ValidationType.WorkloadPlayback,
+        displayName: DISPLAY_NAME,
+        status: ValidationStatus.Skipped,
+        startedAtMs,
+        endedAtMs: Date.now(),
+        payload,
+    };
+}

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -159,6 +159,7 @@ export const cmdNotebooksCreate = "mssql.notebooks.createNotebook";
 export const cmdNotebooksChangeDatabase = "mssql.notebooks.changeDatabase";
 export const cmdNotebooksChangeConnection = "mssql.notebooks.changeConnection";
 export const cmdNotebooksCopyCellMessages = "mssql.notebooks.copyCellMessages";
+export const cmdCloudDeployValidate = "mssql.cloudDeploy.validateEnvironment";
 
 export const piiLogging = "piiLogging";
 export const mssqlPiiLogging = "mssql.piiLogging";

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -3907,3 +3907,78 @@ export class CloudDeployRuns {
         });
     }
 }
+
+export class CloudDeployValidation {
+    public static commandTitle = l10n.t("Cloud Deploy: Validate environment");
+
+    public static noEnvironmentsDeclared = l10n.t(
+        "No Cloud Deploy environments are declared in this workspace. Add one to .mssql/environments.json before running validation.",
+    );
+
+    public static noWorkspaceFolder = l10n.t(
+        "Cloud Deploy validation requires an open workspace folder.",
+    );
+
+    public static pickEnvironmentPlaceholder = l10n.t("Select an environment to validate");
+
+    public static progressTitle = (envName: string): string =>
+        l10n.t({
+            message: "Validating environment '{0}'",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static runPassed = (envName: string): string =>
+        l10n.t({
+            message: "Validation passed for '{0}'.",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static runWarning = (envName: string): string =>
+        l10n.t({
+            message: "Validation finished with warnings for '{0}'.",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static runFailed = (envName: string): string =>
+        l10n.t({
+            message: "Validation failed for '{0}'.",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static runErrored = (envName: string, message: string): string =>
+        l10n.t({
+            message: "Validation runner crashed for '{0}': {1}",
+            args: [envName, message],
+            comment: [
+                "{0} is the user-facing environment name",
+                "{1} is the underlying error message",
+            ],
+        });
+
+    public static runCancelled = (envName: string): string =>
+        l10n.t({
+            message: "Validation cancelled for '{0}'.",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static runSkipped = (envName: string): string =>
+        l10n.t({
+            message: "No validations were declared on '{0}'.",
+            args: [envName],
+            comment: ["{0} is the user-facing environment name"],
+        });
+
+    public static showOutputChannelAction = l10n.t("Show output");
+
+    public static persistFailed = (message: string): string =>
+        l10n.t({
+            message: "Validation finished but the run artifact could not be saved: {0}",
+            args: [message],
+            comment: ["{0} is the underlying I/O error message"],
+        });
+}

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -295,6 +295,10 @@ export default class MainController implements vscode.Disposable {
                 }
                 this.onDeployNewDatabase(initialConnectionGroup);
             });
+            this.registerCommand(Constants.cmdCloudDeployValidate);
+            this._event.on(Constants.cmdCloudDeployValidate, () => {
+                void this.onCloudDeployValidate();
+            });
             this.registerCommand(Constants.cmdRunCurrentStatement);
             this._event.on(Constants.cmdRunCurrentStatement, () => {
                 void this.onRunCurrentStatement();
@@ -2700,6 +2704,130 @@ export default class MainController implements vscode.Disposable {
             initialConnectionGroup,
         );
         reactPanel.revealToForeground();
+    }
+
+    /**
+     * Cloud Deploy: prompt the user to pick a declared environment, dispatch
+     * the validation pipeline against it, and surface a result toast. The
+     * detailed event log lands in the "Cloud Deploy" output channel via the
+     * service's bus subscription.
+     */
+    public async onCloudDeployValidate(): Promise<void> {
+        const environments = this.cloudDeployService.environments;
+        if (environments === undefined) {
+            this._vscodeWrapper.showInformationMessage(
+                LocalizedConstants.CloudDeployValidation.noWorkspaceFolder,
+            );
+            return;
+        }
+
+        const envs = environments.list();
+        if (envs.length === 0) {
+            this._vscodeWrapper.showInformationMessage(
+                LocalizedConstants.CloudDeployValidation.noEnvironmentsDeclared,
+            );
+            return;
+        }
+
+        const items = envs.map((env) => ({
+            label: env.name,
+            description: env.id,
+            detail: env.description,
+            envId: env.id,
+        }));
+        const picked = await vscode.window.showQuickPick(items, {
+            placeHolder: LocalizedConstants.CloudDeployValidation.pickEnvironmentPlaceholder,
+            ignoreFocusOut: true,
+        });
+        if (picked === undefined) {
+            return;
+        }
+
+        const envName = picked.label;
+        const result = await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: LocalizedConstants.CloudDeployValidation.progressTitle(envName),
+                cancellable: true,
+            },
+            async (_progress, token) => {
+                const controller = new AbortController();
+                const tokenSubscription = token.onCancellationRequested(() => controller.abort());
+                try {
+                    return await this.cloudDeployService.validation.run(picked.envId, {
+                        signal: controller.signal,
+                    });
+                } finally {
+                    tokenSubscription.dispose();
+                }
+            },
+        );
+
+        await this.showCloudDeployValidateResult(envName, result);
+    }
+
+    private async showCloudDeployValidateResult(
+        envName: string,
+        result: {
+            record: { status: string; validations: ReadonlyArray<{ errorMessage?: string }> };
+            persistError?: string;
+        },
+    ): Promise<void> {
+        const showOutput = LocalizedConstants.CloudDeployValidation.showOutputChannelAction;
+        const status = result.record.status;
+        let toast: Thenable<string | undefined>;
+        switch (status) {
+            case "passed":
+                toast = vscode.window.showInformationMessage(
+                    LocalizedConstants.CloudDeployValidation.runPassed(envName),
+                    showOutput,
+                );
+                break;
+            case "warning":
+                toast = vscode.window.showWarningMessage(
+                    LocalizedConstants.CloudDeployValidation.runWarning(envName),
+                    showOutput,
+                );
+                break;
+            case "cancelled":
+                toast = vscode.window.showInformationMessage(
+                    LocalizedConstants.CloudDeployValidation.runCancelled(envName),
+                    showOutput,
+                );
+                break;
+            case "skipped":
+                toast = vscode.window.showInformationMessage(
+                    LocalizedConstants.CloudDeployValidation.runSkipped(envName),
+                    showOutput,
+                );
+                break;
+            case "errored": {
+                const message = result.record.validations[0]?.errorMessage ?? "";
+                toast = vscode.window.showErrorMessage(
+                    LocalizedConstants.CloudDeployValidation.runErrored(envName, message),
+                    showOutput,
+                );
+                break;
+            }
+            case "failed":
+            default:
+                toast = vscode.window.showErrorMessage(
+                    LocalizedConstants.CloudDeployValidation.runFailed(envName),
+                    showOutput,
+                );
+                break;
+        }
+
+        if (result.persistError !== undefined) {
+            void this._vscodeWrapper.showWarningMessage(
+                LocalizedConstants.CloudDeployValidation.persistFailed(result.persistError),
+            );
+        }
+
+        const action = await toast;
+        if (action === showOutput) {
+            this.cloudDeployService.outputChannel.show(true);
+        }
     }
 
     /**

--- a/extensions/mssql/test/unit/cloudDeployArtifactProvider.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployArtifactProvider.test.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `ArtifactProvider`:
+ *   * `FakeArtifactProvider` round-trips a string-seeded artifact via UTF-8.
+ *   * `read()` for an unset uri throws `ArtifactNotFoundError` carrying that uri.
+ *   * `exists()` mirrors `set()` state without throwing.
+ *   * Reads are recorded in order with hit/miss flags.
+ *   * `LiveArtifactProvider` translates `ENOENT` into `ArtifactNotFoundError`
+ *     while preserving every other error verbatim.
+ */
+
+import { expect } from "chai";
+
+import {
+    ArtifactNotFoundError,
+    FakeArtifactProvider,
+    LiveArtifactProvider,
+} from "../../src/cloudDeploy/validation";
+import type { FileProvider } from "../../src/cloudDeploy/providers";
+
+class StubFileProvider implements FileProvider {
+    public constructor(private readonly _impl: Partial<FileProvider>) {}
+
+    public readFileBuffer(filePath: string): Promise<Buffer> {
+        if (this._impl.readFileBuffer === undefined) {
+            return Promise.reject(new Error("readFileBuffer not stubbed"));
+        }
+        return this._impl.readFileBuffer(filePath);
+    }
+
+    public writeFileAtomic(): Promise<void> {
+        return Promise.reject(new Error("writeFileAtomic not used in artifact-provider tests"));
+    }
+
+    public fileExists(filePath: string): Promise<boolean> {
+        if (this._impl.fileExists === undefined) {
+            return Promise.resolve(false);
+        }
+        return this._impl.fileExists(filePath);
+    }
+}
+
+suite("CloudDeploy ArtifactProvider", () => {
+    suite("FakeArtifactProvider", () => {
+        test("round-trips a string-seeded artifact as UTF-8 bytes", async () => {
+            const fake = new FakeArtifactProvider();
+            fake.set("file:///workload.json", '{"steps":[]}');
+
+            const buf = await fake.read("file:///workload.json");
+
+            expect(buf.toString("utf-8")).to.equal('{"steps":[]}');
+        });
+
+        test("throws ArtifactNotFoundError carrying the missing uri", async () => {
+            const fake = new FakeArtifactProvider();
+
+            try {
+                await fake.read("file:///nope.json");
+                expect.fail("expected ArtifactNotFoundError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ArtifactNotFoundError);
+                expect((err as ArtifactNotFoundError).uri).to.equal("file:///nope.json");
+            }
+        });
+
+        test("exists() reflects set() state without throwing for missing keys", async () => {
+            const fake = new FakeArtifactProvider();
+            fake.set("file:///present", "hi");
+
+            expect(await fake.exists("file:///present")).to.equal(true);
+            expect(await fake.exists("file:///absent")).to.equal(false);
+        });
+
+        test("records reads in order with hit/miss flags", async () => {
+            const fake = new FakeArtifactProvider();
+            fake.set("file:///present", "hi");
+
+            await fake.read("file:///present");
+            await fake.read("file:///absent").catch(() => undefined);
+            await fake.read("file:///present");
+
+            expect(fake.reads).to.deep.equal([
+                { uri: "file:///present", hit: true },
+                { uri: "file:///absent", hit: false },
+                { uri: "file:///present", hit: true },
+            ]);
+        });
+    });
+
+    suite("LiveArtifactProvider", () => {
+        test("delegates read() to the FileProvider on success", async () => {
+            const live = new LiveArtifactProvider(
+                new StubFileProvider({
+                    readFileBuffer: () => Promise.resolve(Buffer.from("ok", "utf-8")),
+                }),
+            );
+
+            const buf = await live.read("/some/path.json");
+
+            expect(buf.toString("utf-8")).to.equal("ok");
+        });
+
+        test("translates ENOENT into ArtifactNotFoundError carrying the uri", async () => {
+            const enoent = Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" });
+            const live = new LiveArtifactProvider(
+                new StubFileProvider({
+                    readFileBuffer: () => Promise.reject(enoent),
+                }),
+            );
+
+            try {
+                await live.read("/missing.json");
+                expect.fail("expected ArtifactNotFoundError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ArtifactNotFoundError);
+                expect((err as ArtifactNotFoundError).uri).to.equal("/missing.json");
+            }
+        });
+
+        test("re-throws non-ENOENT errors verbatim", async () => {
+            const eperm = Object.assign(new Error("EACCES: denied"), { code: "EACCES" });
+            const live = new LiveArtifactProvider(
+                new StubFileProvider({
+                    readFileBuffer: () => Promise.reject(eperm),
+                }),
+            );
+
+            try {
+                await live.read("/locked.json");
+                expect.fail("expected EACCES error to propagate");
+            } catch (err) {
+                expect(err).to.equal(eperm);
+            }
+        });
+
+        test("exists() delegates to FileProvider.fileExists", async () => {
+            const live = new LiveArtifactProvider(
+                new StubFileProvider({
+                    fileExists: (p) => Promise.resolve(p === "/yes"),
+                }),
+            );
+
+            expect(await live.exists("/yes")).to.equal(true);
+            expect(await live.exists("/no")).to.equal(false);
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployConnectionProvider.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployConnectionProvider.test.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for the Cloud Deploy `ConnectionProvider` surface:
+ *   * `FakeConnectionProvider` records invocations + honors per-env behavior.
+ *   * `FakeConnectionHandle` records executions, returns canned rows, and
+ *     remembers disposal.
+ *   * `LiveConnectionProvider` delegates Container-source-of-truth envs to
+ *     its strategy and rejects non-container envs with a deterministic
+ *     `ConnectionError`.
+ */
+
+import { expect } from "chai";
+
+import { SourceOfTruthKind } from "../../src/cloudDeploy/environments/types";
+import {
+    ConnectionError,
+    ConnectionHandle,
+    FakeConnectionHandle,
+    FakeConnectionProvider,
+    LiveConnectionProvider,
+} from "../../src/cloudDeploy/validation/providers/connectionProvider";
+
+import { makeEnvironmentWithValidations } from "./cloudDeployValidationTestHelpers";
+
+suite("CloudDeploy ConnectionProvider", () => {
+    // -------------------------------------------------------------------------
+    // FakeConnectionProvider
+    // -------------------------------------------------------------------------
+    suite("FakeConnectionProvider", () => {
+        test("connect() defaults to success and returns a FakeConnectionHandle", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            const ctrl = new AbortController();
+
+            const handle = await provider.connect(env, ctrl.signal);
+
+            expect(handle).to.be.instanceOf(FakeConnectionHandle);
+            expect(provider.invocations).to.deep.equal([{ envId: env.id, signalAborted: false }]);
+            expect(provider.handles).to.have.length(1);
+            expect(provider.handles[0]).to.equal(handle);
+        });
+
+        test("connect() throws ConnectionError when configured for failure", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            provider.configure(env.id, {
+                mode: "failure",
+                kind: "auth-failed",
+                message: "wrong password",
+            });
+
+            try {
+                await provider.connect(env, new AbortController().signal);
+                expect.fail("expected ConnectionError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ConnectionError);
+                expect((err as ConnectionError).kind).to.equal("auth-failed");
+                expect((err as ConnectionError).message).to.equal("wrong password");
+            }
+        });
+
+        test("connect() in timeout mode waits for signal abort then throws timeout", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            provider.configure(env.id, { mode: "timeout" });
+
+            const ctrl = new AbortController();
+            const promise = provider.connect(env, ctrl.signal);
+            // Abort after a tick so the await has time to register.
+            setTimeout(() => ctrl.abort(), 5);
+
+            try {
+                await promise;
+                expect.fail("expected ConnectionError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ConnectionError);
+                expect((err as ConnectionError).kind).to.equal("timeout");
+            }
+        });
+
+        test("FakeConnectionHandle.execute records calls and returns canned rows", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            provider.configure(env.id, {
+                mode: "success",
+                handle: {
+                    executeResponses: { "SELECT @@VERSION": [["SQL Server 2022"]] },
+                },
+            });
+
+            const handle = (await provider.connect(
+                env,
+                new AbortController().signal,
+            )) as FakeConnectionHandle;
+            const rows = await handle.execute("SELECT @@VERSION", new AbortController().signal);
+            const fallbackRows = await handle.execute("SELECT 1", new AbortController().signal);
+
+            expect(rows).to.deep.equal([["SQL Server 2022"]]);
+            expect(fallbackRows).to.deep.equal([[]]);
+            expect(handle.executions.map((e) => e.sql)).to.deep.equal([
+                "SELECT @@VERSION",
+                "SELECT 1",
+            ]);
+        });
+
+        test("FakeConnectionHandle.dispose() is idempotent and sets the disposed flag", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            const handle = (await provider.connect(
+                env,
+                new AbortController().signal,
+            )) as FakeConnectionHandle;
+
+            expect(handle.disposed).to.equal(false);
+            await handle.dispose();
+            expect(handle.disposed).to.equal(true);
+            await handle.dispose();
+            expect(handle.disposed).to.equal(true);
+        });
+
+        test("FakeConnectionHandle.execute throws when configured with executeError", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([]);
+            provider.configure(env.id, {
+                mode: "success",
+                handle: { executeError: new ConnectionError("connection-refused", "rst") },
+            });
+
+            const handle = await provider.connect(env, new AbortController().signal);
+            try {
+                await handle.execute("SELECT 1", new AbortController().signal);
+                expect.fail("expected ConnectionError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ConnectionError);
+                expect((err as ConnectionError).kind).to.equal("connection-refused");
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // LiveConnectionProvider
+    // -------------------------------------------------------------------------
+    suite("LiveConnectionProvider", () => {
+        test("delegates Container envs to the strategy with the right profile id", async () => {
+            const stubHandle: ConnectionHandle = {
+                execute: async () => [[]],
+                dispose: async () => {},
+            };
+            const calls: Array<{ profileId: string; signalAborted: boolean }> = [];
+            const provider = new LiveConnectionProvider({
+                connectByProfileId: async (profileId, signal) => {
+                    calls.push({ profileId, signalAborted: signal.aborted });
+                    return stubHandle;
+                },
+            });
+            const env = makeEnvironmentWithValidations([], {
+                sourceOfTruth: {
+                    kind: SourceOfTruthKind.Container,
+                    connectionProfileId: "prof-42",
+                },
+            });
+
+            const handle = await provider.connect(env, new AbortController().signal);
+
+            expect(handle).to.equal(stubHandle);
+            expect(calls).to.deep.equal([{ profileId: "prof-42", signalAborted: false }]);
+        });
+
+        test("throws ConnectionError(unknown) for non-Container source-of-truth envs", async () => {
+            const provider = new LiveConnectionProvider({
+                connectByProfileId: async () => {
+                    throw new Error("strategy should not be called");
+                },
+            });
+            const env = makeEnvironmentWithValidations([], {
+                sourceOfTruth: { kind: SourceOfTruthKind.SqlProj, path: "/tmp/x.sqlproj" },
+            });
+
+            try {
+                await provider.connect(env, new AbortController().signal);
+                expect.fail("expected ConnectionError");
+            } catch (err) {
+                expect(err).to.be.instanceOf(ConnectionError);
+                expect((err as ConnectionError).kind).to.equal("unknown");
+                expect((err as ConnectionError).message).to.match(/no connection profile/);
+            }
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployConnectivityValidator.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployConnectivityValidator.test.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `ConnectivityValidator`:
+ *   * Pass case — `SELECT @@VERSION` returns a row → status `Passed`,
+ *     `outcome: "reachable"`, `summary.serverVersion` populated.
+ *   * Pass case with no row → status `Passed`, `summary.reachable: true`,
+ *     no `serverVersion`.
+ *   * Failure modes — each `ConnectionFailureKind` flows through the
+ *     ConnectionError → `Failed` result with matching `outcome`.
+ *   * Cancellation — pre-aborted signal short-circuits before connecting;
+ *     mid-execute abort surfaces as `CancellationError`.
+ *   * Disposal — the handle's `dispose()` is called on both success and
+ *     failure paths.
+ *   * Errored path — non-`ConnectionError` thrown from the provider is
+ *     re-thrown so the runner classifies as `Errored`, not `Failed`.
+ */
+
+import { expect } from "chai";
+
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import { ValidationStatus, type ConnectivityPayload } from "../../src/cloudDeploy/runs/types";
+import {
+    CancellationError,
+    ConnectionError,
+    ConnectivityValidator,
+    FakeConnectionHandle,
+    FakeConnectionProvider,
+} from "../../src/cloudDeploy/validation";
+
+import { makeEnvironmentWithValidations } from "./cloudDeployValidationTestHelpers";
+
+const RUN_OPTS_BASE = { runId: "run-test" } as const;
+
+suite("CloudDeploy ConnectivityValidator", () => {
+    let provider: FakeConnectionProvider;
+    let validator: ConnectivityValidator;
+
+    setup(() => {
+        provider = new FakeConnectionProvider();
+        validator = new ConnectivityValidator(provider);
+    });
+
+    test("returns Passed with serverVersion when probe yields a row", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "success",
+            handle: { executeResponses: { "SELECT @@VERSION": [["SQL Server 2022 16.0.x"]] } },
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        expect(result.validationId).to.equal(ValidationType.Connectivity);
+        expect(result.displayName).to.equal("Connectivity");
+        const payload = result.payload as ConnectivityPayload;
+        expect(payload.validationType).to.equal(ValidationType.Connectivity);
+        expect(payload.summary).to.deep.equal({
+            reachable: true,
+            serverVersion: "SQL Server 2022 16.0.x",
+        });
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0]).to.include({
+            kind: "connectivity",
+            outcome: "reachable",
+            severity: "info",
+        });
+        expect(payload.findings[0].message).to.match(/SQL Server 2022 16\.0\.x/);
+    });
+
+    test("returns Passed with no serverVersion when probe yields an empty row", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        // Default success behavior with no canned response → handle returns [[]]
+        // (one empty row) so extractServerVersion returns undefined.
+        provider.configure(env.id, { mode: "success" });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        const payload = result.payload as ConnectivityPayload;
+        expect(payload.summary).to.deep.equal({ reachable: true });
+        expect(payload.findings[0].message).to.equal("Connected.");
+    });
+
+    test("disposes the connection on the success path", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "success" });
+
+        await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(provider.handles).to.have.length(1);
+        expect(provider.handles[0].disposed).to.equal(true);
+    });
+
+    test("returns Failed with outcome 'connection-refused' on transport failure", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "failure",
+            kind: "connection-refused",
+            message: "ECONNREFUSED",
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as ConnectivityPayload;
+        expect(payload.summary).to.deep.equal({ reachable: false });
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0]).to.include({
+            kind: "connectivity",
+            outcome: "connection-refused",
+            severity: "error",
+            message: "ECONNREFUSED",
+        });
+    });
+
+    test("returns Failed with outcome 'auth-failed' for auth errors", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "failure", kind: "auth-failed" });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as ConnectivityPayload;
+        expect(payload.findings[0].outcome).to.equal("auth-failed");
+    });
+
+    test("returns Failed when the probe query itself errors", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "success",
+            handle: {
+                executeError: new ConnectionError("host-unreachable", "lost connection mid-query"),
+            },
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as ConnectivityPayload;
+        expect(payload.findings[0].outcome).to.equal("host-unreachable");
+        expect(payload.findings[0].message).to.equal("lost connection mid-query");
+        // Handle disposal still happens on the failure path.
+        expect(provider.handles[0].disposed).to.equal(true);
+    });
+
+    test("propagates CancellationError when signal is aborted before connect", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "success" });
+        const ctrl = new AbortController();
+        ctrl.abort();
+
+        try {
+            await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: ctrl.signal });
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+        }
+        // Validator never opened a connection.
+        expect(provider.invocations).to.have.length(0);
+    });
+
+    test("translates timeout-aborted connect into CancellationError", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "timeout" });
+        const ctrl = new AbortController();
+        const promise = validator.run(env, {}, { ...RUN_OPTS_BASE, signal: ctrl.signal });
+        setTimeout(() => ctrl.abort(), 5);
+
+        try {
+            await promise;
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+            // Reason defaults to "user"; the runner reconciles it against the
+            // signal sentinel and stamps "timeout" if applicable.
+            expect((err as CancellationError).reason).to.equal("user");
+        }
+    });
+
+    test("re-throws non-ConnectionError so the runner classifies as Errored", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        // FakeConnectionHandle's executeError is required to be a ConnectionError;
+        // simulate a programmer-error throw via a wrapped provider.
+        const buggyProvider = new FakeConnectionProvider();
+        const realConnect = buggyProvider.connect.bind(buggyProvider);
+        buggyProvider.connect = async (e, s) => {
+            await realConnect(e, s);
+            throw new Error("kaboom");
+        };
+        const buggyValidator = new ConnectivityValidator(buggyProvider);
+
+        try {
+            await buggyValidator.run(
+                env,
+                {},
+                {
+                    ...RUN_OPTS_BASE,
+                    signal: new AbortController().signal,
+                },
+            );
+            expect.fail("expected non-ConnectionError to bubble out");
+        } catch (err) {
+            expect(err).to.be.instanceOf(Error);
+            expect((err as Error).message).to.equal("kaboom");
+            // Not a ConnectionError; classified as Errored by the runner.
+            expect(err).to.not.be.instanceOf(ConnectionError);
+            expect(err).to.not.be.instanceOf(CancellationError);
+        }
+    });
+
+    test("stamps startedAtMs/endedAtMs in nondecreasing order", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "success" });
+
+        const result = await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        expect(result.endedAtMs).to.be.at.least(result.startedAtMs);
+    });
+
+    // Use FakeConnectionHandle's execution log to confirm the probe SQL.
+    test("issues exactly one SELECT @@VERSION probe per run", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "success" });
+
+        await validator.run(
+            env,
+            {},
+            {
+                ...RUN_OPTS_BASE,
+                signal: new AbortController().signal,
+            },
+        );
+
+        const handle = provider.handles[0];
+        expect(handle).to.be.instanceOf(FakeConnectionHandle);
+        expect(handle.executions.map((e) => e.sql)).to.deep.equal(["SELECT @@VERSION"]);
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployOutputChannelSubscriber.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployOutputChannelSubscriber.test.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `OutputChannelSubscriber` and the `formatEvent` helper.
+ * Covers timestamp/severity/source rendering, payload projection
+ * (primitives, arrays, nested objects), the default debug-drop policy,
+ * the `includeDebug` opt-in, and dispose semantics.
+ */
+
+import { expect } from "chai";
+
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import { formatEvent, OutputChannelSubscriber } from "../../src/cloudDeploy/validation";
+
+class RecordingChannel {
+    public readonly lines: string[] = [];
+
+    public appendLine(value: string): void {
+        this.lines.push(value);
+    }
+}
+
+suite("CloudDeploy OutputChannelSubscriber: formatEvent", () => {
+    test("renders the canonical [time] [severity] [source] type: payload shape", () => {
+        // 2024-01-02T03:04:05.067Z — timestamp formatter uses local time so
+        // assert against derived hh/mm/ss/ms instead of a hardcoded literal.
+        const ts = new Date(2024, 0, 2, 3, 4, 5, 67).getTime();
+        const line = formatEvent({
+            id: "evt-1",
+            timestampMs: ts,
+            source: "environment-store",
+            severity: "info",
+            type: "environments-loaded",
+            payload: { count: 3 },
+        });
+
+        expect(line).to.contain("[info]");
+        expect(line).to.contain("[environment-store]");
+        expect(line).to.contain("environments-loaded");
+        expect(line).to.contain("count=3");
+        // Format is HH:MM:SS.mmm — exactly 12 chars between [ and ].
+        expect(line).to.match(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/);
+    });
+
+    test("pads single-digit milliseconds to three places", () => {
+        const ts = new Date(2024, 0, 1, 0, 0, 0, 7).getTime();
+        const line = formatEvent({
+            id: "evt-2",
+            timestampMs: ts,
+            source: "runner",
+            severity: "info",
+            type: "validation-run-started",
+            payload: {
+                runId: "r-1",
+                environmentId: "e-1",
+                validationTypes: [ValidationType.Connectivity],
+            },
+        });
+
+        expect(line).to.match(/^\[\d{2}:\d{2}:\d{2}\.007\]/);
+    });
+
+    test("renders arrays with bracket-comma syntax", () => {
+        const line = formatEvent({
+            id: "evt-3",
+            timestampMs: Date.now(),
+            source: "runner",
+            severity: "info",
+            type: "validation-run-started",
+            payload: {
+                runId: "r-1",
+                environmentId: "e-1",
+                validationTypes: [ValidationType.Connectivity, ValidationType.StaticAnalysis],
+            },
+        });
+
+        expect(line).to.contain("validationTypes=[");
+        expect(line).to.contain(ValidationType.Connectivity);
+        expect(line).to.contain(ValidationType.StaticAnalysis);
+    });
+
+    test("renders nested objects via JSON.stringify", () => {
+        const line = formatEvent({
+            id: "evt-4",
+            timestampMs: Date.now(),
+            source: "environment-store",
+            severity: "info",
+            type: "environments-changed",
+            payload: {
+                addedIds: ["a"],
+                updatedIds: [],
+                removedIds: [],
+            },
+        });
+
+        expect(line).to.contain("addedIds=[a]");
+        expect(line).to.contain("updatedIds=[]");
+    });
+
+    test("omits the colon when the payload is empty", () => {
+        const line = formatEvent({
+            id: "evt-5",
+            timestampMs: Date.now(),
+            source: "runner",
+            severity: "info",
+            // Synthetic minimal event — formatEvent does not enforce
+            // discriminated-union arms, only the envelope shape.
+            type: "validation-run-started",
+            payload: {},
+        } as unknown as Parameters<typeof formatEvent>[0]);
+
+        expect(line.endsWith("validation-run-started")).to.equal(true);
+    });
+});
+
+suite("CloudDeploy OutputChannelSubscriber: bus subscription", () => {
+    let bus: DiagnosticEventBus;
+    let channel: RecordingChannel;
+
+    setup(() => {
+        bus = new DiagnosticEventBus();
+        channel = new RecordingChannel();
+    });
+
+    teardown(() => {
+        bus.dispose();
+    });
+
+    test("appends a line for every non-debug event", () => {
+        const sub = new OutputChannelSubscriber(channel, bus);
+
+        bus.emit({
+            source: "environment-store",
+            type: "environments-loaded",
+            payload: { count: 1 },
+        });
+        bus.emit({
+            source: "environment-store",
+            severity: "warn",
+            type: "environments-changed",
+            payload: { addedIds: [], updatedIds: [], removedIds: [] },
+        });
+
+        expect(channel.lines).to.have.length(2);
+        expect(channel.lines[0]).to.contain("environments-loaded");
+        expect(channel.lines[1]).to.contain("[warn]");
+
+        sub.dispose();
+    });
+
+    test("drops debug events by default", () => {
+        const sub = new OutputChannelSubscriber(channel, bus);
+
+        bus.emit({
+            source: "validation",
+            severity: "debug",
+            type: "validation-progress",
+            payload: {
+                runId: "r-1",
+                validationType: ValidationType.Connectivity,
+                message: "tick",
+            },
+        });
+
+        expect(channel.lines).to.have.length(0);
+
+        sub.dispose();
+    });
+
+    test("includes debug events when includeDebug is true", () => {
+        const sub = new OutputChannelSubscriber(channel, bus, { includeDebug: true });
+
+        bus.emit({
+            source: "validation",
+            severity: "debug",
+            type: "validation-progress",
+            payload: {
+                runId: "r-1",
+                validationType: ValidationType.Connectivity,
+                message: "tick",
+            },
+        });
+
+        expect(channel.lines).to.have.length(1);
+        expect(channel.lines[0]).to.contain("[debug]");
+
+        sub.dispose();
+    });
+
+    test("dispose unsubscribes — later events are not appended", () => {
+        const sub = new OutputChannelSubscriber(channel, bus);
+        sub.dispose();
+
+        bus.emit({
+            source: "environment-store",
+            type: "environments-loaded",
+            payload: { count: 0 },
+        });
+
+        expect(channel.lines).to.have.length(0);
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployProcessProvider.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployProcessProvider.test.ts
@@ -1,0 +1,214 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for the Cloud Deploy `ProcessProvider` surface:
+ *   * `FakeProcessProvider` records invocations + replays canned responses
+ *     keyed on (command, args[0]); unmatched calls fall through to exit 0;
+ *     `respond("hang")` waits for the abort signal; pre-aborted signal
+ *     short-circuits to a cancelled result.
+ *   * `LiveProcessProvider` spawns a real subprocess, captures stdout +
+ *     stderr, returns a numeric exit code, and forwards `AbortSignal` aborts
+ *     into a SIGTERM-then-SIGKILL kill chain. (One smoke test using `node`,
+ *     guarded by environment availability.)
+ */
+
+import { expect } from "chai";
+
+import {
+    FakeProcessProvider,
+    LiveProcessProvider,
+    type ProcessProvider,
+} from "../../src/cloudDeploy/validation";
+
+suite("CloudDeploy ProcessProvider", () => {
+    // -------------------------------------------------------------------------
+    // FakeProcessProvider
+    // -------------------------------------------------------------------------
+    suite("FakeProcessProvider", () => {
+        test("spawn() records invocations and defaults to exit 0", async () => {
+            const provider = new FakeProcessProvider();
+            const ctrl = new AbortController();
+
+            const result = await provider.spawn(
+                "sqlpackage",
+                ["/Action:DeployReport", "/SourceFile:foo.sqlproj"],
+                { signal: ctrl.signal, cwd: "/tmp" },
+            );
+
+            expect(result.exitCode).to.equal(0);
+            expect(result.stdout).to.equal("");
+            expect(result.stderr).to.equal("");
+            expect(result.aborted).to.equal(false);
+            expect(provider.invocations).to.have.length(1);
+            expect(provider.invocations[0]).to.deep.equal({
+                command: "sqlpackage",
+                args: ["/Action:DeployReport", "/SourceFile:foo.sqlproj"],
+                cwd: "/tmp",
+                env: undefined,
+                stdin: undefined,
+            });
+        });
+
+        test("respond() replays canned exit response keyed on (command, firstArg)", async () => {
+            const provider = new FakeProcessProvider();
+            provider.respond("sqlpackage", "/Action:DeployReport", {
+                mode: "exit",
+                exitCode: 1,
+                stdout: "deploy report begin",
+                stderr: "Warning SQL71558: oops",
+            });
+
+            const result = await provider.spawn("sqlpackage", ["/Action:DeployReport"], {
+                signal: new AbortController().signal,
+            });
+
+            expect(result.exitCode).to.equal(1);
+            expect(result.stdout).to.equal("deploy report begin");
+            expect(result.stderr).to.equal("Warning SQL71558: oops");
+        });
+
+        test("respond() with mode 'throw' rejects the spawn promise", async () => {
+            const provider = new FakeProcessProvider();
+            provider.respond("sqlpackage", "/Action:DeployReport", {
+                mode: "throw",
+                error: new Error("ENOENT"),
+            });
+
+            try {
+                await provider.spawn("sqlpackage", ["/Action:DeployReport"], {
+                    signal: new AbortController().signal,
+                });
+                expect.fail("expected ENOENT");
+            } catch (err) {
+                expect((err as Error).message).to.equal("ENOENT");
+            }
+        });
+
+        test("pre-aborted signal short-circuits to cancelled result", async () => {
+            const provider = new FakeProcessProvider();
+            const ctrl = new AbortController();
+            ctrl.abort();
+
+            const result = await provider.spawn("sqlpackage", ["/Action:DeployReport"], {
+                signal: ctrl.signal,
+            });
+
+            expect(result.aborted).to.equal(true);
+            expect(result.exitCode).to.equal(null);
+            expect(result.signal).to.equal("SIGTERM");
+        });
+
+        test("respond('hang') resolves with cancelled result when signal aborts", async () => {
+            const provider = new FakeProcessProvider();
+            provider.respond("sqlpackage", "/Action:DeployReport", { mode: "hang" });
+            const ctrl = new AbortController();
+
+            const promise = provider.spawn("sqlpackage", ["/Action:DeployReport"], {
+                signal: ctrl.signal,
+            });
+            setTimeout(() => ctrl.abort(), 5);
+
+            const result = await promise;
+            expect(result.aborted).to.equal(true);
+            expect(result.exitCode).to.equal(null);
+        });
+
+        test("multiple respond() entries are dispatched independently", async () => {
+            const provider = new FakeProcessProvider();
+            provider.respond("sqlpackage", "/Action:DeployReport", {
+                mode: "exit",
+                exitCode: 0,
+                stdout: "report",
+            });
+            provider.respond("sqlpackage", "/Action:Publish", {
+                mode: "exit",
+                exitCode: 2,
+                stderr: "publish failed",
+            });
+
+            const reportResult = await provider.spawn("sqlpackage", ["/Action:DeployReport"], {
+                signal: new AbortController().signal,
+            });
+            const publishResult = await provider.spawn("sqlpackage", ["/Action:Publish"], {
+                signal: new AbortController().signal,
+            });
+
+            expect(reportResult.stdout).to.equal("report");
+            expect(reportResult.exitCode).to.equal(0);
+            expect(publishResult.stderr).to.equal("publish failed");
+            expect(publishResult.exitCode).to.equal(2);
+        });
+
+        test("FakeProcessProvider implements the ProcessProvider interface structurally", () => {
+            const provider: ProcessProvider = new FakeProcessProvider();
+            expect(typeof provider.spawn).to.equal("function");
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // LiveProcessProvider (smoke test)
+    // -------------------------------------------------------------------------
+    suite("LiveProcessProvider", () => {
+        test("spawn() captures stdout and exits with code 0 for a node one-liner", async () => {
+            const provider = new LiveProcessProvider();
+            const result = await provider.spawn(
+                process.execPath,
+                ["-e", "process.stdout.write('hello')"],
+                { signal: new AbortController().signal },
+            );
+
+            expect(result.exitCode).to.equal(0);
+            expect(result.stdout).to.equal("hello");
+            expect(result.aborted).to.equal(false);
+        });
+
+        test("spawn() captures stderr and surfaces non-zero exit codes", async () => {
+            const provider = new LiveProcessProvider();
+            const result = await provider.spawn(
+                process.execPath,
+                ["-e", "process.stderr.write('boom'); process.exit(7)"],
+                { signal: new AbortController().signal },
+            );
+
+            expect(result.exitCode).to.equal(7);
+            expect(result.stderr).to.equal("boom");
+        });
+
+        test("spawn() forwards abort signal as kill and reports aborted=true", async () => {
+            const provider = new LiveProcessProvider();
+            const ctrl = new AbortController();
+            const promise = provider.spawn(
+                process.execPath,
+                ["-e", "setInterval(() => {}, 1000)"],
+                { signal: ctrl.signal },
+            );
+            setTimeout(() => ctrl.abort(), 30);
+
+            const result = await promise;
+            expect(result.aborted).to.equal(true);
+            // Killed by signal: exitCode is null and signal is populated.
+            // (Windows reports SIGTERM as well via ChildProcess.signalCode.)
+            expect(result.exitCode === null || result.exitCode !== 0).to.equal(true);
+        });
+
+        test("spawn() rejects when the binary does not exist", async () => {
+            const provider = new LiveProcessProvider();
+            try {
+                await provider.spawn("this-binary-definitely-does-not-exist-cd-d2-c3", [], {
+                    signal: new AbortController().signal,
+                });
+                expect.fail("expected spawn to fail");
+            } catch (err) {
+                expect(err).to.be.instanceOf(Error);
+                // Node sets `code` on the error; commonly "ENOENT". We assert
+                // loosely so platform variance doesn't flake the suite.
+                expect(String((err as NodeJS.ErrnoException).code ?? "")).to.match(
+                    /ENOENT|EACCES|UNKNOWN/,
+                );
+            }
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunner.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunner.test.ts
@@ -1,0 +1,417 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for the Cloud Deploy validation `Runner` orchestrator. Covers:
+ *   * Dispatch order (connectivity-first, declaration order otherwise).
+ *   * Per-`validationStatus` rollup into `RunStatus` via worst-wins.
+ *   * Cancellation: pre-aborted signal, mid-flight cancellation, timeout flavor.
+ *   * Connectivity gating: a failing connectivity validation Skips the rest.
+ *   * Bus event ordering: run-started → per-validation pairs → run-finished.
+ *   * `RunRecord` construction: schemaVersion, env snapshot, runner identity, ids.
+ *   * Disabled validations are silently skipped (no event, no result entry).
+ *   * Errors from `validator.run()` are caught and surfaced as `Errored`.
+ */
+
+import { expect } from "chai";
+
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunStatus,
+    ValidationStatus,
+} from "../../src/cloudDeploy/runs/types";
+import { Runner } from "../../src/cloudDeploy/validation";
+
+import {
+    makeEnvironmentWithValidations,
+    makeFakeRegistry,
+    makeValidationConfig,
+    TestEventCollector,
+} from "./cloudDeployValidationTestHelpers";
+
+suite("CloudDeploy Validation Runner", () => {
+    let bus: DiagnosticEventBus;
+    let collector: TestEventCollector;
+
+    setup(() => {
+        bus = new DiagnosticEventBus();
+        collector = new TestEventCollector(bus);
+    });
+
+    teardown(() => {
+        collector.dispose();
+        bus.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // Dispatch + ordering
+    // -------------------------------------------------------------------------
+
+    suite("dispatch order", () => {
+        test("runs connectivity first even when declared last", async () => {
+            const { registry, connectivity, staticAnalysis, unitTests } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+                makeValidationConfig(ValidationType.Connectivity),
+            ]);
+
+            const startOrder: ValidationType[] = [];
+            for (const v of [connectivity, staticAnalysis, unitTests]) {
+                const original = v.run.bind(v);
+                v.run = async (...args) => {
+                    startOrder.push(v.type);
+                    return original(...args);
+                };
+            }
+
+            await new Runner(registry, bus).run(env);
+
+            expect(startOrder).to.deep.equal([
+                ValidationType.Connectivity,
+                ValidationType.StaticAnalysis,
+                ValidationType.UnitTests,
+            ]);
+        });
+
+        test("preserves declaration order for non-connectivity validations", async () => {
+            const { registry, staticAnalysis, unitTests, workloadPlayback } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.WorkloadPlayback),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const startOrder: ValidationType[] = [];
+            for (const v of [staticAnalysis, unitTests, workloadPlayback]) {
+                const original = v.run.bind(v);
+                v.run = async (...args) => {
+                    startOrder.push(v.type);
+                    return original(...args);
+                };
+            }
+
+            await new Runner(registry, bus).run(env);
+
+            expect(startOrder).to.deep.equal([
+                ValidationType.WorkloadPlayback,
+                ValidationType.StaticAnalysis,
+                ValidationType.UnitTests,
+            ]);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Enabled gating
+    // -------------------------------------------------------------------------
+
+    suite("enabled flag", () => {
+        test("skips disabled validations entirely (no invocation, no result entry)", async () => {
+            const { registry, staticAnalysis, unitTests } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis, { enabled: false }),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(staticAnalysis.invocations).to.have.length(0);
+            expect(unitTests.invocations).to.have.length(1);
+            expect(record.validations).to.have.length(1);
+            expect(record.validations[0].payload.validationType).to.equal(ValidationType.UnitTests);
+        });
+
+        test("empty validations array rolls up to Passed", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(record.status).to.equal(RunStatus.Passed);
+            expect(record.validations).to.have.length(0);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Status rollup
+    // -------------------------------------------------------------------------
+
+    suite("status rollup", () => {
+        test("all-Passed rolls up to Passed", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+            expect(record.status).to.equal(RunStatus.Passed);
+        });
+
+        test("a single Warning rolls up to Warning when nothing worse is present", async () => {
+            const { registry, staticAnalysis } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "warning" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+            expect(record.status).to.equal(RunStatus.Warning);
+        });
+
+        test("Failed beats Warning in the rollup", async () => {
+            const { registry, staticAnalysis, unitTests } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "warning" };
+            unitTests.behavior = { kind: "fail" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+            expect(record.status).to.equal(RunStatus.Failed);
+        });
+
+        test("Errored beats Failed (highest severity wins)", async () => {
+            const { registry, staticAnalysis, unitTests } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "fail" };
+            unitTests.behavior = { kind: "errored", message: "boom" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+            expect(record.status).to.equal(RunStatus.Errored);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Cancellation
+    // -------------------------------------------------------------------------
+
+    suite("cancellation", () => {
+        test("pre-aborted signal Cancels every validation without invoking validators", async () => {
+            const { registry, connectivity, staticAnalysis } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+            const controller = new AbortController();
+            controller.abort();
+
+            const record = await new Runner(registry, bus).run(env, { signal: controller.signal });
+
+            expect(connectivity.invocations).to.have.length(0);
+            expect(staticAnalysis.invocations).to.have.length(0);
+            expect(record.status).to.equal(RunStatus.Cancelled);
+            for (const r of record.validations) {
+                expect(r.status).to.equal(ValidationStatus.Cancelled);
+                expect(r.cancellationReason).to.equal("user");
+            }
+        });
+
+        test("a validator throwing CancellationError mid-flight cancels the remaining validations", async () => {
+            const { registry, connectivity, staticAnalysis, unitTests } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "cancel" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(connectivity.invocations).to.have.length(1);
+            expect(staticAnalysis.invocations).to.have.length(1);
+            expect(unitTests.invocations).to.have.length(0);
+            const byType = new Map(
+                record.validations.map((r) => [r.payload.validationType, r.status]),
+            );
+            expect(byType.get(ValidationType.Connectivity)).to.equal(ValidationStatus.Passed);
+            expect(byType.get(ValidationType.StaticAnalysis)).to.equal(ValidationStatus.Cancelled);
+            expect(byType.get(ValidationType.UnitTests)).to.equal(ValidationStatus.Cancelled);
+            expect(record.status).to.equal(RunStatus.Cancelled);
+        });
+
+        test('timeoutMs surfaces cancellation with reason "timeout"', async () => {
+            const { registry, staticAnalysis } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "wait-then-pass", delayMs: 2_000 };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env, { timeoutMs: 5 });
+
+            expect(record.status).to.equal(RunStatus.Cancelled);
+            expect(record.validations[0].status).to.equal(ValidationStatus.Cancelled);
+            expect(record.validations[0].cancellationReason).to.equal("timeout");
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Connectivity gating
+    // -------------------------------------------------------------------------
+
+    suite("connectivity gating", () => {
+        test("a failing connectivity validation marks subsequent validations Skipped", async () => {
+            const { registry, connectivity, staticAnalysis, unitTests } = makeFakeRegistry();
+            connectivity.behavior = { kind: "fail" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+                makeValidationConfig(ValidationType.Connectivity),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(connectivity.invocations).to.have.length(1);
+            expect(staticAnalysis.invocations).to.have.length(0);
+            expect(unitTests.invocations).to.have.length(0);
+            const byType = new Map(record.validations.map((r) => [r.payload.validationType, r]));
+            expect(byType.get(ValidationType.Connectivity)?.status).to.equal(
+                ValidationStatus.Failed,
+            );
+            expect(byType.get(ValidationType.StaticAnalysis)?.status).to.equal(
+                ValidationStatus.Skipped,
+            );
+            expect(byType.get(ValidationType.UnitTests)?.status).to.equal(ValidationStatus.Skipped);
+        });
+
+        test("a passing connectivity validation does not gate anything", async () => {
+            const { registry, staticAnalysis, unitTests } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+
+            await new Runner(registry, bus).run(env);
+
+            expect(staticAnalysis.invocations).to.have.length(1);
+            expect(unitTests.invocations).to.have.length(1);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Bus emission
+    // -------------------------------------------------------------------------
+
+    suite("bus emission", () => {
+        test("emits validation-run-started first and validation-run-finished last", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+
+            await new Runner(registry, bus).run(env);
+
+            expect(collector.events.length).to.be.greaterThan(0);
+            expect(collector.events[0].type).to.equal("validation-run-started");
+            expect(collector.events[collector.events.length - 1].type).to.equal(
+                "validation-run-finished",
+            );
+        });
+
+        test("validation-run-started carries the dispatch order in validationTypes", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.Connectivity),
+            ]);
+
+            await new Runner(registry, bus).run(env);
+
+            const started = collector.eventsOfType("validation-run-started")[0];
+            expect(started.payload.validationTypes).to.deep.equal([
+                ValidationType.Connectivity,
+                ValidationType.StaticAnalysis,
+            ]);
+        });
+
+        test("emits paired validation-started/validation-finished events for cancelled validations", async () => {
+            const { registry, staticAnalysis } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "cancel" };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+
+            await new Runner(registry, bus).run(env);
+
+            const started = collector.eventsOfType("validation-started");
+            const finished = collector.eventsOfType("validation-finished");
+            expect(started).to.have.length(1);
+            expect(finished).to.have.length(1);
+            expect(finished[0].payload.status).to.equal(ValidationStatus.Cancelled);
+            expect(finished[0].payload.cancellationReason).to.equal("user");
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Errored capture
+    // -------------------------------------------------------------------------
+
+    suite("error capture", () => {
+        test("non-CancellationError exceptions surface as Errored with errorMessage", async () => {
+            const { registry, staticAnalysis } = makeFakeRegistry();
+            staticAnalysis.behavior = { kind: "throw", error: new Error("kaboom") };
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(record.validations[0].status).to.equal(ValidationStatus.Errored);
+            expect(record.validations[0].errorMessage).to.equal("kaboom");
+            expect(record.status).to.equal(RunStatus.Errored);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // RunRecord construction
+    // -------------------------------------------------------------------------
+
+    suite("RunRecord", () => {
+        test("stamps schemaVersion, environmentId, env snapshot, and runner identity", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(record.schemaVersion).to.equal(RUN_RECORD_SCHEMA_VERSION);
+            expect(record.environmentId).to.equal(env.id);
+            expect(record.environmentSnapshot).to.equal(env);
+            expect(record.runner.hostKind).to.equal("vscode");
+            expect(record.runner.userId).to.be.a("string").and.not.empty;
+            expect(record.endedAtMs).to.be.at.least(record.startedAtMs);
+        });
+
+        test("uses the provided runId and runner identity when supplied", async () => {
+            const { registry } = makeFakeRegistry();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+            const runner = {
+                userId: "test-user",
+                displayName: "Test User",
+                hostKind: "vscode" as const,
+            };
+
+            const record = await new Runner(registry, bus).run(env, {
+                runId: "my-run-id",
+                runner,
+            });
+
+            expect(record.runId).to.equal("my-run-id");
+            expect(record.runner).to.deep.equal(runner);
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployRunner.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployRunner.test.ts
@@ -24,7 +24,12 @@ import {
     RunStatus,
     ValidationStatus,
 } from "../../src/cloudDeploy/runs/types";
-import { Runner } from "../../src/cloudDeploy/validation";
+import {
+    ConnectivityValidator,
+    defineRegistry,
+    FakeConnectionProvider,
+    Runner,
+} from "../../src/cloudDeploy/validation";
 
 import {
     makeEnvironmentWithValidations,
@@ -412,6 +417,125 @@ suite("CloudDeploy Validation Runner", () => {
 
             expect(record.runId).to.equal("my-run-id");
             expect(record.runner).to.deep.equal(runner);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Real ConnectivityValidator integration (commit 2)
+    //
+    // Exercises the runner with the real `ConnectivityValidator` wired in
+    // place of the fake-connectivity arm. Proves the end-to-end path —
+    // provider → validator → runner — produces the expected RunRecord
+    // shape and that gating fires off a real Failed result, not just a
+    // fake-configured one.
+    // -------------------------------------------------------------------------
+
+    suite("real ConnectivityValidator integration", () => {
+        function buildRegistryWithRealConnectivity(provider: FakeConnectionProvider) {
+            const fakes = makeFakeRegistry();
+            return defineRegistry({
+                [ValidationType.Connectivity]: new ConnectivityValidator(provider),
+                [ValidationType.StaticAnalysis]: fakes.staticAnalysis,
+                [ValidationType.UnitTests]: fakes.unitTests,
+                [ValidationType.WorkloadPlayback]: fakes.workloadPlayback,
+            });
+        }
+
+        test("real connectivity Pass → run rolls up to Passed; rest of validators run", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+            ]);
+            provider.configure(env.id, {
+                mode: "success",
+                handle: { executeResponses: { "SELECT @@VERSION": [["SQL Server 2022"]] } },
+            });
+            const registry = buildRegistryWithRealConnectivity(provider);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(record.status).to.equal(RunStatus.Passed);
+            const byType = new Map(record.validations.map((r) => [r.payload.validationType, r]));
+            const connRes = byType.get(ValidationType.Connectivity);
+            expect(connRes?.status).to.equal(ValidationStatus.Passed);
+            const summary = (connRes?.payload as { summary: { serverVersion?: string } }).summary;
+            expect(summary.serverVersion).to.equal("SQL Server 2022");
+            expect(byType.get(ValidationType.StaticAnalysis)?.status).to.equal(
+                ValidationStatus.Passed,
+            );
+        });
+
+        test("real connectivity Fail (auth-failed) → run rolls up to Failed; rest are Skipped", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+            ]);
+            provider.configure(env.id, { mode: "failure", kind: "auth-failed" });
+            const registry = buildRegistryWithRealConnectivity(provider);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            expect(record.status).to.equal(RunStatus.Failed);
+            const byType = new Map(record.validations.map((r) => [r.payload.validationType, r]));
+            expect(byType.get(ValidationType.Connectivity)?.status).to.equal(
+                ValidationStatus.Failed,
+            );
+            expect(byType.get(ValidationType.StaticAnalysis)?.status).to.equal(
+                ValidationStatus.Skipped,
+            );
+            expect(byType.get(ValidationType.UnitTests)?.status).to.equal(ValidationStatus.Skipped);
+        });
+
+        test("connectivity always dispatches first even when declared last", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.StaticAnalysis),
+                makeValidationConfig(ValidationType.UnitTests),
+                makeValidationConfig(ValidationType.Connectivity),
+            ]);
+            provider.configure(env.id, { mode: "failure", kind: "connection-refused" });
+            const registry = buildRegistryWithRealConnectivity(provider);
+
+            const record = await new Runner(registry, bus).run(env);
+
+            // The runner reorders connectivity to run first regardless of declaration order.
+            // We assert via the persisted result list (validators don't emit per-arm events
+            // themselves yet; only the runner-synthesized Skipped/Cancelled paths do).
+            expect(record.validations[0].payload.validationType).to.equal(
+                ValidationType.Connectivity,
+            );
+            expect(record.validations[0].status).to.equal(ValidationStatus.Failed);
+        });
+
+        test("provider sees the same env id the runner is processing", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations(
+                [makeValidationConfig(ValidationType.Connectivity)],
+                { id: "env-real-conn" },
+            );
+            const registry = buildRegistryWithRealConnectivity(provider);
+
+            await new Runner(registry, bus).run(env);
+
+            expect(provider.invocations.map((i) => i.envId)).to.deep.equal(["env-real-conn"]);
+        });
+
+        test("timeoutMs cancels real connectivity; runner stamps reason 'timeout'", async () => {
+            const provider = new FakeConnectionProvider();
+            const env = makeEnvironmentWithValidations([
+                makeValidationConfig(ValidationType.Connectivity),
+            ]);
+            provider.configure(env.id, { mode: "timeout" });
+            const registry = buildRegistryWithRealConnectivity(provider);
+
+            const record = await new Runner(registry, bus).run(env, { timeoutMs: 10 });
+
+            const conn = record.validations[0];
+            expect(conn.status).to.equal(ValidationStatus.Cancelled);
+            expect(conn.cancellationReason).to.equal("timeout");
         });
     });
 });

--- a/extensions/mssql/test/unit/cloudDeployStaticAnalysisValidator.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployStaticAnalysisValidator.test.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `StaticAnalysisValidator`:
+ *   * Skipped when sourceOfTruth is `Container` (no project file to scan).
+ *   * Passed when sqlpackage exits 0 with no diagnostics on either stream.
+ *   * Passed with parsed warnings when sqlpackage exits 0 with stderr
+ *     diagnostics (warnings don't fail by default; failOn promotion is
+ *     deferred to TBD-7).
+ *   * Failed with parsed errors when sqlpackage exits non-zero and emits
+ *     `Error SQLnnnnn:` diagnostics.
+ *   * Failed with synthesized finding when sqlpackage exits non-zero and
+ *     emits no parseable diagnostics.
+ *   * Cancellation pre-spawn (`signal.aborted` checked at entry) → throws.
+ *   * Cancellation mid-spawn (subprocess aborted by FakeProcessProvider) →
+ *     throws CancellationError.
+ *   * Spawn failure (binary not found) → re-thrown so the runner classifies
+ *     as Errored.
+ *   * Sqlpackage command override is honored (lets the service layer pass
+ *     an absolute path).
+ *   * Both SqlProj and Dacpac source-of-truth flow through, with the path
+ *     forwarded to sqlpackage via `/SourceFile:`.
+ */
+
+import { expect } from "chai";
+
+import { SourceOfTruthKind, ValidationType } from "../../src/cloudDeploy/environments/types";
+import { ValidationStatus, type StaticAnalysisPayload } from "../../src/cloudDeploy/runs/types";
+import {
+    CancellationError,
+    FakeProcessProvider,
+    StaticAnalysisValidator,
+} from "../../src/cloudDeploy/validation";
+
+import { makeEnvironmentWithValidations } from "./cloudDeployValidationTestHelpers";
+
+const RUN_OPTS_BASE = { runId: "run-test" } as const;
+const PROJECT_PATH = "/work/proj.sqlproj";
+
+function makeSqlProjEnv() {
+    return makeEnvironmentWithValidations([], {
+        sourceOfTruth: { kind: SourceOfTruthKind.SqlProj, path: PROJECT_PATH },
+    });
+}
+
+function makeDacpacEnv() {
+    return makeEnvironmentWithValidations([], {
+        sourceOfTruth: { kind: SourceOfTruthKind.Dacpac, path: "/work/proj.dacpac" },
+    });
+}
+
+suite("CloudDeploy StaticAnalysisValidator", () => {
+    let processes: FakeProcessProvider;
+    let validator: StaticAnalysisValidator;
+
+    setup(() => {
+        processes = new FakeProcessProvider();
+        validator = new StaticAnalysisValidator(processes);
+    });
+
+    test("returns Skipped for Container source-of-truth without spawning sqlpackage", async () => {
+        const env = makeEnvironmentWithValidations([]); // default Container
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        expect(result.validationId).to.equal(ValidationType.StaticAnalysis);
+        expect(result.displayName).to.equal("Static Analysis");
+        const payload = result.payload as StaticAnalysisPayload;
+        expect(payload.validationType).to.equal(ValidationType.StaticAnalysis);
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0]).to.include({
+            kind: "static-analysis",
+            severity: "info",
+            ruleId: "SOURCE_OF_TRUTH_UNSUPPORTED",
+        });
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("returns Passed with zero findings when sqlpackage exits 0 cleanly", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: "<DeployReport/>\n",
+            stderr: "",
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        const payload = result.payload as StaticAnalysisPayload;
+        expect(payload.findings).to.have.length(0);
+        expect(payload.summary).to.deep.equal({ info: 0, warning: 0, error: 0 });
+    });
+
+    test("forwards /SourceFile to sqlpackage with the SqlProj path", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 0,
+        });
+
+        await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: new AbortController().signal });
+
+        expect(processes.invocations).to.have.length(1);
+        expect(processes.invocations[0].command).to.equal("sqlpackage");
+        expect(processes.invocations[0].args).to.deep.equal([
+            "/Action:DeployReport",
+            `/SourceFile:${PROJECT_PATH}`,
+        ]);
+    });
+
+    test("supports Dacpac source-of-truth (forwards the dacpac path)", async () => {
+        const env = makeDacpacEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 0,
+        });
+
+        await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: new AbortController().signal });
+
+        expect(processes.invocations[0].args[1]).to.equal("/SourceFile:/work/proj.dacpac");
+    });
+
+    test("returns Passed with parsed warnings when sqlpackage exits 0 + Warning lines", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 0,
+            stderr: [
+                "Warning SQL71558: The object reference [dbo].[t] differs from the source.",
+                "Warning SQL71562: Procedure [dbo].[p] contains an unresolved reference.",
+                "noise that does not match",
+            ].join("\n"),
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        const payload = result.payload as StaticAnalysisPayload;
+        expect(payload.findings).to.have.length(2);
+        expect(payload.findings[0]).to.include({
+            kind: "static-analysis",
+            severity: "warning",
+            ruleId: "SQL71558",
+        });
+        expect(payload.findings[0].message).to.match(/object reference/);
+        expect(payload.summary).to.deep.equal({ info: 0, warning: 2, error: 0 });
+    });
+
+    test("returns Failed with parsed error findings when sqlpackage exits non-zero", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 1,
+            stderr: [
+                "Error SQL70001: Unresolved reference to object [dbo].[Missing].",
+                "Warning SQL71558: trailing warning",
+            ].join("\n"),
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as StaticAnalysisPayload;
+        expect(payload.findings).to.have.length(2);
+        expect(payload.findings[0]).to.include({
+            severity: "error",
+            ruleId: "SQL70001",
+        });
+        expect(payload.summary).to.deep.equal({ info: 0, warning: 1, error: 1 });
+    });
+
+    test("synthesizes a single error finding when failure has no parseable diagnostics", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 5,
+            stderr: "*** Unhandled Exception in sqlpackage. Aborting.",
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as StaticAnalysisPayload;
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0]).to.include({
+            severity: "error",
+            ruleId: "SQLPACKAGE_FAILED",
+        });
+        expect(payload.findings[0].message).to.match(/exited with code 5/);
+        expect(payload.findings[0].message).to.match(/Unhandled Exception/);
+    });
+
+    test("throws CancellationError when signal is pre-aborted", async () => {
+        const env = makeSqlProjEnv();
+        const ctrl = new AbortController();
+        ctrl.abort();
+
+        try {
+            await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: ctrl.signal });
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+            expect((err as CancellationError).reason).to.equal("user");
+        }
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("throws CancellationError when subprocess is aborted mid-flight", async () => {
+        const env = makeSqlProjEnv();
+        processes.respond("sqlpackage", "/Action:DeployReport", { mode: "hang" });
+        const ctrl = new AbortController();
+
+        const promise = validator.run(env, {}, { ...RUN_OPTS_BASE, signal: ctrl.signal });
+        setTimeout(() => ctrl.abort(), 5);
+
+        try {
+            await promise;
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+        }
+    });
+
+    test("re-throws spawn failures (binary not found) so the runner classifies as Errored", async () => {
+        const env = makeSqlProjEnv();
+        const enoent = Object.assign(new Error("ENOENT: sqlpackage not found"), {
+            code: "ENOENT",
+        });
+        processes.respond("sqlpackage", "/Action:DeployReport", {
+            mode: "throw",
+            error: enoent,
+        });
+
+        try {
+            await validator.run(
+                env,
+                {},
+                { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+            );
+            expect.fail("expected ENOENT to bubble up");
+        } catch (err) {
+            expect(err).to.equal(enoent);
+        }
+    });
+
+    test("honors the sqlpackageCommand override on the validator constructor", async () => {
+        const env = makeSqlProjEnv();
+        const customValidator = new StaticAnalysisValidator(processes, {
+            sqlpackageCommand: "/usr/local/bin/sqlpackage",
+        });
+        processes.respond("/usr/local/bin/sqlpackage", "/Action:DeployReport", {
+            mode: "exit",
+            exitCode: 0,
+        });
+
+        const result = await customValidator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        expect(processes.invocations[0].command).to.equal("/usr/local/bin/sqlpackage");
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployUnitTestsValidator.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployUnitTestsValidator.test.ts
@@ -1,0 +1,312 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `UnitTestsValidator`:
+ *   * Skipped for non-Container source-of-truth (SqlProj / Dacpac) without
+ *     opening a connection.
+ *   * Skipped when the tSQLt schema probe returns zero rows.
+ *   * Skipped when the connection provider throws `ConnectionError`.
+ *   * Passed when every tSQLt result row reports `"Success"`.
+ *   * Failed with mixed Success / Failure / Error rows; summary counts
+ *     line up.
+ *   * Issues the expected SQL sequence: probe → RunAll → results.
+ *   * Cancellation pre-connect (`signal.aborted` at entry) → throws.
+ *   * Cancellation mid-flight (`mode: "timeout"` on the connection
+ *     provider) → throws CancellationError.
+ *   * Validator-itself crash (non-ConnectionError thrown from execute) is
+ *     re-thrown so the runner classifies as Errored.
+ *   * The connection handle is disposed on both success and failure paths.
+ */
+
+import { expect } from "chai";
+
+import { SourceOfTruthKind, ValidationType } from "../../src/cloudDeploy/environments/types";
+import { ValidationStatus, type UnitTestsPayload } from "../../src/cloudDeploy/runs/types";
+import {
+    CancellationError,
+    ConnectionError,
+    FakeConnectionProvider,
+    UnitTestsValidator,
+} from "../../src/cloudDeploy/validation";
+
+import { makeEnvironmentWithValidations } from "./cloudDeployValidationTestHelpers";
+
+const RUN_OPTS_BASE = { runId: "run-test" } as const;
+const PROBE_SQL = "SELECT 1 FROM sys.schemas WHERE name = 'tSQLt'";
+const RUN_ALL_SQL = "EXEC tSQLt.RunAll";
+const RESULTS_SQL = "SELECT Class, TestCase, Result, Msg FROM tSQLt.TestResult ORDER BY Id";
+
+function makeSqlProjEnv() {
+    return makeEnvironmentWithValidations([], {
+        sourceOfTruth: { kind: SourceOfTruthKind.SqlProj, path: "/work/proj.sqlproj" },
+    });
+}
+
+function configureSuccessfulRun(
+    provider: FakeConnectionProvider,
+    envId: string,
+    resultRows: unknown[][],
+): void {
+    provider.configure(envId, {
+        mode: "success",
+        handle: {
+            executeResponses: {
+                [PROBE_SQL]: [[1]],
+                [RUN_ALL_SQL]: [],
+                [RESULTS_SQL]: resultRows,
+            },
+        },
+    });
+}
+
+suite("CloudDeploy UnitTestsValidator", () => {
+    let provider: FakeConnectionProvider;
+    let validator: UnitTestsValidator;
+
+    setup(() => {
+        provider = new FakeConnectionProvider();
+        validator = new UnitTestsValidator(provider);
+    });
+
+    test("returns Skipped for SqlProj source-of-truth without opening a connection", async () => {
+        const env = makeSqlProjEnv();
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        expect(result.validationId).to.equal(ValidationType.UnitTests);
+        expect(result.displayName).to.equal("Unit Tests");
+        const payload = result.payload as UnitTestsPayload;
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0].outcome).to.equal("skipped");
+        expect(payload.summary).to.deep.equal({
+            total: 0,
+            passed: 0,
+            failed: 0,
+            skipped: 1,
+            errored: 0,
+        });
+        expect(provider.invocations).to.have.length(0);
+    });
+
+    test("returns Skipped when tSQLt is not installed (probe yields zero rows)", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "success",
+            handle: { executeResponses: { [PROBE_SQL]: [] } },
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as UnitTestsPayload;
+        expect(payload.findings[0].outcome).to.equal("skipped");
+        expect(payload.findings[0].message).to.match(/tSQLt is not installed/i);
+        // Probe ran, but RunAll / results queries did not.
+        const handle = provider.handles[0];
+        expect(handle.executions.map((e) => e.sql)).to.deep.equal([PROBE_SQL]);
+        expect(handle.disposed).to.equal(true);
+    });
+
+    test("returns Skipped when the connection provider throws ConnectionError", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "failure",
+            kind: "auth-failed",
+            message: "login failed for user 'sa'",
+        });
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as UnitTestsPayload;
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0].outcome).to.equal("skipped");
+        expect(payload.findings[0].message).to.match(/auth-failed/);
+        expect(payload.findings[0].message).to.match(/login failed for user 'sa'/);
+    });
+
+    test("returns Passed when every tSQLt row reports Success", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        configureSuccessfulRun(provider, env.id, [
+            ["MySchema", "testFoo", "Success", ""],
+            ["MySchema", "testBar", "Success", null],
+        ]);
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        const payload = result.payload as UnitTestsPayload;
+        expect(payload.summary).to.deep.equal({
+            total: 2,
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            errored: 0,
+        });
+        expect(payload.findings.map((f) => f.testName)).to.deep.equal([
+            "MySchema.testFoo",
+            "MySchema.testBar",
+        ]);
+        expect(payload.findings.every((f) => f.outcome === "passed")).to.equal(true);
+        // Passed findings do not carry a message.
+        expect(payload.findings[0].message).to.equal(undefined);
+    });
+
+    test("returns Failed with mixed Success / Failure / Error rows and matching summary counts", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        configureSuccessfulRun(provider, env.id, [
+            ["S", "passing", "Success", ""],
+            ["S", "broken", "Failure", "expected 1 got 2"],
+            ["S", "blewUp", "Error", "Msg 50000, divide by zero"],
+            ["S", "weird", "Whatever", "unknown status from a future tSQLt"],
+        ]);
+
+        const result = await validator.run(
+            env,
+            {},
+            { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as UnitTestsPayload;
+        expect(payload.summary).to.deep.equal({
+            total: 4,
+            passed: 1,
+            failed: 1,
+            skipped: 0,
+            // Unknown tSQLt result status maps to "errored" so it surfaces visibly.
+            errored: 2,
+        });
+        expect(payload.findings[1]).to.include({
+            outcome: "failed",
+            message: "expected 1 got 2",
+        });
+        expect(payload.findings[2]).to.include({
+            outcome: "errored",
+            message: "Msg 50000, divide by zero",
+        });
+    });
+
+    test("issues the expected SQL sequence (probe -> RunAll -> results)", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        configureSuccessfulRun(provider, env.id, [["S", "t", "Success", ""]]);
+
+        await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: new AbortController().signal });
+
+        const handle = provider.handles[0];
+        expect(handle.executions.map((e) => e.sql)).to.deep.equal([
+            PROBE_SQL,
+            RUN_ALL_SQL,
+            RESULTS_SQL,
+        ]);
+        expect(handle.disposed).to.equal(true);
+    });
+
+    test("disposes the connection handle on the success path", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        configureSuccessfulRun(provider, env.id, []);
+
+        await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: new AbortController().signal });
+
+        expect(provider.handles[0].disposed).to.equal(true);
+    });
+
+    test("disposes the connection handle when tSQLt is missing", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, {
+            mode: "success",
+            handle: { executeResponses: { [PROBE_SQL]: [] } },
+        });
+
+        await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: new AbortController().signal });
+
+        expect(provider.handles[0].disposed).to.equal(true);
+    });
+
+    test("throws CancellationError when the signal is already aborted at entry", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        const controller = new AbortController();
+        controller.abort();
+
+        try {
+            await validator.run(env, {}, { ...RUN_OPTS_BASE, signal: controller.signal });
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+        }
+        expect(provider.invocations).to.have.length(0);
+    });
+
+    test("throws CancellationError when the signal aborts during connect (mode: timeout)", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        provider.configure(env.id, { mode: "timeout" });
+        const controller = new AbortController();
+
+        const pending = validator.run(env, {}, { ...RUN_OPTS_BASE, signal: controller.signal });
+        controller.abort();
+
+        try {
+            await pending;
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+        }
+    });
+
+    test("re-throws non-ConnectionError thrown from execute (runner classifies as Errored)", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        // success-mode connect, but execute throws a generic Error (simulates a
+        // validator-internal crash rather than a transport failure).
+        provider.configure(env.id, {
+            mode: "success",
+            handle: {
+                executeError: new ConnectionError("unknown"), // overridden below
+                executeResponses: {},
+            },
+        });
+        // Replace the canned ConnectionError with a plain Error to exercise
+        // the "non-ConnectionError → re-throw" path.
+        // (FakeConnectionHandle's executeError is typed as ConnectionError,
+        // so we mutate the handle list after the first connect.)
+        const originalConnect = provider.connect.bind(provider);
+        provider.connect = async (e, signal) => {
+            const handle = await originalConnect(e, signal);
+            (handle as unknown as { execute: () => Promise<never> }).execute = async () => {
+                throw new Error("boom from inside the validator");
+            };
+            return handle;
+        };
+
+        try {
+            await validator.run(
+                env,
+                {},
+                { ...RUN_OPTS_BASE, signal: new AbortController().signal },
+            );
+            expect.fail("expected the plain Error to propagate");
+        } catch (err) {
+            expect(err).to.be.instanceOf(Error);
+            expect((err as Error).message).to.match(/boom from inside the validator/);
+        }
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployValidationApi.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidationApi.test.ts
@@ -1,0 +1,251 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `ValidationService` — the layer that adapts an env id (plus
+ * caller options) onto the `Runner` and optionally persists through D3's
+ * `RunArtifactWriter`. Covers env lookup (hit, miss), persistence
+ * (off / on-success / on-failure / dir-missing), and runner option
+ * pass-through (signal, timeoutMs, runner identity).
+ */
+
+import { expect } from "chai";
+
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+import { EnvironmentStore } from "../../src/cloudDeploy/environments/environmentStore";
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import { RunArtifactWriter } from "../../src/cloudDeploy/runs";
+import { RunStatus, ValidationStatus } from "../../src/cloudDeploy/runs/types";
+import { ValidationService } from "../../src/cloudDeploy/validation";
+
+import { FakeFileProvider, makeEnvironment } from "./cloudDeployRunsTestHelpers";
+import { makeFakeRegistry, makeValidationConfig } from "./cloudDeployValidationTestHelpers";
+
+const ARTIFACT_DIR = "/artifacts";
+
+/**
+ * Minimal in-memory `EnvironmentStore`-shaped stub. The real store needs a
+ * workspace folder + workspace state; the service only calls `.get(id)`,
+ * so a duck-typed object is sufficient for unit tests.
+ */
+class StubEnvironmentStore {
+    private readonly _envs = new Map<string, ReturnType<typeof makeEnvironment>>();
+
+    public set(env: ReturnType<typeof makeEnvironment>): void {
+        this._envs.set(env.id, env);
+    }
+
+    public get(id: string): ReturnType<typeof makeEnvironment> | undefined {
+        return this._envs.get(id);
+    }
+
+    // Other EnvironmentStore methods are unused by ValidationService.
+    public list(): readonly ReturnType<typeof makeEnvironment>[] {
+        return [...this._envs.values()];
+    }
+}
+
+suite("CloudDeploy ValidationService", () => {
+    let bus: DiagnosticEventBus;
+    let envs: StubEnvironmentStore;
+
+    setup(() => {
+        bus = new DiagnosticEventBus();
+        envs = new StubEnvironmentStore();
+    });
+
+    teardown(() => {
+        bus.dispose();
+    });
+
+    test("returns a synthesized errored RunRecord when the env id is unknown", async () => {
+        const { registry } = makeFakeRegistry();
+        const service = new ValidationService(registry, bus, envs as unknown as EnvironmentStore);
+
+        const result = await service.run("ghost-env");
+
+        expect(result.record.status).to.equal(RunStatus.Errored);
+        expect(result.record.environmentId).to.equal("ghost-env");
+        expect(result.record.validations).to.have.length(1);
+        expect(result.record.validations[0].status).to.equal(ValidationStatus.Errored);
+        expect(result.record.validations[0].errorMessage).to.contain("ghost-env");
+        expect(result.runArtifactPath).to.be.undefined;
+    });
+
+    test("dispatches the run when the env is found", async () => {
+        const { registry, connectivity } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const service = new ValidationService(registry, bus, envs as unknown as EnvironmentStore);
+
+        const result = await service.run("ok-env");
+
+        expect(connectivity.invocations).to.have.length(1);
+        expect(connectivity.invocations[0].envId).to.equal("ok-env");
+        expect(result.record.status).to.equal(RunStatus.Passed);
+        expect(result.runArtifactPath).to.be.undefined;
+    });
+
+    test("does not persist when persist is omitted", async () => {
+        const { registry } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const fileProvider = new FakeFileProvider();
+        const writer = new RunArtifactWriter(fileProvider, bus);
+        const service = new ValidationService(
+            registry,
+            bus,
+            envs as unknown as EnvironmentStore,
+            writer,
+        );
+
+        const result = await service.run("ok-env");
+
+        expect(result.runArtifactPath).to.be.undefined;
+        expect(fileProvider.files.size).to.equal(0);
+    });
+
+    test("persists the run artifact when persist is true and writer is wired", async () => {
+        const { registry } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const fileProvider = new FakeFileProvider();
+        const writer = new RunArtifactWriter(fileProvider, bus);
+        const service = new ValidationService(
+            registry,
+            bus,
+            envs as unknown as EnvironmentStore,
+            writer,
+        );
+
+        const result = await service.run("ok-env", { persist: true, artifactDir: ARTIFACT_DIR });
+
+        expect(result.runArtifactPath).to.be.a("string");
+        expect(result.runArtifactPath!).to.contain("artifacts");
+        expect(result.runArtifactPath!.endsWith(".cdrun.zip")).to.equal(true);
+        expect(fileProvider.files.size).to.equal(1);
+        expect(result.persistError).to.be.undefined;
+    });
+
+    test("surfaces persistError when persist=true but artifactDir is missing", async () => {
+        const { registry } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const fileProvider = new FakeFileProvider();
+        const writer = new RunArtifactWriter(fileProvider, bus);
+        const service = new ValidationService(
+            registry,
+            bus,
+            envs as unknown as EnvironmentStore,
+            writer,
+        );
+
+        const result = await service.run("ok-env", { persist: true });
+
+        expect(result.runArtifactPath).to.be.undefined;
+        expect(result.persistError).to.be.a("string");
+        expect(result.record.status).to.equal(RunStatus.Passed);
+    });
+
+    test("surfaces persistError when the writer throws", async () => {
+        const { registry } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        // FileProvider stub whose `writeFileAtomic` always rejects, so the
+        // writer's caller sees the underlying I/O error.
+        const writer = new RunArtifactWriter(
+            {
+                readFileBuffer: () => Promise.reject(new Error("nope")),
+                writeFileAtomic: () => Promise.reject(new Error("disk full")),
+                fileExists: () => Promise.resolve(false),
+            },
+            bus,
+        );
+        const service = new ValidationService(
+            registry,
+            bus,
+            envs as unknown as EnvironmentStore,
+            writer,
+        );
+
+        const result = await service.run("ok-env", { persist: true, artifactDir: ARTIFACT_DIR });
+
+        expect(result.persistError).to.contain("disk full");
+        expect(result.runArtifactPath).to.be.undefined;
+        expect(result.record.status).to.equal(RunStatus.Passed);
+    });
+
+    test("forwards the AbortSignal to the runner", async () => {
+        const { registry, connectivity } = makeFakeRegistry();
+        connectivity.behavior = { kind: "wait-then-pass", delayMs: 1_000 };
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const service = new ValidationService(registry, bus, envs as unknown as EnvironmentStore);
+
+        const controller = new AbortController();
+        const promise = service.run("ok-env", { signal: controller.signal });
+        // Immediately abort; the validator unblocks via signal.
+        controller.abort();
+        const result = await promise;
+
+        expect(result.record.status).to.equal(RunStatus.Cancelled);
+    });
+
+    test("forwards a custom runner identity onto the RunRecord", async () => {
+        const { registry } = makeFakeRegistry();
+        envs.set(
+            makeEnvironment({
+                id: "ok-env",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+        const service = new ValidationService(registry, bus, envs as unknown as EnvironmentStore);
+
+        const result = await service.run("ok-env", {
+            runner: {
+                userId: "ci-user",
+                displayName: "CI",
+                hostKind: "github-actions",
+            },
+        });
+
+        expect(result.record.runner.userId).to.equal("ci-user");
+        expect(result.record.runner.hostKind).to.equal("github-actions");
+    });
+
+    test("operates without an env store — every lookup returns env-not-found", async () => {
+        const { registry } = makeFakeRegistry();
+        const service = new ValidationService(registry, bus, undefined);
+
+        const result = await service.run("any-env");
+
+        expect(result.record.status).to.equal(RunStatus.Errored);
+        expect(result.record.validations[0].errorMessage).to.contain("any-env");
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployValidationE2E.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidationE2E.test.ts
@@ -1,0 +1,220 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * End-to-end tests for the D2 validation pipeline. Wires:
+ *   * A `ValidatorRegistry` of fake validators (mixed pass / warn / fail / errored)
+ *   * A real `DiagnosticEventBus`
+ *   * A real `RunArtifactWriter` over `FakeFileProvider`
+ *   * A real `RunArtifactReader` over the same provider
+ *   * The real `ValidationService`
+ * — and asserts the round-trip: `service.run(envId, {persist})` produces a
+ * `RunRecord` whose on-disk artifact reads back identical, with the
+ * expected `RunStatus` rollups for each scenario.
+ *
+ * These tests deliberately avoid the VS Code surface (`OutputChannelSubscriber`,
+ * command registration). The CloudDeployService wiring is exercised
+ * indirectly: this file proves the pieces compose at the API boundary.
+ */
+
+import { expect } from "chai";
+
+import { DiagnosticEventBus } from "../../src/cloudDeploy/diagnostics";
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import { RunArtifactReader, RunArtifactWriter } from "../../src/cloudDeploy/runs";
+import {
+    RUN_RECORD_SCHEMA_VERSION,
+    RunStatus,
+    ValidationStatus,
+} from "../../src/cloudDeploy/runs/types";
+import { ValidationService } from "../../src/cloudDeploy/validation";
+
+import { FakeFileProvider, makeEnvironment } from "./cloudDeployRunsTestHelpers";
+import { makeFakeRegistry, makeValidationConfig } from "./cloudDeployValidationTestHelpers";
+
+const ARTIFACT_DIR = "/artifacts";
+
+class StubEnvironmentStore {
+    private readonly _envs = new Map<string, ReturnType<typeof makeEnvironment>>();
+
+    public set(env: ReturnType<typeof makeEnvironment>): void {
+        this._envs.set(env.id, env);
+    }
+
+    public get(id: string): ReturnType<typeof makeEnvironment> | undefined {
+        return this._envs.get(id);
+    }
+
+    public list(): readonly ReturnType<typeof makeEnvironment>[] {
+        return [...this._envs.values()];
+    }
+}
+
+interface E2EHarness {
+    readonly bus: DiagnosticEventBus;
+    readonly fileProvider: FakeFileProvider;
+    readonly writer: RunArtifactWriter;
+    readonly reader: RunArtifactReader;
+    readonly service: ValidationService;
+    readonly fakes: ReturnType<typeof makeFakeRegistry>;
+    readonly envs: StubEnvironmentStore;
+}
+
+function makeHarness(): E2EHarness {
+    const bus = new DiagnosticEventBus();
+    const fileProvider = new FakeFileProvider();
+    const writer = new RunArtifactWriter(fileProvider, bus);
+    const reader = new RunArtifactReader(fileProvider);
+    const fakes = makeFakeRegistry();
+    const envs = new StubEnvironmentStore();
+    const service = new ValidationService(
+        fakes.registry,
+        bus,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        envs as any,
+        writer,
+    );
+    return { bus, fileProvider, writer, reader, service, fakes, envs };
+}
+
+suite("CloudDeploy validation pipeline E2E", () => {
+    let h: E2EHarness;
+
+    setup(() => {
+        h = makeHarness();
+    });
+
+    teardown(() => {
+        h.bus.dispose();
+    });
+
+    test("happy path: passing validation persists and reads back identical", async () => {
+        h.envs.set(
+            makeEnvironment({
+                id: "env-pass",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+
+        const result = await h.service.run("env-pass", {
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+        });
+
+        expect(result.persistError).to.be.undefined;
+        expect(result.runArtifactPath).to.be.a("string");
+        expect(result.record.status).to.equal(RunStatus.Passed);
+        expect(result.record.schemaVersion).to.equal(RUN_RECORD_SCHEMA_VERSION);
+
+        const roundTripped = await h.reader.read(result.runArtifactPath!);
+        expect(roundTripped).to.deep.equal(result.record);
+    });
+
+    test("rolls up to Failed when one validator fails", async () => {
+        h.fakes.connectivity.behavior = { kind: "pass" };
+        h.fakes.staticAnalysis.behavior = { kind: "fail" };
+        h.envs.set(
+            makeEnvironment({
+                id: "env-mix",
+                validations: [
+                    makeValidationConfig(ValidationType.Connectivity),
+                    makeValidationConfig(ValidationType.StaticAnalysis),
+                ],
+            }),
+        );
+
+        const result = await h.service.run("env-mix", {
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+        });
+
+        expect(result.record.status).to.equal(RunStatus.Failed);
+        expect(result.record.validations).to.have.length(2);
+        const roundTripped = await h.reader.read(result.runArtifactPath!);
+        expect(roundTripped.status).to.equal(RunStatus.Failed);
+    });
+
+    test("rolls up to Errored when one validator throws", async () => {
+        h.fakes.connectivity.behavior = { kind: "pass" };
+        h.fakes.unitTests.behavior = { kind: "throw", error: new Error("kaboom") };
+        h.envs.set(
+            makeEnvironment({
+                id: "env-err",
+                validations: [
+                    makeValidationConfig(ValidationType.Connectivity),
+                    makeValidationConfig(ValidationType.UnitTests),
+                ],
+            }),
+        );
+
+        const result = await h.service.run("env-err", {
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+        });
+
+        expect(result.record.status).to.equal(RunStatus.Errored);
+        const roundTripped = await h.reader.read(result.runArtifactPath!);
+        expect(roundTripped.status).to.equal(RunStatus.Errored);
+        const erroredArm = roundTripped.validations.find(
+            (v) => v.status === ValidationStatus.Errored,
+        );
+        expect(erroredArm).to.not.be.undefined;
+        expect(erroredArm!.errorMessage).to.contain("kaboom");
+    });
+
+    test("rolls up to Cancelled when the caller aborts mid-run", async () => {
+        h.fakes.connectivity.behavior = { kind: "wait-then-pass", delayMs: 10_000 };
+        h.envs.set(
+            makeEnvironment({
+                id: "env-cancel",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+
+        const ac = new AbortController();
+        const promise = h.service.run("env-cancel", {
+            signal: ac.signal,
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+        });
+        ac.abort();
+        const result = await promise;
+
+        expect(result.record.status).to.equal(RunStatus.Cancelled);
+        const roundTripped = await h.reader.read(result.runArtifactPath!);
+        expect(roundTripped.status).to.equal(RunStatus.Cancelled);
+    });
+
+    test("synthesized env-not-found record is not persisted", async () => {
+        const result = await h.service.run("ghost", {
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+        });
+
+        expect(result.record.status).to.equal(RunStatus.Errored);
+        // env-not-found short-circuits before the writer is even reached.
+        expect(result.runArtifactPath).to.be.undefined;
+        expect(h.fileProvider.files.size).to.equal(0);
+    });
+
+    test("custom runner identity propagates onto the round-tripped artifact", async () => {
+        h.envs.set(
+            makeEnvironment({
+                id: "env-id",
+                validations: [makeValidationConfig(ValidationType.Connectivity)],
+            }),
+        );
+
+        const result = await h.service.run("env-id", {
+            persist: true,
+            artifactDir: ARTIFACT_DIR,
+            runner: { userId: "ci", displayName: "CI", hostKind: "github-actions" },
+        });
+
+        const roundTripped = await h.reader.read(result.runArtifactPath!);
+        expect(roundTripped.runner.userId).to.equal("ci");
+        expect(roundTripped.runner.hostKind).to.equal("github-actions");
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployValidationTestHelpers.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidationTestHelpers.ts
@@ -1,0 +1,316 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cloud Deploy — validation runner shared test helpers.
+ *
+ * Reusable building blocks for every D2 test file:
+ *   * `FakeValidator`: configurable `Validator` that lets a test pick the
+ *     result it returns, optionally delay it, or throw a chosen error.
+ *   * `makeFakeRegistry`: convenience for building a `ValidatorRegistry`
+ *     wired to four fakes (one per `ValidationType` arm) so the runner
+ *     can be exercised end-to-end without any real adapter.
+ *   * `makeValidationConfig`: tiny config builder, defaults to `enabled: true`.
+ *   * `makeEnvironmentWithValidations`: env builder seeded with the
+ *     standard container source-of-truth and the caller's config list.
+ *   * `TestEventCollector`: thin observer on the `DiagnosticEventBus`
+ *     mirroring the D4 helper of the same name. Captures every event for
+ *     ordering / payload assertions.
+ *
+ * Provider fakes for `ConnectionProvider` / `ProcessProvider` /
+ * `ArtifactProvider` land in this file in their respective commits (2, 3,
+ * 5) so each commit's tests have what they need.
+ */
+
+import {
+    ConnectivitySettings,
+    Environment,
+    SourceOfTruthKind,
+    StaticAnalysisSettings,
+    UnitTestsSettings,
+    ValidationConfig,
+    ValidationType,
+    WorkloadPlaybackSettings,
+} from "../../src/cloudDeploy/environments/types";
+import {
+    RunStatus,
+    ValidationPayload,
+    ValidationResult,
+    ValidationStatus,
+} from "../../src/cloudDeploy/runs/types";
+import {
+    CancellationError,
+    SettingsFor,
+    Validator,
+    ValidatorRegistry,
+    ValidatorRunOptions,
+    defineRegistry,
+    throwIfCancelled,
+} from "../../src/cloudDeploy/validation";
+
+export { TestEventCollector } from "./cloudDeployTestEventCollector";
+
+// =============================================================================
+// FakeValidator
+// =============================================================================
+
+/**
+ * Per-call behavior selector. The runner invokes `behaviorFor(env)` (or just
+ * uses the static `behavior`) and reacts accordingly:
+ *
+ *   * `"pass"` — returns the configured `result` or a passing default
+ *     payload of the validator's `type`.
+ *   * `"fail"` — returns a `Failed` result with empty findings.
+ *   * `"errored"` — returns an `Errored` result with `errorMessage`.
+ *   * `"throw"` — throws the configured `error` (defaults to `new Error("boom")`).
+ *   * `"cancel"` — throws `CancellationError` with `reason: "user"`.
+ *   * `"wait-then-pass"` — awaits the signal's `abort` to test cancellation
+ *     mid-flight; throws `CancellationError("user")` on abort, otherwise
+ *     resolves to a passing result after the configured delay.
+ */
+export type FakeBehavior =
+    | { kind: "pass"; result?: Partial<ValidationResult> }
+    | { kind: "fail" }
+    | { kind: "warning" }
+    | { kind: "errored"; message?: string }
+    | { kind: "throw"; error?: unknown }
+    | { kind: "cancel" }
+    | { kind: "wait-then-pass"; delayMs?: number };
+
+export class FakeValidator<T extends ValidationType = ValidationType> implements Validator<T> {
+    public readonly invocations: Array<{
+        envId: string;
+        runId: string;
+        config: SettingsFor<T>;
+    }> = [];
+
+    public behavior: FakeBehavior = { kind: "pass" };
+
+    public constructor(public readonly type: T) {}
+
+    public async run(
+        env: Environment,
+        config: SettingsFor<T>,
+        opts: ValidatorRunOptions,
+    ): Promise<ValidationResult> {
+        this.invocations.push({ envId: env.id, runId: opts.runId, config });
+
+        const startedAtMs = Date.now();
+        // Honor cancellation at entry so a "cancel-before-dispatch" test path
+        // still produces a CancellationError rather than a passing result.
+        throwIfCancelled(opts.signal);
+
+        switch (this.behavior.kind) {
+            case "pass": {
+                const endedAtMs = Date.now();
+                return {
+                    validationId: this.type,
+                    displayName: this.type,
+                    status: ValidationStatus.Passed,
+                    startedAtMs,
+                    endedAtMs,
+                    payload: emptyPayloadFor(this.type),
+                    ...this.behavior.result,
+                };
+            }
+            case "warning": {
+                const endedAtMs = Date.now();
+                return {
+                    validationId: this.type,
+                    displayName: this.type,
+                    status: ValidationStatus.Warning,
+                    startedAtMs,
+                    endedAtMs,
+                    payload: emptyPayloadFor(this.type),
+                };
+            }
+            case "fail": {
+                const endedAtMs = Date.now();
+                return {
+                    validationId: this.type,
+                    displayName: this.type,
+                    status: ValidationStatus.Failed,
+                    startedAtMs,
+                    endedAtMs,
+                    payload: emptyPayloadFor(this.type),
+                };
+            }
+            case "errored": {
+                const endedAtMs = Date.now();
+                return {
+                    validationId: this.type,
+                    displayName: this.type,
+                    status: ValidationStatus.Errored,
+                    startedAtMs,
+                    endedAtMs,
+                    payload: emptyPayloadFor(this.type),
+                    errorMessage: this.behavior.message ?? "fake errored",
+                };
+            }
+            case "throw":
+                throw this.behavior.error ?? new Error("boom");
+            case "cancel":
+                throw new CancellationError("user");
+            case "wait-then-pass": {
+                await waitForAbort(opts.signal, this.behavior.delayMs ?? 10);
+                throwIfCancelled(opts.signal);
+                const endedAtMs = Date.now();
+                return {
+                    validationId: this.type,
+                    displayName: this.type,
+                    status: ValidationStatus.Passed,
+                    startedAtMs,
+                    endedAtMs,
+                    payload: emptyPayloadFor(this.type),
+                };
+            }
+        }
+    }
+}
+
+/**
+ * Builds a registry wired to one `FakeValidator` per `ValidationType` arm.
+ * Tests grab references off the returned object to configure per-validator
+ * behavior before calling `runner.run()`.
+ */
+export interface FakeRegistryBundle {
+    readonly registry: ValidatorRegistry;
+    readonly connectivity: FakeValidator<ValidationType.Connectivity>;
+    readonly staticAnalysis: FakeValidator<ValidationType.StaticAnalysis>;
+    readonly unitTests: FakeValidator<ValidationType.UnitTests>;
+    readonly workloadPlayback: FakeValidator<ValidationType.WorkloadPlayback>;
+}
+
+export function makeFakeRegistry(): FakeRegistryBundle {
+    const connectivity = new FakeValidator(ValidationType.Connectivity);
+    const staticAnalysis = new FakeValidator(ValidationType.StaticAnalysis);
+    const unitTests = new FakeValidator(ValidationType.UnitTests);
+    const workloadPlayback = new FakeValidator(ValidationType.WorkloadPlayback);
+
+    const registry = defineRegistry({
+        [ValidationType.Connectivity]: connectivity,
+        [ValidationType.StaticAnalysis]: staticAnalysis,
+        [ValidationType.UnitTests]: unitTests,
+        [ValidationType.WorkloadPlayback]: workloadPlayback,
+    });
+
+    return { registry, connectivity, staticAnalysis, unitTests, workloadPlayback };
+}
+
+// =============================================================================
+// Config + env builders
+// =============================================================================
+
+export function makeValidationConfig<T extends ValidationType>(
+    type: T,
+    overrides: { enabled?: boolean; settings?: SettingsFor<T> } = {},
+): ValidationConfig {
+    const enabled = overrides.enabled ?? true;
+    const settings = overrides.settings ?? emptySettingsFor(type);
+    // The cast is safe: `type` and `settings` come from the same `T` arm.
+    return { type, enabled, settings } as ValidationConfig;
+}
+
+export function makeEnvironmentWithValidations(
+    validations: ValidationConfig[],
+    overrides: Partial<Environment> = {},
+): Environment {
+    return {
+        id: "env-1",
+        name: "Env 1",
+        sourceOfTruth: { kind: SourceOfTruthKind.Container, connectionProfileId: "conn-1" },
+        validations,
+        ...overrides,
+    };
+}
+
+// =============================================================================
+// TestEventCollector
+// =============================================================================
+
+// Re-exported above from the existing D4 helper to avoid duplication. Tests
+// import `TestEventCollector` directly from this module so each test file
+// has a single source for all D2 test utilities.
+
+// =============================================================================
+// Status-rollup expectation helper
+// =============================================================================
+
+/**
+ * Map of `ValidationStatus` to the matching `RunStatus`. Used by tests that
+ * stamp a single fake's status and want to assert the resulting rollup.
+ * Keeping it in helpers means the matrix is computed once, in one place.
+ */
+export const STATUS_TO_RUN_STATUS: Readonly<Record<ValidationStatus, RunStatus>> = Object.freeze({
+    [ValidationStatus.Passed]: RunStatus.Passed,
+    [ValidationStatus.Skipped]: RunStatus.Skipped,
+    [ValidationStatus.Cancelled]: RunStatus.Cancelled,
+    [ValidationStatus.Warning]: RunStatus.Warning,
+    [ValidationStatus.Failed]: RunStatus.Failed,
+    [ValidationStatus.Errored]: RunStatus.Errored,
+});
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+function waitForAbort(signal: AbortSignal, maxDelayMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+        if (signal.aborted) {
+            resolve();
+            return;
+        }
+        const timer = setTimeout(resolve, maxDelayMs);
+        signal.addEventListener(
+            "abort",
+            () => {
+                clearTimeout(timer);
+                resolve();
+            },
+            { once: true },
+        );
+    });
+}
+
+function emptySettingsFor<T extends ValidationType>(type: T): SettingsFor<T> {
+    // All four settings shapes are currently empty objects; cast widens to
+    // the right arm. Update as soon as a real settings shape gains fields.
+    void type;
+    const empty:
+        | ConnectivitySettings
+        | StaticAnalysisSettings
+        | UnitTestsSettings
+        | WorkloadPlaybackSettings = {};
+    return empty as SettingsFor<T>;
+}
+
+function emptyPayloadFor(type: ValidationType): ValidationPayload {
+    switch (type) {
+        case ValidationType.Connectivity:
+            return {
+                validationType: ValidationType.Connectivity,
+                findings: [],
+                summary: { reachable: true },
+            };
+        case ValidationType.StaticAnalysis:
+            return {
+                validationType: ValidationType.StaticAnalysis,
+                findings: [],
+                summary: { info: 0, warning: 0, error: 0 },
+            };
+        case ValidationType.UnitTests:
+            return {
+                validationType: ValidationType.UnitTests,
+                findings: [],
+                summary: { total: 0, passed: 0, failed: 0, skipped: 0, errored: 0 },
+            };
+        case ValidationType.WorkloadPlayback:
+            return {
+                validationType: ValidationType.WorkloadPlayback,
+                findings: [],
+                summary: { steps: 0, regressions: 0 },
+            };
+    }
+}

--- a/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for the Cloud Deploy validator registry surface:
+ *   * `defineRegistry` freezes the result and preserves entries by type.
+ *   * `createDefaultRegistry` returns a frozen registry with every
+ *     `ValidationType` arm wired (placeholder validators in commit 1; real
+ *     ones in commits 2-5).
+ *   * Lookup-by-`ValidationType` returns the validator that declared that type.
+ */
+
+import { expect } from "chai";
+
+import { ValidationType } from "../../src/cloudDeploy/environments/types";
+import { createDefaultRegistry, defineRegistry, Validator } from "../../src/cloudDeploy/validation";
+
+import { FakeValidator, makeFakeRegistry } from "./cloudDeployValidationTestHelpers";
+
+const ALL_TYPES: readonly ValidationType[] = [
+    ValidationType.Connectivity,
+    ValidationType.StaticAnalysis,
+    ValidationType.UnitTests,
+    ValidationType.WorkloadPlayback,
+];
+
+suite("CloudDeploy Validator Registry", () => {
+    suite("defineRegistry", () => {
+        test("returns a frozen object", () => {
+            const { registry } = makeFakeRegistry();
+            expect(Object.isFrozen(registry)).to.equal(true);
+        });
+
+        test("preserves the validator passed for each ValidationType arm", () => {
+            const { registry, connectivity, staticAnalysis, unitTests, workloadPlayback } =
+                makeFakeRegistry();
+
+            expect(registry[ValidationType.Connectivity]).to.equal(connectivity);
+            expect(registry[ValidationType.StaticAnalysis]).to.equal(staticAnalysis);
+            expect(registry[ValidationType.UnitTests]).to.equal(unitTests);
+            expect(registry[ValidationType.WorkloadPlayback]).to.equal(workloadPlayback);
+        });
+
+        test("each entry's validator.type matches its registry key", () => {
+            const { registry } = makeFakeRegistry();
+            for (const type of ALL_TYPES) {
+                const v: Validator = registry[type];
+                expect(v.type).to.equal(type);
+            }
+        });
+
+        test("supports substituting one arm without disturbing the others", () => {
+            const original = makeFakeRegistry();
+            const replacement = new FakeValidator(ValidationType.StaticAnalysis);
+            const swapped = defineRegistry({
+                [ValidationType.Connectivity]: original.connectivity,
+                [ValidationType.StaticAnalysis]: replacement,
+                [ValidationType.UnitTests]: original.unitTests,
+                [ValidationType.WorkloadPlayback]: original.workloadPlayback,
+            });
+
+            expect(swapped[ValidationType.StaticAnalysis]).to.equal(replacement);
+            expect(swapped[ValidationType.Connectivity]).to.equal(original.connectivity);
+        });
+    });
+
+    suite("createDefaultRegistry", () => {
+        test("returns a frozen registry", () => {
+            const registry = createDefaultRegistry();
+            expect(Object.isFrozen(registry)).to.equal(true);
+        });
+
+        test("populates every ValidationType arm with a validator whose type matches", () => {
+            const registry = createDefaultRegistry();
+            for (const type of ALL_TYPES) {
+                expect(registry[type]).to.not.equal(undefined);
+                expect(registry[type].type).to.equal(type);
+            }
+        });
+
+        test("placeholder validators throw on run() so accidental invocation is loud", () => {
+            const registry = createDefaultRegistry();
+            for (const type of ALL_TYPES) {
+                expect(() =>
+                    (
+                        registry[type] as unknown as {
+                            run: () => unknown;
+                        }
+                    ).run(),
+                )
+                    .to.throw(Error)
+                    .with.property("message")
+                    .that.matches(/not wired yet/);
+            }
+        });
+    });
+});

--- a/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
@@ -7,10 +7,8 @@
  * Tests for the Cloud Deploy validator registry surface:
  *   * `defineRegistry` freezes the result and preserves entries by type.
  *   * `createDefaultRegistry` returns a frozen registry with every
- *     `ValidationType` arm wired. Connectivity uses the real
- *     `ConnectivityValidator` from commit 2; the remaining three arms
- *     (static analysis, unit tests, workload playback) are placeholders
- *     until commits 3-5 land.
+ *     `ValidationType` arm wired to its real validator. As of commit 5,
+ *     no arm is a placeholder.
  *   * Lookup-by-`ValidationType` returns the validator that declared that type.
  */
 
@@ -18,12 +16,11 @@ import { expect } from "chai";
 
 import { ValidationType } from "../../src/cloudDeploy/environments/types";
 import { createDefaultRegistry, defineRegistry, Validator } from "../../src/cloudDeploy/validation";
+import { FakeArtifactProvider } from "../../src/cloudDeploy/validation/providers/artifactProvider";
 import { FakeConnectionProvider } from "../../src/cloudDeploy/validation/providers/connectionProvider";
 import { FakeProcessProvider } from "../../src/cloudDeploy/validation/providers/processProvider";
 
 import { FakeValidator, makeFakeRegistry } from "./cloudDeployValidationTestHelpers";
-
-const PLACEHOLDER_TYPES: readonly ValidationType[] = [ValidationType.WorkloadPlayback];
 
 const ALL_TYPES: readonly ValidationType[] = [
     ValidationType.Connectivity,
@@ -76,6 +73,7 @@ suite("CloudDeploy Validator Registry", () => {
         const providers = {
             connection: new FakeConnectionProvider(),
             process: new FakeProcessProvider(),
+            artifact: new FakeArtifactProvider(),
         };
 
         test("returns a frozen registry", () => {
@@ -112,19 +110,17 @@ suite("CloudDeploy Validator Registry", () => {
             );
         });
 
-        test("placeholder arms still throw on run() so accidental invocation is loud", () => {
+        test("workload-playback arm is wired to the real WorkloadPlaybackValidator (not a placeholder)", () => {
             const registry = createDefaultRegistry(providers);
-            for (const type of PLACEHOLDER_TYPES) {
-                expect(() =>
-                    (
-                        registry[type] as unknown as {
-                            run: () => unknown;
-                        }
-                    ).run(),
-                )
-                    .to.throw(Error)
-                    .with.property("message")
-                    .that.matches(/not wired yet/);
+            expect(registry[ValidationType.WorkloadPlayback].constructor.name).to.equal(
+                "WorkloadPlaybackValidator",
+            );
+        });
+
+        test("every arm exposes a callable run() (no placeholders remain)", () => {
+            const registry = createDefaultRegistry(providers);
+            for (const type of ALL_TYPES) {
+                expect(typeof registry[type].run).to.equal("function");
             }
         });
     });

--- a/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
@@ -7,8 +7,10 @@
  * Tests for the Cloud Deploy validator registry surface:
  *   * `defineRegistry` freezes the result and preserves entries by type.
  *   * `createDefaultRegistry` returns a frozen registry with every
- *     `ValidationType` arm wired (placeholder validators in commit 1; real
- *     ones in commits 2-5).
+ *     `ValidationType` arm wired. Connectivity uses the real
+ *     `ConnectivityValidator` from commit 2; the remaining three arms
+ *     (static analysis, unit tests, workload playback) are placeholders
+ *     until commits 3-5 land.
  *   * Lookup-by-`ValidationType` returns the validator that declared that type.
  */
 
@@ -16,8 +18,15 @@ import { expect } from "chai";
 
 import { ValidationType } from "../../src/cloudDeploy/environments/types";
 import { createDefaultRegistry, defineRegistry, Validator } from "../../src/cloudDeploy/validation";
+import { FakeConnectionProvider } from "../../src/cloudDeploy/validation/providers/connectionProvider";
 
 import { FakeValidator, makeFakeRegistry } from "./cloudDeployValidationTestHelpers";
+
+const PLACEHOLDER_TYPES: readonly ValidationType[] = [
+    ValidationType.StaticAnalysis,
+    ValidationType.UnitTests,
+    ValidationType.WorkloadPlayback,
+];
 
 const ALL_TYPES: readonly ValidationType[] = [
     ValidationType.Connectivity,
@@ -67,22 +76,31 @@ suite("CloudDeploy Validator Registry", () => {
     });
 
     suite("createDefaultRegistry", () => {
+        const providers = { connection: new FakeConnectionProvider() };
+
         test("returns a frozen registry", () => {
-            const registry = createDefaultRegistry();
+            const registry = createDefaultRegistry(providers);
             expect(Object.isFrozen(registry)).to.equal(true);
         });
 
         test("populates every ValidationType arm with a validator whose type matches", () => {
-            const registry = createDefaultRegistry();
+            const registry = createDefaultRegistry(providers);
             for (const type of ALL_TYPES) {
                 expect(registry[type]).to.not.equal(undefined);
                 expect(registry[type].type).to.equal(type);
             }
         });
 
-        test("placeholder validators throw on run() so accidental invocation is loud", () => {
-            const registry = createDefaultRegistry();
-            for (const type of ALL_TYPES) {
+        test("connectivity arm is wired to the real ConnectivityValidator (not a placeholder)", () => {
+            const registry = createDefaultRegistry(providers);
+            expect(registry[ValidationType.Connectivity].constructor.name).to.equal(
+                "ConnectivityValidator",
+            );
+        });
+
+        test("placeholder arms still throw on run() so accidental invocation is loud", () => {
+            const registry = createDefaultRegistry(providers);
+            for (const type of PLACEHOLDER_TYPES) {
                 expect(() =>
                     (
                         registry[type] as unknown as {

--- a/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
@@ -23,10 +23,7 @@ import { FakeProcessProvider } from "../../src/cloudDeploy/validation/providers/
 
 import { FakeValidator, makeFakeRegistry } from "./cloudDeployValidationTestHelpers";
 
-const PLACEHOLDER_TYPES: readonly ValidationType[] = [
-    ValidationType.UnitTests,
-    ValidationType.WorkloadPlayback,
-];
+const PLACEHOLDER_TYPES: readonly ValidationType[] = [ValidationType.WorkloadPlayback];
 
 const ALL_TYPES: readonly ValidationType[] = [
     ValidationType.Connectivity,
@@ -105,6 +102,13 @@ suite("CloudDeploy Validator Registry", () => {
             const registry = createDefaultRegistry(providers);
             expect(registry[ValidationType.StaticAnalysis].constructor.name).to.equal(
                 "StaticAnalysisValidator",
+            );
+        });
+
+        test("unit-tests arm is wired to the real UnitTestsValidator (not a placeholder)", () => {
+            const registry = createDefaultRegistry(providers);
+            expect(registry[ValidationType.UnitTests].constructor.name).to.equal(
+                "UnitTestsValidator",
             );
         });
 

--- a/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployValidatorRegistry.test.ts
@@ -19,11 +19,11 @@ import { expect } from "chai";
 import { ValidationType } from "../../src/cloudDeploy/environments/types";
 import { createDefaultRegistry, defineRegistry, Validator } from "../../src/cloudDeploy/validation";
 import { FakeConnectionProvider } from "../../src/cloudDeploy/validation/providers/connectionProvider";
+import { FakeProcessProvider } from "../../src/cloudDeploy/validation/providers/processProvider";
 
 import { FakeValidator, makeFakeRegistry } from "./cloudDeployValidationTestHelpers";
 
 const PLACEHOLDER_TYPES: readonly ValidationType[] = [
-    ValidationType.StaticAnalysis,
     ValidationType.UnitTests,
     ValidationType.WorkloadPlayback,
 ];
@@ -76,7 +76,10 @@ suite("CloudDeploy Validator Registry", () => {
     });
 
     suite("createDefaultRegistry", () => {
-        const providers = { connection: new FakeConnectionProvider() };
+        const providers = {
+            connection: new FakeConnectionProvider(),
+            process: new FakeProcessProvider(),
+        };
 
         test("returns a frozen registry", () => {
             const registry = createDefaultRegistry(providers);
@@ -95,6 +98,13 @@ suite("CloudDeploy Validator Registry", () => {
             const registry = createDefaultRegistry(providers);
             expect(registry[ValidationType.Connectivity].constructor.name).to.equal(
                 "ConnectivityValidator",
+            );
+        });
+
+        test("static-analysis arm is wired to the real StaticAnalysisValidator (not a placeholder)", () => {
+            const registry = createDefaultRegistry(providers);
+            expect(registry[ValidationType.StaticAnalysis].constructor.name).to.equal(
+                "StaticAnalysisValidator",
             );
         });
 

--- a/extensions/mssql/test/unit/cloudDeployWorkloadPlaybackValidator.test.ts
+++ b/extensions/mssql/test/unit/cloudDeployWorkloadPlaybackValidator.test.ts
@@ -1,0 +1,445 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tests for `WorkloadPlaybackValidator`:
+ *   * Skipped for non-Container source-of-truth (no replay target).
+ *   * Skipped when `workloadUri` or `baselineUri` is missing in settings.
+ *   * Skipped when either artifact is missing on disk
+ *     (`ArtifactNotFoundError`).
+ *   * Failed when the replay tool exits non-zero; stderr surfaces in the
+ *     synthesized finding.
+ *   * Passed when no per-step metric exceeds its threshold.
+ *   * Failed with one finding per step that exceeds latency / throughput /
+ *     error-rate / plan-hash thresholds.
+ *   * Threshold overrides via settings change which steps trip.
+ *   * Pre-aborted signal throws `CancellationError` without reading
+ *     artifacts.
+ *   * Mid-flight cancel via `mode: "hang"` then abort throws
+ *     `CancellationError`.
+ *   * Malformed baseline JSON re-throws so the runner classifies as
+ *     `Errored`.
+ *   * The captured workload bytes are forwarded to the replay tool via
+ *     stdin verbatim.
+ *   * Custom `replayCommand` is used in place of the default.
+ */
+
+import { expect } from "chai";
+
+import { SourceOfTruthKind } from "../../src/cloudDeploy/environments/types";
+import { ValidationStatus, type WorkloadPlaybackPayload } from "../../src/cloudDeploy/runs/types";
+import {
+    CancellationError,
+    FakeArtifactProvider,
+    FakeProcessProvider,
+    WorkloadPlaybackValidator,
+} from "../../src/cloudDeploy/validation";
+
+import { makeEnvironmentWithValidations } from "./cloudDeployValidationTestHelpers";
+
+const RUN_OPTS_BASE = { runId: "run-test" } as const;
+const WORKLOAD_URI = "file:///workload.json";
+const BASELINE_URI = "file:///baseline.json";
+const DEFAULT_COMMAND = "sql-workload-replay";
+
+const BASELINE_JSON = JSON.stringify({
+    steps: [
+        {
+            id: "stepA",
+            latencyMs: 100,
+            throughputQps: 1000,
+            errorRate: 0.01,
+            planHash: "h1",
+        },
+        {
+            id: "stepB",
+            latencyMs: 50,
+            throughputQps: 500,
+            errorRate: 0.0,
+            planHash: "h2",
+        },
+    ],
+});
+
+const NO_REGRESSION_OBSERVED_JSON = JSON.stringify({
+    steps: [
+        {
+            id: "stepA",
+            latencyMs: 105,
+            throughputQps: 1010,
+            errorRate: 0.01,
+            planHash: "h1",
+        },
+        {
+            id: "stepB",
+            latencyMs: 52,
+            throughputQps: 510,
+            errorRate: 0.0,
+            planHash: "h2",
+        },
+    ],
+});
+
+function abortedSignal(): AbortSignal {
+    const c = new AbortController();
+    c.abort();
+    return c.signal;
+}
+
+function liveSignal(): AbortSignal {
+    return new AbortController().signal;
+}
+
+function seedHappyArtifacts(artifacts: FakeArtifactProvider, observed: string): void {
+    artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+    artifacts.set(BASELINE_URI, BASELINE_JSON);
+    void observed; // observed is forwarded by the test that owns processes.respond
+}
+
+suite("CloudDeploy WorkloadPlaybackValidator", () => {
+    let artifacts: FakeArtifactProvider;
+    let processes: FakeProcessProvider;
+    let validator: WorkloadPlaybackValidator;
+
+    setup(() => {
+        artifacts = new FakeArtifactProvider();
+        processes = new FakeProcessProvider();
+        validator = new WorkloadPlaybackValidator(artifacts, processes);
+    });
+
+    test("returns Skipped for SqlProj source-of-truth without reading artifacts", async () => {
+        const env = makeEnvironmentWithValidations([], {
+            sourceOfTruth: { kind: SourceOfTruthKind.SqlProj, path: "/work/proj.sqlproj" },
+        });
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        expect(result.displayName).to.equal("Workload Playback");
+        expect(artifacts.reads).to.have.length(0);
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("returns Skipped when workloadUri is missing", async () => {
+        const env = makeEnvironmentWithValidations([]);
+
+        const result = await validator.run(
+            env,
+            { baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings[0].message).to.match(/workloadUri/);
+        expect(artifacts.reads).to.have.length(0);
+    });
+
+    test("returns Skipped when baselineUri is missing", async () => {
+        const env = makeEnvironmentWithValidations([]);
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings[0].message).to.match(/baselineUri/);
+        expect(artifacts.reads).to.have.length(0);
+    });
+
+    test("returns Skipped when the workload artifact is missing on disk", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        // workload uri unset; baseline uri set so we exercise "workload missing first" specifically.
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings[0].message).to.match(/Captured workload artifact not found/);
+        // We attempted to read workload only; baseline read never happens.
+        expect(artifacts.reads.map((r) => r.uri)).to.deep.equal([WORKLOAD_URI]);
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("returns Skipped when the baseline artifact is missing on disk", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        // baseline uri intentionally not seeded.
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Skipped);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings[0].message).to.match(/Baseline artifact not found/);
+        expect(artifacts.reads.map((r) => r.uri)).to.deep.equal([WORKLOAD_URI, BASELINE_URI]);
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("returns Failed with stderr excerpt when the replay tool exits non-zero", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        seedHappyArtifacts(artifacts, "");
+        processes.respond(DEFAULT_COMMAND, "", {
+            mode: "exit",
+            exitCode: 2,
+            stdout: "",
+            stderr: "replay tool: connection refused",
+        });
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0].message).to.match(/exited with code 2/);
+        expect(payload.findings[0].message).to.match(/connection refused/);
+    });
+
+    test("returns Passed when every step is within thresholds", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        processes.respond(DEFAULT_COMMAND, "", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: NO_REGRESSION_OBSERVED_JSON,
+        });
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings).to.have.length(0);
+        expect(payload.summary).to.deep.equal({ steps: 2, regressions: 0 });
+    });
+
+    test("emits one finding per regression kind when thresholds are exceeded", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        const observed = JSON.stringify({
+            steps: [
+                // stepA: latency +50%, plan changed
+                {
+                    id: "stepA",
+                    latencyMs: 150,
+                    throughputQps: 1000,
+                    errorRate: 0.01,
+                    planHash: "h1-new",
+                },
+                // stepB: throughput -50%, error-rate +10pp
+                {
+                    id: "stepB",
+                    latencyMs: 50,
+                    throughputQps: 250,
+                    errorRate: 0.1,
+                    planHash: "h2",
+                },
+            ],
+        });
+        processes.respond(DEFAULT_COMMAND, "", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: observed,
+        });
+
+        const result = await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        const byKind = payload.findings.map((f) => `${f.stepId}:${f.regression}`).sort();
+        expect(byKind).to.deep.equal([
+            "stepA:latency",
+            "stepA:plan-change",
+            "stepB:error-rate",
+            "stepB:throughput",
+        ]);
+        expect(payload.summary).to.deep.equal({ steps: 2, regressions: 4 });
+    });
+
+    test("threshold overrides change which steps trip", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        // 10% latency bump on stepA: under default 25% threshold (would Pass)
+        // but should trip with a 5% override.
+        const observed = JSON.stringify({
+            steps: [
+                {
+                    id: "stepA",
+                    latencyMs: 110,
+                    throughputQps: 1000,
+                    errorRate: 0.01,
+                    planHash: "h1",
+                },
+                {
+                    id: "stepB",
+                    latencyMs: 50,
+                    throughputQps: 500,
+                    errorRate: 0.0,
+                    planHash: "h2",
+                },
+            ],
+        });
+        processes.respond(DEFAULT_COMMAND, "", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: observed,
+        });
+
+        const result = await validator.run(
+            env,
+            {
+                workloadUri: WORKLOAD_URI,
+                baselineUri: BASELINE_URI,
+                latencyRegressionThreshold: 0.05,
+            },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Failed);
+        const payload = result.payload as WorkloadPlaybackPayload;
+        expect(payload.findings).to.have.length(1);
+        expect(payload.findings[0].stepId).to.equal("stepA");
+        expect(payload.findings[0].regression).to.equal("latency");
+    });
+
+    test("pre-aborted signal throws CancellationError without reading artifacts", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+
+        try {
+            await validator.run(
+                env,
+                { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+                { ...RUN_OPTS_BASE, signal: abortedSignal() },
+            );
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+            expect(artifacts.reads).to.have.length(0);
+            expect(processes.invocations).to.have.length(0);
+        }
+    });
+
+    test("mid-flight cancel during replay throws CancellationError", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        processes.respond(DEFAULT_COMMAND, "", { mode: "hang" });
+
+        const controller = new AbortController();
+        const runPromise = validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: controller.signal },
+        );
+        // Give the validator time to read artifacts and call spawn before we abort.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        controller.abort();
+
+        try {
+            await runPromise;
+            expect.fail("expected CancellationError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(CancellationError);
+        }
+    });
+
+    test("malformed baseline JSON re-throws so the runner classifies as Errored", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, "not valid json");
+
+        try {
+            await validator.run(
+                env,
+                { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+                { ...RUN_OPTS_BASE, signal: liveSignal() },
+            );
+            expect.fail("expected the malformed baseline to throw");
+        } catch (err) {
+            expect(err).to.be.instanceOf(Error);
+            expect((err as Error).message).to.match(/baseline/);
+        }
+        // Replay tool was never spawned.
+        expect(processes.invocations).to.have.length(0);
+    });
+
+    test("forwards the captured workload bytes to the replay tool via stdin", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        const workloadBody = '{"steps":[{"id":"x"}]}';
+        artifacts.set(WORKLOAD_URI, workloadBody);
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        processes.respond(DEFAULT_COMMAND, "", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: NO_REGRESSION_OBSERVED_JSON,
+        });
+
+        await validator.run(
+            env,
+            { workloadUri: WORKLOAD_URI, baselineUri: BASELINE_URI },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(processes.invocations).to.have.length(1);
+        expect(processes.invocations[0].command).to.equal(DEFAULT_COMMAND);
+        expect(processes.invocations[0].args).to.deep.equal([]);
+        expect(processes.invocations[0].stdin).to.equal(workloadBody);
+    });
+
+    test("uses the configured replayCommand override", async () => {
+        const env = makeEnvironmentWithValidations([]);
+        artifacts.set(WORKLOAD_URI, '{"steps":[]}');
+        artifacts.set(BASELINE_URI, BASELINE_JSON);
+        processes.respond("/usr/local/bin/replay-it", "", {
+            mode: "exit",
+            exitCode: 0,
+            stdout: NO_REGRESSION_OBSERVED_JSON,
+        });
+
+        const result = await validator.run(
+            env,
+            {
+                workloadUri: WORKLOAD_URI,
+                baselineUri: BASELINE_URI,
+                replayCommand: "/usr/local/bin/replay-it",
+            },
+            { ...RUN_OPTS_BASE, signal: liveSignal() },
+        );
+
+        expect(result.status).to.equal(ValidationStatus.Passed);
+        expect(processes.invocations[0].command).to.equal("/usr/local/bin/replay-it");
+    });
+});

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1159,6 +1159,12 @@
     <trans-unit id="++CODE++b977b950c1ae31e5aeb9ef778cc20a66fc034eb81e738e0206104b677962c465">
       <source xml:lang="en">Cloud</source>
     </trans-unit>
+    <trans-unit id="++CODE++d382470c6b4261e4ea031cac9be9a74628d898bffabc0927354e0819dddfa9d9">
+      <source xml:lang="en">Cloud Deploy validation requires an open workspace folder.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++f37f6991dc9211725f0ea880623ec796f773ddfe12bd9674aeee2732c1b84803">
+      <source xml:lang="en">Cloud Deploy: Validate environment</source>
+    </trans-unit>
     <trans-unit id="++CODE++3c7b470089d5686bf5295ce8455026208381441672b649aebdc03663e68b6975">
       <source xml:lang="en">Code Analysis</source>
     </trans-unit>
@@ -4560,6 +4566,9 @@
     <trans-unit id="++CODE++6d7af8a57c85229b9b08306d93d38a7f0f2d369dc90a339ea4708ca45a92252b">
       <source xml:lang="en">No Azure accounts found</source>
     </trans-unit>
+    <trans-unit id="++CODE++2c5ca5eb3cecc14d02190a0af2f2b96f80df2c617aec0f30b76cac8038b318a2">
+      <source xml:lang="en">No Cloud Deploy environments are declared in this workspace. Add one to .mssql/environments.json before running validation.</source>
+    </trans-unit>
     <trans-unit id="++CODE++dd1e244b4e319bb25477890a9327b3a2419908e042cd4063f9235a0afed6e908">
       <source xml:lang="en">No Microsoft Entra account can be found for removal.</source>
     </trans-unit>
@@ -4812,6 +4821,10 @@
     </trans-unit>
     <trans-unit id="++CODE++1714986c355ccdf8acce319f8df2b13f9ccae0f5ee87915f3fa4bbc917b155a7">
       <source xml:lang="en">No tools to process.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++8b4564fde7c27738de579297fbb9ccf584147ddef5d0b9344593a1769f2c6fb5">
+      <source xml:lang="en">No validations were declared on &apos;{0}&apos;.</source>
+      <note>{0} is the user-facing environment name</note>
     </trans-unit>
     <trans-unit id="++CODE++751ae077912b834895870d0d5210c09ca02659375aab7843a26689a7aa50a0fc">
       <source xml:lang="en">No workspace folder is open. Open a folder to add the MCP server configuration.</source>
@@ -6238,6 +6251,9 @@
     <trans-unit id="++CODE++3e75bab98257a9ea127e284caff7f62dff2d154f115bb79a6a087b51fd54936d">
       <source xml:lang="en">Select an account for authentication</source>
     </trans-unit>
+    <trans-unit id="++CODE++3287ffb87674eac3d99a1d87b20897547085bf20e81e0a69d882118a48008999">
+      <source xml:lang="en">Select an environment to validate</source>
+    </trans-unit>
     <trans-unit id="++CODE++1032e1d25c0d5131be3195e1e53197385eb21d860f4f14f7bbc4cfcce4bfd109">
       <source xml:lang="en">Select an extension to manage connection sharing permissions</source>
     </trans-unit>
@@ -6457,6 +6473,9 @@
     </trans-unit>
     <trans-unit id="++CODE++8a4cdc1c1353b76118cc7e7eb513c9d9cb49db4012aec7b94b52971b4518edf4">
       <source xml:lang="en">Show masked command (hides sensitive information)</source>
+    </trans-unit>
+    <trans-unit id="++CODE++9dbbb249c2a73b47d012a1400a3c4691302b025b42cc80ad58f62a7d37b83786">
+      <source xml:lang="en">Show output</source>
     </trans-unit>
     <trans-unit id="++CODE++6aeaa6a53d09dcad071fdda6280b1e7c42aa164cd0514304ff162e7da440ffaa">
       <source xml:lang="en">Show password</source>
@@ -7384,11 +7403,40 @@
       <source xml:lang="en">Using {0} to process your request...</source>
       <note>{0} is the model name that will be processing the request</note>
     </trans-unit>
+    <trans-unit id="++CODE++a73a6576ca228a2f04383ae754a60e2e43ab9d6e55e03e3b1db5db0bef2fcf18">
+      <source xml:lang="en">Validating environment &apos;{0}&apos;</source>
+      <note>{0} is the user-facing environment name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++0f238dd5246e2e2e8f28a226a63d775e507a2ecac6258e32779fd9d72d8dfc37">
+      <source xml:lang="en">Validation cancelled for &apos;{0}&apos;.</source>
+      <note>{0} is the user-facing environment name</note>
+    </trans-unit>
     <trans-unit id="++CODE++23a86f5a2daebf62665f27e6c911523cf8c7fa74b48dd330ca058d0285defb0c">
       <source xml:lang="en">Validation failed</source>
     </trans-unit>
+    <trans-unit id="++CODE++0178f1f64766c9f8d1cb1ca88062dd61bdc86a32eaf4142bd2478f82ca49324d">
+      <source xml:lang="en">Validation failed for &apos;{0}&apos;.</source>
+      <note>{0} is the user-facing environment name</note>
+    </trans-unit>
     <trans-unit id="++CODE++acae50e95fddfac1fc564a334d7ccdd9442623a3e6fb58c935c2c6a2b98ee87b">
       <source xml:lang="en">Validation failed. Please check your inputs</source>
+    </trans-unit>
+    <trans-unit id="++CODE++99195bf0750b8cb30b432e3b96dd2e71d5e534660e2affa6d5630c247a57d759">
+      <source xml:lang="en">Validation finished but the run artifact could not be saved: {0}</source>
+      <note>{0} is the underlying I/O error message</note>
+    </trans-unit>
+    <trans-unit id="++CODE++0c62b7331803f7012e2ce32cae4d435ce961176099460dac9e1330524934b6eb">
+      <source xml:lang="en">Validation finished with warnings for &apos;{0}&apos;.</source>
+      <note>{0} is the user-facing environment name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++19442d669566e053a2d982fd9dc1f4d1073e298c83a2db11d4c564f5e6ddd777">
+      <source xml:lang="en">Validation passed for &apos;{0}&apos;.</source>
+      <note>{0} is the user-facing environment name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++cbb1b9bac41685d294c9e6c7a3a56ebf7e8188cdcac7fae422df7fb8a856996c">
+      <source xml:lang="en">Validation runner crashed for &apos;{0}&apos;: {1}</source>
+      <note>{0} is the user-facing environment name
+{1} is the underlying error message</note>
     </trans-unit>
     <trans-unit id="++CODE++8e37953d23daca5ff01b8282c33f4e0a2152f1d1885f94c06418617e3ee1d24e">
       <source xml:lang="en">Value</source>
@@ -8121,6 +8169,9 @@
     </trans-unit>
     <trans-unit id="mssql.clearPooledConnections">
       <source xml:lang="en">Clear Pooled Connections</source>
+    </trans-unit>
+    <trans-unit id="mssql.cloudDeploy.validateEnvironment">
+      <source xml:lang="en">Cloud Deploy: Validate environment</source>
     </trans-unit>
     <trans-unit id="mssql.objectExplorer.Tooltip.commandTimeoutLabel">
       <source xml:lang="en">Command Timeout</source>


### PR DESCRIPTION
First of two stacked PRs for the Cloud Deploy validation slice. Read this one first.

Brings up the validation engine end of Cloud Deploy: the Runner architecture and
contract, the connection/connectivity provider, the process provider + static-analysis
validator, the unit-tests validator, the workload-playback validator + artifact
provider, and the service wiring + VS Code surface with E2E tests.

### Stack
- **PR 1 (this):** validation runner → `dev/cloud-deploy`
- **PR 2:** run dashboard → `t-achhatkuli/dev/cloud-deploy-validation-runner`

### Notes
- Some files here (e.g. `staticAnalysisValidator.ts`) are revised in PR 2 so final behavior is there.

### Testing
Unit suite green. A live end-to-end smoke harness exists on a separate branch
(`t-achhatkuli/dev/cloud-deploy-smoke-harness`) — see that branch's
`samples/cloudDeploy/smoke/README.md`.