### PR TITLE
Upgrading time display utils

### DIFF
--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -457,13 +457,15 @@ export default class QueryRunner {
         this._statusView.executedQuery(result.ownerUri);
         this._statusView.setExecutionTime(
             result.ownerUri,
-            Utils.parseNumAsTimeString(this._totalElapsedMilliseconds),
+            Utils.durationToDisplay(this._totalElapsedMilliseconds, { format: "clock" }),
         );
         let hasError = this._batchSets.some((batch) => batch.hasError === true);
         this.removeRunningQuery();
         this.unregisterAllNotificationUris();
         this._completeEmitter.fire({
-            totalMilliseconds: Utils.parseNumAsTimeString(this._totalElapsedMilliseconds),
+            totalMilliseconds: Utils.durationToDisplay(this._totalElapsedMilliseconds, {
+                format: "clock",
+            }),
             hasError,
         });
         sendActionEvent(
@@ -496,7 +498,10 @@ export default class QueryRunner {
         this._totalElapsedMilliseconds += executionTime;
         if (executionTime > 0) {
             // send a time message in the format used for query complete
-            this.sendBatchTimeMessage(batch.id, Utils.parseNumAsTimeString(executionTime));
+            this.sendBatchTimeMessage(
+                batch.id,
+                Utils.durationToDisplay(executionTime, { format: "clock" }),
+            );
         }
         this._batchCompleteEmitter.fire(batch);
     }
@@ -605,7 +610,9 @@ export default class QueryRunner {
         }
 
         this._completeEmitter.fire({
-            totalMilliseconds: Utils.parseNumAsTimeString(this._totalElapsedMilliseconds),
+            totalMilliseconds: Utils.durationToDisplay(this._totalElapsedMilliseconds, {
+                format: "clock",
+            }),
             hasError: !!error,
         });
         this._statusView.executedQuery(this._ownerUri);

--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -578,27 +578,127 @@ export function isBoolean(obj: any): obj is boolean {
 }
 
 /**
- * Takes a number of milliseconds and converts it to a string like HH:MM:SS.fff
- * @param value The number of milliseconds to convert to a timespan string
- * @returns A properly formatted timespan string.
+ * Breaks a Unix-epoch-milliseconds timestamp into the pieces a caller usually wants for
+ * human-friendly logs. When `epochMilliseconds` is omitted, formats "now" instead.
+ *
+ * @param epochMilliseconds The Unix-epoch-milliseconds timestamp to format. Defaults to
+ *   `Date.now()`. Note: if you have an `exp`-style claim in seconds (the JWT default),
+ *   multiply by 1000 at the call site.
+ * @param includeTimezone Whether to include the timezone offset in the ISO string.
+ *   Default: `false`.
+ * @param includeMilliseconds Whether to include the millisecond component in both
+ *   the ISO string and the relative duration. Default: `true`.
+ * @returns
+ * - `epochMilliseconds`: the resolved input, echoed for convenience.
+ * - `iso`: formatted as `YYYY-MM-DDTHH:mm:ss[.fff][±HH:MM]` in the current
+ *   timezone, e.g. `2026-06-04T01:16:18.123`.
+ * - `relative`: a coarse, human-readable distance from "now" — `"in 4m 57s 0ms"`
+ *   for future timestamps, `"3h 12m 0s 0ms ago"` for past ones, `"now"` when
+ *   input equals current time.
  */
-export function parseNumAsTimeString(value: number): string {
-    let tempVal = value;
-    let h = Math.floor(tempVal / msInH);
-    tempVal %= msInH;
-    let m = Math.floor(tempVal / msInM);
-    tempVal %= msInM;
-    let s = Math.floor(tempVal / msInS);
-    tempVal %= msInS;
+export function epochToDisplay(
+    epochMilliseconds?: number,
+    { includeTimezone = false, includeMilliseconds = true } = {},
+): { epochMilliseconds: number; iso: string; relative: string } {
+    // capture "now"
+    const now = Date.now();
+    const resolvedMs = epochMilliseconds ?? now;
+    const date = new Date(resolvedMs);
 
-    let hs = h < 10 ? "0" + h : "" + h;
-    let ms = m < 10 ? "0" + m : "" + m;
-    let ss = s < 10 ? "0" + s : "" + s;
-    let mss = tempVal < 10 ? "00" + tempVal : tempVal < 100 ? "0" + tempVal : "" + tempVal;
+    // construct ISO format
+    const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+    const offsetMinutesTotal = -date.getTimezoneOffset();
+    const offsetMinutes = Math.abs(offsetMinutesTotal);
+    let iso =
+        `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+        `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 
-    let rs = hs + ":" + ms + ":" + ss;
+    if (includeMilliseconds) {
+        iso += `.${pad(date.getMilliseconds(), 3)}`;
+    }
 
-    return tempVal > 0 ? rs + "." + mss : rs;
+    if (includeTimezone) {
+        const offsetSign = offsetMinutesTotal >= 0 ? "+" : "-";
+        iso += `${offsetSign}${pad(Math.floor(offsetMinutes / 60))}:${pad(offsetMinutes % 60)}`;
+    }
+
+    // construct relative
+    const deltaMs = resolvedMs - now;
+    const duration = durationToDisplay(deltaMs, {
+        format: "human",
+        includeMilliseconds,
+        includeSign: false,
+    });
+
+    let relative: string;
+    if (deltaMs === 0) {
+        relative = "now";
+    } else if (deltaMs > 0) {
+        relative = `in ${duration}`;
+    } else {
+        relative = `${duration} ago`;
+    }
+
+    return { epochMilliseconds: resolvedMs, iso, relative };
+}
+
+/**
+ * Converts a number of milliseconds into a human-readable duration string.
+ *
+ * @param milliseconds The duration to render. May be negative — the sign is
+ *   dropped (so the caller can compose the preposition: "in X" vs "X ago").
+ * @param format Output style:
+ *   - `"human"` (default): `"1h 2m 3s"` / `"45s"` / `"45s 100ms"`. Higher
+ *     units are omitted until they're non-zero, but every unit below the
+ *     highest non-zero one is kept (so `1h 0m 5s`, not `1h 5s`).
+ *   - `"clock"`: zero-padded `HH:MM:SS[.fff]`. This replicates the legacy
+ *     `parseNumAsTimeString` output used by query / notebook timing displays.
+ * @param includeMilliseconds Whether to include the milliseconds component.
+ *   Default: `true`. Renders as `" Xms"` in `"human"` format and `.fff` in
+ *   `"clock"` format.
+ * @param includeSign Whether to include `-` for negative values.  If `false`, the absolute value is used.
+ *   Default: `false`.
+ */
+export function durationToDisplay(
+    milliseconds: number,
+    {
+        format = "human",
+        includeMilliseconds = true,
+        includeSign = false,
+    }: { format?: "human" | "clock"; includeMilliseconds?: boolean; includeSign?: boolean } = {},
+): string {
+    const sign = includeSign && milliseconds < 0 ? "-" : "";
+
+    let remaining = Math.abs(milliseconds);
+    const hours = Math.floor(remaining / msInH);
+    remaining %= msInH;
+    const minutes = Math.floor(remaining / msInM);
+    remaining %= msInM;
+    const seconds = Math.floor(remaining / msInS);
+    const millis = remaining % msInS;
+
+    if (format === "clock") {
+        const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+        let result = `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+        if (includeMilliseconds) {
+            result += `.${pad(millis, 3)}`;
+        }
+        return sign + result;
+    }
+
+    // "human"
+    const parts: string[] = [];
+    if (hours > 0) {
+        parts.push(`${hours}h`);
+    }
+    if (minutes > 0 || hours > 0) {
+        parts.push(`${minutes}m`);
+    }
+    parts.push(`${seconds}s`);
+    if (includeMilliseconds) {
+        parts.push(`${millis}ms`);
+    }
+    return sign + parts.join(" ");
 }
 
 function getConfiguration(): vscode.WorkspaceConfiguration {

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -902,7 +902,7 @@ export class SqlNotebookController implements vscode.Disposable {
             const parsedElapsed = Utils.parseTimeString(elapsedTime);
             return total + (typeof parsedElapsed === "number" ? parsedElapsed : 0);
         }, 0);
-        return Utils.parseNumAsTimeString(totalMilliseconds);
+        return Utils.durationToDisplay(totalMilliseconds, { format: "clock" });
     }
 
     private async handleMagic(

--- a/extensions/mssql/src/utils/utils.ts
+++ b/extensions/mssql/src/utils/utils.ts
@@ -232,11 +232,3 @@ export function decodeQueryResultLinkFragment(fragment: string): string {
         return fragment;
     }
 }
-
-export function formatEpochSecondsForDisplay(epochSeconds: number | undefined): string {
-    if (epochSeconds === undefined) {
-        return "unknown";
-    }
-
-    return new Date(epochSeconds * 1000).toISOString();
-}

--- a/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
+++ b/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
@@ -469,7 +469,7 @@ suite("SqlNotebookController", () => {
             const executionTimeBlock = output.blocks[2];
             expect(executionTimeBlock).to.deep.equal({
                 type: "text",
-                text: LocalizedConstants.elapsedTimeLabel("00:00:02"),
+                text: LocalizedConstants.elapsedTimeLabel("00:00:02.000"),
             });
         });
 

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -242,8 +242,8 @@ suite("Query Runner tests", () => {
         setupWorkspaceConfig(configResult);
 
         let dateNow = new Date();
-        let fiveSecondsAgo = new Date(dateNow.getTime() - 5000);
-        let elapsedTimeString = Utils.parseNumAsTimeString(5000);
+        let fiveSecondsAgo = new Date(dateNow.getTime() - 5_000);
+        let elapsedTimeString = Utils.durationToDisplay(5_000, { format: "clock" });
         let batchComplete: QueryExecuteBatchNotificationParams = {
             ownerUri: "uri",
             batchSummary: {

--- a/extensions/mssql/test/unit/utils.test.ts
+++ b/extensions/mssql/test/unit/utils.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import * as sinon from "sinon";
 import * as Utils from "../../src/models/utils";
 import * as Constants from "../../src/constants/constants";
 import { ConnectionCredentials } from "../../src/models/connectionCredentials";
@@ -11,7 +12,7 @@ import { IConnectionProfile, IConnectionProfileWithSource } from "../../src/mode
 import * as utilUtils from "../../src/utils/utils";
 import * as vscode from "vscode";
 
-suite("Utility Tests - parseTimeString", () => {
+suite("Utility Tests - Timestamp handling", () => {
     test("should return false if nothing passed", () => {
         expect(Utils.parseTimeString(undefined)).to.equal(false);
         expect(Utils.parseTimeString("")).to.equal(false);
@@ -33,14 +34,175 @@ suite("Utility Tests - parseTimeString", () => {
         // Allow time without milliseconds
         expect(Utils.parseTimeString("2:13:30")).to.equal(8010000);
     });
-});
 
-suite("Utility Tests - parseNumAsTimeString", () => {
-    test("returns the correct value", () => {
-        expect(Utils.parseNumAsTimeString(8010000)).to.equal("02:13:30");
-        expect(Utils.parseNumAsTimeString(220)).to.equal("00:00:00.220");
-        expect(Utils.parseNumAsTimeString(0)).to.equal("00:00:00");
-        expect(Utils.parseNumAsTimeString(5002)).to.equal("00:00:05.002");
+    suite("durationToDisplay", () => {
+        test("human format with milliseconds", () => {
+            // Defaults to "human" format with milliseconds always shown.
+            expect(Utils.durationToDisplay(0)).to.equal("0s 0ms");
+            expect(Utils.durationToDisplay(220)).to.equal("0s 220ms");
+            expect(Utils.durationToDisplay(1000)).to.equal("1s 0ms");
+            expect(Utils.durationToDisplay(59_000)).to.equal("59s 0ms");
+            expect(Utils.durationToDisplay(60_000)).to.equal("1m 0s 0ms");
+            expect(Utils.durationToDisplay(61_500)).to.equal("1m 1s 500ms");
+            expect(Utils.durationToDisplay(3_599_999)).to.equal("59m 59s 999ms");
+            expect(Utils.durationToDisplay(3_600_000)).to.equal("1h 0m 0s 0ms");
+            expect(Utils.durationToDisplay(3_661_500)).to.equal("1h 1m 1s 500ms");
+            expect(Utils.durationToDisplay(7_497_123)).to.equal("2h 4m 57s 123ms");
+        });
+
+        test("human format without milliseconds", () => {
+            expect(Utils.durationToDisplay(0, { includeMilliseconds: false })).to.equal("0s");
+            expect(Utils.durationToDisplay(61_500, { includeMilliseconds: false })).to.equal(
+                "1m 1s",
+            );
+            expect(Utils.durationToDisplay(3_661_999, { includeMilliseconds: false })).to.equal(
+                "1h 1m 1s",
+            );
+        });
+
+        test("durationToDisplay - clock format with milliseconds", () => {
+            expect(Utils.durationToDisplay(8_010_000, { format: "clock" })).to.equal(
+                "02:13:30.000",
+            );
+            expect(Utils.durationToDisplay(220, { format: "clock" })).to.equal("00:00:00.220");
+            expect(Utils.durationToDisplay(0, { format: "clock" })).to.equal("00:00:00.000");
+            expect(Utils.durationToDisplay(5_002, { format: "clock" })).to.equal("00:00:05.002");
+        });
+
+        test("durationToDisplay - clock format without milliseconds", () => {
+            expect(
+                Utils.durationToDisplay(8_010_000, { format: "clock", includeMilliseconds: false }),
+            ).to.equal("02:13:30");
+            expect(
+                Utils.durationToDisplay(0, { format: "clock", includeMilliseconds: false }),
+            ).to.equal("00:00:00");
+        });
+
+        test("negative durations", () => {
+            expect(
+                Utils.durationToDisplay(-5_002, {
+                    format: "clock",
+                    includeSign: true,
+                }),
+            ).to.equal("-00:00:05.002");
+
+            expect(
+                Utils.durationToDisplay(-3_661_000, {
+                    format: "human",
+                    includeSign: true,
+                }),
+            ).to.equal("-1h 1m 1s 0ms");
+        });
+    });
+
+    suite("epochToDisplay", () => {
+        // Fixed instant the fake clock will report as "now" for every test in
+        // this suite. Chosen to be in the user's local-timezone past so we can
+        // assert against an exact, deterministic ISO string regardless of where
+        // the test runs.
+        const MOCK_NOW_EPOCH_MS = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+        let sandbox: sinon.SinonSandbox;
+
+        setup(() => {
+            sandbox = sinon.createSandbox();
+            sandbox.useFakeTimers(MOCK_NOW_EPOCH_MS);
+        });
+
+        teardown(() => {
+            sandbox.restore();
+        });
+
+        /**
+         * Builds the ISO string the helper should produce for `epochMs`. We
+         * compute it from `Date` rather than hardcoding so the test stays valid
+         * across timezones. The helper format is
+         * `YYYY-MM-DDTHH:mm:ss[.fff][±HH:MM]`.
+         */
+        function expectedIso(
+            epochMs: number,
+            includeTimezone: boolean,
+            includeMilliseconds: boolean,
+        ): string {
+            const date = new Date(epochMs);
+            const pad = (n: number, width = 2) => String(n).padStart(width, "0");
+            let iso =
+                `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+                `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+            if (includeMilliseconds) {
+                iso += `.${pad(date.getMilliseconds(), 3)}`;
+            }
+            if (includeTimezone) {
+                const offsetTotal = -date.getTimezoneOffset();
+                const sign = offsetTotal >= 0 ? "+" : "-";
+                const absMinutes = Math.abs(offsetTotal);
+                iso += `${sign}${pad(Math.floor(absMinutes / 60))}:${pad(absMinutes % 60)}`;
+            }
+            return iso;
+        }
+
+        test('returns "now" relative when input equals current time or is omitted', () => {
+            let result = Utils.epochToDisplay(MOCK_NOW_EPOCH_MS);
+            expect(result).to.deep.equal({
+                epochMilliseconds: MOCK_NOW_EPOCH_MS,
+                iso: expectedIso(MOCK_NOW_EPOCH_MS, false, true),
+                relative: "now",
+            });
+
+            result = Utils.epochToDisplay();
+            expect(result).to.deep.equal({
+                epochMilliseconds: MOCK_NOW_EPOCH_MS,
+                iso: expectedIso(MOCK_NOW_EPOCH_MS, false, true),
+                relative: "now",
+            });
+        });
+
+        test("renders future timestamps as 'in <duration>'", () => {
+            // 4 minutes 57 seconds 250 ms in the future
+            const future = MOCK_NOW_EPOCH_MS + (4 * 60 + 57) * 1000 + 250;
+            const result = Utils.epochToDisplay(future);
+            expect(result).to.deep.equal({
+                epochMilliseconds: future,
+                iso: expectedIso(future, false, true),
+                relative: "in 4m 57s 250ms",
+            });
+        });
+
+        test("renders past timestamps as '<duration> ago'", () => {
+            // 3 hours 12 minutes 4 seconds ago (no ms component)
+            const past = MOCK_NOW_EPOCH_MS - (3 * 3600 + 12 * 60 + 4) * 1000;
+            const result = Utils.epochToDisplay(past);
+            expect(result).to.deep.equal({
+                epochMilliseconds: past,
+                iso: expectedIso(past, false, true),
+                relative: "3h 12m 4s 0ms ago",
+            });
+        });
+
+        test("includes a timezone offset suffix in the ISO when includeTimezone is true", () => {
+            const future = MOCK_NOW_EPOCH_MS + 30_000;
+            const result = Utils.epochToDisplay(future, { includeTimezone: true });
+            expect(result.iso).to.equal(expectedIso(future, true, true));
+            // Offset must appear after the ms component, format /[+-]\d\d:\d\d$/
+            expect(result.iso).to.match(/\.\d{3}[+-]\d{2}:\d{2}$/);
+            expect(result.epochMilliseconds).to.equal(future);
+            expect(result.relative).to.equal("in 30s 0ms");
+        });
+
+        test("omits the timezone offset from the ISO when includeTimezone is false (default)", () => {
+            const result = Utils.epochToDisplay(MOCK_NOW_EPOCH_MS);
+            // No trailing offset and no trailing "Z" should appear when omitted.
+            expect(result.iso).to.not.match(/[+-]\d{2}:\d{2}$/);
+            expect(result.iso).to.not.match(/Z$/);
+        });
+
+        test("omits milliseconds from both ISO and relative when includeMilliseconds is false", () => {
+            // 4 minutes 57 seconds + 250 ms — the ms portion should be dropped from both pieces.
+            const future = MOCK_NOW_EPOCH_MS + (4 * 60 + 57) * 1000 + 250;
+            const result = Utils.epochToDisplay(future, { includeMilliseconds: false });
+            expect(result.iso).to.equal(expectedIso(future, false, false));
+            expect(result.iso).to.not.match(/\.\d{3}/);
+            expect(result.relative).to.equal("in 4m 57s");
+        });
     });
 });
 


### PR DESCRIPTION
## Description

Upgrades time display utils to handle multiple formats (human-readable `6hr32m20s` and clock `06:32:20`.  Also has options for milliseconds and timezones.

Also adds method for displaying an epoch as an ISO `2026-06-01T06:32:20.123` or a relative string `in 5m32s`/`5m32s ago`.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
