### PR TITLE
Add link for container image signature verification

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3320,6 +3320,7 @@
     "Learn more about SQL Server 2025 features": "Learn more about SQL Server 2025 features",
     "Compare SQL Server editions": "Compare SQL Server editions",
     "Configure and customize SQL Server containers": "Configure and customize SQL Server containers",
+    "Verify a container image by using the Notation CLI": "Verify a container image by using the Notation CLI",
     "Getting Docker Ready...": "Getting Docker Ready...",
     "Checking pre-requisites": "Checking pre-requisites",
     "Create Container": "Create Container",

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1964,6 +1964,9 @@ export class LocConstants {
             learnMoreAboutSqlServer2025: l10n.t("Learn more about SQL Server 2025 features"),
             sqlServerEditionsComparison: l10n.t("Compare SQL Server editions"),
             configureAndCustomizeSqlServer: l10n.t("Configure and customize SQL Server containers"),
+            verifyContainerImageNotationCli: l10n.t(
+                "Verify a container image by using the Notation CLI",
+            ),
             gettingDockerReady: l10n.t("Getting Docker Ready..."),
             checkingPrerequisites: l10n.t("Checking pre-requisites"),
             createContainer: l10n.t("Create Container"),

--- a/extensions/mssql/src/webviews/pages/Deployment/LocalContainers/localContainersDeploymentInfoPage.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/LocalContainers/localContainersDeploymentInfoPage.tsx
@@ -119,7 +119,7 @@ export const LocalContainersDeploymentInfoPage: React.FC = () => {
             label: locConstants.localContainers.configureAndCustomizeSqlServer,
         },
         {
-            href: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tutorial-sign-trusted-ca#verify-a-container-image-by-using-the-notation-cli",
+            href: "https://aka.ms/verify-a-container-image-by-using-the-notation-cli",
             label: locConstants.localContainers.verifyContainerImageNotationCli,
         },
     ];

--- a/extensions/mssql/src/webviews/pages/Deployment/LocalContainers/localContainersDeploymentInfoPage.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/LocalContainers/localContainersDeploymentInfoPage.tsx
@@ -118,6 +118,10 @@ export const LocalContainersDeploymentInfoPage: React.FC = () => {
             href: "https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-docker-container-configure",
             label: locConstants.localContainers.configureAndCustomizeSqlServer,
         },
+        {
+            href: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tutorial-sign-trusted-ca#verify-a-container-image-by-using-the-notation-cli",
+            label: locConstants.localContainers.verifyContainerImageNotationCli,
+        },
     ];
 
     return (

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7405,6 +7405,9 @@
     <trans-unit id="++CODE++1fbf278b53995ff39f69ce0e2aef7d56406fb890b82cd87febce6995e98776cd">
       <source xml:lang="en">Value is required</source>
     </trans-unit>
+    <trans-unit id="++CODE++895538d92b916860948aefae4e0444d5fb238835e6cc5af248c89c0582e741dd">
+      <source xml:lang="en">Verify a container image by using the Notation CLI</source>
+    </trans-unit>
     <trans-unit id="++CODE++cfe6ccd3cadc45db712e2b8e0c06ec209cb988570e74b89253baac39c9d6fab6">
       <source xml:lang="en">Verify backup when finished</source>
     </trans-unit>


### PR DESCRIPTION
## Description

This PR adds a link to the docker deployment webview about how a docker container image can have its signature verified using the Notation CLI.

The new link appears at the bottom of the "learn more" section:
<img width="909" height="569" alt="image" src="https://github.com/user-attachments/assets/2f411cb8-aa09-466d-bf89-89a677b5a2cc" />


_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
