### PR TITLE
MCP: Update package and show override launch notification

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -21,7 +21,7 @@ export const config = {
     },
     sqlToolsMcp: {
         packageId: "Microsoft.SqlServer.SQLtools.MCPserver",
-        version: "2.0.24",
+        version: "2.0.35",
         installDir: "./sqltools-mcp/{#version#}/{#platform#}",
         packageRuntimeIds: {
             Windows_64: "win-x64",

--- a/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpServerDefinitionProvider.ts
+++ b/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpServerDefinitionProvider.ts
@@ -33,6 +33,7 @@ export class SqlToolsMcpServerDefinitionProvider
     private readonly didChangeEmitter = new vscode.EventEmitter<void>();
     private readonly configChangeDisposable: vscode.Disposable;
     private readonly dotnetPathByRuntimeConfig = new Map<string, string>();
+    private readonly notifiedOverrideFolders = new Set<string>();
 
     readonly onDidChangeMcpServerDefinitions = this.didChangeEmitter.event;
 
@@ -121,6 +122,7 @@ export class SqlToolsMcpServerDefinitionProvider
             }
 
             const launchInfo = await this.bridgeManager.prepareLaunch();
+            this.notifyOverrideLaunch();
             sendSqlToolsMcpAction(
                 TelemetryActions.SqlToolsMcpDefinitionResolution,
                 {
@@ -239,6 +241,18 @@ export class SqlToolsMcpServerDefinitionProvider
 
         throw new Error(
             `SQL Tools MCP override path does not contain SQLtoolsMCPserver or SQLtoolsMCPserver.dll: ${overrideFolder}`,
+        );
+    }
+
+    private notifyOverrideLaunch(): void {
+        const overrideFolder = process.env[sqlToolsMcpOverrideEnvVar];
+        if (!overrideFolder || this.notifiedOverrideFolders.has(overrideFolder)) {
+            return;
+        }
+
+        this.notifiedOverrideFolders.add(overrideFolder);
+        void vscode.window.showInformationMessage(
+            `Launched SQL Tools MCP server from overridden path: ${overrideFolder}`,
         );
     }
 

--- a/extensions/mssql/test/unit/sqlToolsMcp/sqlToolsMcpServerDefinitionProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlToolsMcp/sqlToolsMcpServerDefinitionProvider.test.ts
@@ -35,6 +35,7 @@ suite("SQL Tools MCP server definition provider", () => {
     let bridgeManager: sinon.SinonStubbedInstance<SqlToolsMcpBridgeManager>;
     let logger: sinon.SinonStubbedInstance<Logger>;
     let dotnetRuntimeProvider: sinon.SinonStubbedInstance<DotnetRuntimeProvider>;
+    let showInformationMessageStub: sinon.SinonStub;
     let configListener: ((event: vscode.ConfigurationChangeEvent) => void) | undefined;
     let originalOverride: string | undefined;
 
@@ -70,6 +71,9 @@ suite("SQL Tools MCP server definition provider", () => {
             configListener = listener;
             return new vscode.Disposable(() => {});
         });
+        showInformationMessageStub = sandbox
+            .stub(vscode.window, "showInformationMessage")
+            .resolves(undefined);
     });
 
     teardown(() => {
@@ -206,6 +210,20 @@ suite("SQL Tools MCP server definition provider", () => {
         expect(definitions[0].args).to.deep.equal([
             path.join("/override/sqltools-mcp", "SQLtoolsMCPserver.dll"),
         ]);
+        expect(showInformationMessageStub).not.to.have.been.called;
+    });
+
+    test("notifies once when resolving a server from the override path", async () => {
+        process.env.MSSQL_SQLTOOLS_MCP = "/override/sqltools-mcp";
+        existingPaths.add(path.join("/override/sqltools-mcp", getExecutableName()));
+        const provider = createProvider();
+
+        await provider.resolveMcpServerDefinition();
+        await provider.resolveMcpServerDefinition();
+
+        expect(showInformationMessageStub).to.have.been.calledOnceWith(
+            "Launched SQL Tools MCP server from overridden path: /override/sqltools-mcp",
+        );
     });
 
     test("throws when the override path does not contain a launchable payload", async () => {
@@ -222,6 +240,7 @@ suite("SQL Tools MCP server definition provider", () => {
         }
 
         expect(bridgeManager.prepareLaunch).not.to.have.been.called;
+        expect(showInformationMessageStub).not.to.have.been.called;
     });
 
     test("notifies and initializes when the feature flag changes on", () => {


### PR DESCRIPTION
## Description

- Bumps the bundled SQL Tools MCP package version from `2.0.24` to `2.0.35`.
- Adds a notification when `MSSQL_SQLTOOLS_MCP` is used successfully.
- Shows the override notification once only after MCP server resolution succeeds and the bridge launch is prepared.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
