### PR TITLE
MCP: Coordinate registered connections with native tools

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1455,10 +1455,14 @@
         "comment": ["{0} is the operation name"]
     },
     "No active schema designer found. Please open Data API builder first using mssql_dab with operation 'show' or from the UI.": "No active schema designer found. Please open Data API builder first using mssql_dab with operation 'show' or from the UI.",
-    "Missing connectionId. Please provide a connectionId to open Data API builder.": "Missing connectionId. Please provide a connectionId to open Data API builder.",
+    "Missing connection reference. Please provide exactly one of connectionId or connectionName.": "Missing connection reference. Please provide exactly one of connectionId or connectionName.",
+    "Ambiguous connection reference. Please provide only one of connectionId or connectionName.": "Ambiguous connection reference. Please provide only one of connectionId or connectionName.",
+    "No SQL Tools MCP connection found for connectionName: {0}/{0} is the SQL Tools MCP registered connection name": {
+        "message": "No SQL Tools MCP connection found for connectionName: {0}",
+        "comment": ["{0} is the SQL Tools MCP registered connection name"]
+    },
     "No active schema designer found. Please open one first using mssql_schema_designer with operation 'show' or from the UI.": "No active schema designer found. Please open one first using mssql_schema_designer with operation 'show' or from the UI.",
     "Schema designer state changed. Fetch the latest schema and retry the operation.": "Schema designer state changed. Fetch the latest schema and retry the operation.",
-    "Missing connectionId. Please provide a connectionId to open the schema designer.": "Missing connectionId. Please provide a connectionId to open the schema designer.",
     "Table added to schema designer successfully.": "Table added to schema designer successfully.",
     "Failed to add table to schema designer.": "Failed to add table to schema designer.",
     "Table updated in schema designer successfully.": "Table updated in schema designer successfully.",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2753,7 +2753,7 @@
         "languageModelTools": [
             {
                 "name": "mssql_schema_designer",
-                "modelDescription": "Work with the currently active Schema Designer. Use 'show' to open a designer for a connectionId when needed. Operations: 'get_overview' returns a bounded list of tables (and optionally column names/types; omitted automatically for large schemas); 'get_table' returns bounded details for a single table; 'apply_edits' applies a sequential list of edits and returns only a small receipt plus the post-mutation version. Mutations require 'expectedVersion'; on mismatch, returns 'stale_state' with currentVersion and a bounded currentOverview.",
+                "modelDescription": "Work with the currently active Schema Designer. Use 'show' to open a designer with exactly one of connectionId or connectionName when needed. Operations: 'get_overview' returns a bounded list of tables (and optionally column names/types; omitted automatically for large schemas); 'get_table' returns bounded details for a single table; 'apply_edits' applies a sequential list of edits and returns only a small receipt plus the post-mutation version. Mutations require 'expectedVersion'; on mismatch, returns 'stale_state' with currentVersion and a bounded currentOverview.",
                 "tags": [
                     "databases",
                     "mssql",
@@ -2776,8 +2776,13 @@
                             ]
                         },
                         "connectionId": {
-                            "description": "Connection ID to use when opening the schema designer (show operation only).",
+                            "description": "VS Code runtime connection ID to use when opening the schema designer (show operation only). Do not use this field for a ConnectionId returned by a SQL Tools MCP tool. Provide exactly one of connectionId or connectionName.",
                             "title": "Connection ID",
+                            "type": "string"
+                        },
+                        "connectionName": {
+                            "description": "SQL Tools MCP registered connection name to use when opening the schema designer (show operation only). Pass a ConnectionId returned by a SQL Tools MCP tool in this connectionName field. Provide exactly one of connectionId or connectionName.",
+                            "title": "Connection Name",
                             "type": "string"
                         },
                         "payload": {
@@ -3697,8 +3702,17 @@
                                     ]
                                 }
                             },
-                            "required": [
-                                "connectionId"
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "connectionId"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "connectionName"
+                                    ]
+                                }
                             ]
                         },
                         {
@@ -3790,7 +3804,7 @@
             },
             {
                 "name": "mssql_dab",
-                "modelDescription": "Work with the Data API builder configuration in the currently active schema designer. Use 'get_state' to inspect it and 'apply_changes' to modify it; use 'show' only to open the Data API builder view for a connectionId when needed. Operations: 'get_state' returns the current version, summary, and bounded configuration state (full config may be omitted for large configurations); 'apply_changes' uses payload { expectedVersion, targetHint?, changes } and returns the post-mutation version plus summary, with optional returnState control. Mutations require 'expectedVersion'; on mismatch, returns 'stale_state' with the current version and latest summary/config according to returnState. Entity refs are either { id }, { schemaName, tableName } for table compatibility, or { schemaName, sourceName, sourceType } where sourceType is table, view, or stored-procedure. Column refs are either { id } or { name }. Change types: { type: 'set_api_types', apiTypes }, { type: 'add_entity', entity }, { type: 'remove_entity', entity }, { type: 'set_entity_enabled', entity, isEnabled }, { type: 'set_entity_actions', entity, enabledActions }, { type: 'set_column_exposed', entity, column, isExposed }, { type: 'patch_entity_settings', entity, set }, { type: 'set_only_enabled_entities', entities }, { type: 'set_all_entities_enabled', isEnabled }. patch_entity_settings.set supports entityName, authorizationRole, customRestPath, restEnabled, customGraphQLType, graphQLEnabled, table-only mcpDmlToolsEnabled, and stored-procedure-only storedProcedureRestMethods, storedProcedureGraphQLOperation, exposeAsMcpCustomTool.",
+                "modelDescription": "Work with the Data API builder configuration in the currently active schema designer. Use 'get_state' to inspect it and 'apply_changes' to modify it; use 'show' only to open the Data API builder view with exactly one of connectionId or connectionName when needed. Operations: 'get_state' returns the current version, summary, and bounded configuration state (full config may be omitted for large configurations); 'apply_changes' uses payload { expectedVersion, targetHint?, changes } and returns the post-mutation version plus summary, with optional returnState control. Mutations require 'expectedVersion'; on mismatch, returns 'stale_state' with the current version and latest summary/config according to returnState. Entity refs are either { id }, { schemaName, tableName } for table compatibility, or { schemaName, sourceName, sourceType } where sourceType is table, view, or stored-procedure. Column refs are either { id } or { name }. Change types: { type: 'set_api_types', apiTypes }, { type: 'add_entity', entity }, { type: 'remove_entity', entity }, { type: 'set_entity_enabled', entity, isEnabled }, { type: 'set_entity_actions', entity, enabledActions }, { type: 'set_column_exposed', entity, column, isExposed }, { type: 'patch_entity_settings', entity, set }, { type: 'set_only_enabled_entities', entities }, { type: 'set_all_entities_enabled', isEnabled }. patch_entity_settings.set supports entityName, authorizationRole, customRestPath, restEnabled, customGraphQLType, graphQLEnabled, table-only mcpDmlToolsEnabled, and stored-procedure-only storedProcedureRestMethods, storedProcedureGraphQLOperation, exposeAsMcpCustomTool.",
                 "tags": [
                     "databases",
                     "mssql",
@@ -3998,8 +4012,14 @@
                             ]
                         },
                         "connectionId": {
-                            "description": "Connection ID to use when opening Data API builder (show operation only). Do not include for get_state/apply_changes when an active designer is already open.",
+                            "description": "VS Code runtime connection ID to use when opening Data API builder (show operation only). Do not use this field for a ConnectionId returned by a SQL Tools MCP tool. Provide exactly one of connectionId or connectionName. Do not include for get_state/apply_changes when an active designer is already open.",
                             "title": "Connection ID",
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "connectionName": {
+                            "description": "SQL Tools MCP registered connection name to use when opening Data API builder (show operation only). Pass a ConnectionId returned by a SQL Tools MCP tool in this connectionName field. Provide exactly one of connectionId or connectionName. Do not include for get_state/apply_changes when an active designer is already open.",
+                            "title": "Connection Name",
                             "type": "string",
                             "minLength": 1
                         },

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -2619,17 +2619,24 @@ export class MssqlChatAgent {
     public static dabToolNoActiveDesigner = l10n.t(
         "No active schema designer found. Please open Data API builder first using mssql_dab with operation 'show' or from the UI.",
     );
-    public static dabToolMissingConnectionId = l10n.t(
-        "Missing connectionId. Please provide a connectionId to open Data API builder.",
+    public static toolMissingConnectionReference = l10n.t(
+        "Missing connection reference. Please provide exactly one of connectionId or connectionName.",
     );
+    public static toolAmbiguousConnectionReference = l10n.t(
+        "Ambiguous connection reference. Please provide only one of connectionId or connectionName.",
+    );
+    public static noSqlToolsMcpConnectionName = (connectionName: string) => {
+        return l10n.t({
+            message: "No SQL Tools MCP connection found for connectionName: {0}",
+            args: [connectionName],
+            comment: ["{0} is the SQL Tools MCP registered connection name"],
+        });
+    };
     public static schemaDesignerNoActiveDesigner = l10n.t(
         "No active schema designer found. Please open one first using mssql_schema_designer with operation 'show' or from the UI.",
     );
     public static schemaDesignerStaleState = l10n.t(
         "Schema designer state changed. Fetch the latest schema and retry the operation.",
-    );
-    public static schemaDesignerMissingConnectionId = l10n.t(
-        "Missing connectionId. Please provide a connectionId to open the schema designer.",
     );
     public static schemaDesignerAddTableSuccess = l10n.t(
         "Table added to schema designer successfully.",

--- a/extensions/mssql/src/copilot/tools/dabTool.ts
+++ b/extensions/mssql/src/copilot/tools/dabTool.ts
@@ -15,11 +15,12 @@ import { sendActionEvent } from "../../telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../../sharedInterfaces/telemetry";
 import { Dab } from "../../sharedInterfaces/dab";
 import { matchesStrictTargetHint, ToolTargetHint } from "./toolsUtils";
+import { resolveToolConnectionReference } from "./toolConnectionResolver";
 
 type DabToolOperation = "show" | "get_state" | "apply_changes";
 
 export type DabToolParams =
-    | { operation: "show"; connectionId: string }
+    | { operation: "show"; connectionId?: string; connectionName?: string }
     | { operation: "get_state" }
     | {
           operation: "apply_changes";
@@ -206,30 +207,25 @@ export class DabTool extends ToolBase<DabToolParams> {
 
         try {
             if (operation === "show") {
-                const { connectionId } = options.input;
-                if (!connectionId) {
+                const resolvedConnection = resolveToolConnectionReference(
+                    options.input,
+                    this._connectionManager,
+                );
+                if ("reason" in resolvedConnection) {
                     const err: DabToolError = {
                         success: false,
-                        reason: "invalid_request",
-                        message: loc.dabToolMissingConnectionId,
+                        reason: resolvedConnection.reason,
+                        message: resolvedConnection.message,
                     };
                     sendToolTelemetry({ operation, success: false, reason: err.reason });
                     return json(err);
                 }
 
-                const connInfo = this._connectionManager.getConnectionInfo(connectionId);
-                const connCreds = connInfo?.credentials;
-                if (!connCreds) {
-                    const err: DabToolError = {
-                        success: false,
-                        reason: "invalid_request",
-                        message: loc.noConnectionError(connectionId),
-                    };
-                    sendToolTelemetry({ operation, success: false, reason: err.reason });
-                    return json(err);
-                }
-
-                const designer = await this._showDab(connectionId, connCreds.database);
+                const connCreds = resolvedConnection.connectionInfo.credentials;
+                const designer = await this._showDab(
+                    resolvedConnection.ownerUri,
+                    connCreds.database,
+                );
                 sendToolTelemetry({
                     operation,
                     success: true,

--- a/extensions/mssql/src/copilot/tools/schemaDesignerTool.ts
+++ b/extensions/mssql/src/copilot/tools/schemaDesignerTool.ts
@@ -15,12 +15,13 @@ import { SchemaDesignerWebviewController } from "../../schemaDesigner/schemaDesi
 import { sendActionEvent } from "../../telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../../sharedInterfaces/telemetry";
 import { matchesStrictTargetHint, ToolTargetContext, ToolTargetHint } from "./toolsUtils";
+import { resolveToolConnectionReference } from "./toolConnectionResolver";
 
 type IncludeOverviewColumns = "none" | "names" | "namesAndTypes";
 type IncludeTableColumns = IncludeOverviewColumns | "full";
 
 export type SchemaDesignerToolParams =
-    | { operation: "show"; connectionId: string }
+    | { operation: "show"; connectionId?: string; connectionName?: string }
     | { operation: "get_overview"; options?: { includeColumns?: IncludeOverviewColumns } }
     | {
           operation: "get_table";
@@ -264,30 +265,25 @@ export class SchemaDesignerTool extends ToolBase<SchemaDesignerToolParams> {
 
         try {
             if (operation === "show") {
-                const { connectionId } = options.input;
-                if (!connectionId) {
+                const resolvedConnection = resolveToolConnectionReference(
+                    options.input,
+                    this._connectionManager,
+                );
+                if ("reason" in resolvedConnection) {
                     const err: SchemaDesignerToolError = {
                         success: false,
-                        reason: "invalid_request",
-                        message: loc.schemaDesignerMissingConnectionId,
+                        reason: resolvedConnection.reason,
+                        message: resolvedConnection.message,
                     };
                     sendToolTelemetry({ operation, success: false, reason: err.reason });
                     return json(err);
                 }
 
-                const connInfo = this._connectionManager.getConnectionInfo(connectionId);
-                const connCreds = connInfo?.credentials;
-                if (!connCreds) {
-                    const err: SchemaDesignerToolError = {
-                        success: false,
-                        reason: "invalid_request",
-                        message: loc.noConnectionError(connectionId),
-                    };
-                    sendToolTelemetry({ operation, success: false, reason: err.reason });
-                    return json(err);
-                }
-
-                const designer = await this._showSchema(connectionId, connCreds.database);
+                const connCreds = resolvedConnection.connectionInfo.credentials;
+                const designer = await this._showSchema(
+                    resolvedConnection.ownerUri,
+                    connCreds.database,
+                );
                 const schema = await designer.getSchemaState();
                 const version = this.computeSchemaVersion(schema);
                 sendToolTelemetry({ operation, success: true });

--- a/extensions/mssql/src/copilot/tools/toolConnectionResolver.ts
+++ b/extensions/mssql/src/copilot/tools/toolConnectionResolver.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import ConnectionManager, { ConnectionInfo } from "../../controllers/connectionManager";
+import { MssqlChatAgent as loc } from "../../constants/locConstants";
+import { sqlToolsMcpConnectionRegistry } from "../../sqlToolsMcp/sqlToolsMcpConnectionRegistry";
+
+export interface ToolConnectionReference {
+    connectionId?: string;
+    connectionName?: string;
+}
+
+export interface ResolvedToolConnection {
+    ownerUri: string;
+    connectionInfo: ConnectionInfo;
+}
+
+export interface ToolConnectionResolutionError {
+    reason: "invalid_request";
+    message: string;
+}
+
+export function resolveToolConnectionReference(
+    connectionReference: ToolConnectionReference,
+    connectionManager: ConnectionManager,
+): ResolvedToolConnection | ToolConnectionResolutionError {
+    const connectionId = connectionReference.connectionId;
+    const connectionName = connectionReference.connectionName;
+
+    if (connectionId && connectionName) {
+        return {
+            reason: "invalid_request",
+            message: loc.toolAmbiguousConnectionReference,
+        };
+    }
+
+    if (!connectionId && !connectionName) {
+        return {
+            reason: "invalid_request",
+            message: loc.toolMissingConnectionReference,
+        };
+    }
+
+    if (connectionName) {
+        const ownerUri = sqlToolsMcpConnectionRegistry.get(connectionName)?.ownerUri;
+        if (!ownerUri) {
+            return {
+                reason: "invalid_request",
+                message: loc.noSqlToolsMcpConnectionName(connectionName),
+            };
+        }
+
+        return resolveNativeConnection(ownerUri, connectionManager);
+    }
+
+    const nativeConnection = resolveNativeConnection(connectionId!, connectionManager);
+    if (!("reason" in nativeConnection)) {
+        return nativeConnection;
+    }
+
+    // Compatibility shim: model-generated calls may pass the MCP returned
+    // ConnectionId as connectionId. MCP stores that value as connectionName.
+    const mcpOwnerUri = sqlToolsMcpConnectionRegistry.get(connectionId!)?.ownerUri;
+    if (!mcpOwnerUri) {
+        return nativeConnection;
+    }
+
+    return resolveNativeConnection(mcpOwnerUri, connectionManager);
+}
+
+function resolveNativeConnection(
+    ownerUri: string,
+    connectionManager: ConnectionManager,
+): ResolvedToolConnection | ToolConnectionResolutionError {
+    const connectionInfo = connectionManager.getConnectionInfo(ownerUri);
+    if (!connectionInfo?.credentials) {
+        return {
+            reason: "invalid_request",
+            message: loc.noConnectionError(ownerUri),
+        };
+    }
+
+    return { ownerUri, connectionInfo };
+}

--- a/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpConnectionRegistry.ts
+++ b/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpConnectionRegistry.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BridgePlatformContext } from "./contracts";
+
+export interface SqlToolsMcpRegisteredConnection {
+    connectionHandle: string;
+    ownerUri: string;
+    platformContext: BridgePlatformContext;
+    disposed: boolean;
+    queryTail: Promise<void>;
+}
+
+export class SqlToolsMcpConnectionRegistry {
+    private readonly registeredConnections = new Map<string, SqlToolsMcpRegisteredConnection>();
+
+    get(connectionName: string): SqlToolsMcpRegisteredConnection | undefined {
+        return this.registeredConnections.get(connectionName);
+    }
+
+    set(connectionName: string, context: SqlToolsMcpRegisteredConnection): void {
+        this.registeredConnections.set(connectionName, context);
+    }
+
+    delete(connectionName: string): boolean {
+        return this.registeredConnections.delete(connectionName);
+    }
+
+    values(): IterableIterator<SqlToolsMcpRegisteredConnection> {
+        return this.registeredConnections.values();
+    }
+
+    clear(): void {
+        this.registeredConnections.clear();
+    }
+}
+
+export const sqlToolsMcpConnectionRegistry = new SqlToolsMcpConnectionRegistry();

--- a/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpRuntime.ts
+++ b/extensions/mssql/src/sqlToolsMcp/sqlToolsMcpRuntime.ts
@@ -35,17 +35,13 @@ import {
     sendSqlToolsMcpAction,
     sendSqlToolsMcpError,
 } from "./sqlToolsMcpTelemetry";
-
-interface RegisteredExecutionContext {
-    connectionHandle: string;
-    ownerUri: string;
-    platformContext: BridgePlatformContext;
-    disposed: boolean;
-    queryTail: Promise<void>;
-}
+import {
+    SqlToolsMcpRegisteredConnection,
+    sqlToolsMcpConnectionRegistry,
+} from "./sqlToolsMcpConnectionRegistry";
 
 export class SqlToolsMcpRuntime {
-    private readonly registeredConnections = new Map<string, RegisteredExecutionContext>();
+    private readonly registeredConnections = sqlToolsMcpConnectionRegistry;
     private readonly platformContextDetector: PlatformContextDetector;
 
     constructor(
@@ -374,7 +370,7 @@ export class SqlToolsMcpRuntime {
         return await this.platformContextDetector.detect(ownerUri, connectionInfo, serverInfo);
     }
 
-    private async cleanupContext(context: RegisteredExecutionContext): Promise<void> {
+    private async cleanupContext(context: SqlToolsMcpRegisteredConnection): Promise<void> {
         await context.queryTail;
 
         try {
@@ -385,7 +381,7 @@ export class SqlToolsMcpRuntime {
     }
 
     private async runSerializedQuery<T>(
-        context: RegisteredExecutionContext,
+        context: SqlToolsMcpRegisteredConnection,
         cancellationToken: HeadlessQueryCancellationToken | undefined,
         callback: () => Promise<T>,
     ): Promise<T> {
@@ -413,7 +409,7 @@ export class SqlToolsMcpRuntime {
     }
 
     private throwIfQueryCannotStart(
-        context: RegisteredExecutionContext,
+        context: SqlToolsMcpRegisteredConnection,
         cancellationToken: HeadlessQueryCancellationToken | undefined,
     ): void {
         if (context.disposed) {

--- a/extensions/mssql/test/unit/dabTool.test.ts
+++ b/extensions/mssql/test/unit/dabTool.test.ts
@@ -21,6 +21,7 @@ import { SchemaDesigner } from "../../src/sharedInterfaces/schemaDesigner";
 import { MssqlChatAgent as loc } from "../../src/constants/locConstants";
 import { IConnectionProfile } from "../../src/models/interfaces";
 import * as telemetry from "../../src/telemetry/telemetry";
+import { sqlToolsMcpConnectionRegistry } from "../../src/sqlToolsMcp/sqlToolsMcpConnectionRegistry";
 
 chai.use(sinonChai);
 
@@ -32,6 +33,7 @@ suite("DabTool Tests", () => {
     let dabTool: DabTool;
 
     const sampleConnectionId = "connection-dab-123";
+    const sampleConnectionName = "McpDabConnection";
     const sampleDatabase = "AdventureWorks";
     const sampleServer = "localhost";
 
@@ -133,16 +135,18 @@ suite("DabTool Tests", () => {
         mockConnectionManager = sandbox.createStubInstance(ConnectionManager);
         mockToken = {} as vscode.CancellationToken;
         showDabStub = sandbox.stub();
+        sqlToolsMcpConnectionRegistry.clear();
         dabTool = new DabTool(mockConnectionManager, showDabStub as any);
         sandbox.stub(telemetry, "sendActionEvent");
     });
 
     teardown(() => {
+        sqlToolsMcpConnectionRegistry.clear();
         sandbox.restore();
     });
 
     suite("Tool behavior", () => {
-        test("returns invalid_request when show is missing connectionId", async () => {
+        test("returns invalid_request when show is missing connection reference", async () => {
             const options = {
                 input: {
                     operation: "show",
@@ -152,7 +156,23 @@ suite("DabTool Tests", () => {
             const parsed = JSON.parse(await dabTool.call(options, mockToken));
             expect(parsed.success).to.equal(false);
             expect(parsed.reason).to.equal("invalid_request");
-            expect(parsed.message).to.equal(loc.dabToolMissingConnectionId);
+            expect(parsed.message).to.equal(loc.toolMissingConnectionReference);
+            expect(showDabStub.called).to.equal(false);
+        });
+
+        test("returns invalid_request when show has both connectionId and connectionName", async () => {
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionId: sampleConnectionId,
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<DabToolParams>;
+
+            const parsed = JSON.parse(await dabTool.call(options, mockToken));
+            expect(parsed.success).to.equal(false);
+            expect(parsed.reason).to.equal("invalid_request");
+            expect(parsed.message).to.equal(loc.toolAmbiguousConnectionReference);
             expect(showDabStub.called).to.equal(false);
         });
 
@@ -170,6 +190,21 @@ suite("DabTool Tests", () => {
             expect(parsed.success).to.equal(false);
             expect(parsed.reason).to.equal("invalid_request");
             expect(parsed.message).to.equal(loc.noConnectionError(sampleConnectionId));
+            expect(showDabStub.called).to.equal(false);
+        });
+
+        test("returns invalid_request when show connectionName is not registered", async () => {
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<DabToolParams>;
+
+            const parsed = JSON.parse(await dabTool.call(options, mockToken));
+            expect(parsed.success).to.equal(false);
+            expect(parsed.reason).to.equal("invalid_request");
+            expect(parsed.message).to.equal(loc.noSqlToolsMcpConnectionName(sampleConnectionName));
             expect(showDabStub.called).to.equal(false);
         });
 
@@ -209,6 +244,85 @@ suite("DabTool Tests", () => {
             expect(parsed).to.not.have.property("config");
             expect(parsed).to.not.have.property("version");
             expect(parsed).to.not.have.property("summary");
+            expect(showDabStub.calledOnceWith(sampleConnectionId, sampleDatabase)).to.equal(true);
+            expect(mockDesigner.getDabToolState.called).to.equal(false);
+        });
+
+        test("show opens DAB from registered SQL Tools MCP connectionName", async () => {
+            const mockCredentials = {
+                database: sampleDatabase,
+            } as IConnectionProfile;
+
+            const mockConnectionInfo = {
+                connectionId: sampleConnectionId,
+                credentials: mockCredentials,
+            } as unknown as ConnectionInfo;
+
+            sqlToolsMcpConnectionRegistry.set(sampleConnectionName, {
+                connectionHandle: "connection-handle",
+                ownerUri: sampleConnectionId,
+                platformContext: { contextSettings: {} },
+                disposed: false,
+                queryTail: Promise.resolve(),
+            });
+            mockConnectionManager.getConnectionInfo.returns(mockConnectionInfo);
+
+            const mockDesigner = sandbox.createStubInstance(SchemaDesignerWebviewController);
+            sandbox.stub(mockDesigner as any, "server").get(() => sampleServer);
+            sandbox.stub(mockDesigner as any, "database").get(() => sampleDatabase);
+            showDabStub.resolves(mockDesigner);
+
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<DabToolParams>;
+
+            const parsed = JSON.parse(await dabTool.call(options, mockToken));
+            expect(parsed.success).to.equal(true);
+            expect(parsed.message).to.equal(loc.dabToolShowSuccessMessage);
+            expect(showDabStub.calledOnceWith(sampleConnectionId, sampleDatabase)).to.equal(true);
+            expect(mockDesigner.getDabToolState.called).to.equal(false);
+        });
+
+        test("show opens DAB when MCP connectionName is passed as connectionId", async () => {
+            const mcpConnectionId = "conn_dab_mcp_123";
+            const mockCredentials = {
+                database: sampleDatabase,
+            } as IConnectionProfile;
+
+            const mockConnectionInfo = {
+                connectionId: sampleConnectionId,
+                credentials: mockCredentials,
+            } as unknown as ConnectionInfo;
+
+            sqlToolsMcpConnectionRegistry.set(mcpConnectionId, {
+                connectionHandle: "connection-handle",
+                ownerUri: sampleConnectionId,
+                platformContext: { contextSettings: {} },
+                disposed: false,
+                queryTail: Promise.resolve(),
+            });
+            mockConnectionManager.getConnectionInfo.withArgs(mcpConnectionId).returns(undefined);
+            mockConnectionManager.getConnectionInfo
+                .withArgs(sampleConnectionId)
+                .returns(mockConnectionInfo);
+
+            const mockDesigner = sandbox.createStubInstance(SchemaDesignerWebviewController);
+            sandbox.stub(mockDesigner as any, "server").get(() => sampleServer);
+            sandbox.stub(mockDesigner as any, "database").get(() => sampleDatabase);
+            showDabStub.resolves(mockDesigner);
+
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionId: mcpConnectionId,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<DabToolParams>;
+
+            const parsed = JSON.parse(await dabTool.call(options, mockToken));
+            expect(parsed.success).to.equal(true);
             expect(showDabStub.calledOnceWith(sampleConnectionId, sampleDatabase)).to.equal(true);
             expect(mockDesigner.getDabToolState.called).to.equal(false);
         });

--- a/extensions/mssql/test/unit/dabToolManifest.test.ts
+++ b/extensions/mssql/test/unit/dabToolManifest.test.ts
@@ -61,13 +61,14 @@ suite("DAB LM tool manifest schema", () => {
         expect(tool.inputSchema?.properties).to.include.keys(
             "operation",
             "connectionId",
+            "connectionName",
             "payload",
             "options",
         );
         expect(tool.inputSchema?.required).to.deep.equal(["operation"]);
     });
 
-    test("validates top-level operation enum and show connectionId guidance", () => {
+    test("validates top-level operation enum and show connection guidance", () => {
         const tool = getTool();
         expect(tool.inputSchema?.properties?.operation?.enum).to.deep.equal([
             "get_state",
@@ -79,6 +80,16 @@ suite("DAB LM tool manifest schema", () => {
             "show operation only",
         );
         expect(tool.inputSchema?.properties?.connectionId?.description).to.contain(
+            "Do not include for get_state/apply_changes",
+        );
+        expect(tool.inputSchema?.properties?.connectionId?.description).to.contain(
+            "Do not use this field for a ConnectionId returned by a SQL Tools MCP tool",
+        );
+        expect(tool.inputSchema?.properties?.connectionName?.minLength).to.equal(1);
+        expect(tool.inputSchema?.properties?.connectionName?.description).to.contain(
+            "Pass a ConnectionId returned by a SQL Tools MCP tool",
+        );
+        expect(tool.inputSchema?.properties?.connectionName?.description).to.contain(
             "Do not include for get_state/apply_changes",
         );
     });

--- a/extensions/mssql/test/unit/schemaDesignerTool.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerTool.test.ts
@@ -23,6 +23,7 @@ import { IConnectionProfile } from "../../src/models/interfaces";
 import { SchemaDesignerWebviewController } from "../../src/schemaDesigner/schemaDesignerWebviewController";
 import * as telemetry from "../../src/telemetry/telemetry";
 import { TelemetryActions, TelemetryViews } from "../../src/sharedInterfaces/telemetry";
+import { sqlToolsMcpConnectionRegistry } from "../../src/sqlToolsMcp/sqlToolsMcpConnectionRegistry";
 
 chai.use(sinonChai);
 
@@ -35,6 +36,7 @@ suite("SchemaDesignerTool Tests", () => {
     let schemaDesignerTool: SchemaDesignerTool;
 
     const sampleConnectionId = "connection-schema-123";
+    const sampleConnectionName = "McpSchemaConnection";
     const sampleDatabase = "SampleDb";
     const sampleServer = "testserver";
 
@@ -176,16 +178,18 @@ suite("SchemaDesignerTool Tests", () => {
         mockToken = {} as vscode.CancellationToken;
         showSchemaStub = sandbox.stub();
         sendActionEventStub = sandbox.stub(telemetry, "sendActionEvent");
+        sqlToolsMcpConnectionRegistry.clear();
 
         schemaDesignerTool = new SchemaDesignerTool(mockConnectionManager, showSchemaStub as any);
     });
 
     teardown(() => {
+        sqlToolsMcpConnectionRegistry.clear();
         sandbox.restore();
     });
 
     suite("show", () => {
-        test("returns invalid_request when connectionId is missing", async () => {
+        test("returns invalid_request when connection reference is missing", async () => {
             const options = {
                 input: {
                     operation: "show",
@@ -197,7 +201,7 @@ suite("SchemaDesignerTool Tests", () => {
 
             expect(parsedResult.success).to.be.false;
             expect(parsedResult.reason).to.equal("invalid_request");
-            expect(parsedResult.message).to.equal(loc.schemaDesignerMissingConnectionId);
+            expect(parsedResult.message).to.equal(loc.toolMissingConnectionReference);
             expect(showSchemaStub).to.not.have.been.called;
             expectNoSchemaDump(parsedResult);
 
@@ -206,6 +210,25 @@ suite("SchemaDesignerTool Tests", () => {
                 success: "false",
                 reason: "invalid_request",
             });
+        });
+
+        test("returns invalid_request when connectionId and connectionName are both provided", async () => {
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionId: sampleConnectionId,
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<SchemaDesignerToolParams>;
+
+            const result = await schemaDesignerTool.call(options, mockToken);
+            const parsedResult = JSON.parse(result);
+
+            expect(parsedResult.success).to.be.false;
+            expect(parsedResult.reason).to.equal("invalid_request");
+            expect(parsedResult.message).to.equal(loc.toolAmbiguousConnectionReference);
+            expect(showSchemaStub).to.not.have.been.called;
+            expectNoSchemaDump(parsedResult);
         });
 
         test("returns invalid_request when connectionId is unknown", async () => {
@@ -232,6 +255,26 @@ suite("SchemaDesignerTool Tests", () => {
                 success: "false",
                 reason: "invalid_request",
             });
+        });
+
+        test("returns invalid_request when connectionName is not registered", async () => {
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<SchemaDesignerToolParams>;
+
+            const result = await schemaDesignerTool.call(options, mockToken);
+            const parsedResult = JSON.parse(result);
+
+            expect(parsedResult.success).to.be.false;
+            expect(parsedResult.reason).to.equal("invalid_request");
+            expect(parsedResult.message).to.equal(
+                loc.noSqlToolsMcpConnectionName(sampleConnectionName),
+            );
+            expect(showSchemaStub).to.not.have.been.called;
+            expectNoSchemaDump(parsedResult);
         });
 
         test("opens designer and returns a version (no schema)", async () => {
@@ -283,6 +326,95 @@ suite("SchemaDesignerTool Tests", () => {
                 operation: "show",
                 success: "true",
             });
+        });
+
+        test("opens designer from registered SQL Tools MCP connectionName", async () => {
+            const mockCredentials = {
+                database: sampleDatabase,
+            } as IConnectionProfile;
+
+            const mockConnectionInfo = {
+                connectionId: sampleConnectionId,
+                credentials: mockCredentials,
+            } as unknown as ConnectionInfo;
+
+            sqlToolsMcpConnectionRegistry.set(sampleConnectionName, {
+                connectionHandle: "connection-handle",
+                ownerUri: sampleConnectionId,
+                platformContext: { contextSettings: {} },
+                disposed: false,
+                queryTail: Promise.resolve(),
+            });
+            mockConnectionManager.getConnectionInfo.returns(mockConnectionInfo);
+
+            const mockDesigner = sandbox.createStubInstance(SchemaDesignerWebviewController);
+            sandbox.stub(mockDesigner as any, "server").get(() => sampleServer);
+            sandbox.stub(mockDesigner as any, "database").get(() => sampleDatabase);
+            mockDesigner.getSchemaState.resolves(mockSchema);
+
+            showSchemaStub.resolves(mockDesigner);
+
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionName: sampleConnectionName,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<SchemaDesignerToolParams>;
+
+            const result = await schemaDesignerTool.call(options, mockToken);
+            const parsedResult = JSON.parse(result);
+
+            expect(parsedResult.success).to.be.true;
+            expect(parsedResult.version).to.equal(computeSchemaVersion(mockSchema));
+            expect(showSchemaStub).to.have.been.calledOnceWith(sampleConnectionId, sampleDatabase);
+            expectNoSchemaDump(parsedResult);
+        });
+
+        test("opens designer when MCP connectionName is passed as connectionId", async () => {
+            const mcpConnectionId = "conn_schema_mcp_123";
+            const mockCredentials = {
+                database: sampleDatabase,
+            } as IConnectionProfile;
+
+            const mockConnectionInfo = {
+                connectionId: sampleConnectionId,
+                credentials: mockCredentials,
+            } as unknown as ConnectionInfo;
+
+            sqlToolsMcpConnectionRegistry.set(mcpConnectionId, {
+                connectionHandle: "connection-handle",
+                ownerUri: sampleConnectionId,
+                platformContext: { contextSettings: {} },
+                disposed: false,
+                queryTail: Promise.resolve(),
+            });
+            mockConnectionManager.getConnectionInfo
+                .withArgs(mcpConnectionId)
+                .returns(undefined as any);
+            mockConnectionManager.getConnectionInfo
+                .withArgs(sampleConnectionId)
+                .returns(mockConnectionInfo);
+
+            const mockDesigner = sandbox.createStubInstance(SchemaDesignerWebviewController);
+            sandbox.stub(mockDesigner as any, "server").get(() => sampleServer);
+            sandbox.stub(mockDesigner as any, "database").get(() => sampleDatabase);
+            mockDesigner.getSchemaState.resolves(mockSchema);
+
+            showSchemaStub.resolves(mockDesigner);
+
+            const options = {
+                input: {
+                    operation: "show",
+                    connectionId: mcpConnectionId,
+                },
+            } as vscode.LanguageModelToolInvocationOptions<SchemaDesignerToolParams>;
+
+            const result = await schemaDesignerTool.call(options, mockToken);
+            const parsedResult = JSON.parse(result);
+
+            expect(parsedResult.success).to.be.true;
+            expect(showSchemaStub).to.have.been.calledOnceWith(sampleConnectionId, sampleDatabase);
+            expectNoSchemaDump(parsedResult);
         });
     });
 

--- a/extensions/mssql/test/unit/schemaDesignerToolManifest.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerToolManifest.test.ts
@@ -8,6 +8,38 @@ import * as fs from "fs";
 import * as path from "path";
 
 suite("Schema Designer LM tool manifest schema", () => {
+    test("mssql_schema_designer show requires exactly one connection reference", () => {
+        const packageJsonPath = path.join(__dirname, "..", "..", "..", "package.json");
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+        const tool = (packageJson.contributes?.languageModelTools ?? []).find(
+            (t: any) => t?.name === "mssql_schema_designer",
+        );
+        expect(tool, "missing mssql_schema_designer tool in contributes.languageModelTools").to
+            .exist;
+
+        expect(tool.inputSchema?.properties).to.include.keys(
+            "operation",
+            "connectionId",
+            "connectionName",
+        );
+        expect(tool.inputSchema?.properties?.connectionId?.description).to.contain(
+            "Do not use this field for a ConnectionId returned by a SQL Tools MCP tool",
+        );
+        expect(tool.inputSchema?.properties?.connectionName?.description).to.contain(
+            "Pass a ConnectionId returned by a SQL Tools MCP tool",
+        );
+
+        const showVariant = (tool.inputSchema?.oneOf ?? []).find(
+            (variant: any) => variant?.properties?.operation?.enum?.[0] === "show",
+        );
+        expect(showVariant, "missing inputSchema.oneOf variant for show").to.exist;
+        expect(showVariant.oneOf, "show: connection reference oneOf").to.deep.equal([
+            { required: ["connectionId"] },
+            { required: ["connectionName"] },
+        ]);
+    });
+
     test("mssql_schema_designer edits use op-specific oneOf schemas", () => {
         const packageJsonPath = path.join(__dirname, "..", "..", "..", "package.json");
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));

--- a/extensions/mssql/test/unit/sqlToolsMcp/sqlToolsMcpRuntime.test.ts
+++ b/extensions/mssql/test/unit/sqlToolsMcp/sqlToolsMcpRuntime.test.ts
@@ -21,6 +21,7 @@ import { BridgeErrorCode, BridgeRequestError } from "../../../src/sqlToolsMcp/co
 import { SqlToolsMcpRuntime } from "../../../src/sqlToolsMcp/sqlToolsMcpRuntime";
 import { DbCellValue } from "../../../src/models/contracts/queryExecute";
 import { stubTelemetry } from "../utils";
+import { sqlToolsMcpConnectionRegistry } from "../../../src/sqlToolsMcp/sqlToolsMcpConnectionRegistry";
 
 chai.use(sinonChai);
 
@@ -45,9 +46,11 @@ suite("SQL Tools MCP runtime", () => {
         sandbox.stub(connectionManager, "connectionStore").get(() => connectionStore);
         connectionManager.connect.resolves(true);
         connectionManager.disconnect.resolves(true);
+        sqlToolsMcpConnectionRegistry.clear();
     });
 
     teardown(() => {
+        sqlToolsMcpConnectionRegistry.clear();
         sandbox.restore();
     });
 

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -342,6 +342,9 @@
     <trans-unit id="++CODE++1888bd4ce917e9c8cecde43608d69624f56668f86f1bbe4331494db33fb52578">
       <source xml:lang="en">Always show in new tab</source>
     </trans-unit>
+    <trans-unit id="++CODE++c8adc945cb73b3f301ba86327f4b6758f8a2a5a7f3a232e892b441a177ce75ff">
+      <source xml:lang="en">Ambiguous connection reference. Please provide only one of connectionId or connectionName.</source>
+    </trans-unit>
     <trans-unit id="++CODE++df50fadac20ad5c3b190a9af94532fd84c01e0787f15b55212fa2f41de09a091">
       <source xml:lang="en">An active connection is required for GitHub Copilot to understand your database schema and proceed.&#10;Select &quot;{0}&quot; to establish a connection.</source>
       <note>{0} is the button text (e.g., &apos;Connect&apos; or &apos;Open SQL editor and connect&apos;)</note>
@@ -4393,11 +4396,8 @@
       <source xml:lang="en">Min: {0}</source>
       <note>{0} is the min</note>
     </trans-unit>
-    <trans-unit id="++CODE++42c869c9cf0bc65de28be00cb8d74e9103e69df8251055669978ecbc7b656d71">
-      <source xml:lang="en">Missing connectionId. Please provide a connectionId to open Data API builder.</source>
-    </trans-unit>
-    <trans-unit id="++CODE++8fb917aef4a1254af9e6133030fd694b942178662f086614bb8abf4e94c309e4">
-      <source xml:lang="en">Missing connectionId. Please provide a connectionId to open the schema designer.</source>
+    <trans-unit id="++CODE++c4cb38118e976f2ec6af215b6206c1aeadd0a3a1a95b4ab00681c97e9a276753">
+      <source xml:lang="en">Missing connection reference. Please provide exactly one of connectionId or connectionName.</source>
     </trans-unit>
     <trans-unit id="++CODE++910bb9ebcad74af9fe7fae916e94812f8a97c60f93e76a1167b4ca1583d70f27">
       <source xml:lang="en">Missing schema payload for replace_schema operation.</source>
@@ -4588,6 +4588,10 @@
     </trans-unit>
     <trans-unit id="++CODE++b5353eb771f89b7df467f5082500e61791da1296427482e4eb5bb0cc5b6bec04">
       <source xml:lang="en">No Queries Available</source>
+    </trans-unit>
+    <trans-unit id="++CODE++51376cb4a62d2ba04bbfabe2409c9957f6d4839845b43a39b01d38c368d1912b">
+      <source xml:lang="en">No SQL Tools MCP connection found for connectionName: {0}</source>
+      <note>{0} is the SQL Tools MCP registered connection name</note>
     </trans-unit>
     <trans-unit id="++CODE++b363e5f44515909e667e5e4b24f9690b87a202de3c6b1f1f7b8b597205461ad6">
       <source xml:lang="en">No account selected</source>


### PR DESCRIPTION
## Description

Allows Schema Designer and Data API Builder tools to open connections registered through SQL Tools MCP.

SQL Tools MCP returns a registered connection identifier that subsequent MCP calls pass as `connectionName`. Native extension tools previously accepted only the VS Code runtime `connectionId`, causing MCP connection identifiers to fail when passed across tool surfaces.

This change:

- exposes MCP registered connections through an extension-owned registry
- allows Schema Designer and DAB `show` operations to accept either:
  - `connectionId` for native VS Code connections
  - `connectionName` for SQL Tools MCP registered connections
- adds a compatibility fallback when an MCP connection identifier is passed as `connectionId`
- updates tool schemas and descriptions to guide the model toward `connectionName`
- validates ambiguous, missing, unknown, native, MCP, and compatibility paths
- updates localization resources for the new validation messages

The compatibility fallback is intentionally isolated in the shared resolver and can be removed if the MCP/native connection contracts are aligned later.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation performed:

- `npm run build:extension:typecheck`
- `npm run lint`
- focused VS Code test run covering Schema Designer, DAB, manifest schemas, and MCP runtime: 126 tests passed

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Sample chat:
<img width="522" height="755" alt="Screenshot 2026-06-17 at 4 40 33 PM" src="https://github.com/user-attachments/assets/a6dfbe0b-966a-440c-bdb5-9b625b6c94a3" />
