### PR TITLE
Improve Vector Handling in Edit Data

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3573,7 +3573,7 @@
     "less than": "less than",
     "is null": "is null",
     "is not null": "is not null",
-    "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.": "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.",
+    "Vector values are read-only in this editor. Use T-SQL to modify the value or regenerate the embedding.": "Vector values are read-only in this editor. Use T-SQL to modify the value or regenerate the embedding.",
     "Search Database Objects": "Search Database Objects",
     "Loading database objects": "Loading database objects",
     "Connecting to {0}.../{0} is the server name": {

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -3573,6 +3573,7 @@
     "less than": "less than",
     "is null": "is null",
     "is not null": "is not null",
+    "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.": "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.",
     "Search Database Objects": "Search Database Objects",
     "Loading database objects": "Loading database objects",
     "Connecting to {0}.../{0} is the server name": {

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -2423,6 +2423,9 @@ export class LocConstants {
             filterOpLessThan: l10n.t("less than"),
             filterOpIsNull: l10n.t("is null"),
             filterOpIsNotNull: l10n.t("is not null"),
+            vectorReadonlyTooltip: l10n.t(
+                "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.",
+            ),
         };
     }
 

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -2424,7 +2424,7 @@ export class LocConstants {
             filterOpIsNull: l10n.t("is null"),
             filterOpIsNotNull: l10n.t("is not null"),
             vectorReadonlyTooltip: l10n.t(
-                "Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.",
+                "Vector values are read-only in this editor. Use T-SQL to modify the value or regenerate the embedding.",
             ),
         };
     }

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
@@ -441,6 +441,19 @@
     transition: 0.5s background;
 }
 
+/* Visually hidden but always present in the accessibility tree */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Vector column readonly tooltip */
 .vector-readonly-tooltip {
     position: fixed;

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
@@ -432,3 +432,19 @@
     background-color: var(--vscode-editor-selectionBackground, rgba(0, 0, 255, 0.2)) !important;
     transition: 0.5s background;
 }
+
+/* Vector column readonly tooltip */
+.vector-readonly-tooltip {
+    position: fixed;
+    z-index: 9999;
+    max-width: 300px;
+    padding: 6px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--vscode-editorHoverWidget-foreground);
+    background-color: var(--vscode-editorHoverWidget-background);
+    border: 1px solid var(--vscode-editorHoverWidget-border);
+    border-radius: 3px;
+    box-shadow: 0 2px 8px var(--vscode-widget-shadow);
+    pointer-events: none;
+}

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.css
@@ -106,6 +106,14 @@
     color: var(--vscode-editorGhostText-foreground, #888);
 }
 
+.table-cell-vector {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: block;
+    width: 100%;
+}
+
 /* Row number column */
 .table-row-number {
     color: var(--vscode-foreground);

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -122,12 +122,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         const firstCellSelectedRef = useRef<boolean>(false);
         // Plain-text column names for callers that need a label without HTML.
         const columnDisplayNamesRef = useRef<Map<string | number, string>>(new Map());
-        const vectorColumnFieldsRef = useRef<Set<string>>(new Set());
-        const [vectorTooltip, setVectorTooltip] = useState<{
-            visible: boolean;
-            x: number;
-            y: number;
-        }>({ visible: false, x: 0, y: 0 });
+        const [vectorTooltip, setVectorTooltip] = useState<{ x: number; y: number } | null>(null);
 
         // Create a custom pager component
         const BoundCustomPager = useMemo(
@@ -374,8 +369,6 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
 
         // Create columns from columnInfo
         function createColumns(columnInfo: any[], currentThemeKind?: ColorThemeKind): Column[] {
-            vectorColumnFieldsRef.current.clear();
-
             // Data columns
             const dataColumns: Column[] = columnInfo.map((colInfo, index) => {
                 const headerName = colInfo.dataTypeName
@@ -441,18 +434,16 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     },
                 };
 
-                if (colInfo.isEditable && colInfo.dataTypeName?.toLowerCase() !== "vector") {
+                const isVector = colInfo.dataTypeName?.toLowerCase() === "vector";
+                if (colInfo.isEditable && !isVector) {
                     column.editor = {
                         model: Editors.text,
                     };
                 }
 
-                if (colInfo.dataTypeName?.toLowerCase() === "vector") {
-                    vectorColumnFieldsRef.current.add(`col${index}`);
-                }
-
-                // Add originalIndex as a custom property for tracking edits with hidden columns
+                // Add originalIndex and isVector as custom properties for use at interaction time
                 (column as any).originalIndex = index;
+                (column as any).isVector = isVector;
 
                 return column;
             });
@@ -841,10 +832,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         }, [dataset]);
 
         useEffect(() => {
-            if (!vectorTooltip.visible) {
+            if (!vectorTooltip) {
                 return;
             }
-            const dismiss = () => setVectorTooltip((prev) => ({ ...prev, visible: false }));
+            const dismiss = () => setVectorTooltip(null);
             const onKeyDown = (e: KeyboardEvent) => {
                 if (e.key === "Escape") {
                     dismiss();
@@ -856,7 +847,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 document.removeEventListener("click", dismiss);
                 document.removeEventListener("keydown", onKeyDown);
             };
-        }, [vectorTooltip.visible]);
+        }, [vectorTooltip]);
 
         function handleDblClick(e: MouseEvent, args: any) {
             const grid = reactGridRef.current?.slickGrid;
@@ -864,10 +855,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 return;
             }
             const column = grid.getVisibleColumns()[args.cell];
-            if (!column || !vectorColumnFieldsRef.current.has(String(column.field))) {
+            if (!(column as any)?.isVector) {
                 return;
             }
-            setVectorTooltip({ visible: true, x: e.clientX, y: e.clientY });
+            setVectorTooltip({ x: e.clientX, y: e.clientY });
         }
 
         function handleCellChange(_e: CustomEvent, args: any) {
@@ -976,6 +967,15 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 return;
             }
             const column = grid.getVisibleColumns()[activeCell.cell];
+            if ((column as any)?.isVector) {
+                const cellNode = grid.getCellNode(activeCell.row, activeCell.cell);
+                const rect = cellNode?.getBoundingClientRect();
+                if (rect) {
+                    setVectorTooltip({ x: rect.left, y: rect.bottom });
+                }
+                e.preventDefault();
+                return;
+            }
             if (column?.id !== "undo") {
                 return;
             }
@@ -1518,7 +1518,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                         handleDblClick($event.detail.eventData, $event.detail.args)
                     }
                 />
-                {vectorTooltip.visible && (
+                {vectorTooltip && (
                     <div
                         className="vector-readonly-tooltip"
                         style={{ left: vectorTooltip.x + 12, top: vectorTooltip.y + 12 }}>

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -831,8 +831,9 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             }
         }, [dataset]);
 
+        const tooltipOpen = vectorTooltip !== null;
         useEffect(() => {
-            if (!vectorTooltip) {
+            if (!tooltipOpen) {
                 return;
             }
             const dismiss = () => setVectorTooltip(null);
@@ -847,7 +848,11 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 document.removeEventListener("click", dismiss);
                 document.removeEventListener("keydown", onKeyDown);
             };
-        }, [vectorTooltip]);
+        }, [tooltipOpen]);
+
+        function isVectorCol(col: Column | undefined): boolean {
+            return !!(col as any)?.isVector;
+        }
 
         function handleDblClick(e: MouseEvent, args: any) {
             const grid = reactGridRef.current?.slickGrid;
@@ -855,7 +860,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 return;
             }
             const column = grid.getVisibleColumns()[args.cell];
-            if (!(column as any)?.isVector) {
+            if (!isVectorCol(column)) {
                 return;
             }
             setVectorTooltip({ x: e.clientX, y: e.clientY });
@@ -967,13 +972,14 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 return;
             }
             const column = grid.getVisibleColumns()[activeCell.cell];
-            if ((column as any)?.isVector) {
+            if (isVectorCol(column)) {
                 const cellNode = grid.getCellNode(activeCell.row, activeCell.cell);
                 const rect = cellNode?.getBoundingClientRect();
                 if (rect) {
                     setVectorTooltip({ x: rect.left, y: rect.bottom });
                 }
                 e.preventDefault();
+                e.stopPropagation();
                 return;
             }
             if (column?.id !== "undo") {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -433,7 +433,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     },
                 };
 
-                if (colInfo.isEditable) {
+                if (colInfo.isEditable && colInfo.dataTypeName?.toLowerCase() !== "vector") {
                     column.editor = {
                         model: Editors.text,
                     };

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -122,6 +122,12 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         const firstCellSelectedRef = useRef<boolean>(false);
         // Plain-text column names for callers that need a label without HTML.
         const columnDisplayNamesRef = useRef<Map<string | number, string>>(new Map());
+        const vectorColumnFieldsRef = useRef<Set<string>>(new Set());
+        const [vectorTooltip, setVectorTooltip] = useState<{
+            visible: boolean;
+            x: number;
+            y: number;
+        }>({ visible: false, x: 0, y: 0 });
 
         // Create a custom pager component
         const BoundCustomPager = useMemo(
@@ -368,6 +374,8 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
 
         // Create columns from columnInfo
         function createColumns(columnInfo: any[], currentThemeKind?: ColorThemeKind): Column[] {
+            vectorColumnFieldsRef.current.clear();
+
             // Data columns
             const dataColumns: Column[] = columnInfo.map((colInfo, index) => {
                 const headerName = colInfo.dataTypeName
@@ -437,6 +445,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     column.editor = {
                         model: Editors.text,
                     };
+                }
+
+                if (colInfo.dataTypeName?.toLowerCase() === "vector") {
+                    vectorColumnFieldsRef.current.add(`col${index}`);
                 }
 
                 // Add originalIndex as a custom property for tracking edits with hidden columns
@@ -827,6 +839,36 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 void reactGridRef.current.paginationService.goToPageNumber(targetPage);
             }
         }, [dataset]);
+
+        useEffect(() => {
+            if (!vectorTooltip.visible) {
+                return;
+            }
+            const dismiss = () => setVectorTooltip((prev) => ({ ...prev, visible: false }));
+            const onKeyDown = (e: KeyboardEvent) => {
+                if (e.key === "Escape") {
+                    dismiss();
+                }
+            };
+            document.addEventListener("click", dismiss, { once: true });
+            document.addEventListener("keydown", onKeyDown);
+            return () => {
+                document.removeEventListener("click", dismiss);
+                document.removeEventListener("keydown", onKeyDown);
+            };
+        }, [vectorTooltip.visible]);
+
+        function handleDblClick(e: MouseEvent, args: any) {
+            const grid = reactGridRef.current?.slickGrid;
+            if (!grid) {
+                return;
+            }
+            const column = grid.getVisibleColumns()[args.cell];
+            if (!column || !vectorColumnFieldsRef.current.has(String(column.field))) {
+                return;
+            }
+            setVectorTooltip({ visible: true, x: e.clientX, y: e.clientY });
+        }
 
         function handleCellChange(_e: CustomEvent, args: any) {
             // Capture pagination state
@@ -1472,7 +1514,17 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     onSort={($event) => handleSort($event, $event.detail.args)}
                     onSortChanged={($event) => handleSlickSortChanged($event.detail)}
                     onSortCleared={() => handleSlickSortCleared()}
+                    onDblClick={($event) =>
+                        handleDblClick($event.detail.eventData, $event.detail.args)
+                    }
                 />
+                {vectorTooltip.visible && (
+                    <div
+                        className="vector-readonly-tooltip"
+                        style={{ left: vectorTooltip.x + 12, top: vectorTooltip.y + 12 }}>
+                        {loc.tableExplorer.vectorReadonlyTooltip}
+                    </div>
+                )}
             </div>
         );
     },

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -425,6 +425,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                             cellClasses.push("table-cell-null");
                         }
 
+                        if (isVector) {
+                            cellClasses.push("table-cell-vector");
+                        }
+
                         const elmType = hasFailed || isModified ? "div" : "span";
                         return createDomElement(elmType, {
                             className: cellClasses.join(" "),

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -123,6 +123,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         // Plain-text column names for callers that need a label without HTML.
         const columnDisplayNamesRef = useRef<Map<string | number, string>>(new Map());
         const [vectorTooltip, setVectorTooltip] = useState<{ x: number; y: number } | null>(null);
+        const tooltipOpenCountRef = useRef(0);
 
         // Create a custom pager component
         const BoundCustomPager = useMemo(
@@ -438,7 +439,8 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     },
                 };
 
-                const isVector = colInfo.dataTypeName?.toLowerCase() === "vector";
+                const isVector =
+                    colInfo.dataTypeName?.trim().toLowerCase().startsWith("vector") ?? false;
                 if (colInfo.isEditable && !isVector) {
                     column.editor = {
                         model: Editors.text,
@@ -867,6 +869,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             if (!isVectorCol(column)) {
                 return;
             }
+            tooltipOpenCountRef.current += 1;
             setVectorTooltip({ x: e.clientX, y: e.clientY });
         }
 
@@ -980,6 +983,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 const cellNode = grid.getCellNode(activeCell.row, activeCell.cell);
                 const rect = cellNode?.getBoundingClientRect();
                 if (rect) {
+                    tooltipOpenCountRef.current += 1;
                     setVectorTooltip({ x: rect.left, y: rect.bottom });
                 }
                 e.preventDefault();
@@ -1528,8 +1532,16 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                         handleDblClick($event.detail.eventData, $event.detail.args)
                     }
                 />
+                <div aria-live="polite" aria-atomic="true" className="sr-only">
+                    {vectorTooltip && (
+                        <span key={tooltipOpenCountRef.current}>
+                            {loc.tableExplorer.vectorReadonlyTooltip}
+                        </span>
+                    )}
+                </div>
                 {vectorTooltip && (
                     <div
+                        role="tooltip"
                         className="vector-readonly-tooltip"
                         style={{ left: vectorTooltip.x + 12, top: vectorTooltip.y + 12 }}>
                         {loc.tableExplorer.vectorReadonlyTooltip}

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7414,6 +7414,9 @@
     <trans-unit id="++CODE++1fbf278b53995ff39f69ce0e2aef7d56406fb890b82cd87febce6995e98776cd">
       <source xml:lang="en">Value is required</source>
     </trans-unit>
+    <trans-unit id="++CODE++b2b4eebef641504f67311f2066e8fefd7405b2ff07f1211138e119b2da9174d6">
+      <source xml:lang="en">Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.</source>
+    </trans-unit>
     <trans-unit id="++CODE++895538d92b916860948aefae4e0444d5fb238835e6cc5af248c89c0582e741dd">
       <source xml:lang="en">Verify a container image by using the Notation CLI</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7414,8 +7414,8 @@
     <trans-unit id="++CODE++1fbf278b53995ff39f69ce0e2aef7d56406fb890b82cd87febce6995e98776cd">
       <source xml:lang="en">Value is required</source>
     </trans-unit>
-    <trans-unit id="++CODE++b2b4eebef641504f67311f2066e8fefd7405b2ff07f1211138e119b2da9174d6">
-      <source xml:lang="en">Vector values are usually generated embeddings and may be high-dimensional. Use T-SQL or regenerate the embedding to modify this value.</source>
+    <trans-unit id="++CODE++020047fc73e369f164014c46ff59e909f16aa48075f1646315b139843c2dcfbc">
+      <source xml:lang="en">Vector values are read-only in this editor. Use T-SQL to modify the value or regenerate the embedding.</source>
     </trans-unit>
     <trans-unit id="++CODE++895538d92b916860948aefae4e0444d5fb238835e6cc5af248c89c0582e741dd">
       <source xml:lang="en">Verify a container image by using the Notation CLI</source>


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/vscode-mssql/issues/21812

This PR prevents vector types from being modified in the Edit Data grid.

The changes in this PR are the following:
1. Vectors are dynamically truncated based on the grid's column width:
<img width="752" height="138" alt="image" src="https://github.com/user-attachments/assets/5f9ff698-5803-4fdb-a7cb-5ff44ab07d17" />

2. When a user attempts to modify a grid cell in the vector column, the following tooltip appears informing them that the operation cannot be completed.
<img width="380" height="80" alt="image" src="https://github.com/user-attachments/assets/582414b8-035b-4a18-8f07-a91d8d961834" />




_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
