### PR TITLE
Update slickgrid-react to 10.8.2

### DIFF
--- a/extensions/mssql/package-lock.json
+++ b/extensions/mssql/package-lock.json
@@ -101,7 +101,7 @@
                 "sinon": "^21.0.3",
                 "sinon-chai": "^4.0.1",
                 "slickgrid": "github:Microsoft/SlickGrid.ADS#v2.3.51",
-                "slickgrid-react": "10.7.0",
+                "slickgrid-react": "10.8.2",
                 "source-map-support": "^0.5.21",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.8.3",
@@ -1382,14 +1382,11 @@
             }
         },
         "node_modules/@excel-builder-vanilla/types": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@excel-builder-vanilla/types/-/types-5.0.0.tgz",
-            "integrity": "sha512-k0qMo9+velvx2EJne0gwT1NacDRCIWdCHpwTu5hjuRKrr1BzKCiTqgBKUf9zL74HIU7dejoWl3wgguWrccTFXg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@excel-builder-vanilla/types/-/types-5.1.0.tgz",
+            "integrity": "sha512-R2FPgeuArFQaeGrqVTvXlRs6OsTrUGf7GtN4eQT4sf2AD9FhjzTYfkisVWzA3tvr5+snYmleQKBK3QixlgNrgQ==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "fflate": "^0.8.2"
-            },
             "funding": {
                 "type": "ko_fi",
                 "url": "https://ko-fi.com/ghiscoding"
@@ -3728,24 +3725,23 @@
             "license": "MIT"
         },
         "node_modules/@slickgrid-universal/common": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/common/-/common-10.7.0.tgz",
-            "integrity": "sha512-Rfudx2aLA70tJS2cjvaD/nbyn5fVyNFHPfWAjmZz3m+FFPP2dAgKDYXHIrTHrwEvBirdCYgfYBkexostO2wqvg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/common/-/common-10.8.2.tgz",
+            "integrity": "sha512-Xy/akYTRkSmijCYPuPoKsJwxKtclmYdKcVxP6p1i0WfQPBvxAmPII4z0mfe/Sut9eN0KgejUS8eEdLZDEGuMFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@excel-builder-vanilla/types": "^5.0.0",
-                "@formkit/tempo": "^1.0.0",
+                "@excel-builder-vanilla/types": "^5.1.0",
+                "@formkit/tempo": "^1.1.0",
                 "@slickgrid-universal/binding": "10.1.0",
-                "@slickgrid-universal/event-pub-sub": "10.7.0",
-                "@slickgrid-universal/utils": "10.7.0",
+                "@slickgrid-universal/event-pub-sub": "10.8.2",
+                "@slickgrid-universal/utils": "10.8.2",
                 "@types/sortablejs": "^1.15.9",
                 "@types/trusted-types": "^2.0.7",
                 "autocompleter": "^9.3.2",
                 "dequal": "^2.0.3",
-                "multiple-select-vanilla": "^5.1.0",
+                "multiple-select-vanilla": "^5.2.1",
                 "sortablejs": "^1.15.7",
-                "un-flatten-tree": "^2.0.12",
                 "vanilla-calendar-pro": "^3.1.0"
             },
             "engines": {
@@ -3757,52 +3753,52 @@
             }
         },
         "node_modules/@slickgrid-universal/custom-footer-component": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/custom-footer-component/-/custom-footer-component-10.7.0.tgz",
-            "integrity": "sha512-wftjxuvGhBd5qy7F4ZvOG10X2wU1rJOv8zIOPTKMRLQj/ICn0PnncLYVWyWtvj1W2LkeC2li5sJInv38QdHcgQ==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/custom-footer-component/-/custom-footer-component-10.8.2.tgz",
+            "integrity": "sha512-8/FY1F3dbhPvikqpXPkL1ZALII06Rp9j1ejuprekHZWowsHiSKhvgQw+/bs9YXI3IeTZICkDu4FXOQbN6CPrSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@formkit/tempo": "^1.0.0",
+                "@formkit/tempo": "^1.1.0",
                 "@slickgrid-universal/binding": "10.1.0",
-                "@slickgrid-universal/common": "10.7.0"
+                "@slickgrid-universal/common": "10.8.2"
             }
         },
         "node_modules/@slickgrid-universal/empty-warning-component": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/empty-warning-component/-/empty-warning-component-10.7.0.tgz",
-            "integrity": "sha512-J7q4uQJP7olfhA+sE3+MFpEVlYuYaAW/3QeAan0odyDjzvlMFoGV20m5dZv/UkEnAcOsPEG3L9jXXOnF4DaPJg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/empty-warning-component/-/empty-warning-component-10.8.2.tgz",
+            "integrity": "sha512-pd0bxsL+g9UvofdfMFi9sZzhr3WP9ziGKiDM530NwRWPjHSfLhRBBEmoeWoINbuOC6BYoqvLeMqH8sUCfhA2FA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@slickgrid-universal/common": "10.7.0"
+                "@slickgrid-universal/common": "10.8.2"
             }
         },
         "node_modules/@slickgrid-universal/event-pub-sub": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/event-pub-sub/-/event-pub-sub-10.7.0.tgz",
-            "integrity": "sha512-G2vfJHn4DR/6OUWmRErr+D6xR4CXZshjNGiwPeb9Feqace/o84zxRk4PRG7T48rnK1nE0JnYcDMjqrUgfnwY0g==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/event-pub-sub/-/event-pub-sub-10.8.2.tgz",
+            "integrity": "sha512-LK5pmsj77t/1/wFnweKyb83S1WN2OKPXhHgHvltGrEtSBxWwiLTw8PK4k/vDvaEgVzGNg5z3kDZo1XRVhk7l4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@slickgrid-universal/utils": "10.7.0"
+                "@slickgrid-universal/utils": "10.8.2"
             }
         },
         "node_modules/@slickgrid-universal/pagination-component": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/pagination-component/-/pagination-component-10.7.0.tgz",
-            "integrity": "sha512-6BwdeFq5KOfE8zayfXuyXKN4OhjI+sjHubgVu7GEgjmhMAhcC4ong2SvIE4lZ53TiJSK7Age24A5I2SNvCBhYg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/pagination-component/-/pagination-component-10.8.2.tgz",
+            "integrity": "sha512-WV5IFgd6hZMcxQZ8JjWvUKFPriU1c9/a/gA4lFPLodfEEjJuT/vs39uuDu7/4qf8CuQ1NRQtbst2A9a1DGfMJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@slickgrid-universal/binding": "10.1.0",
-                "@slickgrid-universal/common": "10.7.0"
+                "@slickgrid-universal/common": "10.8.2"
             }
         },
         "node_modules/@slickgrid-universal/utils": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/@slickgrid-universal/utils/-/utils-10.7.0.tgz",
-            "integrity": "sha512-Ci0WuGDC2Wbh/aiDgCe2NUxYCTSPE45NwSJg2TKlTGtXHEtiEVS9OgfalPXTzjj6S010B62VrL1RMyIioeQO1A==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/@slickgrid-universal/utils/-/utils-10.8.2.tgz",
+            "integrity": "sha512-4aWBNnQHW/xiIDL8NfcVpGNXdTfiyj/TJ4C/1/ldGQ3aJlhGg7fD4/EXaaH5kqfIL/pvo6n/R+vSy8Dk0UeXRQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -6933,13 +6929,6 @@
                 "reusify": "^1.0.4"
             }
         },
-        "node_modules/fflate": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/figures": {
             "version": "1.7.0",
             "license": "MIT",
@@ -9881,9 +9870,9 @@
             "license": "MIT"
         },
         "node_modules/multiple-select-vanilla": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/multiple-select-vanilla/-/multiple-select-vanilla-5.1.0.tgz",
-            "integrity": "sha512-myURI7mTSe3AT37vN/1q/MiEi1CBESDjAE/sU4v70quXelFrAmxUYGZ1KUMM3T20zlmB1Z2aC/a3eUbP/+iVSQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/multiple-select-vanilla/-/multiple-select-vanilla-5.2.1.tgz",
+            "integrity": "sha512-lda2Tx5XgzglHcwo00VyvQhUTkayYNvgmV6+WqsZ4oN8O4cIVcOP0nY+yXcO5++IYLv7B3r2gEUC6Vp6jteHnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12345,18 +12334,18 @@
             }
         },
         "node_modules/slickgrid-react": {
-            "version": "10.7.0",
-            "resolved": "https://registry.npmjs.org/slickgrid-react/-/slickgrid-react-10.7.0.tgz",
-            "integrity": "sha512-KSuLeIVpkh9S8vNCvmRzUAkB44X2a4wwFaZjKTJLREEj15+LOAWIKWpJBcCxcFDPQcG9JAoeqHzAWobpw9O39A==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/slickgrid-react/-/slickgrid-react-10.8.2.tgz",
+            "integrity": "sha512-Bua2c5ecw2/rz7jlhb9nvsAdNBIJGbJ829k42aEEiizPa1QR1vG/ZQ5TAaoxf7KqE9uktYWYgT2KwqkpgzBFTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@slickgrid-universal/common": "10.7.0",
-                "@slickgrid-universal/custom-footer-component": "10.7.0",
-                "@slickgrid-universal/empty-warning-component": "10.7.0",
-                "@slickgrid-universal/event-pub-sub": "10.7.0",
-                "@slickgrid-universal/pagination-component": "10.7.0",
-                "@slickgrid-universal/utils": "10.7.0",
+                "@slickgrid-universal/common": "10.8.2",
+                "@slickgrid-universal/custom-footer-component": "10.8.2",
+                "@slickgrid-universal/empty-warning-component": "10.8.2",
+                "@slickgrid-universal/event-pub-sub": "10.8.2",
+                "@slickgrid-universal/pagination-component": "10.8.2",
+                "@slickgrid-universal/utils": "10.8.2",
                 "dequal": "^2.0.3",
                 "sortablejs": "^1.15.7"
             },
@@ -13290,13 +13279,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/un-flatten-tree": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/un-flatten-tree/-/un-flatten-tree-2.0.12.tgz",
-            "integrity": "sha512-E7v59ADEqVQs9gTZYxoe3uGs6Jj/a3gJ7lSJaTIBTc5w0+B3PJ/kVjs/Y/A26NBWEW8WAo556PpRatH4XHZR1w==",
             "dev": true,
             "license": "MIT"
         },

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -135,7 +135,7 @@
         "sinon": "^21.0.3",
         "sinon-chai": "^4.0.1",
         "slickgrid": "github:Microsoft/SlickGrid.ADS#v2.3.51",
-        "slickgrid-react": "10.7.0",
+        "slickgrid-react": "10.8.2",
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",

--- a/extensions/mssql/src/webviews/common/FluentSlickGrid/FluentSlickGrid.tsx
+++ b/extensions/mssql/src/webviews/common/FluentSlickGrid/FluentSlickGrid.tsx
@@ -97,28 +97,6 @@ type SlickgridReactPublicProps = React.JSX.LibraryManagedAttributes<
     React.ComponentProps<typeof SlickgridReact>
 >;
 
-/**
- * Works around a bug in `slickgrid-react`'s `initialization()`: when a `customDataView`
- * prop is supplied, the library skips assigning its internal `this.dataView` (it only does
- * so inside the `if (!this.props.customDataView)` branch), yet later in the same method it
- * unconditionally dereferences `this.dataView` (e.g. `this.dataView.setGrid(...)`), throwing
- * "Cannot read properties of undefined". We can't use `SlickgridReact` directly for grids
- * that rely on a custom data view (such as the virtualized query-result grid).
- *
- * This subclass pre-seeds `this.dataView` with the provided `customDataView` before calling
- * `super.initialization()`, so every internal reference resolves correctly. Grids that don't
- * pass a `customDataView` are unaffected.
- */
-class FluentSlickgridReact extends SlickgridReact {
-    public override initialization(...args: Parameters<SlickgridReact["initialization"]>): void {
-        if (this.props.customDataView && !this.dataView) {
-            this.dataView = this.props.customDataView as typeof this.dataView;
-        }
-
-        super.initialization(...args);
-    }
-}
-
 export interface FluentSlickGridProps extends Omit<SlickgridReactPublicProps, "options"> {
     options: GridOption;
 }
@@ -144,5 +122,5 @@ export const FluentSlickGrid: React.FC<FluentSlickGridProps> = ({ options, ...pr
         [options],
     );
 
-    return <FluentSlickgridReact {...props} options={mergedOptions} />;
+    return <SlickgridReact {...props} options={mergedOptions} />;
 };


### PR DESCRIPTION
## Description

Updates `slickgrid-react` from `10.7.0` to `10.8.2` and refreshes the related `@slickgrid-universal/*` lockfile entries.

`slickgrid-react@10.8.2` now initializes `customDataView` upstream, so this removes the local `FluentSlickgridReact` subclass workaround and lets the shared `FluentSlickGrid` wrapper render `SlickgridReact` directly.

Validation performed:
- `npm run build:webviews`
- `npx eslint --quiet src/webviews/common/FluentSlickGrid/FluentSlickGrid.tsx`
- `git diff --check` for changed files
- `npm install --package-lock-only --ignore-scripts`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)