### PR TITLE
Add RefactorLog support: contracts, service methods, tree rendering and tests

### DIFF
--- a/extensions/mssql/src/models/contracts/sqlProjects/sqlProjectsContracts.ts
+++ b/extensions/mssql/src/models/contracts/sqlProjects/sqlProjectsContracts.ts
@@ -245,6 +245,28 @@ export namespace MoveNoneItemRequest {
 
 //#endregion
 
+//#region RefactorLog functions
+
+export namespace GetRefactorLogItemsRequest {
+    export const type = new RequestType<mssql.SqlProjectParams, mssql.GetScriptsResult, void>(
+        "sqlProjects/getRefactorLogItems",
+    );
+}
+
+export namespace AddRefactorLogItemRequest {
+    export const type = new RequestType<mssql.SqlProjectScriptParams, mssql.ResultStatus, void>(
+        "sqlProjects/addRefactorLogItem",
+    );
+}
+
+export namespace DeleteRefactorLogItemRequest {
+    export const type = new RequestType<mssql.SqlProjectScriptParams, mssql.ResultStatus, void>(
+        "sqlProjects/deleteRefactorLogItem",
+    );
+}
+
+//#endregion
+
 //#endregion
 
 //#region SQLCMD variable functions

--- a/extensions/mssql/src/services/sqlProjectsService.ts
+++ b/extensions/mssql/src/services/sqlProjectsService.ts
@@ -713,4 +713,42 @@ export class SqlProjectsService implements mssql.ISqlProjectsService {
         };
         return this._client.sendRequest(contracts.MoveNoneItemRequest.type, params);
     }
+
+    /**
+     * Get all RefactorLog items in a project
+     * @param projectUri Absolute path of the project, including .sqlproj
+     */
+    public async getRefactorLogItems(projectUri: string): Promise<mssql.GetScriptsResult> {
+        const params: mssql.SqlProjectParams = { projectUri: projectUri };
+        return this._client.sendRequest(contracts.GetRefactorLogItemsRequest.type, params);
+    }
+
+    /**
+     * Add a RefactorLog item to a project
+     * @param projectUri Absolute path of the project, including .sqlproj
+     * @param path Path of the .refactorlog file, relative to the .sqlproj
+     */
+    public async addRefactorLogItem(projectUri: string, path: string): Promise<mssql.ResultStatus> {
+        const params: mssql.SqlProjectScriptParams = {
+            projectUri: projectUri,
+            path: path,
+        };
+        return this._client.sendRequest(contracts.AddRefactorLogItemRequest.type, params);
+    }
+
+    /**
+     * Delete a RefactorLog item from a project
+     * @param projectUri Absolute path of the project, including .sqlproj
+     * @param path Path of the .refactorlog file, relative to the .sqlproj
+     */
+    public async deleteRefactorLogItem(
+        projectUri: string,
+        path: string,
+    ): Promise<mssql.ResultStatus> {
+        const params: mssql.SqlProjectScriptParams = {
+            projectUri: projectUri,
+            path: path,
+        };
+        return this._client.sendRequest(contracts.DeleteRefactorLogItemRequest.type, params);
+    }
 }

--- a/extensions/mssql/test/unit/sqlProjectsService.test.ts
+++ b/extensions/mssql/test/unit/sqlProjectsService.test.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as sinon from "sinon";
+import * as chai from "chai";
+import { expect } from "chai";
+import sinonChai from "sinon-chai";
+import SqlToolsServiceClient from "../../src/languageservice/serviceclient";
+import { SqlProjectsService } from "../../src/services/sqlProjectsService";
+import * as contracts from "../../src/models/contracts/sqlProjects/sqlProjectsContracts";
+import { GetScriptsResult, ResultStatus } from "vscode-mssql";
+
+chai.use(sinonChai);
+
+suite("SqlProjectsService - RefactorLog methods", () => {
+    const PROJECT_URI = "/path/to/TestProject.sqlproj";
+    const REFACTORLOG_PATH = "TestProject.refactorlog";
+
+    let sandbox: sinon.SinonSandbox;
+    let clientStub: sinon.SinonStubbedInstance<SqlToolsServiceClient>;
+    let service: SqlProjectsService;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        clientStub = sandbox.createStubInstance(SqlToolsServiceClient);
+        service = new SqlProjectsService(clientStub as unknown as SqlToolsServiceClient);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test("getRefactorLogItems sends GetRefactorLogItemsRequest with correct params", async () => {
+        const expectedResult: GetScriptsResult = {
+            success: true,
+            errorMessage: "",
+            scripts: [REFACTORLOG_PATH],
+        };
+        clientStub.sendRequest.resolves(expectedResult);
+
+        const result = await service.getRefactorLogItems(PROJECT_URI);
+
+        expect(clientStub.sendRequest).to.have.been.calledOnceWith(
+            contracts.GetRefactorLogItemsRequest.type,
+            { projectUri: PROJECT_URI },
+        );
+        expect(result).to.deep.equal(expectedResult);
+        expect(result.scripts).to.deep.equal([REFACTORLOG_PATH]);
+    });
+
+    test("addRefactorLogItem sends AddRefactorLogItemRequest with correct params", async () => {
+        const expectedResult: ResultStatus = { success: true, errorMessage: "" };
+        clientStub.sendRequest.resolves(expectedResult);
+
+        const result = await service.addRefactorLogItem(PROJECT_URI, REFACTORLOG_PATH);
+
+        expect(clientStub.sendRequest).to.have.been.calledOnceWith(
+            contracts.AddRefactorLogItemRequest.type,
+            { projectUri: PROJECT_URI, path: REFACTORLOG_PATH },
+        );
+        expect(result).to.deep.equal(expectedResult);
+        expect(result.success).to.be.true;
+    });
+
+    test("deleteRefactorLogItem sends DeleteRefactorLogItemRequest with correct params", async () => {
+        const expectedResult: ResultStatus = { success: true, errorMessage: "" };
+        clientStub.sendRequest.resolves(expectedResult);
+
+        const result = await service.deleteRefactorLogItem(PROJECT_URI, REFACTORLOG_PATH);
+
+        expect(clientStub.sendRequest).to.have.been.calledOnceWith(
+            contracts.DeleteRefactorLogItemRequest.type,
+            { projectUri: PROJECT_URI, path: REFACTORLOG_PATH },
+        );
+        expect(result).to.deep.equal(expectedResult);
+        expect(result.success).to.be.true;
+    });
+
+    test("getRefactorLogItems returns empty scripts array when project has no RefactorLog items", async () => {
+        const expectedResult: GetScriptsResult = {
+            success: true,
+            errorMessage: "",
+            scripts: [],
+        };
+        clientStub.sendRequest.resolves(expectedResult);
+
+        const result = await service.getRefactorLogItems(PROJECT_URI);
+
+        expect(result.success).to.be.true;
+        expect(result.scripts).to.deep.equal([]);
+    });
+
+    test("addRefactorLogItem propagates failure from service", async () => {
+        const expectedResult: ResultStatus = {
+            success: false,
+            errorMessage: "File not found: TestProject.refactorlog",
+        };
+        clientStub.sendRequest.resolves(expectedResult);
+
+        const result = await service.addRefactorLogItem(PROJECT_URI, REFACTORLOG_PATH);
+
+        expect(result.success).to.be.false;
+        expect(result.errorMessage).to.include("File not found");
+    });
+});

--- a/extensions/mssql/typings/vscode-mssql.d.ts
+++ b/extensions/mssql/typings/vscode-mssql.d.ts
@@ -1004,6 +1004,26 @@ declare module "vscode-mssql" {
             path: string,
             destinationPath: string,
         ): Promise<ResultStatus>;
+
+        /**
+         * Get all RefactorLog items in a project
+         * @param projectUri Absolute path of the project, including .sqlproj
+         */
+        getRefactorLogItems(projectUri: string): Promise<GetScriptsResult>;
+
+        /**
+         * Add a RefactorLog item to a project
+         * @param projectUri Absolute path of the project, including .sqlproj
+         * @param path Path of the .refactorlog file, relative to the .sqlproj
+         */
+        addRefactorLogItem(projectUri: string, path: string): Promise<ResultStatus>;
+
+        /**
+         * Delete a RefactorLog item from a project
+         * @param projectUri Absolute path of the project, including .sqlproj
+         * @param path Path of the .refactorlog file, relative to the .sqlproj
+         */
+        deleteRefactorLogItem(projectUri: string, path: string): Promise<ResultStatus>;
     }
 
     /**

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -780,6 +780,7 @@ export enum DatabaseProjectItemType {
     noneFile = "databaseProject.itemType.file.noneFile",
     sqlObjectScript = "databaseProject.itemType.file.sqlObjectScript",
     publishProfile = "databaseProject.itemType.file.publishProfile",
+    refactorLogFile = "databaseProject.itemType.file.refactorLogFile",
 }
 
 //#endregion

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -73,6 +73,7 @@ export class Project implements ISqlProject {
     private _preDeployScripts: FileProjectEntry[] = [];
     private _postDeployScripts: FileProjectEntry[] = [];
     private _noneDeployScripts: FileProjectEntry[] = [];
+    private _refactorLogItems: FileProjectEntry[] = [];
     private _sqlProjStyle: ProjectType;
     private _isCrossPlatformCompatible: boolean = false;
     private _outputPath: string = "";
@@ -136,6 +137,10 @@ export class Project implements ISqlProject {
 
     public get noneDeployScripts(): FileProjectEntry[] {
         return this._noneDeployScripts;
+    }
+
+    public get refactorLogItems(): FileProjectEntry[] {
+        return this._refactorLogItems;
     }
 
     public get sqlProjStyle(): ProjectType {
@@ -347,6 +352,7 @@ export class Project implements ISqlProject {
         await this.readPostDeployScripts(true);
 
         await this.readNoneItems(); // also populates list of publish profiles, determined by file extension
+        await this.readRefactorLogItems();
 
         await this.readSqlObjectScripts(); // get SQL object scripts
         await this.readFolders(); // get folders
@@ -556,6 +562,23 @@ export class Project implements ISqlProject {
         }
     }
 
+    private async readRefactorLogItems(): Promise<void> {
+        const result: GetScriptsResult = await (
+            this.sqlProjService as vscodeMssql.ISqlProjectsService
+        ).getRefactorLogItems(this.projectFilePath);
+        utils.throwIfFailed(result);
+
+        this._refactorLogItems = [];
+
+        if (result.scripts?.length > 0) {
+            for (var scriptPath of result.scripts) {
+                this._refactorLogItems.push(
+                    this.createFileProjectEntry(scriptPath, EntryType.File),
+                );
+            }
+        }
+    }
+
     private async readDatabaseReferences(): Promise<void> {
         this._databaseReferences = [];
         const databaseReferencesResult = await this.sqlProjService.getDatabaseReferences(
@@ -639,6 +662,7 @@ export class Project implements ISqlProject {
         this._preDeployScripts = [];
         this._postDeployScripts = [];
         this._noneDeployScripts = [];
+        this._refactorLogItems = [];
         this._outputPath = "";
         this._configuration = Configuration.Debug;
         this._publishProfiles = [];
@@ -740,6 +764,7 @@ export class Project implements ISqlProject {
         await this.readPreDeployScripts();
         await this.readPostDeployScripts();
         await this.readNoneItems();
+        await this.readRefactorLogItems();
         await this.readFolders();
     }
 
@@ -754,6 +779,7 @@ export class Project implements ISqlProject {
         await this.readPreDeployScripts();
         await this.readPostDeployScripts();
         await this.readNoneItems();
+        await this.readRefactorLogItems();
         await this.readFolders();
     }
 
@@ -772,6 +798,7 @@ export class Project implements ISqlProject {
         await this.readPreDeployScripts();
         await this.readPostDeployScripts();
         await this.readNoneItems();
+        await this.readRefactorLogItems();
         await this.readFolders();
     }
 
@@ -845,6 +872,7 @@ export class Project implements ISqlProject {
 
         await this.readPreDeployScripts();
         await this.readNoneItems();
+        await this.readRefactorLogItems();
         await this.readFolders();
     }
 
@@ -889,6 +917,7 @@ export class Project implements ISqlProject {
 
         await this.readPostDeployScripts();
         await this.readNoneItems();
+        await this.readRefactorLogItems();
         await this.readFolders();
     }
 
@@ -944,6 +973,30 @@ export class Project implements ISqlProject {
         await this.readNoneItems();
         await this.readFolders();
     }
+
+    //#region RefactorLog items
+
+    public async addRefactorLogItem(relativePath: string): Promise<void> {
+        const result = await (
+            this.sqlProjService as vscodeMssql.ISqlProjectsService
+        ).addRefactorLogItem(this.projectFilePath, relativePath);
+        utils.throwIfFailed(result);
+
+        await this.readRefactorLogItems();
+        await this.readFolders();
+    }
+
+    public async deleteRefactorLogItem(relativePath: string): Promise<void> {
+        const result = await (
+            this.sqlProjService as vscodeMssql.ISqlProjectsService
+        ).deleteRefactorLogItem(this.projectFilePath, relativePath);
+        utils.throwIfFailed(result);
+
+        await this.readRefactorLogItems();
+        await this.readFolders();
+    }
+
+    //#endregion
 
     //#endregion
 
@@ -1018,6 +1071,7 @@ export class Project implements ISqlProject {
                 normalizedRelativeFilePath,
             );
             await this.readNoneItems();
+            await this.readRefactorLogItems();
         }
 
         utils.throwIfFailed(result);

--- a/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
@@ -144,6 +144,19 @@ export class NoneNode extends FileNode {
     }
 }
 
+export class RefactorLogNode extends FileNode {
+    public override get treeItem(): vscode.TreeItem {
+        const treeItem = super.treeItem;
+        treeItem.contextValue = this.type;
+
+        return treeItem;
+    }
+
+    public get type(): DatabaseProjectItemType {
+        return DatabaseProjectItemType.refactorLogFile;
+    }
+}
+
 export class PublishProfileNode extends FileNode {
     public override get treeItem(): vscode.TreeItem {
         const treeItem = super.treeItem;

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -136,6 +136,16 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
             this.addNode(newNode, noneEntry);
         }
 
+        // refactor log items
+        for (const refactorLogEntry of this.project.refactorLogItems) {
+            const newNode = new fileTree.RefactorLogNode(
+                refactorLogEntry.fsUri,
+                this.projectFileUri,
+                refactorLogEntry.relativePath,
+            );
+            this.addNode(newNode, refactorLogEntry);
+        }
+
         // publish profiles
         for (const publishProfile of this.project.publishProfiles) {
             const newNode = new fileTree.PublishProfileNode(

--- a/extensions/sql-database-projects/test/baselines/baselines.ts
+++ b/extensions/sql-database-projects/test/baselines/baselines.ts
@@ -31,6 +31,7 @@ export let openSdkStyleSqlProjectWithFilesSpecifiedBaseline: string;
 export let openSdkStyleSqlProjectWithGlobsSpecifiedBaseline: string;
 export let sqlProjPropertyReadBaseline: string;
 export let databaseReferencesReadBaseline: string;
+export let openSqlProjectWithRefactorLogBaseline: string;
 
 const baselineFolderPath = path.join(__dirname, "..", "..", "..", "test", "baselines");
 
@@ -118,6 +119,10 @@ export async function loadBaselines() {
     databaseReferencesReadBaseline = await loadBaseline(
         baselineFolderPath,
         "databaseReferencesReadBaseline.xml",
+    );
+    openSqlProjectWithRefactorLogBaseline = await loadBaseline(
+        baselineFolderPath,
+        "openSqlProjectWithRefactorLogBaseline.xml",
     );
 }
 

--- a/extensions/sql-database-projects/test/baselines/openSqlProjectWithRefactorLogBaseline.xml
+++ b/extensions/sql-database-projects/test/baselines/openSqlProjectWithRefactorLogBaseline.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Name>TestProjectName</Name>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectVersion>4.1</ProjectVersion>
+    <ProjectGuid>{BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575}</ProjectGuid>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
+    <OutputType>Database</OutputType>
+    <RootPath>
+    </RootPath>
+    <RootNamespace>TestProjectName</RootNamespace>
+    <AssemblyName>TestProjectName</AssemblyName>
+    <ModelCollation>1033, CI</ModelCollation>
+    <DefaultFileStructure>BySchemaAndSchemaType</DefaultFileStructure>
+    <DeployToDatabase>True</DeployToDatabase>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetLanguage>CS</TargetLanguage>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <SqlServerVerification>False</SqlServerVerification>
+    <IncludeCompositeObjects>True</IncludeCompositeObjects>
+    <TargetDatabaseSet>True</TargetDatabaseSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>bin\Release\</OutputPath>
+    <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>bin\Debug\</OutputPath>
+    <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
+    <!-- Default to the v11.0 targets path if the targets file for the current VS version is not found -->
+    <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
+    <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <ItemGroup>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <Build Include="Tables\Users.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <RefactorLog Include="TestProjectName.refactorlog" />
+    <RefactorLog Include="Refactoring\OldRenames.refactorlog" />
+  </ItemGroup>
+  <Target Name="BeforeBuild">
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
+  </Target>
+</Project>

--- a/extensions/sql-database-projects/test/project.test.ts
+++ b/extensions/sql-database-projects/test/project.test.ts
@@ -1670,6 +1670,62 @@ suite("Project: publish profiles", function (): void {
     });
 });
 
+suite("Project: RefactorLog items", function (): void {
+    suiteSetup(async function (): Promise<void> {
+        await baselines.loadBaselines();
+    });
+
+    suiteTeardown(async function (): Promise<void> {
+        await testUtils.deleteGeneratedTestFolder();
+    });
+
+    test("Should read RefactorLog items from sqlproj", async function (): Promise<void> {
+        const projFilePath = await testUtils.createTestSqlProjFile(
+            this.test,
+            baselines.openSqlProjectWithRefactorLogBaseline,
+        );
+        const project = await Project.openProject(projFilePath);
+
+        expect(project.refactorLogItems.length, "refactorLogItems should be loaded").to.equal(2);
+        expect(
+            project.refactorLogItems.find((f) => f.relativePath === "TestProjectName.refactorlog"),
+            "TestProjectName.refactorlog not read",
+        ).to.not.equal(undefined);
+        expect(
+            project.refactorLogItems.find(
+                (f) => f.relativePath === "Refactoring\\OldRenames.refactorlog",
+            ),
+            "Refactoring\\OldRenames.refactorlog not read",
+        ).to.not.equal(undefined);
+    });
+
+    test("Should add and delete RefactorLog item", async function (): Promise<void> {
+        const projFilePath = await testUtils.createTestSqlProjFile(
+            this.test,
+            baselines.openProjectFileBaseline,
+        );
+        const project = await Project.openProject(projFilePath);
+        expect(project.refactorLogItems.length, "Baseline number of RefactorLog items").to.equal(0);
+
+        // Create the file on disk so STS can add it
+        const refactorLogName = "TestProject.refactorlog";
+        const refactorLogPath = path.join(project.projectFolderPath, refactorLogName);
+        await fs.writeFile(refactorLogPath, "<Operations></Operations>");
+
+        await project.addRefactorLogItem(refactorLogName);
+        expect(project.refactorLogItems.length, "RefactorLog item count after add").to.equal(1);
+        expect(
+            project.refactorLogItems.find((f) => f.relativePath === refactorLogName),
+            `${refactorLogName} should be in refactorLogItems`,
+        ).to.not.equal(undefined);
+
+        await project.deleteRefactorLogItem(refactorLogName);
+        expect(project.refactorLogItems.length, "RefactorLog item count after delete").to.equal(0);
+        expect(await exists(refactorLogPath), "RefactorLog file should have been deleted from disk")
+            .to.be.false;
+    });
+});
+
 suite("Project: properties", function (): void {
     let sandbox: sinon.SinonSandbox;
 

--- a/extensions/sql-database-projects/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/test/projectTree.test.ts
@@ -14,6 +14,7 @@ import {
     FileNode,
     sortFileFolderNodes,
     SqlObjectFileNode,
+    RefactorLogNode,
 } from "../src/models/tree/fileFolderTreeItem";
 import { ProjectRootTreeItem } from "../src/models/tree/projectTreeItem";
 import { DatabaseProjectItemType } from "../src/common/constants";
@@ -189,5 +190,52 @@ suite("Project Tree tests", function (): void {
             "/TestProj/MyFile1.sql",
             "/TestProj/MyFile2.sql",
         ]);
+    });
+
+    test("Should render RefactorLog items as RefactorLogNodes with correct context value", function (): void {
+        const root = os.platform() === "win32" ? "Z:\\" : "/";
+        const proj = new Project(vscode.Uri.file(`${root}TestProj.sqlproj`).fsPath);
+
+        proj.refactorLogItems.push(
+            proj.createFileProjectEntry("TestProj.refactorlog", EntryType.File),
+        );
+        proj.refactorLogItems.push(
+            proj.createFileProjectEntry(
+                path.join("Refactoring", "OldRenames.refactorlog"),
+                EntryType.File,
+            ),
+        );
+        proj.folders.push(proj.createFileProjectEntry("Refactoring", EntryType.Folder));
+
+        const tree = new ProjectRootTreeItem(proj);
+
+        expect(tree.children.map((x) => x.relativeProjectUri.path)).to.deep.equal([
+            "/TestProj/Database References",
+            "/TestProj/SQLCMD Variables",
+            "/TestProj/Refactoring",
+            "/TestProj/TestProj.refactorlog",
+        ]);
+
+        const refactorLogNode = tree.children.find(
+            (x) => x.relativeProjectUri.path === "/TestProj/TestProj.refactorlog",
+        );
+        expect(refactorLogNode, "Root RefactorLog node should exist").to.not.be.undefined;
+        expect(refactorLogNode).to.be.instanceOf(RefactorLogNode);
+        expect(refactorLogNode?.treeItem.contextValue).to.equal(
+            DatabaseProjectItemType.refactorLogFile,
+        );
+
+        const refactoringFolder = tree.children.find(
+            (x) => x.relativeProjectUri.path === "/TestProj/Refactoring",
+        ) as FolderNode;
+        expect(refactoringFolder, "Refactoring folder node should exist").to.not.be.undefined;
+        const nestedRefactorLogNode = refactoringFolder.children.find(
+            (x) => x.relativeProjectUri.path === "/TestProj/Refactoring/OldRenames.refactorlog",
+        );
+        expect(nestedRefactorLogNode, "Nested RefactorLog node should exist").to.not.be.undefined;
+        expect(nestedRefactorLogNode).to.be.instanceOf(RefactorLogNode);
+        expect(nestedRefactorLogNode?.treeItem.contextValue).to.equal(
+            DatabaseProjectItemType.refactorLogFile,
+        );
     });
 });


### PR DESCRIPTION
## Summary

Adds end-to-end support for displaying `<RefactorLog>` entries from SQL project files in the database project tree view.

## Changes

### `extensions/mssql` — service layer
- **`sqlProjectsContracts.ts`** — Added `GetRefactorLogItemsRequest`, `AddRefactorLogItemRequest`, `DeleteRefactorLogItemRequest` request types
- **`sqlProjectsService.ts`** — Added `getRefactorLogItems`, `addRefactorLogItem`, `deleteRefactorLogItem` methods
- **`vscode-mssql.d.ts`** — Added 3 new methods to `ISqlProjectsService` interface

### `extensions/sql-database-projects` — tree UI
- **`constants.ts`** — Added `DatabaseProjectItemType.refactorLogFile` constant
- **`fileFolderTreeItem.ts`** — Added `RefactorLogNode` class (mirrors `NoneNode`)
- **`project.ts`** — Added `_refactorLogItems` field, `refactorLogItems` getter, `readRefactorLogItems()`, `addRefactorLogItem()`, `deleteRefactorLogItem()`; wired `readRefactorLogItems()` alongside all `readNoneItems()` callsites
- **`projectTreeItem.ts`** — Renders `RefactorLogNode` entries in tree `construct()` loop

### Tests
- **`sqlProjectsService.test.ts`** (new) — 5 unit tests for new service methods
- **`project.test.ts`** — Added "Project: RefactorLog items" suite with read/add/delete tests
- **`projectTree.test.ts`** — Added test verifying `RefactorLogNode` rendering with correct context value
- **`openSqlProjectWithRefactorLogBaseline.xml`** (new) — Test fixture with 2 `<RefactorLog>` entries
