### PR TITLE
Fix query selection drift after connecting disconnected editor

### DIFF
--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -2817,11 +2817,6 @@ export default class MainController implements vscode.Disposable {
                 return;
             }
 
-            // check if we're connected and editing a SQL file
-            if (!(await this.ensureReadyToExecuteQuery())) {
-                return;
-            }
-
             let editor = self._vscodeWrapper.activeTextEditor;
             let uri = self._vscodeWrapper.activeTextEditorUri;
             let title = path.basename(editor.document.fileName);
@@ -2840,19 +2835,37 @@ export default class MainController implements vscode.Disposable {
                 return;
             }
 
+            let querySelection: ISelectionData;
+            let shouldRunSelection = false;
             if (!editor.selection.isEmpty) {
                 if (editor.document.getText(editor.selection).trim().length === 0) {
                     return;
                 }
 
                 let selection = editor.selection;
-                let querySelection: ISelectionData = {
+                querySelection = {
                     startLine: selection.start.line,
                     startColumn: selection.start.character,
                     endLine: selection.end.line,
                     endColumn: selection.end.character,
                 };
+                shouldRunSelection = true;
+            } else {
+                // only the start line and column are used to determine the current statement
+                querySelection = {
+                    startLine: editor.selection.start.line,
+                    startColumn: editor.selection.start.character,
+                    endLine: 0,
+                    endColumn: 0,
+                };
+            }
 
+            // check if we're connected and editing a SQL file
+            if (!(await this.ensureReadyToExecuteQuery())) {
+                return;
+            }
+
+            if (shouldRunSelection) {
                 await self._outputContentProvider.runQuery(
                     self._statusview,
                     uri,
@@ -2861,14 +2874,6 @@ export default class MainController implements vscode.Disposable {
                 );
                 return;
             }
-
-            // only the start line and column are used to determine the current statement
-            let querySelection: ISelectionData = {
-                startLine: editor.selection.start.line,
-                startColumn: editor.selection.start.character,
-                endLine: 0,
-                endColumn: 0,
-            };
 
             await self._outputContentProvider.runCurrentStatement(
                 self._statusview,
@@ -2889,11 +2894,6 @@ export default class MainController implements vscode.Disposable {
     public async onRunQuery(executionPlanOptions?: ExecutionPlanOptions): Promise<void> {
         try {
             if (!this.canRunCommand() || !this.validateTextDocumentHasFocus()) {
-                return;
-            }
-
-            // check if we're connected and editing a SQL file
-            if (!(await this.ensureReadyToExecuteQuery())) {
                 return;
             }
 
@@ -2928,6 +2928,11 @@ export default class MainController implements vscode.Disposable {
                     endLine: selection.end.line,
                     endColumn: selection.end.character,
                 };
+            }
+
+            // check if we're connected and editing a SQL file
+            if (!(await this.ensureReadyToExecuteQuery())) {
+                return;
             }
 
             // check if current connection is still valid / active - if not, refresh azure account token

--- a/extensions/mssql/test/unit/mainController.test.ts
+++ b/extensions/mssql/test/unit/mainController.test.ts
@@ -161,11 +161,14 @@ suite("MainController Tests", function () {
         let controllerAccess: MainControllerTestAccess;
         let runCurrentStatementStub: sinon.SinonStub;
         let runQueryStub: sinon.SinonStub;
+        let ensureReadyToExecuteQueryStub: sinon.SinonStub;
         let statusView: unknown;
 
         setup(() => {
             controllerAccess = accessMainController(mainController);
-            sandbox.stub(mainController, "ensureReadyToExecuteQuery").resolves(true);
+            ensureReadyToExecuteQueryStub = sandbox
+                .stub(mainController, "ensureReadyToExecuteQuery")
+                .resolves(true);
             sandbox.stub(vscodeWrapper, "activeTextEditorUri").get(() => "file:///test/query.sql");
 
             runCurrentStatementStub = sandbox.stub().resolves();
@@ -224,6 +227,66 @@ suite("MainController Tests", function () {
             expect(runCurrentStatementStub).to.not.have.been.called;
         });
 
+        test("runs the originally selected text when selection changes while connecting", async () => {
+            const originalSelection = new vscode.Selection(0, 0, 0, 11);
+            const changedSelection = new vscode.Selection(1, 0, 1, 11);
+            let activeEditor = createQueryTextEditor(
+                originalSelection,
+                "select 'a';\nselect 'b';",
+                "select 'a';",
+            );
+            sandbox.stub(vscodeWrapper, "activeTextEditor").get(() => activeEditor);
+            ensureReadyToExecuteQueryStub.callsFake(async () => {
+                activeEditor = createQueryTextEditor(
+                    changedSelection,
+                    "select 'a';\nselect 'b';",
+                    "select 'b';",
+                );
+                return true;
+            });
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runQueryStub).to.have.been.calledOnceWithExactly(
+                statusView,
+                "file:///test/query.sql",
+                {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 11,
+                },
+                "query.sql",
+            );
+            expect(runCurrentStatementStub).to.not.have.been.called;
+        });
+
+        test("runs the original current statement when cursor changes while connecting", async () => {
+            const originalSelection = new vscode.Selection(0, 7, 0, 7);
+            const changedSelection = new vscode.Selection(1, 7, 1, 7);
+            let activeEditor = createQueryTextEditor(originalSelection, "select 'a';\nselect 'b';");
+            sandbox.stub(vscodeWrapper, "activeTextEditor").get(() => activeEditor);
+            ensureReadyToExecuteQueryStub.callsFake(async () => {
+                activeEditor = createQueryTextEditor(changedSelection, "select 'a';\nselect 'b';");
+                return true;
+            });
+
+            await mainController.onRunCurrentStatement();
+
+            expect(runCurrentStatementStub).to.have.been.calledOnceWithExactly(
+                statusView,
+                "file:///test/query.sql",
+                {
+                    startLine: 0,
+                    startColumn: 7,
+                    endLine: 0,
+                    endColumn: 0,
+                },
+                "query.sql",
+            );
+            expect(runQueryStub).to.not.have.been.called;
+        });
+
         test("does not execute when the selection contains only whitespace", async () => {
             const selection = new vscode.Selection(0, 0, 0, 4);
             sandbox
@@ -267,6 +330,67 @@ suite("MainController Tests", function () {
 
             expect(runQueryStub).to.not.have.been.called;
             expect(runCurrentStatementStub).to.not.have.been.called;
+        });
+    });
+
+    suite("onRunQuery Tests", () => {
+        let controllerAccess: MainControllerTestAccess;
+        let runQueryStub: sinon.SinonStub;
+        let ensureReadyToExecuteQueryStub: sinon.SinonStub;
+        let statusView: unknown;
+
+        setup(() => {
+            controllerAccess = accessMainController(mainController);
+            ensureReadyToExecuteQueryStub = sandbox
+                .stub(mainController, "ensureReadyToExecuteQuery")
+                .resolves(true);
+            sandbox.stub(vscodeWrapper, "activeTextEditorUri").get(() => "file:///test/query.sql");
+
+            runQueryStub = sandbox.stub().resolves();
+            controllerAccess._outputContentProvider = {
+                runCurrentStatement: sandbox.stub().resolves(),
+                runQuery: runQueryStub,
+            };
+            statusView = {};
+            controllerAccess._statusview = statusView;
+            connectionManager.refreshAzureAccountToken.resolves();
+        });
+
+        test("runs the originally selected query when selection changes while connecting", async () => {
+            const originalSelection = new vscode.Selection(0, 0, 0, 11);
+            const changedSelection = new vscode.Selection(1, 0, 1, 11);
+            let activeEditor = createQueryTextEditor(
+                originalSelection,
+                "select 'a';\nselect 'b';",
+                "select 'a';",
+            );
+            sandbox.stub(vscodeWrapper, "activeTextEditor").get(() => activeEditor);
+            ensureReadyToExecuteQueryStub.callsFake(async () => {
+                activeEditor = createQueryTextEditor(
+                    changedSelection,
+                    "select 'a';\nselect 'b';",
+                    "select 'b';",
+                );
+                return true;
+            });
+
+            await mainController.onRunQuery();
+
+            expect(connectionManager.refreshAzureAccountToken).to.have.been.calledOnceWithExactly(
+                "file:///test/query.sql",
+            );
+            expect(runQueryStub).to.have.been.calledOnceWithExactly(
+                statusView,
+                "file:///test/query.sql",
+                {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 11,
+                },
+                "query.sql",
+                undefined,
+            );
         });
     });
 
@@ -400,6 +524,34 @@ suite("MainController Tests", function () {
     });
 
     suite("ensureReadyToExecuteQuery Tests", () => {
+        test("returns true when the active SQL editor is already connected", async () => {
+            const testUri = "file:///test/connected.sql";
+            sandbox.stub(vscodeWrapper, "activeTextEditorUri").get(() => testUri);
+            sandbox.stub(vscodeWrapper, "isEditingSqlFile").get(() => true);
+            connectionManager.isConnected.withArgs(testUri).returns(true);
+
+            const result = await mainController.ensureReadyToExecuteQuery();
+
+            expect(result).to.equal(true);
+            expect(connectionManager.isConnecting).to.not.have.been.called;
+        });
+
+        test("returns true after prompting and connecting", async () => {
+            const testUri = "file:///test/notConnected.sql";
+            sandbox.stub(vscodeWrapper, "activeTextEditorUri").get(() => testUri);
+            sandbox.stub(vscodeWrapper, "isEditingSqlFile").get(() => true);
+            connectionManager.isConnected.withArgs(testUri).returns(false);
+            connectionManager.isConnecting.withArgs(testUri).returns(false);
+            const promptToConnectStub = sandbox
+                .stub(mainController, "promptToConnect")
+                .resolves(true);
+
+            const result = await mainController.ensureReadyToExecuteQuery();
+
+            expect(result).to.equal(true);
+            expect(promptToConnectStub).to.have.been.calledOnce;
+        });
+
         test("returns false and shows info message when connection is in progress", async () => {
             const testUri = "file:///test/connecting.sql";
             const controllerAccess = accessMainController(mainController);

--- a/extensions/mssql/test/unit/perFileConnection.test.ts
+++ b/extensions/mssql/test/unit/perFileConnection.test.ts
@@ -17,6 +17,7 @@ import * as LocalizedConstants from "../../src/constants/locConstants";
 import ConnectionManager from "../../src/controllers/connectionManager";
 import MainController from "../../src/controllers/mainController";
 import VscodeWrapper from "../../src/controllers/vscodeWrapper";
+import { languageId } from "../../src/constants/constants";
 import { ConnectionStore } from "../../src/models/connectionStore";
 import * as ConnectionContracts from "../../src/models/contracts/connection";
 import * as LanguageServiceContracts from "../../src/models/contracts/languageService";
@@ -33,6 +34,20 @@ chai.use(sinonChai);
 
 let sandbox: sinon.SinonSandbox;
 let extensionContext: vscode.ExtensionContext;
+
+function createQueryTextEditor(uri: string, text: string): vscode.TextEditor {
+    const selection = new vscode.Selection(0, 0, 0, 0);
+    return {
+        document: {
+            uri: vscode.Uri.parse(uri),
+            fileName: uri,
+            languageId,
+            getText: () => text,
+        },
+        selection,
+        selections: [selection],
+    } as unknown as vscode.TextEditor;
+}
 
 suite("Per File Connection Tests", () => {
     let manager: ConnectionManager;
@@ -284,9 +299,13 @@ suite("Per File Connection Tests", () => {
     });
 
     test("Prompts for new connection before running query if disconnected", async () => {
+        const testFile = "file://my/test/file.sql";
         const vscodeWrapperStub = stubVscodeWrapper(sandbox);
         sandbox.stub(vscodeWrapperStub, "isEditingSqlFile").get(() => true);
-        sandbox.stub(vscodeWrapperStub, "activeTextEditorUri").get(() => "file://my/test/file.sql");
+        sandbox.stub(vscodeWrapperStub, "activeTextEditorUri").get(() => testFile);
+        sandbox
+            .stub(vscodeWrapperStub, "activeTextEditor")
+            .get(() => createQueryTextEditor(testFile, "SELECT 1"));
 
         const connectionManagerStub = sandbox.createStubInstance(ConnectionManager);
         connectionManagerStub.isConnected.returns(false);


### PR DESCRIPTION
## Description

Fixes #22372

When Run Query or Run Current Statement is invoked from a disconnected SQL editor, the extension prompts the user to connect and then continues execution after the connection succeeds. Previously, execution read the active editor and selection after the async connection flow completed, so focus or selection changes during connection could cause the wrong query text to run.

This change captures the editor URI, title, and selection/cursor state before awaiting connection setup, then uses that captured state for execution after the connection succeeds.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Validation performed:

- `npm run build:extension`
- `npx vscode-test --label "Unit Tests" --grep "(onRunQuery|onRunCurrentStatement|ensureReadyToExecuteQuery)" --coverage=false`