### PR TITLE
Send object params for parse connection string request

### DIFF
--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -465,10 +465,9 @@ export default class ConnectionManager {
      * Parses the connection string into a ConnectionDetails object
      */
     public async parseConnectionString(connectionString: string): Promise<ConnectionDetails> {
-        return await this.client.sendRequest(
-            ConnectionContracts.ParseConnectionStringRequest.type,
+        return this.client.sendRequest(ConnectionContracts.ParseConnectionStringRequest.type, {
             connectionString,
-        );
+        });
     }
 
     /**

--- a/extensions/mssql/src/models/contracts/connection.ts
+++ b/extensions/mssql/src/models/contracts/connection.ts
@@ -240,11 +240,15 @@ export class GetConnectionStringParams {
 // ------------------------------- </ Get Connection String Request > --------------------------------------
 
 // ------------------------------- < Parse Connection String Request > ---------------------------------------
+export interface ParseConnectionStringParams {
+    connectionString: string;
+}
+
 /**
  * Parse Connection String request callback declaration
  */
 export namespace ParseConnectionStringRequest {
-    export const type = new RequestType<string, ConnectionDetails, void>(
+    export const type = new RequestType<ParseConnectionStringParams, ConnectionDetails, void>(
         "connection/parseConnectionString",
     );
 }

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -284,6 +284,30 @@ suite("ConnectionManager Tests", () => {
 
             expect(mockVscodeWrapper.showErrorMessage).to.have.been.calledOnce;
         });
+
+        test("parseConnectionString sends object params to the service", async () => {
+            const testConnectionString =
+                "Server=localhost,14335;User Id=sa;Password=Aasimkhan30@a;TrustServerCertificate=True;\n";
+            const expectedResult = {
+                options: {
+                    server: "localhost,14335",
+                    user: "sa",
+                    password: "Aasimkhan30@a",
+                    authenticationType: "SqlLogin",
+                    trustServerCertificate: true,
+                },
+            } as ConnectionDetails;
+
+            mockServiceClient.sendRequest
+                .withArgs(ParseConnectionStringRequest.type, {
+                    connectionString: testConnectionString,
+                })
+                .resolves(expectedResult);
+
+            const result = await connectionManager.parseConnectionString(testConnectionString);
+
+            expect(result).to.equal(expectedResult);
+        });
     });
 
     suite("Token request handling", () => {


### PR DESCRIPTION
## Description

Updates the extension side of `connection/parseConnectionString` to send object-shaped request params instead of a primitive string.

This avoids the JSON-RPC primitive-param serialization issue introduced by the newer language client/jsonrpc stack, where the SQL Tools Service endpoint can receive a positional array instead of the raw string it previously expected.

Changes:

- Adds `ParseConnectionStringParams` with `connectionString`.
- Updates `ConnectionManager.parseConnectionString` to send `{ connectionString }`.
- Adds unit coverage verifying the object payload is sent to the service.

Addresses #22374.

Paired SQL Tools Service PR: microsoft/sqltoolsservice#2739

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation performed:

- `npm run build:extension:typecheck`
- `npm run build:extension:emit`
- Focused VS Code unit test command was attempted, but the VS Code test runner timed out during shutdown as seen locally before.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)