### PR TITLE
Send object params for parse connection string request

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260623.1",
+        version: "6.0.20260625.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -465,10 +465,9 @@ export default class ConnectionManager {
      * Parses the connection string into a ConnectionDetails object
      */
     public async parseConnectionString(connectionString: string): Promise<ConnectionDetails> {
-        return await this.client.sendRequest(
-            ConnectionContracts.ParseConnectionStringRequest.type,
+        return this.client.sendRequest(ConnectionContracts.ParseConnectionStringRequest.type, {
             connectionString,
-        );
+        });
     }
 
     /**

--- a/extensions/mssql/src/models/contracts/connection.ts
+++ b/extensions/mssql/src/models/contracts/connection.ts
@@ -240,11 +240,15 @@ export class GetConnectionStringParams {
 // ------------------------------- </ Get Connection String Request > --------------------------------------
 
 // ------------------------------- < Parse Connection String Request > ---------------------------------------
+export interface ParseConnectionStringParams {
+    connectionString: string;
+}
+
 /**
  * Parse Connection String request callback declaration
  */
 export namespace ParseConnectionStringRequest {
-    export const type = new RequestType<string, ConnectionDetails, void>(
+    export const type = new RequestType<ParseConnectionStringParams, ConnectionDetails, void>(
         "connection/parseConnectionString",
     );
 }

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -284,6 +284,30 @@ suite("ConnectionManager Tests", () => {
 
             expect(mockVscodeWrapper.showErrorMessage).to.have.been.calledOnce;
         });
+
+        test("parseConnectionString sends object params to the service", async () => {
+            const testConnectionString =
+                "Server=localhost,14335;User Id=sa;Password=Aasimkhan30@a;TrustServerCertificate=True;\n";
+            const expectedResult = {
+                options: {
+                    server: "localhost,14335",
+                    user: "sa",
+                    password: "Aasimkhan30@a",
+                    authenticationType: "SqlLogin",
+                    trustServerCertificate: true,
+                },
+            } as ConnectionDetails;
+
+            mockServiceClient.sendRequest
+                .withArgs(ParseConnectionStringRequest.type, {
+                    connectionString: testConnectionString,
+                })
+                .resolves(expectedResult);
+
+            const result = await connectionManager.parseConnectionString(testConnectionString);
+
+            expect(result).to.equal(expectedResult);
+        });
     });
 
     suite("Token request handling", () => {

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -284,30 +284,6 @@ suite("ConnectionManager Tests", () => {
 
             expect(mockVscodeWrapper.showErrorMessage).to.have.been.calledOnce;
         });
-
-        test("parseConnectionString sends object params to the service", async () => {
-            const testConnectionString =
-                "Server=localhost,14335;User Id=sa;Password=Aasimkhan30@a;TrustServerCertificate=True;\n";
-            const expectedResult = {
-                options: {
-                    server: "localhost,14335",
-                    user: "sa",
-                    password: "Aasimkhan30@a",
-                    authenticationType: "SqlLogin",
-                    trustServerCertificate: true,
-                },
-            } as ConnectionDetails;
-
-            mockServiceClient.sendRequest
-                .withArgs(ParseConnectionStringRequest.type, {
-                    connectionString: testConnectionString,
-                })
-                .resolves(expectedResult);
-
-            const result = await connectionManager.parseConnectionString(testConnectionString);
-
-            expect(result).to.equal(expectedResult);
-        });
     });
 
     suite("Token request handling", () => {


### PR DESCRIPTION
## Summary
- remove redundant parse connection string unit test that contained a real password literal
- republish the branch cleanly after remote branch reset

Fixes: https://github.com/microsoft/vscode-mssql/issues/22374

## Validation
- verified leaked literal no longer exists in tracked files with `git grep`
