### PR TITLE
Guard schema designer initialization

### DIFF
--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -95,6 +95,9 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
     private _messageListener:
         | ((message: SchemaDesigner.SchemaDesignerMessageNotificationParams) => void)
         | undefined;
+    private _initializeSchemaDesignerPromise:
+        | Promise<SchemaDesigner.CreateSessionResponse>
+        | undefined;
     public schemaDesignerDetails: SchemaDesigner.CreateSessionResponse | undefined = undefined;
     public baselineSchema: SchemaDesigner.Schema | undefined = undefined;
 
@@ -174,51 +177,14 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
 
     private setupRequestHandlers() {
         this.onRequest(SchemaDesigner.InitializeSchemaDesignerRequest.type, async () => {
-            const schemaDesignerInitActivity = startActivity(
-                TelemetryViews.SchemaDesigner,
-                TelemetryActions.Initialize,
-                undefined, // correlationId
-                undefined, // startActivityAdditionalProps
-                undefined, // startActivityAdditionalMeasurements
-                undefined, // connectionInfo
-                undefined, // serverInfo
-                true, // include callstack in telemetry
-            );
+            if (!this._initializeSchemaDesignerPromise) {
+                this._initializeSchemaDesignerPromise = this.initializeSchemaDesignerSession();
+            }
+
             try {
-                let sessionResponse: SchemaDesigner.CreateSessionResponse;
-                const cacheItem = this.schemaDesignerCache.get(this._key);
-                const hasCachedSession = !!cacheItem?.schemaDesignerDetails?.sessionId;
-
-                if (!hasCachedSession) {
-                    this._sessionId = uuid();
-                    sessionResponse = await this.schemaDesignerService.createSession({
-                        sessionId: this._sessionId,
-                        connectionString: this.connectionString,
-                        accessToken: this.accessToken,
-                        databaseName: this.databaseName,
-                    });
-                    this.baselineSchema = sessionResponse.schema;
-                    this.schemaDesignerCache.set(this._key, {
-                        schemaDesignerDetails: sessionResponse,
-                        baselineSchema: sessionResponse.schema,
-                        dabConfig: cacheItem?.dabConfig,
-                        isDirty: cacheItem?.isDirty ?? false,
-                    });
-                } else {
-                    sessionResponse = cacheItem.schemaDesignerDetails;
-                    this.baselineSchema = cacheItem.baselineSchema;
-                    this._sessionId = sessionResponse.sessionId;
-                }
-
-                this.schemaDesignerDetails = sessionResponse;
-                this._sessionId = sessionResponse.sessionId;
-                schemaDesignerInitActivity.end(ActivityStatus.Succeeded, undefined, {
-                    tableCount: sessionResponse?.schema?.tables?.length,
-                });
-                return sessionResponse;
-            } catch (error) {
-                schemaDesignerInitActivity.endFailed(toError(error), false);
-                throw error;
+                return await this._initializeSchemaDesignerPromise;
+            } finally {
+                this._initializeSchemaDesignerPromise = undefined;
             }
         });
 
@@ -660,6 +626,55 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
 
             return addMcpServerToWorkspace(payload.serverName, payload.serverUrl);
         });
+    }
+
+    private async initializeSchemaDesignerSession(): Promise<SchemaDesigner.CreateSessionResponse> {
+        const schemaDesignerInitActivity = startActivity(
+            TelemetryViews.SchemaDesigner,
+            TelemetryActions.Initialize,
+            undefined, // correlationId
+            undefined, // startActivityAdditionalProps
+            undefined, // startActivityAdditionalMeasurements
+            undefined, // connectionInfo
+            undefined, // serverInfo
+            true, // include callstack in telemetry
+        );
+        try {
+            let sessionResponse: SchemaDesigner.CreateSessionResponse;
+            const cacheItem = this.schemaDesignerCache.get(this._key);
+            const hasCachedSession = !!cacheItem?.schemaDesignerDetails?.sessionId;
+
+            if (!hasCachedSession) {
+                this._sessionId = uuid();
+                sessionResponse = await this.schemaDesignerService.createSession({
+                    sessionId: this._sessionId,
+                    connectionString: this.connectionString,
+                    accessToken: this.accessToken,
+                    databaseName: this.databaseName,
+                });
+                this.baselineSchema = sessionResponse.schema;
+                this.schemaDesignerCache.set(this._key, {
+                    schemaDesignerDetails: sessionResponse,
+                    baselineSchema: sessionResponse.schema,
+                    dabConfig: cacheItem?.dabConfig,
+                    isDirty: cacheItem?.isDirty ?? false,
+                });
+            } else {
+                sessionResponse = cacheItem.schemaDesignerDetails;
+                this.baselineSchema = cacheItem.baselineSchema;
+                this._sessionId = sessionResponse.sessionId;
+            }
+
+            this.schemaDesignerDetails = sessionResponse;
+            this._sessionId = sessionResponse.sessionId;
+            schemaDesignerInitActivity.end(ActivityStatus.Succeeded, undefined, {
+                tableCount: sessionResponse?.schema?.tables?.length,
+            });
+            return sessionResponse;
+        } catch (error) {
+            schemaDesignerInitActivity.endFailed(toError(error), false);
+            throw error;
+        }
     }
 
     private setupReducers() {

--- a/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
@@ -310,6 +310,37 @@ suite("SchemaDesignerWebviewController tests", () => {
             expect(schemaDesignerCache.size).to.equal(1);
         });
 
+        test("should coalesce concurrent initialization requests", async () => {
+            let resolveCreateSession!: (value: SchemaDesigner.CreateSessionResponse) => void;
+            const createSessionPromise = new Promise<SchemaDesigner.CreateSessionResponse>(
+                (resolve) => {
+                    resolveCreateSession = resolve;
+                },
+            );
+            mockSchemaDesignerService.createSession.returns(createSessionPromise as any);
+
+            createController();
+
+            const handler = requestHandlers.get(
+                SchemaDesigner.InitializeSchemaDesignerRequest.type.method,
+            );
+
+            const firstResultPromise = handler!({});
+            const secondResultPromise = handler!({});
+
+            expect(mockSchemaDesignerService.createSession).to.have.been.calledOnce;
+
+            resolveCreateSession(mockCreateSessionResponse);
+            const [firstResult, secondResult] = await Promise.all([
+                firstResultPromise,
+                secondResultPromise,
+            ]);
+
+            expect(firstResult).to.deep.equal(mockCreateSessionResponse);
+            expect(secondResult).to.deep.equal(mockCreateSessionResponse);
+            expect(schemaDesignerCache.size).to.equal(1);
+        });
+
         test("should reuse cached session when available", async () => {
             const cacheKey = `${connectionString}-${databaseName}`;
             schemaDesignerCache.set(cacheKey, {
@@ -329,6 +360,32 @@ suite("SchemaDesignerWebviewController tests", () => {
             expect(mockSchemaDesignerService.createSession).to.not.have.been.called;
             expect(result).to.deep.equal(mockCreateSessionResponse);
             expect(schemaDesignerCache.get(cacheKey)?.isDirty).to.be.true;
+        });
+
+        test("should allow retry after initialization error", async () => {
+            const error = new Error("Initialization failed");
+            mockSchemaDesignerService.createSession.onFirstCall().rejects(error);
+            mockSchemaDesignerService.createSession
+                .onSecondCall()
+                .resolves(mockCreateSessionResponse);
+
+            createController();
+
+            const handler = requestHandlers.get(
+                SchemaDesigner.InitializeSchemaDesignerRequest.type.method,
+            );
+
+            try {
+                await handler!({});
+                expect.fail("Should have thrown");
+            } catch (err) {
+                expect(err).to.equal(error);
+            }
+
+            const result = await handler!({});
+
+            expect(mockSchemaDesignerService.createSession).to.have.been.calledTwice;
+            expect(result).to.deep.equal(mockCreateSessionResponse);
         });
 
         test("should handle initialization error", async () => {


### PR DESCRIPTION
## Description

Prevents duplicate Schema Designer backend sessions when overlapping `initializeSchemaDesigner` requests arrive for the same webview. The controller now tracks an in-flight initialization promise and shares it across callers, then clears it after completion so cached sessions and retries continue to work.

This avoids racing concurrent `schemaDesigner/createSession` calls that generate different session IDs for the same designer.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation performed:

- `npm run build:extension:typecheck`
- `npx eslint --quiet --no-cache src/schemaDesigner/schemaDesignerWebviewController.ts test/unit/schemaDesignerWebviewController.test.ts`
- `npx vscode-test --grep "SchemaDesignerWebviewController tests"` - 79 passing

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)