### PR TITLE
Warn on duplicate object name for Rename and Move to Schema

### DIFF
--- a/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
@@ -188,9 +188,9 @@ export class SqlMoveToSchemaProvider implements vscode.CodeActionProvider {
         }
 
         // Warn if an object with the same name already exists in the target schema.
-        if (response.warningMessage) {
+        if (response.message && response.isWarning) {
             const choice = await vscode.window.showWarningMessage(
-                response.warningMessage,
+                response.message,
                 { modal: true },
                 msgYes,
             );

--- a/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import { SqlMoveToSchema as loc } from "../constants/locConstants";
+import { SqlMoveToSchema as loc, msgYes, msgNo } from "../constants/locConstants";
 import { cmdMoveToSchema } from "../constants/constants";
 import SqlToolsServerClient from "./serviceclient";
 import {
@@ -185,6 +185,18 @@ export class SqlMoveToSchemaProvider implements vscode.CodeActionProvider {
         if (!response || !response.changes || Object.keys(response.changes).length === 0) {
             void vscode.window.showInformationMessage(loc.noMovableSymbolAtCursor);
             return;
+        }
+
+        // Warn if an object with the same name already exists in the target schema.
+        if (response.warningMessage) {
+            const choice = await vscode.window.showWarningMessage(
+                response.warningMessage,
+                msgYes,
+                msgNo,
+            );
+            if (choice !== msgYes) {
+                return; // user declined — do nothing silently
+            }
         }
 
         const changes = response.changes as Record<string, SqlSymbolRenameTextEdit[]>;

--- a/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import { SqlMoveToSchema as loc, msgYes, msgNo } from "../constants/locConstants";
+import { SqlMoveToSchema as loc, msgYes } from "../constants/locConstants";
 import { cmdMoveToSchema } from "../constants/constants";
 import SqlToolsServerClient from "./serviceclient";
 import {
@@ -191,8 +191,8 @@ export class SqlMoveToSchemaProvider implements vscode.CodeActionProvider {
         if (response.warningMessage) {
             const choice = await vscode.window.showWarningMessage(
                 response.warningMessage,
+                { modal: true },
                 msgYes,
-                msgNo,
             );
             if (choice !== msgYes) {
                 return; // user declined — do nothing silently

--- a/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
@@ -152,10 +152,15 @@ export class SqlSymbolRenameProvider implements vscode.RenameProvider {
             throw new Error(loc.renameOnlyInProjectFiles);
         }
 
-        // Name collision — ask the user before proceeding.
-        if (response.warningMessage) {
+        // Hard rejection — surface the error message and abort.
+        if (response.message && !response.isWarning) {
+            throw new Error(response.message);
+        }
+
+        // Name collision warning — ask the user before proceeding.
+        if (response.message && response.isWarning) {
             const choice = await vscode.window.showWarningMessage(
-                response.warningMessage,
+                response.message,
                 { modal: true },
                 msgYes,
             );

--- a/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
@@ -12,7 +12,7 @@ import {
     SqlSymbolRenameRequest,
     SqlSymbolRenameTextEdit,
 } from "../models/contracts/languageService";
-import { SqlSymbolRename as loc } from "../constants/locConstants";
+import { SqlSymbolRename as loc, msgYes, msgNo } from "../constants/locConstants";
 
 /** Escapes a string for safe use inside an XML attribute value (e.g. an Include path). */
 function escapeXmlAttribute(value: string): string {
@@ -150,6 +150,18 @@ export class SqlSymbolRenameProvider implements vscode.RenameProvider {
 
         if (!response) {
             throw new Error(loc.renameOnlyInProjectFiles);
+        }
+
+        // Name collision — ask the user before proceeding.
+        if (response.warningMessage) {
+            const choice = await vscode.window.showWarningMessage(
+                response.warningMessage,
+                msgYes,
+                msgNo,
+            );
+            if (choice !== msgYes) {
+                return new vscode.WorkspaceEdit(); // user declined — apply nothing silently
+            }
         }
 
         const workspaceEdit = new vscode.WorkspaceEdit();

--- a/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlSymbolRenameProvider.ts
@@ -12,7 +12,7 @@ import {
     SqlSymbolRenameRequest,
     SqlSymbolRenameTextEdit,
 } from "../models/contracts/languageService";
-import { SqlSymbolRename as loc, msgYes, msgNo } from "../constants/locConstants";
+import { SqlSymbolRename as loc, msgYes } from "../constants/locConstants";
 
 /** Escapes a string for safe use inside an XML attribute value (e.g. an Include path). */
 function escapeXmlAttribute(value: string): string {
@@ -156,8 +156,8 @@ export class SqlSymbolRenameProvider implements vscode.RenameProvider {
         if (response.warningMessage) {
             const choice = await vscode.window.showWarningMessage(
                 response.warningMessage,
+                { modal: true },
                 msgYes,
-                msgNo,
             );
             if (choice !== msgYes) {
                 return new vscode.WorkspaceEdit(); // user declined — apply nothing silently

--- a/extensions/mssql/src/models/contracts/languageService.ts
+++ b/extensions/mssql/src/models/contracts/languageService.ts
@@ -175,7 +175,13 @@ export interface SqlSymbolRenameResponse {
      */
     refactorLogContent: string | null;
     newName: string;
-    warningMessage?: string | null;
+    /**
+     * When non-null, a message to surface to the user.
+     * If isWarning is true, show a confirmation dialog; otherwise show a blocking error.
+     */
+    message?: string | null;
+    /** True when message is a confirmation warning; false (default) when it is a hard rejection. */
+    isWarning?: boolean;
 }
 
 export namespace SqlSymbolRenameRequest {
@@ -205,7 +211,13 @@ export interface SqlMoveToSchemaResponse {
      */
     refactorLogContent: string | null;
     targetSchema: string;
-    warningMessage?: string | null;
+    /**
+     * When non-null, a message to surface to the user.
+     * If isWarning is true, show a confirmation dialog; otherwise show a blocking error.
+     */
+    message?: string | null;
+    /** True when message is a confirmation warning; false (default) when it is a hard rejection. */
+    isWarning?: boolean;
 }
 
 export namespace SqlMoveToSchemaRequest {

--- a/extensions/mssql/src/models/contracts/languageService.ts
+++ b/extensions/mssql/src/models/contracts/languageService.ts
@@ -175,6 +175,7 @@ export interface SqlSymbolRenameResponse {
      */
     refactorLogContent: string | null;
     newName: string;
+    warningMessage?: string | null;
 }
 
 export namespace SqlSymbolRenameRequest {
@@ -204,6 +205,7 @@ export interface SqlMoveToSchemaResponse {
      */
     refactorLogContent: string | null;
     targetSchema: string;
+    warningMessage?: string | null;
 }
 
 export namespace SqlMoveToSchemaRequest {

--- a/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
@@ -350,7 +350,7 @@ suite("SqlSymbolRenameProvider Tests", () => {
             );
         });
 
-        test("returns empty WorkspaceEdit when STS returns warningMessage and user cancels", async () => {
+        test("returns empty WorkspaceEdit when STS returns warning message and user cancels", async () => {
             const projUri = vscode.Uri.file(defaultProjFile);
             findFilesStub.resolves([projUri]);
             const fileUri = vscode.Uri.file(defaultSqlFile).toString();
@@ -367,8 +367,9 @@ suite("SqlSymbolRenameProvider Tests", () => {
                     ],
                 },
                 newName: "Orders",
-                warningMessage:
+                message:
                     "A schema object with the name [Orders] already exists. Would you like to continue?",
+                isWarning: true,
             });
             sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined); // user dismissed/cancelled
 
@@ -384,7 +385,7 @@ suite("SqlSymbolRenameProvider Tests", () => {
             expect(edit!.entries()).to.have.length(0); // empty — no changes applied
         });
 
-        test("applies edits when STS returns warningMessage and user confirms", async () => {
+        test("applies edits when STS returns warning message and user confirms", async () => {
             const projUri = vscode.Uri.file(defaultProjFile);
             findFilesStub.resolves([projUri]);
             const fileUri = vscode.Uri.file(defaultSqlFile).toString();
@@ -401,8 +402,9 @@ suite("SqlSymbolRenameProvider Tests", () => {
                     ],
                 },
                 newName: "Orders",
-                warningMessage:
+                message:
                     "A schema object with the name [Orders] already exists. Would you like to continue?",
+                isWarning: true,
             });
             sandbox
                 .stub(vscode.window, "showWarningMessage")
@@ -808,7 +810,7 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                 );
             });
 
-            test("does not call applyEdit when warningMessage is returned and user dismisses", async () => {
+            test("does not call applyEdit when warning message is returned and user dismisses", async () => {
                 const fileUri = vscode.Uri.file(defaultSqlFile).toString();
                 sendRequestStub
                     .withArgs(ListProjectSchemasRequest.type)
@@ -825,8 +827,9 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                             },
                         ],
                     },
-                    warningMessage:
+                    message:
                         "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
+                    isWarning: true,
                 });
                 messageBoxes.showWarningMessage.resolves(undefined); // user dismissed
 
@@ -836,7 +839,7 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                 expect(applyEditStub).to.not.have.been.called;
             });
 
-            test("calls applyEdit when warningMessage is returned and user confirms Yes", async () => {
+            test("calls applyEdit when warning message is returned and user confirms Yes", async () => {
                 const fileUri = vscode.Uri.file(defaultSqlFile).toString();
                 sendRequestStub
                     .withArgs(ListProjectSchemasRequest.type)
@@ -853,8 +856,9 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                             },
                         ],
                     },
-                    warningMessage:
+                    message:
                         "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
+                    isWarning: true,
                 });
                 messageBoxes.showWarningMessage.resolves("Yes" as vscode.MessageItem & string);
 

--- a/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
@@ -349,6 +349,75 @@ suite("SqlSymbolRenameProvider Tests", () => {
                 }),
             );
         });
+
+        test("returns empty WorkspaceEdit when STS returns warningMessage and user cancels", async () => {
+            const projUri = vscode.Uri.file(defaultProjFile);
+            findFilesStub.resolves([projUri]);
+            const fileUri = vscode.Uri.file(defaultSqlFile).toString();
+            sendRequestStub.withArgs(SqlSymbolRenameRequest.type).resolves({
+                changes: {
+                    [fileUri]: [
+                        {
+                            range: {
+                                start: { line: 0, character: 0 },
+                                end: { line: 0, character: 7 },
+                            },
+                            newText: "Orders",
+                        },
+                    ],
+                },
+                newName: "Orders",
+                warningMessage:
+                    "A schema object with the name [Orders] already exists. Would you like to continue?",
+            });
+            sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined); // user dismissed/cancelled
+
+            const doc = makeDocument(sandbox);
+            const edit = await provider.provideRenameEdits(
+                doc,
+                new vscode.Position(0, 0),
+                "Orders",
+                token,
+            );
+
+            expect(edit).to.be.instanceOf(vscode.WorkspaceEdit);
+            expect(edit!.entries()).to.have.length(0); // empty — no changes applied
+        });
+
+        test("applies edits when STS returns warningMessage and user confirms", async () => {
+            const projUri = vscode.Uri.file(defaultProjFile);
+            findFilesStub.resolves([projUri]);
+            const fileUri = vscode.Uri.file(defaultSqlFile).toString();
+            sendRequestStub.withArgs(SqlSymbolRenameRequest.type).resolves({
+                changes: {
+                    [fileUri]: [
+                        {
+                            range: {
+                                start: { line: 0, character: 0 },
+                                end: { line: 0, character: 7 },
+                            },
+                            newText: "Orders",
+                        },
+                    ],
+                },
+                newName: "Orders",
+                warningMessage:
+                    "A schema object with the name [Orders] already exists. Would you like to continue?",
+            });
+            sandbox.stub(vscode.window, "showWarningMessage").resolves("Yes" as any);
+
+            const doc = makeDocument(sandbox);
+            const edit = await provider.provideRenameEdits(
+                doc,
+                new vscode.Position(0, 0),
+                "Orders",
+                token,
+            );
+
+            expect(edit).to.be.instanceOf(vscode.WorkspaceEdit);
+            expect(edit!.entries()).to.have.length(1); // edits applied
+            expect(edit!.entries()[0][0].toString()).to.equal(fileUri);
+        });
     });
 
     // -------------------------------------------------------------------------

--- a/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
@@ -404,7 +404,9 @@ suite("SqlSymbolRenameProvider Tests", () => {
                 warningMessage:
                     "A schema object with the name [Orders] already exists. Would you like to continue?",
             });
-            sandbox.stub(vscode.window, "showWarningMessage").resolves("Yes" as any);
+            sandbox
+                .stub(vscode.window, "showWarningMessage")
+                .resolves("Yes" as vscode.MessageItem & string);
 
             const doc = makeDocument(sandbox);
             const edit = await provider.provideRenameEdits(
@@ -803,6 +805,67 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                 await provider.runMoveToSchema(doc, new vscode.Position(0, 7));
                 expect(messageBoxes.showErrorMessage).to.have.been.calledWith(
                     moveLoc.applyEditFailed,
+                );
+            });
+
+            test("does not call applyEdit when warningMessage is returned and user dismisses", async () => {
+                const fileUri = vscode.Uri.file(defaultSqlFile).toString();
+                sendRequestStub
+                    .withArgs(ListProjectSchemasRequest.type)
+                    .resolves({ schemas: ["hr"] });
+                sendRequestStub.withArgs(SqlMoveToSchemaRequest.type).resolves({
+                    changes: {
+                        [fileUri]: [
+                            {
+                                range: {
+                                    start: { line: 0, character: 7 },
+                                    end: { line: 0, character: 14 },
+                                },
+                                newText: "[hr].[MyTable]",
+                            },
+                        ],
+                    },
+                    warningMessage:
+                        "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
+                });
+                sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined); // user dismissed
+
+                const doc = makeMoveDocument(sandbox, { lineText: "SELECT MyTable" });
+                await provider.runMoveToSchema(doc, new vscode.Position(0, 7));
+
+                expect(applyEditStub).to.not.have.been.called;
+            });
+
+            test("calls applyEdit when warningMessage is returned and user confirms Yes", async () => {
+                const fileUri = vscode.Uri.file(defaultSqlFile).toString();
+                sendRequestStub
+                    .withArgs(ListProjectSchemasRequest.type)
+                    .resolves({ schemas: ["hr"] });
+                sendRequestStub.withArgs(SqlMoveToSchemaRequest.type).resolves({
+                    changes: {
+                        [fileUri]: [
+                            {
+                                range: {
+                                    start: { line: 0, character: 7 },
+                                    end: { line: 0, character: 14 },
+                                },
+                                newText: "[hr].[MyTable]",
+                            },
+                        ],
+                    },
+                    warningMessage:
+                        "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
+                });
+                sandbox
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves("Yes" as vscode.MessageItem & string);
+
+                const doc = makeMoveDocument(sandbox, { lineText: "SELECT MyTable" });
+                await provider.runMoveToSchema(doc, new vscode.Position(0, 7));
+
+                expect(applyEditStub).to.have.been.calledWith(
+                    sinon.match.instanceOf(vscode.WorkspaceEdit),
+                    sinon.match({ isRefactoring: true }),
                 );
             });
         });

--- a/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
@@ -828,7 +828,7 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                     warningMessage:
                         "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
                 });
-                sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined); // user dismissed
+                messageBoxes.showWarningMessage.resolves(undefined); // user dismissed
 
                 const doc = makeMoveDocument(sandbox, { lineText: "SELECT MyTable" });
                 await provider.runMoveToSchema(doc, new vscode.Position(0, 7));
@@ -856,9 +856,7 @@ suite("SqlMoveToSchemaProvider Tests", () => {
                     warningMessage:
                         "A schema object with the name [hr].[MyTable] already exists. Would you like to continue?",
                 });
-                sandbox
-                    .stub(vscode.window, "showWarningMessage")
-                    .resolves("Yes" as vscode.MessageItem & string);
+                messageBoxes.showWarningMessage.resolves("Yes" as vscode.MessageItem & string);
 
                 const doc = makeMoveDocument(sandbox, { lineText: "SELECT MyTable" });
                 await provider.runMoveToSchema(doc, new vscode.Position(0, 7));


### PR DESCRIPTION
## Summary

When renaming a SQL object or moving it to a schema where a name conflict exists, the client now shows a Yes/Cancel confirmation dialog (matching the SSDT-style prompt) before applying the workspace edits. Previously the operation was silently rejected with no feedback.

## Changes

**Contracts** (`languageService.ts`)
- `SqlSymbolRenameResponse` — added `warningMessage?` property
- `SqlMoveToSchemaResponse` — added `warningMessage?` property

**Rename provider** (`sqlSymbolRenameProvider.ts`)
- If `response.warningMessage` is set, shows a `showWarningMessage` prompt with **Yes** / **Cancel** buttons before proceeding. 

**Move to Schema provider** (`sqlMoveToSchemaProvider.ts`)
- Same pattern: shows warning prompt and returns early on cancel.

**Depends on** https://github.com/microsoft/sqltoolsservice/pull/2748

<img width="399" height="101" alt="image" src="https://github.com/user-attachments/assets/bfd12c52-ce76-4e0a-8d84-8ad8d9b3f89d" />

<img width="2391" height="1446" alt="7_1_MoveToSchema_duplicate" src="https://github.com/user-attachments/assets/5e2b1fd3-417c-41d3-ab3a-f48b4e16392e" />
<img width="2391" height="1446" alt="7_1_Rename_duplicate" src="https://github.com/user-attachments/assets/25ec6513-10ac-4ff9-8856-308548b4ebe5" />
