### PR TITLE
vBump  STS to 6.0.20260701.1

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260625.1",
+        version: "6.0.20260701.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/sql-database-projects/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/test/buildHelper.test.ts
@@ -124,6 +124,9 @@ suite("BuildHelper: Build Helper tests", function (): void {
     });
 
     test("Should have all required DLLs in build directory", async function (): Promise<void> {
+        // Stub file-existence checks so all files are considered present — no download triggered.
+        sandbox.stub(utils, "exists").resolves(true);
+
         const testContext: TestContext = createContext();
         const buildHelper = new BuildHelper();
         const success = await buildHelper.createBuildDirFolder(testContext.outputChannel);

--- a/extensions/sql-database-projects/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/test/buildHelper.test.ts
@@ -74,12 +74,10 @@ suite("BuildHelper: Build Helper tests", function (): void {
         }
     });
 
-    test("Should get correct build folder", async function (): Promise<void> {
-        const testContext: TestContext = createContext();
+    test("Should get correct build folder", function (): void {
         const buildHelper = new BuildHelper();
-        await buildHelper.createBuildDirFolder(testContext.outputChannel);
 
-        // get expected path for build
+        // extensionBuildDirPath is set in the constructor — no network calls needed.
         const extensionPath =
             vscode.extensions.getExtension(sqldbproj.extension.vsCodeName)?.extensionPath ?? "";
         expect(buildHelper.extensionBuildDirPath).to.equal(

--- a/extensions/sql-database-projects/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/test/buildHelper.test.ts
@@ -124,15 +124,18 @@ suite("BuildHelper: Build Helper tests", function (): void {
     });
 
     test("Should have all required DLLs in build directory", async function (): Promise<void> {
-        // Stub file-existence checks so all files are considered present — no download triggered.
+        // Treat all files as present and fail the test if a network download is attempted.
         sandbox.stub(utils, "exists").resolves(true);
+        sandbox
+            .stub(HttpClient.prototype, "download")
+            .throws(new Error("download should not be called"));
 
         const testContext: TestContext = createContext();
         const buildHelper = new BuildHelper();
         const success = await buildHelper.createBuildDirFolder(testContext.outputChannel);
 
-        // Verify that the build directory was created successfully
-        expect(success, "Build directory creation should succeed").to.be.true;
+        expect(success, "Build directory creation should succeed when all files are present").to.be
+            .true;
 
         const buildDirPath = buildHelper.extensionBuildDirPath;
 


### PR DESCRIPTION
## Description

This PR vbumpt sts version from  6.0.20260625.1 to  6.0.20260701.1 

<img width="704" height="631" alt="image" src="https://github.com/user-attachments/assets/a1709e65-95a0-4456-8135-82c990971578" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
