### PR TITLE
Update problem matcher for new DacFx error format

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -571,7 +571,7 @@
                 "owner": "sqlproj-builder",
                 "fileLocation": "absolute",
                 "pattern": {
-                    "regexp": "^(.*\\.sql)\\((\\d+),(\\d+)\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
+                    "regexp": "^(.*\\.sql)\\((\\d+),(\\d+)(?:,\\d+,\\d+)?\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -571,13 +571,13 @@
                 "owner": "sqlproj-builder",
                 "fileLocation": "absolute",
                 "pattern": {
-                    "regexp": "^(.*\\.sql)\\((\\d+),(\\d+),(\\d+),(\\d+)\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
+                    "regexp": "^(.*\\.sql)\\((\\d+),(\\d+)\\):\\s+\\w+\\s+(warning|error)\\s+(\\w+):\\s+(.*?)?$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
-                    "severity": 6,
-                    "code": 7,
-                    "message": 8
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6
                 }
             }
         ],


### PR DESCRIPTION
## Summary
Updates the SQL Project problem matcher regex to parse  and support the new DacFx error format going to be available in future Microsoft.Build.Sql versions

## Changes
- Updated regex pattern from `(line,col,endLine,endCol)` to `(line,col)` format and optional existing `(line,col)` format
- Adjusted capture group numbers:
  - severity: group 6 → 4
  - code: group 7 → 5  
  - message: group 8 → 6

## Breaking Change ⚠️
**This PR depends on DacFx PR #2112158 and both**

### Why Both Are Needed:
- **Old DacFx** outputs: `file.sql(10,5,10,5): SQL error SQL71501: Message`
- **New DacFx** outputs: `file.sql(10,5): SQL error SQL71501: Message`
- **Old regex** expects 4 numbers: `\((\d+),(\d+),(\d+),(\d+)\)`
- **New regex** support 2 numbers: `\((\d+),(\d+)\)` along with old 4-number format

### Release Coordination:
| Scenario | DacFx | VS Code Regex | Result |
|----------|-------|--------------|--------|
| Current | 4 numbers | 4 numbers | ✅ Works |
| This PR only | 4 numbers | 2 numbers | ✅ Works |
| DacFx only | 2 numbers | 4 numbers | ✅ Works |

## Testing
Validated that:
1. Old regex (4 numbers) correctly parses current DacFx output with `owner: "sqlproj-builder"`
2. New regex (2 numbers) will parse new DacFx output format too

**Before the change:**
<img width="644" height="124" alt="image" src="https://github.com/user-attachments/assets/529babbb-525f-4537-ba73-8c6c26c00580" />


**After the change:** Problem tab is empty as the problem matcher no longer matches with curret dacfx 4-number format
<img width="604" height="74" alt="image" src="https://github.com/user-attachments/assets/475ddd0f-9cb0-4546-ab42-42c87b62555c" />
<img width="857" height="174" alt="image" src="https://github.com/user-attachments/assets/4477547d-26ea-46e6-9496-b5d76d3c9297" />

