### PR TITLE
Fix schema designer actions on server nodes

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -637,12 +637,12 @@
                 },
                 {
                     "command": "mssql.schemaDesigner",
-                    "when": "view === objectExplorer && (viewItem =~ /\\btype=(Database|Server)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/)",
+                    "when": "view == objectExplorer && (viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/)",
                     "group": "2a_MSSQL_databaseDesign@1"
                 },
                 {
                     "command": "mssql.buildDataApi",
-                    "when": "view === objectExplorer && (viewItem =~ /\\btype=(Database|Server)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/)",
+                    "when": "view == objectExplorer && (viewItem =~ /\\btype=(Database)\\b/ || viewItem =~ /\\bsubType=(Database|DockerContainerDatabase)\\b/)",
                     "group": "2a_MSSQL_databaseDesign@2"
                 },
                 {


### PR DESCRIPTION
## Description

Fixes #22316.

Updates the Object Explorer context menu contributions for **Visualize and Design Schema...** and **Build Data API...** so they only appear on database nodes, including Docker container database nodes, instead of also appearing on server nodes where invoking them throws an error.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Validation performed:

- `jq empty extensions/mssql/package.json`
- `npm run lint -- --target mssql`

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)