### PR TITLE
Fix Object Explorer filtered refresh

### DIFF
--- a/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
@@ -98,38 +98,57 @@ export class ObjectExplorerFilter {
         }
         await this._filterWebviewController.whenWebviewReady();
         this._filterWebviewController.revealToForeground();
-        return await new Promise((resolve, _reject) => {
-            this._filterWebviewController.onSubmit((e) => {
-                if (e) {
-                    sendActionEvent(
-                        TelemetryViews.ObjectExplorerFilter,
-                        TelemetryActions.Submit,
-                        {
-                            nodeType: treeNode.nodeType,
-                            correlationId,
-                            filters: JSON.stringify(e.map((e) => e.name)),
-                        },
-                        {
-                            filterCount: e.length,
-                        },
-                    );
+        return await new Promise<vscodeMssql.NodeFilter[] | undefined>((resolve) => {
+            let settled = false;
+            const disposables: vscode.Disposable[] = [];
+
+            const complete = (filters: vscodeMssql.NodeFilter[] | undefined) => {
+                if (settled) {
+                    return;
                 }
-                resolve(e);
-            });
-            this._filterWebviewController.onCancel(() => {
-                sendActionEvent(TelemetryViews.ObjectExplorerFilter, TelemetryActions.Cancel, {
-                    nodeType: treeNode.nodeType,
-                    correlationId,
-                });
-                resolve(undefined);
-            });
-            this._filterWebviewController.onDisposed(() => {
-                sendActionEvent(TelemetryViews.ObjectExplorerFilter, TelemetryActions.Cancel, {
-                    nodeType: treeNode.nodeType,
-                    correlationId,
-                });
-                resolve(undefined);
-            });
+
+                settled = true;
+                disposables.forEach((d) => d.dispose());
+                resolve(filters);
+            };
+
+            disposables.push(
+                this._filterWebviewController.onSubmit((e) => {
+                    if (e) {
+                        sendActionEvent(
+                            TelemetryViews.ObjectExplorerFilter,
+                            TelemetryActions.Submit,
+                            {
+                                nodeType: treeNode.nodeType,
+                                correlationId,
+                                filters: JSON.stringify(e.map((e) => e.name)),
+                            },
+                            {
+                                filterCount: e.length,
+                            },
+                        );
+                    }
+                    complete(e);
+                }),
+            );
+            disposables.push(
+                this._filterWebviewController.onCancel(() => {
+                    sendActionEvent(TelemetryViews.ObjectExplorerFilter, TelemetryActions.Cancel, {
+                        nodeType: treeNode.nodeType,
+                        correlationId,
+                    });
+                    complete(undefined);
+                }),
+            );
+            disposables.push(
+                this._filterWebviewController.onDisposed(() => {
+                    sendActionEvent(TelemetryViews.ObjectExplorerFilter, TelemetryActions.Cancel, {
+                        nodeType: treeNode.nodeType,
+                        correlationId,
+                    });
+                    complete(undefined);
+                }),
+            );
         });
     }
 }

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -122,6 +122,11 @@ export class ObjectExplorerService {
      */
     private _inFlightChildrenFetches: Map<TreeNodeInfo, Promise<void>> = new Map();
 
+    /**
+     * Nodes that need another refresh as soon as their current load finishes.
+     */
+    private _refreshQueuedAfterInFlight: Set<TreeNodeInfo> = new Set();
+
     constructor(
         private _connectionManager: ConnectionManager,
         private _refreshCallback: (node: TreeNodeInfo) => void,
@@ -594,8 +599,15 @@ export class ObjectExplorerService {
         );
 
         if (wasRefresh) {
-            element.shouldRefresh = false;
             this.cleanNodeChildren(element);
+
+            if (hasInFlight) {
+                this._logger.trace(
+                    `getNodeChildren: queueing refresh after in-flight load for ${getNodeDescriptor(element)}`,
+                );
+                this._refreshQueuedAfterInFlight.add(element);
+                return this.setLoadingUiForNode(element);
+            }
         } else {
             if (this._treeNodeToChildrenMap.has(element)) {
                 return this._treeNodeToChildrenMap.get(element);
@@ -696,8 +708,21 @@ export class ObjectExplorerService {
                     await this.createSessionAndExpandNode(element);
                 }
             } finally {
-                element.shouldRefresh = false;
                 this._inFlightChildrenFetches.delete(element);
+
+                if (this._refreshQueuedAfterInFlight.delete(element)) {
+                    this._logger.trace(
+                        `getOrCreateNodeChildrenWithSession: starting queued refresh for ${getNodeDescriptor(element)}`,
+                    );
+                    element.shouldRefresh = true;
+                    element.loadingLabel = undefined;
+                    this.cleanNodeChildren(element);
+                    await this.setLoadingUiForNode(element);
+                    void this.getOrCreateNodeChildrenWithSession(element);
+                    return;
+                }
+
+                element.shouldRefresh = false;
                 this._logger.trace(
                     `getOrCreateNodeChildrenWithSession end: ${getNodeDescriptor(element)} — refresh callback follows`,
                 );

--- a/extensions/mssql/src/webviews/pages/ObjectExplorerFilter/ObjectExplorerFilterPage.tsx
+++ b/extensions/mssql/src/webviews/pages/ObjectExplorerFilter/ObjectExplorerFilterPage.tsx
@@ -186,7 +186,7 @@ export const ObjectExplorerFilterPage = () => {
         setIntialFocus();
         loadUiFilters();
         setErrorMessage(undefined);
-    }, [filterProperties]);
+    }, [filterProperties, existingFilters, nodePath]);
     if (!context || !filterProperties) {
         return undefined;
     }

--- a/extensions/mssql/test/unit/objectExplorerService.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerService.test.ts
@@ -696,6 +696,144 @@ suite("OE Service Tests", () => {
             ).to.be.false;
         });
 
+        test("getNodeChildren should send RefreshRequest when node is marked for refresh", async () => {
+            const connectionProfile = createMockConnectionProfile({ id: "conn1" });
+            setUpOETreeRoot(objectExplorerService, [connectionProfile]);
+
+            const connectionNode = (objectExplorerService as any)._connectionNodes.get(
+                connectionProfile.id,
+            ) as ConnectionNode;
+            connectionNode.sessionId = "session123";
+            connectionNode.filters = [
+                { name: "Name", operator: 8, value: "cdwi" },
+            ] as import("vscode-mssql").NodeFilter[];
+            connectionNode.shouldRefresh = true;
+
+            mockClient.sendRequest.withArgs(RefreshRequest.type, sinon.match.any).resolves(true);
+
+            await (objectExplorerService as any).getNodeChildren(connectionNode);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockClient.sendRequest, "Refresh request should be sent").to.have.been
+                .calledOnce;
+            expect(
+                mockClient.sendRequest.args[0][0],
+                "Request type should be RefreshRequest",
+            ).to.equal(RefreshRequest.type);
+            expect(
+                mockClient.sendRequest.args[0][1],
+                "Refresh payload should include filters",
+            ).to.deep.equal({
+                sessionId: connectionNode.sessionId,
+                nodePath: connectionNode.nodePath,
+                filters: connectionNode.filters,
+            });
+
+            const pendingExpandKey = `${connectionNode.sessionId}${connectionNode.nodePath}`;
+            const pendingExpand = (objectExplorerService as any)._pendingExpands.get(
+                pendingExpandKey,
+            ) as Deferred<any>;
+            const inFlightPromise = (objectExplorerService as any)._inFlightChildrenFetches.get(
+                connectionNode,
+            );
+
+            pendingExpand.resolve({
+                sessionId: connectionNode.sessionId,
+                nodes: [],
+                errorMessage: "",
+            });
+            await inFlightPromise;
+
+            expect(connectionNode.shouldRefresh, "Refresh flag should be cleared after refresh").to
+                .be.false;
+        });
+
+        test("getNodeChildren should queue a filtered refresh when refresh is requested during an in-flight load", async () => {
+            const connectionProfile = createMockConnectionProfile({ id: "conn1" });
+            setUpOETreeRoot(objectExplorerService, [connectionProfile]);
+
+            const connectionNode = (objectExplorerService as any)._connectionNodes.get(
+                connectionProfile.id,
+            ) as ConnectionNode;
+            connectionNode.sessionId = "session123";
+
+            mockClient.sendRequest.withArgs(ExpandRequest.type, sinon.match.any).resolves(true);
+            mockClient.sendRequest.withArgs(RefreshRequest.type, sinon.match.any).resolves(true);
+
+            await (objectExplorerService as any).getNodeChildren(connectionNode);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const pendingExpandKey = `${connectionNode.sessionId}${connectionNode.nodePath}`;
+            const firstPending = (objectExplorerService as any)._pendingExpands.get(
+                pendingExpandKey,
+            ) as Deferred<any>;
+            const firstInFlight = (objectExplorerService as any)._inFlightChildrenFetches.get(
+                connectionNode,
+            );
+
+            connectionNode.filters = [
+                { name: "Name", operator: 8, value: "cdwi" },
+            ] as import("vscode-mssql").NodeFilter[];
+            connectionNode.shouldRefresh = true;
+            await (objectExplorerService as any).getNodeChildren(connectionNode);
+
+            expect(
+                mockClient.sendRequest,
+                "Refresh should wait for the current load to finish",
+            ).to.have.been.calledOnceWithExactly(ExpandRequest.type, sinon.match.any);
+
+            firstPending.resolve({
+                sessionId: connectionNode.sessionId,
+                nodes: [
+                    {
+                        nodePath: `${connectionNode.nodePath}/oldChild`,
+                        nodeType: "table",
+                        nodeSubType: "",
+                        label: "oldChild",
+                    },
+                ],
+                errorMessage: "",
+            });
+            await firstInFlight;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            expect(
+                mockClient.sendRequest.callCount,
+                "Queued refresh should send a second request",
+            ).to.equal(2);
+            expect(
+                mockClient.sendRequest.args[1][0],
+                "Queued request should be RefreshRequest",
+            ).to.equal(RefreshRequest.type);
+            expect(
+                mockClient.sendRequest.args[1][1],
+                "Queued refresh should use latest filters",
+            ).to.deep.equal({
+                sessionId: connectionNode.sessionId,
+                nodePath: connectionNode.nodePath,
+                filters: connectionNode.filters,
+            });
+
+            const secondPending = (objectExplorerService as any)._pendingExpands.get(
+                pendingExpandKey,
+            ) as Deferred<any>;
+            const secondInFlight = (objectExplorerService as any)._inFlightChildrenFetches.get(
+                connectionNode,
+            );
+
+            secondPending.resolve({
+                sessionId: connectionNode.sessionId,
+                nodes: [],
+                errorMessage: "",
+            });
+            await secondInFlight;
+
+            expect(
+                (objectExplorerService as any)._refreshQueuedAfterInFlight.has(connectionNode),
+                "Queued refresh marker should be cleared",
+            ).to.be.false;
+        });
+
         test("expandNode should handle error response from SQL Tools Service", async () => {
             // Mock node and session ID
             const mockNode = new TreeNodeInfo(


### PR DESCRIPTION
## Summary
- preserve `shouldRefresh` until Object Explorer sends the service request so refresh/filter actions use `RefreshRequest` instead of stale `ExpandRequest` results
- queue a follow-up refresh when filters change while a node load is already in flight, so the latest filters are applied after the current load finishes
- reload the filter dialog when existing filters or node path changes, and dispose per-session filter dialog listeners after submit/cancel/close

Fixes #22326
Fixes #22040
Fixes #21832

## Validation
- `npm run lint`
- `npm run build:extension:typecheck`
- `npm run build:webviews`
- `npm run build:extension:emit && npm test -- --grep "OE Service Tests|ObjectExplorerFilter tests"`