### PR TITLE
Fix flaky sql-database-projects Templates tests by stubbing NuGet lookup

### DIFF
--- a/extensions/sql-database-projects/test/templates.test.ts
+++ b/extensions/sql-database-projects/test/templates.test.ts
@@ -5,6 +5,8 @@
 
 import { expect } from "chai";
 import * as semver from "semver";
+import * as sinon from "sinon";
+import axios from "axios";
 import * as templates from "../src/templates/templates";
 import { shouldThrowSpecificError, getTemplatesRootPath } from "./testUtils";
 import { ItemType } from "sqldbproj";
@@ -15,9 +17,20 @@ import { DBProjectConfigurationKey } from "../src/tools/netcoreTool";
 const templatesPath = getTemplatesRootPath();
 
 suite("Templates", function (): void {
+    let sandbox: sinon.SinonSandbox;
+
     setup(async () => {
+        sandbox = sinon.createSandbox();
+        // Stub the NuGet lookup so template loading doesn't hit the live network (offline/CI).
+        sandbox
+            .stub(axios, "get")
+            .resolves({ status: 200, data: { versions: ["2.0.0", "2.1.0", "2.2.0"] } });
         templates.reset();
         await templates.loadTemplates(templatesPath);
+    });
+
+    teardown(function (): void {
+        sandbox.restore();
     });
 
     test("Should throw error when attempting to use templates before loaded from file", async function (): Promise<void> {


### PR DESCRIPTION
## Description

The `Templates` suite in `sql-database-projects` fails in CI with an `AggregateError`. Its `before each` hook calls `templates.loadTemplates(...)`, which resolves the `Microsoft.Build.Sql` version through `resolveNugetVersion`. For a floating version (e.g. `2.*`) this makes a live HTTP request to `https://api.nuget.org/v3-flatcontainer/...`. CI/offline environments have no outbound access to nuget.org, so `axios` throws and the entire suite's setup fails.

This PR stubs `axios.get` in the suite's `setup`/`teardown` (using a sinon sandbox, matching the existing pattern in `netCoreTool.test.ts`) so template loading no longer depends on network access. No production code is changed.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
