### PR TITLE
Add GitHub workflow to trigger buddy build when a dev tag is pushed.

### DIFF
--- a/.github/workflows/trigger-buddy-build.yml
+++ b/.github/workflows/trigger-buddy-build.yml
@@ -1,0 +1,18 @@
+name: Trigger Buddy Build
+
+on:
+  push:
+    tags:
+      - "dev-*"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Azure DevOps Buddy Pipeline
+        run: |
+          curl -X POST \
+            "https://dev.azure.com/msdata/SQLToolsAndLibraries/_apis/pipelines/34537/runs?api-version=7.0" \
+            -H "Authorization: Basic $(echo -n :${{ secrets.ADO_PAT }} | base64)" \
+            -H "Content-Type: application/json" \
+            -d '{"resources":{"repositories":{"vscode-mssql":{"refName":"refs/tags/${{ github.ref_name }}"}}}}'

--- a/.github/workflows/trigger-buddy-build.yml
+++ b/.github/workflows/trigger-buddy-build.yml
@@ -13,6 +13,6 @@ jobs:
         run: |
           curl -X POST \
             "https://dev.azure.com/msdata/SQLToolsAndLibraries/_apis/pipelines/34537/runs?api-version=7.0" \
-            -H "Authorization: Basic $(echo -n :${{ secrets.ADO_PAT }} | base64)" \
+            -H "Authorization: Basic $(echo -n :${{ secrets.ADO_BUDDY_PAT }} | base64)" \
             -H "Content-Type: application/json" \
             -d '{"resources":{"repositories":{"vscode-mssql":{"refName":"refs/tags/${{ github.ref_name }}"}}}}'


### PR DESCRIPTION
## Description

This PR adds a GitHub workflow that triggers the buddy build when a tag that matches "dev-*" is pushed to the repo.

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
