### PR TITLE
Port Microsoft.Build.Sql version bump to release/1.44

### DIFF
--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -10,6 +10,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added **Rename Symbol** refactoring support for SQL project files.
 - Added **Move to Schema** refactoring support for SQL project files.
+- Adds support for Microsoft.Build.Sql version to 2.2.0.
 
 ## [1.6.1] - 2026-06-03
 

--- a/extensions/sql-database-projects/README.md
+++ b/extensions/sql-database-projects/README.md
@@ -51,7 +51,7 @@ CREATE TABLE [dbo].[Product] (
 ### General Settings
 
 - `sqlDatabaseProjects.dotnetSDK Location`: The path to the folder containing the `dotnet` folder for the .NET SDK. If not set, the extension will attempt to find the .NET SDK on the system.
-- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql to use for SQL projects. Controls the SDK version referenced in newly created SDK-style project templates and the binaries used when building non-SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 2.1.0.
+- `sqlDatabaseProjects.microsoftBuildSqlVersion`: Version of Microsoft.Build.Sql to use for SQL projects. Controls the SDK version referenced in newly created SDK-style project templates and the binaries used when building non-SDK-style SQL projects. If not set, the extension will use Microsoft.Build.Sql 2.2.0.
 - `sqlDatabaseProjects.netCoreDoNotAsk`: When true, no longer prompts to install .NET SDK when a supported installation is not found.
 - `sqlDatabaseProjects.collapseProjectNodes`: Option to set the default state of the project nodes in the database projects view to collapsed. If not set, the extension will default to expanded.
 

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -73,7 +73,7 @@
                     },
                     "sqlDatabaseProjects.microsoftBuildSqlVersion": {
                         "type": "string",
-                        "default": "2.1.0",
+                        "default": "2.2.0",
                         "description": "%sqlDatabaseProjects.microsoftBuildSqlVersion%"
                     },
                     "sqlDatabaseProjects.autoCreateFolders": {

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -37,7 +37,7 @@ export const minSupportedNetCoreVersionForBuild = "8.0.0";
  * NOTE: Keep this in sync with the default value in package.json:
  * sqlDatabaseProjects.microsoftBuildSqlVersion.default
  */
-export const FALLBACK_MICROSOFT_BUILD_SQL_VERSION = "2.1.0";
+export const FALLBACK_MICROSOFT_BUILD_SQL_VERSION = "2.2.0";
 
 export const enum netCoreInstallState {
     netCoreNotPresent,


### PR DESCRIPTION
PR: https://github.com/microsoft/vscode-mssql/pull/22436
Issue: https://github.com/microsoft/vscode-mssql/issues/22434 (Part of this issue is revert the floating version resolution and vbump build.sql in regular appraoch)


Port of the Microsoft.Build.Sql version bump to release/1.44.