### PR TITLE
Update package-lock.json after version bump

### DIFF
--- a/extensions/mssql/package-lock.json
+++ b/extensions/mssql/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mssql",
-    "version": "1.44.0",
+    "version": "1.45.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mssql",
-            "version": "1.44.0",
+            "version": "1.45.0",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@azure/arm-maintenance": "^1.0.0-beta.2",

--- a/extensions/sql-database-projects/package-lock.json
+++ b/extensions/sql-database-projects/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sql-database-projects-vscode",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sql-database-projects-vscode",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "@microsoft/ads-extension-telemetry": "^3.0.1",


### PR DESCRIPTION
Updates the `package-lock.json` files to match the version bumps from #22426 (mssql `1.45.0`, sql-database-projects `1.6.3`), which merged the `package.json` changes without the corresponding lockfile updates.

🤖 This PR was created by the Release Manager agent to bring the lockfiles in sync with the bumped package versions.