### PR TITLE
Fix connection dialog opening in 'Edit Connection' mode when launched from protocol handler

### DIFF
--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -291,12 +291,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         // Load connection (if specified); happens after form is loaded so that the form can be updated
         if (connectionToEdit) {
             try {
-                await this.loadConnectionToEdit(connectionToEdit);
-                if (openAsNewDraft) {
-                    this._connectionBeingEdited = undefined;
-                    this.state.isEditingConnection = false;
-                    this.state.editingConnectionDisplayName = undefined;
-                }
+                await this.loadConnectionToEdit(connectionToEdit, openAsNewDraft);
             } catch (err) {
                 this.loadEmptyConnection();
                 void vscode.window.showErrorMessage(getErrorMessage(err));
@@ -1852,9 +1847,12 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         }
     }
 
-    private async loadConnectionToEdit(connectionToEdit: IConnectionInfo) {
+    private async loadConnectionToEdit(
+        connectionToEdit: IConnectionInfo,
+        openAsNewDraft: boolean = false,
+    ): Promise<void> {
         if (connectionToEdit) {
-            await this.setConnectionForEdit(connectionToEdit);
+            await this.setConnectionForEdit(connectionToEdit, openAsNewDraft);
             this.updateState();
 
             if (this.isConnectionReadyForDatabaseFetch(this.state.connectionProfile)) {
@@ -1870,17 +1868,32 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         this.state.editingConnectionDisplayName = undefined;
     }
 
-    private async setConnectionForEdit(connectionToLoad: IConnectionInfo): Promise<void> {
+    private async setConnectionForEdit(
+        connectionToLoad: IConnectionInfo,
+        openAsNewDraft: boolean = false,
+    ): Promise<void> {
         this.clearFormError();
         const initializedConnection = await this.initializeConnectionForDialog(
             structuredClone(connectionToLoad),
         );
 
-        this._connectionBeingEdited = structuredClone(initializedConnection);
         this.state.connectionProfile = initializedConnection;
         this.state.selectedInputMode = ConnectionInputMode.Parameters;
-        this.state.isEditingConnection = true;
-        this.state.editingConnectionDisplayName = getConnectionDisplayName(initializedConnection);
+
+        if (openAsNewDraft) {
+            // pre-filling the form, but not editing an existing connection
+            this.state.connectionProfile.id = undefined;
+            this.state.connectionProfile.groupId = undefined;
+            this._connectionBeingEdited = undefined;
+            this.state.isEditingConnection = false;
+            this.state.editingConnectionDisplayName = undefined;
+        } else {
+            // editing an existing connection
+            this._connectionBeingEdited = structuredClone(initializedConnection);
+            this.state.isEditingConnection = true;
+            this.state.editingConnectionDisplayName =
+                getConnectionDisplayName(initializedConnection);
+        }
 
         await this.updateItemVisibility();
         await this.handleAzureMFAEdits("authenticationType");

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -159,6 +159,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         private _objectExplorerProvider: ObjectExplorerProvider,
         connectionToEdit?: IConnectionInfo,
         initialConnectionGroup?: IConnectionGroup,
+        private _openAsNewDraft?: boolean,
     ) {
         super(
             context,
@@ -199,7 +200,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         this._fabricBrowseProvider = new FabricBrowseProvider(host);
 
         this.registerRpcHandlers();
-        void this.initializeDialog(connectionToEdit, initialConnectionGroup)
+        void this.initializeDialog(connectionToEdit, initialConnectionGroup, this._openAsNewDraft)
             .then(() => {
                 this.updateState();
                 this.initialized.resolve();
@@ -224,6 +225,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private async initializeDialog(
         connectionToEdit: IConnectionInfo,
         initialConnectionGroup?: IConnectionGroup,
+        openAsNewDraft?: boolean,
     ): Promise<void> {
         const useVscodeAccounts = previewService.isFeatureEnabled(
             PreviewFeature.UseVscodeAccountsForEntraMFA,
@@ -290,6 +292,11 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         if (connectionToEdit) {
             try {
                 await this.loadConnectionToEdit(connectionToEdit);
+                if (openAsNewDraft) {
+                    this._connectionBeingEdited = undefined;
+                    this.state.isEditingConnection = false;
+                    this.state.editingConnectionDisplayName = undefined;
+                }
             } catch (err) {
                 this.loadEmptyConnection();
                 void vscode.window.showErrorMessage(getErrorMessage(err));

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -2619,9 +2619,6 @@ export default class MainController implements vscode.Disposable {
     }
 
     /**
-     * Let users pick from a list of connections
-     */
-    /**
      * Opens the connection dialog prepopulated with the given connection info, in "create new connection" mode
      * (as opposed to "edit existing connection" mode). Used when an external source (e.g. protocol handler)
      * provides connection parameters that don't match any existing saved profile.
@@ -2638,6 +2635,9 @@ export default class MainController implements vscode.Disposable {
         connDialog.revealToForeground();
     }
 
+    /**
+     * Let users pick from a list of connections
+     */
     public async promptToConnect(): Promise<boolean> {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
             let credentials = await this._connectionMgr.promptToConnect();

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -2621,6 +2621,23 @@ export default class MainController implements vscode.Disposable {
     /**
      * Let users pick from a list of connections
      */
+    /**
+     * Opens the connection dialog prepopulated with the given connection info, in "create new connection" mode
+     * (as opposed to "edit existing connection" mode). Used when an external source (e.g. protocol handler)
+     * provides connection parameters that don't match any existing saved profile.
+     */
+    public openConnectionDialogForNewProfile(connectionInfo?: IConnectionInfo): void {
+        const connDialog = new ConnectionDialogWebviewController(
+            this._context,
+            this,
+            this._objectExplorerProvider,
+            connectionInfo,
+            undefined,
+            true, // openAsNewDraft
+        );
+        connDialog.revealToForeground();
+    }
+
     public async promptToConnect(): Promise<boolean> {
         if (this.canRunCommand() && this.validateTextDocumentHasFocus()) {
             let credentials = await this._connectionMgr.promptToConnect();

--- a/extensions/mssql/src/mssqlProtocolHandler.ts
+++ b/extensions/mssql/src/mssqlProtocolHandler.ts
@@ -13,7 +13,6 @@ import { AuthenticationType } from "./sharedInterfaces/connectionDialog";
 import { ILogger } from "./sharedInterfaces/logger";
 import { logger } from "./models/logger";
 import MainController from "./controllers/mainController";
-import { cmdAddObjectExplorer } from "./constants/constants";
 import { getConnectionDisplayName } from "./models/connectionInfo";
 import { MatchScore } from "./models/utils";
 import { sendActionEvent, sendErrorEvent } from "./telemetry/telemetry";
@@ -165,7 +164,9 @@ export class MssqlProtocolHandler {
     }
 
     private openConnectionDialog(connProfile: IConnectionProfile | undefined): void {
-        vscode.commands.executeCommand(cmdAddObjectExplorer, connProfile);
+        // Always open as a new connection draft (prepopulated, but not in "edit existing" mode),
+        // since the profile came from an external URI and hasn't been saved yet.
+        this.mainController.openConnectionDialogForNewProfile(connProfile);
     }
 
     /**


### PR DESCRIPTION
## Description

Addresses #22469

When launching the connection dialog from the protocol handler, the form was pre-filled, but the header was incorrectly indicating that the user was editing a connection rather than creating a new one.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md) 