### PR TITLE
[PORT] - fix(sql-database-projects): bundle DacFx DLLs in VSIX and remove stal…

### DIFF
--- a/extensions/sql-database-projects/src/tools/buildHelper.ts
+++ b/extensions/sql-database-projects/src/tools/buildHelper.ts
@@ -62,9 +62,8 @@ export class BuildHelper {
         }
 
         const dacFxDllsExist = await this.ensureDacFxDllsPresence(outputChannel);
-        const scriptDomExists = await this.ensureScriptDomDllPresence(outputChannel);
 
-        if (!dacFxDllsExist || !scriptDomExists) {
+        if (!dacFxDllsExist) {
             return false;
         }
 
@@ -87,6 +86,8 @@ export class BuildHelper {
             "System.IO.Packaging.dll",
             "Microsoft.Data.Tools.Schema.SqlTasks.targets",
             "Microsoft.SqlServer.Server.dll",
+            "Microsoft.SqlServer.TransactSql.ScriptDom.dll",
+            "Microsoft.Data.Tools.Sql.DesignServices.dll",
         ];
 
         const sdkVersion = getMicrosoftBuildSqlVersion();
@@ -96,21 +97,6 @@ export class BuildHelper {
             sdkVersion,
             dacFxBuildFiles,
             microsoftBuildSqlDllLocation,
-            outputChannel,
-        );
-    }
-
-    public async ensureScriptDomDllPresence(outputChannel: vscode.OutputChannel): Promise<boolean> {
-        const scriptdomNugetPkgName = "Microsoft.SqlServer.TransactSql.ScriptDom";
-        const scriptDomDll = "Microsoft.SqlServer.TransactSql.ScriptDom.dll";
-        const scriptDomNugetVersion = "170.128.0"; // TODO: make this a configurable setting, like the Microsoft.Build.Sql version
-        const scriptDomDllLocation = path.join("lib", "netstandard2.1");
-
-        return this.ensureNugetAndFilesPresence(
-            scriptdomNugetPkgName,
-            scriptDomNugetVersion,
-            [scriptDomDll],
-            scriptDomDllLocation,
             outputChannel,
         );
     }

--- a/extensions/sql-database-projects/test/buildHelper.test.ts
+++ b/extensions/sql-database-projects/test/buildHelper.test.ts
@@ -139,106 +139,8 @@ suite("BuildHelper: Build Helper tests", function (): void {
 
         const buildDirPath = buildHelper.extensionBuildDirPath;
 
-        // List of required DLLs from Microsoft.Build.Sql package
-        const requiredDacFxFiles: string[] = [
-            "Microsoft.Build.Sql.dll",
-            "Microsoft.Data.SqlClient.dll",
-            "Microsoft.Data.Tools.Schema.Sql.dll",
-            "Microsoft.Data.Tools.Schema.Tasks.Sql.dll",
-            "Microsoft.Data.Tools.Utilities.dll",
-            "Microsoft.SqlServer.Dac.dll",
-            "Microsoft.SqlServer.Dac.Extensions.dll",
-            "Microsoft.SqlServer.Types.dll",
-            "System.ComponentModel.Composition.dll",
-            "System.IO.Packaging.dll",
-            "Microsoft.Data.Tools.Schema.SqlTasks.targets",
-            "Microsoft.SqlServer.Server.dll",
-        ];
-
-        // List of required DLLs from ScriptDom package
-        const requiredScriptDomFiles: string[] = ["Microsoft.SqlServer.TransactSql.ScriptDom.dll"];
-
-        // Combine all required files
-        const allRequiredFiles = [...requiredDacFxFiles, ...requiredScriptDomFiles];
-
-        // Verify each required file exists in the build directory
-        for (const fileName of allRequiredFiles) {
-            const filePath = path.join(buildDirPath, fileName);
-            const exists = await utils.exists(filePath);
-            expect(
-                exists,
-                `Required file '${fileName}' should exist in build directory at ${filePath}`,
-            ).to.be.true;
-        }
-    });
-
-    test("createBuildDirFolder downloads and places all DLLs in BuildDirectory when files are missing", async function (): Promise<void> {
-        const buildHelper = new BuildHelper();
-        const buildDirPath = buildHelper.extensionBuildDirPath;
-
-        // Simulate all DLLs missing from BuildDirectory, but allow real fs checks
-        // on the extracted folder so the copy-to-BuildDirectory step works correctly.
-        // Also allow the directory-existence check (buildDirPath itself) to return true
-        // so createBuildDirFolder does not attempt to re-create the existing directory.
-        sandbox.stub(utils, "exists").callsFake(async (filePath: string): Promise<boolean> => {
-            if (filePath === buildDirPath) {
-                return true; // The directory itself exists — don't try to mkdir it
-            }
-            // Only pretend files directly in BuildDirectory are missing (not in subdirectories)
-            if (filePath.startsWith(buildDirPath + path.sep)) {
-                const relativePath = path.relative(buildDirPath, filePath);
-                if (!relativePath.includes(path.sep)) {
-                    return false; // File directly in BuildDirectory - pretend it's missing
-                }
-            }
-            return fs.existsSync(filePath); // Real check for extracted folders
-        });
-
-        // Stub the download so no real network call is made; create dummy files in the
-        // expected extracted-folder structure so the production copy logic can run normally.
-        sandbox
-            .stub(BuildHelper.prototype, "downloadAndExtractNuget")
-            .callsFake(
-                async (
-                    _url: string,
-                    _nupkgPath: string,
-                    extractFolderPath: string,
-                ): Promise<void> => {
-                    const nugetName = path.basename(extractFolderPath);
-                    const isScriptDom = nugetName.includes("ScriptDom");
-                    const subFolder = isScriptDom
-                        ? path.join("lib", "netstandard2.1")
-                        : path.join("tools", "net8.0");
-                    const dirPath = path.join(extractFolderPath, subFolder);
-                    fs.mkdirSync(dirPath, { recursive: true });
-                    const files = isScriptDom
-                        ? ["Microsoft.SqlServer.TransactSql.ScriptDom.dll"]
-                        : [
-                              "Microsoft.Build.Sql.dll",
-                              "Microsoft.Data.SqlClient.dll",
-                              "Microsoft.Data.Tools.Schema.Sql.dll",
-                              "Microsoft.Data.Tools.Schema.Tasks.Sql.dll",
-                              "Microsoft.Data.Tools.Utilities.dll",
-                              "Microsoft.SqlServer.Dac.dll",
-                              "Microsoft.SqlServer.Dac.Extensions.dll",
-                              "Microsoft.SqlServer.Types.dll",
-                              "System.ComponentModel.Composition.dll",
-                              "System.IO.Packaging.dll",
-                              "Microsoft.Data.Tools.Schema.SqlTasks.targets",
-                              "Microsoft.SqlServer.Server.dll",
-                          ];
-                    for (const file of files) {
-                        fs.writeFileSync(path.join(dirPath, file), "");
-                    }
-                },
-            );
-
-        const testContext: TestContext = createContext();
-        const success = await buildHelper.createBuildDirFolder(testContext.outputChannel);
-
-        expect(success, "createBuildDirFolder should return true after placing DLLs").to.be.true;
-
-        const allExpectedFiles = [
+        // List of required DLLs — all sourced from the Microsoft.Build.Sql package (tools/net8.0/)
+        const allRequiredFiles: string[] = [
             "Microsoft.Build.Sql.dll",
             "Microsoft.Data.SqlClient.dll",
             "Microsoft.Data.Tools.Schema.Sql.dll",
@@ -252,12 +154,16 @@ suite("BuildHelper: Build Helper tests", function (): void {
             "Microsoft.Data.Tools.Schema.SqlTasks.targets",
             "Microsoft.SqlServer.Server.dll",
             "Microsoft.SqlServer.TransactSql.ScriptDom.dll",
+            "Microsoft.Data.Tools.Sql.DesignServices.dll",
         ];
 
-        for (const fileName of allExpectedFiles) {
+        // Verify each required file exists in the build directory
+        for (const fileName of allRequiredFiles) {
+            const filePath = path.join(buildDirPath, fileName);
+            const exists = await utils.exists(filePath);
             expect(
-                fs.existsSync(path.join(buildDirPath, fileName)),
-                `${fileName} should exist in BuildDirectory after download`,
+                exists,
+                `Required file '${fileName}' should exist in build directory at ${filePath}`,
             ).to.be.true;
         }
     });


### PR DESCRIPTION
# PR: https://github.com/microsoft/vscode-mssql/pull/22464
# ISSUE: https://github.com/microsoft/vscode-mssql/issues/22465

- After reverting commit a2000b293, a test stub was introduced that wrote fake placeholder DLL files directly into the source BuildDirectory to stub the situation. Since those files weren't cleaned up, they ended up being bundled with the extension during packaging. At runtime, the check found the (placeholder) DLLs already and skipped the download. Because these were empty files named as .dll, the build operations failed.

## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
