### PR TITLE
Pre-set Entra MFA auth when selecting server/database in Browse Azure/Fabric mode

### DIFF
--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -332,7 +332,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 state.connectionProfile.server = undefined;
                 state.connectionProfile.database = undefined;
                 state.connectionProfile.user = undefined;
-                state.browseAuthChangedByUser = false;
             }
 
             this.updateState();
@@ -993,37 +992,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     ): Promise<void> {
         if (propertyName !== "profileName" && propertyName !== "groupId") {
             this.state.testConnectionSucceeded = false;
-        }
-
-        const browseAuthProperties: (keyof IConnectionDialogProfile)[] = [
-            "authenticationType",
-            "accountId",
-            "tenantId",
-        ];
-        const inBrowseMode =
-            this.state.selectedInputMode === ConnectionInputMode.AzureBrowse ||
-            this.state.selectedInputMode === ConnectionInputMode.FabricBrowse;
-
-        // Track when the user manually changes auth fields while in a browse mode,
-        // so we don't overwrite their choices when they later select a different server.
-        if (inBrowseMode && browseAuthProperties.includes(propertyName)) {
-            this.state.browseAuthChangedByUser = true;
-        }
-
-        // When a server is selected in browse mode and the user hasn't manually changed auth,
-        // pre-set auth to Entra MFA with the current browse account and tenant.
-        if (
-            propertyName === "server" &&
-            this.state.connectionProfile.server &&
-            inBrowseMode &&
-            !this.state.browseAuthChangedByUser &&
-            this.state.selectedAccountId &&
-            this.state.selectedTenantId
-        ) {
-            this.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
-            this.state.connectionProfile.accountId = this.state.selectedAccountId;
-            this.state.connectionProfile.tenantId = this.state.selectedTenantId;
-            await this.handleAzureMFAEdits("authenticationType");
         }
 
         await this.handleAzureMFAEdits(propertyName);

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -332,6 +332,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 state.connectionProfile.server = undefined;
                 state.connectionProfile.database = undefined;
                 state.connectionProfile.user = undefined;
+                state.browseAuthChangedByUser = false;
             }
 
             this.updateState();
@@ -993,6 +994,38 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         if (propertyName !== "profileName" && propertyName !== "groupId") {
             this.state.testConnectionSucceeded = false;
         }
+
+        const browseAuthProperties: (keyof IConnectionDialogProfile)[] = [
+            "authenticationType",
+            "accountId",
+            "tenantId",
+        ];
+        const inBrowseMode =
+            this.state.selectedInputMode === ConnectionInputMode.AzureBrowse ||
+            this.state.selectedInputMode === ConnectionInputMode.FabricBrowse;
+
+        // Track when the user manually changes auth fields while in a browse mode,
+        // so we don't overwrite their choices when they later select a different server.
+        if (inBrowseMode && browseAuthProperties.includes(propertyName)) {
+            this.state.browseAuthChangedByUser = true;
+        }
+
+        // When a server is selected in browse mode and the user hasn't manually changed auth,
+        // pre-set auth to Entra MFA with the current browse account and tenant.
+        if (
+            propertyName === "server" &&
+            this.state.connectionProfile.server &&
+            inBrowseMode &&
+            !this.state.browseAuthChangedByUser &&
+            this.state.selectedAccountId &&
+            this.state.selectedTenantId
+        ) {
+            this.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+            this.state.connectionProfile.accountId = this.state.selectedAccountId;
+            this.state.connectionProfile.tenantId = this.state.selectedTenantId;
+            await this.handleAzureMFAEdits("authenticationType");
+        }
+
         await this.handleAzureMFAEdits(propertyName);
 
         if (

--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -71,8 +71,6 @@ export class ConnectionDialogWebviewState
     public favoritedAzureSubscriptionIds: string[] = [];
     public favoritedFabricWorkspaceIds: string[] = [];
     public notSignedInTenant: { id: string; name: string } | undefined;
-    /** Whether the user has manually changed auth fields since entering a browse mode. Used to avoid overwriting intentional auth changes when a server/database is selected from browse results. */
-    public browseAuthChangedByUser: boolean = false;
 
     constructor(params?: Partial<ConnectionDialogWebviewState>) {
         for (const key in params) {

--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -71,6 +71,8 @@ export class ConnectionDialogWebviewState
     public favoritedAzureSubscriptionIds: string[] = [];
     public favoritedFabricWorkspaceIds: string[] = [];
     public notSignedInTenant: { id: string; name: string } | undefined;
+    /** Whether the user has manually changed auth fields since entering a browse mode. Used to avoid overwriting intentional auth changes when a server/database is selected from browse results. */
+    public browseAuthChangedByUser: boolean = false;
 
     constructor(params?: Partial<ConnectionDialogWebviewState>) {
         for (const key in params) {

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -9,6 +9,7 @@ import { useConnectionDialogSelector } from "./connectionDialogSelector";
 import { Label, makeStyles } from "@fluentui/react-components";
 import { FormField } from "../../common/forms/form.component";
 import {
+    AuthenticationType,
     ConnectionDialogContextProps,
     ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
@@ -40,6 +41,9 @@ export const AzureBrowsePage = () => {
     );
     const formComponents = useConnectionDialogSelector((s) => s.formComponents);
     const mainOptions = useConnectionDialogSelector((s) => s.connectionComponents.mainOptions);
+
+    const selectedAccountId = useConnectionDialogSelector((s) => s.selectedAccountId);
+    const selectedTenantId = useConnectionDialogSelector((s) => s.selectedTenantId);
 
     if (context === undefined) {
         return undefined;
@@ -89,9 +93,17 @@ export const AzureBrowsePage = () => {
                         }}
                         onSelectDatabase={(db) => {
                             setConnectionProperty("server", db.server);
+
                             if (db.databases.length > 0) {
                                 setConnectionProperty("database", db.databases[0]);
                             }
+
+                            setConnectionProperty(
+                                "authenticationType",
+                                AuthenticationType.AzureMFA,
+                            );
+                            setConnectionProperty("accountId", selectedAccountId ?? "");
+                            setConnectionProperty("tenantId", selectedTenantId ?? "");
                         }}
                         strings={{
                             title: Loc.connectionDialog.azureDatabases,

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
@@ -9,6 +9,7 @@ import { useConnectionDialogSelector } from "./connectionDialogSelector";
 import { Label, makeStyles } from "@fluentui/react-components";
 import { FormField } from "../../common/forms/form.component";
 import {
+    AuthenticationType,
     ConnectionDialogContextProps,
     ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
@@ -34,6 +35,9 @@ export const FabricBrowsePage = () => {
     const formState = useConnectionDialogSelector((s) => s.formState);
     const mainOptions = useConnectionDialogSelector((s) => s.connectionComponents.mainOptions);
     const formComponents = useConnectionDialogSelector((s) => s.formComponents);
+    const selectedAccountId = useConnectionDialogSelector((s) => s.selectedAccountId);
+    const selectedTenantId = useConnectionDialogSelector((s) => s.selectedTenantId);
+
     if (context === undefined) {
         return undefined;
     }
@@ -61,25 +65,32 @@ export const FabricBrowsePage = () => {
         context!.selectSqlCollection(collection.id);
     }
 
+    function setCommonConnectionProperties(database: SqlDbInfo) {
+        setConnectionProperty("profileName", generateProfileName(database));
+        setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
+        setConnectionProperty("accountId", selectedAccountId ?? "");
+        setConnectionProperty("tenantId", selectedTenantId ?? "");
+    }
+
     async function handleDatabaseSelected(database: SqlDbInfo) {
         switch (database.type) {
             case SqlArtifactTypes.SqlAnalyticsEndpoint: {
                 const serverUrl = await context!.getSqlAnalyticsEndpointUriFromFabric(database);
                 setConnectionProperty("server", serverUrl);
-                setConnectionProperty("profileName", generateProfileName(database));
+                setCommonConnectionProperties(database);
 
                 return;
             }
             case SqlArtifactTypes.SqlDatabase:
                 setConnectionProperty("server", database.server);
                 setConnectionProperty("database", database.databases[0]);
-                setConnectionProperty("profileName", generateProfileName(database));
+                setCommonConnectionProperties(database);
 
                 return;
             case SqlArtifactTypes.Warehouse:
                 setConnectionProperty("server", database.server);
                 setConnectionProperty("database", database.displayName);
-                setConnectionProperty("profileName", generateProfileName(database));
+                setCommonConnectionProperties(database);
 
                 return;
             default:

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
@@ -9,7 +9,6 @@ import { useConnectionDialogSelector } from "./connectionDialogSelector";
 import { Label, makeStyles } from "@fluentui/react-components";
 import { FormField } from "../../common/forms/form.component";
 import {
-    AuthenticationType,
     ConnectionDialogContextProps,
     ConnectionDialogFormItemSpec,
     ConnectionDialogWebviewState,
@@ -68,7 +67,6 @@ export const FabricBrowsePage = () => {
                 const serverUrl = await context!.getSqlAnalyticsEndpointUriFromFabric(database);
                 setConnectionProperty("server", serverUrl);
                 setConnectionProperty("profileName", generateProfileName(database));
-                setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
 
                 return;
             }
@@ -76,14 +74,12 @@ export const FabricBrowsePage = () => {
                 setConnectionProperty("server", database.server);
                 setConnectionProperty("database", database.databases[0]);
                 setConnectionProperty("profileName", generateProfileName(database));
-                setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
 
                 return;
             case SqlArtifactTypes.Warehouse:
                 setConnectionProperty("server", database.server);
                 setConnectionProperty("database", database.displayName);
                 setConnectionProperty("profileName", generateProfileName(database));
-                setConnectionProperty("authenticationType", AuthenticationType.AzureMFA);
 
                 return;
             default:


### PR DESCRIPTION
## Description

Addresses #22472

When a user selects a server or database in Browse Azure or Browse Fabric mode, authentication is now automatically pre-populated with Entra MFA + the account and tenant used for browsing.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md) 