### PR TITLE
Hide addAadAccount/removeAadAccount from command palette when useVscodeAccountsForEntraMFA is enabled

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -999,6 +999,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "mssql.addAadAccount",
+                    "when": "!config.mssql.preview.useVscodeAccountsForEntraMFA"
+                },
+                {
+                    "command": "mssql.removeAadAccount",
+                    "when": "!config.mssql.preview.useVscodeAccountsForEntraMFA"
+                },
+                {
                     "command": "mssql.objectExplorerNewQuery",
                     "when": "view == objectExplorer && viewItem =~ /\\btype=(disconnectedServer|Server|Database)\\b/"
                 },


### PR DESCRIPTION
Fixes #22473

## Changes

When `mssql.preview.useVscodeAccountsForEntraMFA` is `true` (the default), VS Code handles Entra MFA account sign-in natively. In this mode, `mssql.addAadAccount` and `mssql.removeAadAccount` are unnecessary and confusing in the command palette.

Added `commandPalette` entries in `package.json` with `when: "!config.mssql.preview.useVscodeAccountsForEntraMFA"` for both commands, hiding them when the setting is enabled.

### Files changed

- `extensions/mssql/package.json` — added `commandPalette` when-clauses for `mssql.addAadAccount` and `mssql.removeAadAccount`