### PR TITLE
Update preview status of shortcuts configuration and beta query results grid

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -579,7 +579,7 @@
                 },
                 {
                     "command": "mssql.shortcutsConfiguration.open",
-                    "when": "view == objectExplorer && (config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures)",
+                    "when": "view == objectExplorer",
                     "title": "%mssql.shortcutsConfiguration.open%",
                     "group": "navigation"
                 }
@@ -943,48 +943,37 @@
                     "when": "false"
                 },
                 {
-                    "command": "mssql.shortcutsConfiguration.open",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.shortcutsConfiguration.open"
                 },
                 {
-                    "command": "mssql.quickQueries.run1",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run1"
                 },
                 {
-                    "command": "mssql.quickQueries.run2",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run2"
                 },
                 {
-                    "command": "mssql.quickQueries.run3",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run3"
                 },
                 {
-                    "command": "mssql.quickQueries.run4",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run4"
                 },
                 {
-                    "command": "mssql.quickQueries.run5",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run5"
                 },
                 {
-                    "command": "mssql.quickQueries.run6",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run6"
                 },
                 {
-                    "command": "mssql.quickQueries.run7",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run7"
                 },
                 {
-                    "command": "mssql.quickQueries.run8",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run8"
                 },
                 {
-                    "command": "mssql.quickQueries.run9",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run9"
                 },
                 {
-                    "command": "mssql.quickQueries.run10",
-                    "when": "config.mssql.preview.shortcutsConfiguration || config.mssql.enableExperimentalFeatures"
+                    "command": "mssql.quickQueries.run10"
                 },
                 {
                     "command": "mssql.notebooks.copyCellMessages",
@@ -1823,12 +1812,6 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%mssql.preview.betaResultsGrid.description%",
-                    "scope": "application"
-                },
-                "mssql.preview.shortcutsConfiguration": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%mssql.preview.shortcutsConfiguration.description%",
                     "scope": "application"
                 },
                 "mssql.preview.useVscodeAccountsForEntraMFA": {

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -205,7 +205,6 @@
     "mssql.chooseAuthMethod": "Chooses which Authentication method to use",
     "mssql.preview.betaResultsGrid.description": "Enables the preview query results grid experience with improved state management and more column customization options, including showing, hiding, and freezing columns.",
     "mssql.preview.useVscodeAccountsForEntraMFA.description": "Uses VS Code signed-in accounts for Microsoft Entra ID MFA authentication to SQL. Restart Visual Studio Code after changing this setting.",
-    "mssql.preview.shortcutsConfiguration.description": "Enables the keyboard shortcuts configuration editor and Quick Queries commands.",
     "mssql.authCodeGrant.description": "Prompts users to sign in using their browser.",
     "mssql.deviceCode.description": "Allows users to sign in to input-constrained devices.",
     "mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription": "When enabled, connection groups will be collapsed instead of expanded at startup.",

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -296,9 +296,6 @@ export default class MainController implements vscode.Disposable {
                 const commandId = getQuickQueryCommandId(slotNumber);
                 this.registerCommand(commandId);
                 this._event.on(commandId, () => {
-                    if (!this.isShortcutsConfigurationEnabled()) {
-                        return;
-                    }
                     void this.runAndLogErrors(quickQueryService.run(slotNumber));
                 });
             }
@@ -2912,9 +2909,6 @@ export default class MainController implements vscode.Disposable {
     }
 
     public openShortcutsConfiguration(focusedQuickQuerySlot?: number): void {
-        if (!this.isShortcutsConfigurationEnabled()) {
-            return;
-        }
         if (
             this._shortcutsConfigurationController &&
             !this._shortcutsConfigurationController.isDisposed
@@ -2935,10 +2929,6 @@ export default class MainController implements vscode.Disposable {
         });
         this._shortcutsConfigurationController = controller;
         controller.revealToForeground();
-    }
-
-    private isShortcutsConfigurationEnabled(): boolean {
-        return previewService.isFeatureEnabled(PreviewFeature.ShortcutsConfiguration);
     }
 
     private configureQuickQueryService(): void {

--- a/extensions/mssql/src/previews/previewService.ts
+++ b/extensions/mssql/src/previews/previewService.ts
@@ -12,7 +12,6 @@ import * as vscode from "vscode";
  */
 export enum PreviewFeature {
     BetaResultsGrid = "betaResultsGrid",
-    ShortcutsConfiguration = "shortcutsConfiguration",
     UseVscodeAccountsForEntraMFA = "useVscodeAccountsForEntraMFA",
 }
 

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -8919,9 +8919,6 @@
     <trans-unit id="mssql.enableExperimentalFeatures.description">
       <source xml:lang="en">Enables experimental features in the MSSQL extension. The features are not production-ready and may have bugs or issues. Restart Visual Studio Code after changing this setting.</source>
     </trans-unit>
-    <trans-unit id="mssql.preview.shortcutsConfiguration.description">
-      <source xml:lang="en">Enables the keyboard shortcuts configuration editor and Quick Queries commands.</source>
-    </trans-unit>
     <trans-unit id="mssql.preview.betaResultsGrid.description">
       <source xml:lang="en">Enables the preview query results grid experience with improved state management and more column customization options, including showing, hiding, and freezing columns.</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Addresses #22477

* Ungates query shortcut UX entirely
* No change for beta query results grid (already disabled by default, even when `enableExperimentalFeatures` is enabled

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md) 
