### PR TITLE
Fix: Database project creates objects with wrong path delimiter on Li…

### DIFF
--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -11,6 +11,8 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added **Rename Symbol** refactoring support for SQL project files.
 - Added **Move to Schema** refactoring support for SQL project files.
 - Adds support for Microsoft.Build.Sql version to 2.2.0.
+- Removed the preview feature **"Generate SQL Projects from OpenAPI/Swagger spec"**.
+- Fixed an issue where database projects created objects with wrong path delimiter on Linux/macOS.
 
 ## [1.6.1] - 2026-06-03
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -788,8 +788,12 @@ export class ProjectsController {
         fallback: string,
         autoCreate: boolean,
     ): Promise<string> {
+        // Normalize paths for comparison: convert backslashes to forward slashes for cross-platform comparison
+        const normalizedTargetPath = utils.getPlatformSafeFileEntryPath(targetPath).toLowerCase();
         const existing = project.folders.find(
-            (f) => f.relativePath.toLowerCase() === targetPath.toLowerCase(),
+            (f) =>
+                utils.getPlatformSafeFileEntryPath(f.relativePath).toLowerCase() ===
+                normalizedTargetPath,
         );
         if (existing) {
             return existing.relativePath;
@@ -877,7 +881,7 @@ export class ProjectsController {
 
             // basePath is a single-segment schema folder (e.g. "dbo").
             // Check for / create the ObjectType subfolder under it.
-            const subfolderPath = utils.convertSlashesForSqlProj(path.join(basePath, folderName));
+            const subfolderPath = path.join(basePath, folderName);
             return this.findOrAddFolder(project, subfolderPath, basePath, autoCreate);
         }
 
@@ -900,11 +904,15 @@ export class ProjectsController {
 
         // Schema-dependent items (e.g. dbo/Tables/, sales/StoredProcedures/)
         const resolvedSchema = schemaName ?? constants.defaultSchemaName;
-        const nestedPath = utils.convertSlashesForSqlProj(path.join(resolvedSchema, folderName));
+        const nestedPath = path.join(resolvedSchema, folderName);
 
         // Single scan for nestedPath — avoids a second scan inside findOrAddFolder.
+        // Normalize paths for comparison: convert backslashes to forward slashes for cross-platform comparison
+        const normalizedNestedPath = utils.getPlatformSafeFileEntryPath(nestedPath).toLowerCase();
         const existingNested = project.folders.find(
-            (f) => f.relativePath.toLowerCase() === nestedPath.toLowerCase(),
+            (f) =>
+                utils.getPlatformSafeFileEntryPath(f.relativePath).toLowerCase() ===
+                normalizedNestedPath,
         );
         if (existingNested) {
             return existingNested.relativePath;

--- a/extensions/sql-database-projects/test/projectController.test.ts
+++ b/extensions/sql-database-projects/test/projectController.test.ts
@@ -322,11 +322,18 @@ suite("ProjectsController", function (): void {
                 expect(
                     await projController.resolveItemFolder(ItemType.schema, project, undefined),
                     "schema: should return Security/ when it exists",
-                ).to.equal(utils.convertSlashesForSqlProj(constants.securityFolderName));
+                ).to.equal(constants.securityFolderName);
+                // Normalize paths for cross-platform comparison
+                const result = await projController.resolveItemFolder(
+                    ItemType.table,
+                    project,
+                    "dbo",
+                );
+                const expectedPath = path.join("dbo", "Tables");
                 expect(
-                    await projController.resolveItemFolder(ItemType.table, project, "dbo"),
+                    utils.getPlatformSafeFileEntryPath(result).toLowerCase(),
                     "table: should return dbo/Tables when it exists",
-                ).to.equal(utils.convertSlashesForSqlProj(path.join("dbo", "Tables")));
+                ).to.equal(utils.getPlatformSafeFileEntryPath(expectedPath).toLowerCase());
             });
 
             test("resolveItemFolder: Stays at basePath without creating folders when subfolder is missing (auto-create OFF)", async function (): Promise<void> {
@@ -394,12 +401,18 @@ suite("ProjectsController", function (): void {
 
                 // One representative schema-dependent type is sufficient to verify the hierarchy
                 const foldersBefore = project.folders.length;
-                const expectedPath = utils.convertSlashesForSqlProj(path.join("dbo", "Tables"));
+                const expectedPath = path.join("dbo", "Tables");
 
+                // Normalize paths for cross-platform comparison
+                const result = await projController.resolveItemFolder(
+                    ItemType.table,
+                    project,
+                    "dbo",
+                );
                 expect(
-                    await projController.resolveItemFolder(ItemType.table, project, "dbo"),
+                    utils.getPlatformSafeFileEntryPath(result).toLowerCase(),
                     "table: returns dbo/Tables",
-                ).to.equal(expectedPath);
+                ).to.equal(utils.getPlatformSafeFileEntryPath(expectedPath).toLowerCase());
 
                 const reloaded = await Project.openProject(project.projectFilePath);
                 expect(reloaded.folders.length, "dbo/ and dbo/Tables should be created").to.equal(
@@ -411,7 +424,9 @@ suite("ProjectsController", function (): void {
                 ).to.be.true;
                 expect(
                     reloaded.folders.some(
-                        (f) => f.relativePath.toLowerCase() === expectedPath.toLowerCase(),
+                        (f) =>
+                            utils.getPlatformSafeFileEntryPath(f.relativePath).toLowerCase() ===
+                            utils.getPlatformSafeFileEntryPath(expectedPath).toLowerCase(),
                     ),
                     "dbo/Tables folder should exist",
                 ).to.be.true;
@@ -441,9 +456,9 @@ suite("ProjectsController", function (): void {
                 expect(
                     reloaded.folders.some(
                         (f) =>
-                            f.relativePath.toLowerCase() ===
+                            utils.getPlatformSafeFileEntryPath(f.relativePath).toLowerCase() ===
                             utils
-                                .convertSlashesForSqlProj(path.join("dbo", "Sequences"))
+                                .getPlatformSafeFileEntryPath(path.join("dbo", "Sequences"))
                                 .toLowerCase(),
                     ),
                     "dbo/Sequences should NOT have been created",
@@ -460,19 +475,19 @@ suite("ProjectsController", function (): void {
 
                 await project.addFolder("dbo");
                 const foldersBefore = project.folders.length;
-                const expectedPath = utils.convertSlashesForSqlProj(
-                    path.join("dbo", "StoredProcedures"),
-                );
+                const expectedPath = path.join("dbo", "StoredProcedures");
 
+                // Normalize paths for cross-platform comparison
+                const result = await projController.resolveItemFolder(
+                    ItemType.storedProcedure,
+                    project,
+                    "dbo",
+                    "dbo",
+                );
                 expect(
-                    await projController.resolveItemFolder(
-                        ItemType.storedProcedure,
-                        project,
-                        "dbo",
-                        "dbo",
-                    ),
+                    utils.getPlatformSafeFileEntryPath(result).toLowerCase(),
                     "Should create and return dbo/StoredProcedures",
-                ).to.equal(expectedPath);
+                ).to.equal(utils.getPlatformSafeFileEntryPath(expectedPath).toLowerCase());
 
                 const reloaded = await Project.openProject(project.projectFilePath);
                 expect(
@@ -481,7 +496,9 @@ suite("ProjectsController", function (): void {
                 ).to.equal(foldersBefore + 1);
                 expect(
                     reloaded.folders.some(
-                        (f) => f.relativePath.toLowerCase() === expectedPath.toLowerCase(),
+                        (f) =>
+                            utils.getPlatformSafeFileEntryPath(f.relativePath).toLowerCase() ===
+                            utils.getPlatformSafeFileEntryPath(expectedPath).toLowerCase(),
                     ),
                     "dbo/StoredProcedures folder should exist",
                 ).to.be.true;
@@ -501,7 +518,7 @@ suite("ProjectsController", function (): void {
                 await project.addFolder("Tables"); // root-level ObjectType folder (e.g. old project layout)
                 await project.addFolder(path.join("dbo", "Tables")); // already in Schema/ObjectType
                 const foldersBefore = project.folders.length;
-                const dboTablesPath = utils.convertSlashesForSqlProj(path.join("dbo", "Tables"));
+                const dboTablesPath = path.join("dbo", "Tables");
 
                 // 1. Non-schema-dependent type from a schema folder: must NOT create dbo/DatabaseTriggers
                 expect(


### PR DESCRIPTION
## ISSUE: https://github.com/microsoft/vscode-mssql/issues/22396 & https://github.com/microsoft/vscode-mssql/issues/22327
## PR: https://github.com/microsoft/vscode-mssql/pull/22476

## Description

This PR fixes

- The bug where SQL Database Projects create folders with literal backslashes in their names on Linux/macOS as (dbo\Tables/Table1.sql) instead of creating proper (dbo\Tables\Table1.sql) nested directory structures.
- Updated test expectations to use path.join() instead of hardcoded backslash paths
- Added getPlatformSafeFileEntryPath() for cross-platform path comparisons in assertions
- Added changelog updates

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
