### PR TITLE
Avoid blocking on serverless check when connection times out

### DIFF
--- a/extensions/mssql/src/connectionconfig/azureHelpers.ts
+++ b/extensions/mssql/src/connectionconfig/azureHelpers.ts
@@ -32,7 +32,7 @@ import {
     user,
 } from "../constants/constants";
 import { ILogger } from "../sharedInterfaces/logger";
-import { getLogger } from "../models/logger";
+import logger from "../models/logger";
 import { groupQuickPickItems, MssqlQuickPickItem } from "../utils/quickpickHelpers";
 import {
     AlwaysEncryptedEnclaveType,
@@ -71,14 +71,17 @@ import { IConnectionInfo } from "vscode-mssql";
 
 export const azureSubscriptionFilterConfigKey = "mssql.selectedAzureSubscriptions";
 export const MANAGED_INSTANCE_PUBLIC_PORT = 3342;
-const azureHelperLogger = getLogger("AzureHelpers");
+const azureHelperLogger = logger.withPrefix("Azure Helpers");
 const azureSqlServerSuffix = ".database.";
 
 //#region VS Code integration
 
 let _azureProvider: VSCodeAzureSubscriptionProvider | undefined;
 
-export const azureStatusesToRetry = ["Paused", "Pausing", "Resuming"];
+/** Key statuses for Azure SQL databases.  Any status not included here is considered non-retryable. */
+export type AzureSqlDatabaseStatus = "Paused" | "Pausing" | "Resuming" | "Online" | "UnableToCheck";
+
+export const azureStatusesToRetry: AzureSqlDatabaseStatus[] = ["Paused", "Pausing", "Resuming"];
 
 export class VsCodeAzureHelper {
     /**
@@ -417,10 +420,10 @@ export class VsCodeAzureHelper {
 
     /**
      * Uses the Azure ARM API to check the wake status of a database. All failures are logged and
-     * swallowed, returning undefined so the caller surfaces the original connection error.
+     * swallowed, returning "UnableToCheck".
      *
-     * @param credentials the connection being attempted.
-     * @param databaseName optional database name override, used when the database being accessed differs
+     * @param connection the connection being attempted.
+     * @param database optional database name override, used when the database being accessed differs
      *   from the connection's database (e.g. expanding a  database node on a server connection).
      * @param source short label identifying the caller who initiated the check
      */
@@ -428,7 +431,7 @@ export class VsCodeAzureHelper {
         connection: IConnectionInfo,
         database?: string,
         source?: string,
-    ): Promise<string | undefined> {
+    ): Promise<AzureSqlDatabaseStatus> {
         const databaseName = database ?? connection.database;
         const serverName = this.getAzureSqlServerName(connection.server);
         const accountId = connection.accountId;
@@ -440,63 +443,75 @@ export class VsCodeAzureHelper {
             azureHelperLogger.trace(
                 `Pause status check ${sourceSuffix}: could not determine status for ${target}`,
             );
-            return undefined;
+            return "UnableToCheck";
         }
+
+        azureHelperLogger.trace(
+            `Pause status check ${sourceSuffix}: determining if ${accountId} can check status for ${target}`,
+        );
 
         try {
             const subscriptions = await this.getSubscriptionsForAccount(accountId);
 
             for (const subscription of subscriptions) {
-                const sql = new SqlManagementClient(
-                    subscription.credential,
-                    subscription.subscriptionId,
-                    {
-                        endpoint: getCloudProviderSettings().settings.armResource.endpoint,
-                    },
-                );
+                try {
+                    const sql = new SqlManagementClient(
+                        subscription.credential,
+                        subscription.subscriptionId,
+                        {
+                            endpoint: getCloudProviderSettings().settings.armResource.endpoint,
+                        },
+                    );
 
-                const servers = await listAllIterator(sql.servers.list());
-                const matchingServer = servers.find(
-                    (server) => server.name?.toLowerCase() === serverName.toLowerCase(),
-                );
+                    const servers = await listAllIterator(sql.servers.list());
+                    const matchingServer = servers.find(
+                        (server) => server.name?.toLowerCase() === serverName.toLowerCase(),
+                    );
 
-                if (!matchingServer?.id) {
+                    if (!matchingServer?.id) {
+                        continue;
+                    }
+
+                    const resourceGroupName = extractFromResourceId(
+                        matchingServer.id,
+                        "resourceGroups",
+                    );
+                    if (!resourceGroupName) {
+                        continue;
+                    }
+
+                    const database = await sql.databases.get(
+                        resourceGroupName,
+                        serverName,
+                        databaseName,
+                    );
+
+                    azureHelperLogger.trace(
+                        `Pause check ${sourceSuffix}: database ${target} is ${database.status}`,
+                    );
+
+                    return (database?.status as AzureSqlDatabaseStatus) ?? "UnableToCheck";
+                } catch (err) {
+                    azureHelperLogger.trace(
+                        `Pause check ${sourceSuffix}: error occurred while checking database ${target} on subscription ${subscription.subscriptionId}; continuing... ${getErrorMessage(err)}`,
+                    );
+
                     continue;
                 }
-
-                const resourceGroupName = extractFromResourceId(
-                    matchingServer.id,
-                    "resourceGroups",
-                );
-                if (!resourceGroupName) {
-                    continue;
-                }
-
-                const database = await sql.databases.get(
-                    resourceGroupName,
-                    serverName,
-                    databaseName,
-                );
-
-                azureHelperLogger.trace(
-                    `Pause check ${sourceSuffix}: database ${target} is ${database.status}`,
-                );
-
-                return database?.status ?? undefined;
             }
         } catch (err) {
             azureHelperLogger.trace(
-                `Pause check ${sourceSuffix}: error occurred while checking database ${target}: ${getErrorMessage(err)}`,
+                `Pause check ${sourceSuffix}: error occurred while checking database ${target}; exiting. ${getErrorMessage(err)}`,
             );
 
-            return undefined;
+            return "UnableToCheck";
         }
 
         azureHelperLogger.trace(
             `Pause check ${sourceSuffix}: database ${target} could not be found for user ${accountId}`,
         );
 
-        return undefined;
+        return "UnableToCheck";
     }
 
     private static getAzureSqlServerName(server: string | undefined): string | undefined {

--- a/extensions/mssql/src/connectionconfig/azureHelpers.ts
+++ b/extensions/mssql/src/connectionconfig/azureHelpers.ts
@@ -83,7 +83,28 @@ export type AzureSqlDatabaseStatus = "Paused" | "Pausing" | "Resuming" | "Online
 
 export const azureStatusesToRetry: AzureSqlDatabaseStatus[] = ["Paused", "Pausing", "Resuming"];
 
+/**
+ * Location of an Azure SQL logical server resource, resolved from an account + server name. This
+ * is the expensive-to-compute, stable part of a pause-status check (finding which subscription and
+ * resource group a server lives in), so it is cached and reused across status checks.
+ */
+export interface SqlServerResourceInfo {
+    accountId: string;
+    subscriptionId: string;
+    resourceGroup: string;
+}
+
 export class VsCodeAzureHelper {
+    /**
+     * Cache of Azure SQL server resource lookups, keyed by `${accountId}|${serverName}`. Stores the
+     * in-flight/resolved promise so concurrent callers share one lookup and resolved results
+     * (including "UnableToCheck") are reused instead of re-scanning every subscription each time.
+     */
+    private static readonly _sqlResourceCache = new Map<
+        string,
+        Promise<SqlServerResourceInfo | "UnableToCheck">
+    >();
+
     /**
      * Returns the singleton `VSCodeAzureSubscriptionProvider` instance used for all Azure auth operations.
      */
@@ -422,6 +443,10 @@ export class VsCodeAzureHelper {
      * Uses the Azure ARM API to check the wake status of a database. All failures are logged and
      * swallowed, returning "UnableToCheck".
      *
+     * The (expensive) server-to-subscription/resource-group lookup is delegated to
+     * {@link findSqlResource}, which is cached, so repeated status checks for the same server only
+     * pay for the live `databases.get` status call.
+     *
      * @param connection the connection being attempted.
      * @param database optional database name override, used when the database being accessed differs
      *   from the connection's database (e.g. expanding a  database node on a server connection).
@@ -446,11 +471,109 @@ export class VsCodeAzureHelper {
             return "UnableToCheck";
         }
 
-        azureHelperLogger.trace(
-            `Pause status check ${sourceSuffix}: determining if ${accountId} can check status for ${target}`,
-        );
+        // Resolve (from cache when possible) which subscription/resource group the server lives in.
+        const resource = await this.findSqlResource(accountId, serverName);
+        if (resource === "UnableToCheck") {
+            azureHelperLogger.trace(
+                `Pause status check ${sourceSuffix}: server for ${target} could not be located for user ${accountId}`,
+            );
+            return "UnableToCheck";
+        }
 
         try {
+            const subscriptions = await this.getSubscriptionsForAccount(accountId);
+            const subscription = subscriptions.find(
+                (sub) => sub.subscriptionId === resource.subscriptionId,
+            );
+
+            if (!subscription) {
+                azureHelperLogger.trace(
+                    `Pause status check ${sourceSuffix}: subscription ${resource.subscriptionId} for ${target} is no longer available to user ${accountId}`,
+                );
+                return "UnableToCheck";
+            }
+
+            const sql = new SqlManagementClient(
+                subscription.credential,
+                subscription.subscriptionId,
+                {
+                    endpoint: getCloudProviderSettings().settings.armResource.endpoint,
+                },
+            );
+
+            const dbResource = await sql.databases.get(
+                resource.resourceGroup,
+                serverName,
+                databaseName,
+            );
+
+            azureHelperLogger.trace(
+                `Pause check ${sourceSuffix}: database ${target} is ${dbResource.status}`,
+            );
+
+            return (dbResource?.status as AzureSqlDatabaseStatus) ?? "UnableToCheck";
+        } catch (err) {
+            azureHelperLogger.trace(
+                `Pause check ${sourceSuffix}: error occurred while checking database ${target}; exiting. ${getErrorMessage(err)}`,
+            );
+
+            return "UnableToCheck";
+        }
+    }
+
+    /**
+     * Finds which subscription and resource group an Azure SQL logical server belongs to for the
+     * given account, by scanning the account's subscriptions. The result (including "UnableToCheck"
+     * when the server can't be located) is cached by `${accountId}|${serverName}`, and concurrent
+     * lookups share a single in-flight promise, so the expensive per-subscription server scan runs
+     * at most once per server per session.
+     *
+     * @param accountId the Azure account to search within.
+     * @param serverName the Azure SQL logical server name (without the `.database.*` suffix).
+     */
+    public static findSqlResource(
+        accountId: string,
+        serverName: string,
+    ): Promise<SqlServerResourceInfo | "UnableToCheck"> {
+        const cacheKey = `${accountId}|${serverName.toLowerCase()}`;
+
+        const cached = this._sqlResourceCache.get(cacheKey);
+        if (cached) {
+            azureHelperLogger.trace(
+                `SQL resource lookup: cache hit for server "${serverName}" (user ${accountId})`,
+            );
+            return cached;
+        }
+
+        azureHelperLogger.trace(
+            `SQL resource lookup: cache miss for server "${serverName}" (user ${accountId}); searching subscriptions`,
+        );
+
+        // The worker never rejects (all failures resolve to "UnableToCheck"), so the cached promise
+        // is always safe to reuse.
+        const lookup = this.searchForSqlResource(accountId, serverName);
+        this._sqlResourceCache.set(cacheKey, lookup);
+        return lookup;
+    }
+
+    /**
+     * Clears the cached {@link findSqlResource} lookups. Useful when account/subscription
+     * membership may have changed, and for keeping unit tests isolated from one another.
+     */
+    public static clearSqlResourceCache(): void {
+        azureHelperLogger.trace("SQL resource lookup: clearing cache");
+        this._sqlResourceCache.clear();
+    }
+
+    private static async searchForSqlResource(
+        accountId: string,
+        serverName: string,
+    ): Promise<SqlServerResourceInfo | "UnableToCheck"> {
+        try {
+            azureHelperLogger.trace(
+                `SQL resource lookup: searching for '${serverName}' in account '${accountId}'`,
+            );
+
             const subscriptions = await this.getSubscriptionsForAccount(accountId);
 
             for (const subscription of subscriptions) {
@@ -472,28 +595,26 @@ export class VsCodeAzureHelper {
                         continue;
                     }
 
-                    const resourceGroupName = extractFromResourceId(
+                    const resourceGroup = extractFromResourceId(
                         matchingServer.id,
                         "resourceGroups",
                     );
-                    if (!resourceGroupName) {
+                    if (!resourceGroup) {
                         continue;
                     }
 
-                    const database = await sql.databases.get(
-                        resourceGroupName,
-                        serverName,
-                        databaseName,
-                    );
-
                     azureHelperLogger.trace(
-                        `Pause check ${sourceSuffix}: database ${target} is ${database.status}`,
+                        `SQL resource lookup: found server "${serverName}" in subscription ${subscription.subscriptionId}, resource group ${resourceGroup} (user ${accountId})`,
                     );
 
-                    return (database?.status as AzureSqlDatabaseStatus) ?? "UnableToCheck";
+                    return {
+                        accountId,
+                        subscriptionId: subscription.subscriptionId,
+                        resourceGroup,
+                    };
                 } catch (err) {
                     azureHelperLogger.trace(
-                        `Pause check ${sourceSuffix}: error occurred while checking database ${target} on subscription ${subscription.subscriptionId}; continuing... ${getErrorMessage(err)}`,
+                        `SQL resource lookup: error searching subscription ${subscription.subscriptionId} for server "${serverName}"; continuing... ${getErrorMessage(err)}`,
                     );
 
                     continue;
@@ -501,14 +622,14 @@ export class VsCodeAzureHelper {
             }
         } catch (err) {
             azureHelperLogger.trace(
-                `Pause check ${sourceSuffix}: error occurred while checking database ${target}; exiting. ${getErrorMessage(err)}`,
+                `SQL resource lookup: error searching for server "${serverName}"; exiting. ${getErrorMessage(err)}`,
             );
 
             return "UnableToCheck";
         }
 
         azureHelperLogger.trace(
-            `Pause check ${sourceSuffix}: database ${target} could not be found for user ${accountId}`,
+            `SQL resource lookup: server "${serverName}" could not be found for user ${accountId}`,
         );
 
         return "UnableToCheck";

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -11,7 +11,11 @@ import { AccountStore } from "../azure/accountStore";
 import { AzureController } from "../azure/azureController";
 import { MsalAzureController } from "../azure/msal/msalAzureController";
 import { getCloudId, getCloudProviderSettings } from "../azure/providerSettings";
-import { azureStatusesToRetry, VsCodeAzureHelper } from "../connectionconfig/azureHelpers";
+import {
+    azureStatusesToRetry,
+    AzureSqlDatabaseStatus,
+    VsCodeAzureHelper,
+} from "../connectionconfig/azureHelpers";
 import {
     acquireTokenFromVscodeAccountForResource,
     getCloudResourceEndpoint,
@@ -1438,9 +1442,9 @@ export default class ConnectionManager {
 
         // If the connection can be checked, start the serverless status check in parallel with the connection attempt.
         // The result determines silent retry if the connection attempt times out.
-        const serverlessStatusPromise = isPauseAwareConnection
+        const serverlessStatusPromise: Promise<AzureSqlDatabaseStatus> = isPauseAwareConnection
             ? VsCodeAzureHelper.getAzureSqlDatabaseStatus(credentials, undefined, "direct connect")
-            : undefined;
+            : Promise.resolve("UnableToCheck");
         // Add the connection to the active connections list
         let connectionInfo: ConnectionInfo = new ConnectionInfo();
         connectionInfo.credentials = credentials;
@@ -1649,15 +1653,22 @@ export default class ConnectionManager {
     /**
      * Determines whether a timed-out connection/expand attempt should be silently retried.
      *
+     * The connection/expand attempt has already timed out by the time this is called, so we only
+     * consult the pause-state check if it has ALREADY resolved. If it's still in flight we do NOT
+     * wait for it (which could take much longer than the connection timeout for users with many
+     * subscriptions) — we surface the timeout error immediately instead.
+     *
      * @param credentials the connection being attempted.
      * @param failedAttempts number of connection attempts that have already failed (including initial attempt).
-     * @param statusPromise In-flight status check promise
+     * @param statusPromise In-flight status check promise. Resolves to an
+     *   {@link AzureSqlDatabaseStatus} (never `undefined`); `undefined` from the race below means
+     *   the check hadn't resolved yet.
      * @param databaseName optional database name override for the status check.
      */
     public async shouldRetryForPausedServerlessDatabase(
         credentials: IConnectionInfo,
         failedAttempts: number,
-        statusPromise: Promise<string | undefined>,
+        statusPromise: Promise<AzureSqlDatabaseStatus>,
         databaseName?: string,
     ): Promise<boolean> {
         if (
@@ -1667,9 +1678,19 @@ export default class ConnectionManager {
             return false;
         }
 
-        const status = await statusPromise;
+        // Peek at the status check without waiting: race it against an already-resolved `undefined`.
+        // Since the status check never resolves to `undefined`, a resulting `undefined` unambiguously
+        // means "the check hasn't finished yet" -> don't retry, surface the timeout now.
+        const status = await Promise.race([statusPromise, Promise.resolve(undefined)]);
 
-        if (!status || !azureStatusesToRetry.includes(status)) {
+        if (status === undefined) {
+            this._logger.info(
+                `Serverless pause-aware retry: pause-state check for database "${databaseName ?? credentials.database}" on "${credentials.server}" did not finish before the connection timeout; surfacing the error without retrying.`,
+            );
+            return false;
+        }
+
+        if (!azureStatusesToRetry.includes(status)) {
             return false;
         }
 

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -60,7 +60,7 @@ import { NewDeploymentTreeNode } from "../deployment/newDeploymentTreeNode";
 import { getErrorMessage, uuid } from "../utils/utils";
 import { ConnectionConfig } from "../connectionconfig/connectionconfig";
 import { MissingEntraAuthAccountError } from "../azure/vscodeEntraMfaUtils";
-import { VsCodeAzureHelper } from "../connectionconfig/azureHelpers";
+import { AzureSqlDatabaseStatus, VsCodeAzureHelper } from "../connectionconfig/azureHelpers";
 import { PreviewFeature, previewService } from "../previews/previewService";
 import { getNodeDescriptor } from "./nodes/nodeUtils";
 
@@ -235,7 +235,7 @@ export class ObjectExplorerService {
                           databaseName,
                           "OE expand",
                       )
-                    : undefined;
+                    : Promise.resolve<AzureSqlDatabaseStatus>("UnableToCheck");
 
                 this.showResumingDatabaseLabelWhenWaking(
                     () => node,
@@ -656,7 +656,7 @@ export class ObjectExplorerService {
      */
     private showResumingDatabaseLabelWhenWaking(
         resolveNode: () => TreeNodeInfo | undefined,
-        statusPromise: Promise<string | undefined> | undefined,
+        statusPromise: Promise<AzureSqlDatabaseStatus> | undefined,
         isStillLoading: () => boolean,
     ): void {
         if (!statusPromise) {
@@ -719,14 +719,13 @@ export class ObjectExplorerService {
                     this.cleanNodeChildren(element);
                     await this.setLoadingUiForNode(element);
                     void this.getOrCreateNodeChildrenWithSession(element);
-                    return;
+                } else {
+                    element.shouldRefresh = false;
+                    this._logger.trace(
+                        `getOrCreateNodeChildrenWithSession end: ${getNodeDescriptor(element)} - refresh callback follows`,
+                    );
+                    this._refreshCallback(element);
                 }
-
-                element.shouldRefresh = false;
-                this._logger.trace(
-                    `getOrCreateNodeChildrenWithSession end: ${getNodeDescriptor(element)} — refresh callback follows`,
-                );
-                this._refreshCallback(element);
             }
         })();
 
@@ -837,13 +836,14 @@ export class ObjectExplorerService {
         // Retry loop for paused Azure serverless databases
         const maxAttempts = serverlessWakeMaxRetryAttempts + 1;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            const serverlessStatusPromise = canCheckDatabasePauseStatus(connectionProfile)
-                ? VsCodeAzureHelper.getAzureSqlDatabaseStatus(
-                      connectionProfile,
-                      undefined,
-                      "OE session",
-                  )
-                : undefined;
+            const serverlessStatusPromise: Promise<AzureSqlDatabaseStatus> =
+                canCheckDatabasePauseStatus(connectionProfile)
+                    ? VsCodeAzureHelper.getAzureSqlDatabaseStatus(
+                          connectionProfile,
+                          undefined,
+                          "OE session",
+                      )
+                    : Promise.resolve("UnableToCheck");
 
             this.showResumingDatabaseLabelWhenWaking(
                 () => this.getConnectionNodeFromProfile(connectionProfile),

--- a/extensions/mssql/test/unit/azureHelpers.test.ts
+++ b/extensions/mssql/test/unit/azureHelpers.test.ts
@@ -492,7 +492,7 @@ suite("Azure Helpers", () => {
             accountId: "account-1",
         } as unknown as import("vscode-mssql").IConnectionInfo;
 
-        test("returns undefined without querying Azure when accountId is missing", async () => {
+        test("returns UnableToCheck without querying Azure when accountId is missing", async () => {
             const getSubs = sandbox.stub(
                 azureHelpers.VsCodeAzureHelper,
                 "getSubscriptionsForAccount",
@@ -503,11 +503,11 @@ suite("Azure Helpers", () => {
                 accountId: undefined,
             } as any);
 
-            expect(result).to.be.undefined;
+            expect(result).to.equal("UnableToCheck");
             expect(getSubs.called, "should not query subscriptions").to.be.false;
         });
 
-        test("returns undefined for a server name that isn't an Azure SQL server", async () => {
+        test("returns UnableToCheck for a server name that isn't an Azure SQL server", async () => {
             const getSubs = sandbox.stub(
                 azureHelpers.VsCodeAzureHelper,
                 "getSubscriptionsForAccount",
@@ -518,11 +518,11 @@ suite("Azure Helpers", () => {
                 server: "localhost",
             } as any);
 
-            expect(result).to.be.undefined;
+            expect(result).to.equal("UnableToCheck");
             expect(getSubs.called, "should not query subscriptions").to.be.false;
         });
 
-        test("returns undefined without a database name to look up", async () => {
+        test("returns UnableToCheck without a database name to look up", async () => {
             const getSubs = sandbox.stub(
                 azureHelpers.VsCodeAzureHelper,
                 "getSubscriptionsForAccount",
@@ -533,11 +533,11 @@ suite("Azure Helpers", () => {
                 database: undefined,
             } as any);
 
-            expect(result).to.be.undefined;
+            expect(result).to.equal("UnableToCheck");
             expect(getSubs.called, "should not query subscriptions").to.be.false;
         });
 
-        test("returns undefined when the account has no subscriptions to search", async () => {
+        test("returns UnableToCheck when the account has no subscriptions to search", async () => {
             const getSubs = sandbox
                 .stub(azureHelpers.VsCodeAzureHelper, "getSubscriptionsForAccount")
                 .resolves([]);
@@ -545,7 +545,7 @@ suite("Azure Helpers", () => {
             const result =
                 await azureHelpers.VsCodeAzureHelper.getAzureSqlDatabaseStatus(azureConnection);
 
-            expect(result).to.be.undefined;
+            expect(result).to.equal("UnableToCheck");
             expect(getSubs).to.have.been.calledOnceWithExactly("account-1");
         });
     });

--- a/extensions/mssql/test/unit/azureHelpers.test.ts
+++ b/extensions/mssql/test/unit/azureHelpers.test.ts
@@ -41,6 +41,8 @@ suite("Azure Helpers", () => {
 
     teardown(() => {
         sandbox.restore();
+        // Static cache persists across tests; clear it to keep tests isolated.
+        azureHelpers.VsCodeAzureHelper.clearSqlResourceCache();
     });
 
     suite("VsCodeAzureHelpers", () => {

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -1248,11 +1248,33 @@ suite("ConnectionManager Tests", () => {
                 expect(result).to.be.false;
             });
 
-            test("returns false when the status check can't determine a status", async () => {
+            test("returns false when the status check reports UnableToCheck", async () => {
                 const result = await testConnectionManager.shouldRetryForPausedServerlessDatabase(
                     azureMfaUserDbConnection(),
                     1,
-                    Promise.resolve(undefined as unknown as string),
+                    Promise.resolve("UnableToCheck"),
+                );
+                expect(result).to.be.false;
+            });
+
+            test("returns false when the database is online (not a waking status)", async () => {
+                const result = await testConnectionManager.shouldRetryForPausedServerlessDatabase(
+                    azureMfaUserDbConnection(),
+                    1,
+                    Promise.resolve("Online"),
+                );
+                expect(result).to.be.false;
+            });
+
+            test("returns false immediately when the status check hasn't resolved before the timeout", async () => {
+                // A never-resolving promise simulates an ARM check still in flight when the
+                // connection attempt has already timed out. The method must not wait for it.
+                const neverResolves = new Promise<azureHelpers.AzureSqlDatabaseStatus>(() => {});
+
+                const result = await testConnectionManager.shouldRetryForPausedServerlessDatabase(
+                    azureMfaUserDbConnection(),
+                    1,
+                    neverResolves,
                 );
                 expect(result).to.be.false;
             });


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/22493

This PR addresses an issue where connections that are potentially able to be checked for database pause status block on the completion of the check before attempting a retry after timeout.  For most users, this is likely fine, but when users have access to many and/or large subscriptions, this check can take a long time and delays a potential retry needlessly (and without indicating to the user).  This occurs because every subscription the Entra user has access to must be searched for the database in question.

This PR fixes that with the following changes:
* if a connection times out before the ARM status check is complete, the timeout error is immediately displayed to the user
* if/when a database is found in a subscription + resource group, that information is cached for the rest of the session to avoid subsequent searches
* in-progress search promises are cached to avoid duplicate concurrent efforts

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
