### PR TITLE
Add preview SQL formatter setting

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2443,6 +2443,12 @@
                     "default": false,
                     "scope": "window"
                 },
+                "mssql.format.enablePreviewFormatter": {
+                    "type": "boolean",
+                    "description": "%mssql.format.enablePreviewFormatter%",
+                    "default": false,
+                    "scope": "window"
+                },
                 "mssql.format.datatypeCasing": {
                     "type": "string",
                     "description": "%mssql.format.datatypeCasing%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -143,6 +143,7 @@
     "mssql.splitPaneSelection": "[Optional] Configuration options for which column new result panes should open in",
     "mssql.preventAutoExecuteScript": "Prevent automatic execution of scripts (e.g., 'Select Top 1000'). When enabled, scripts will not be automatically executed upon generation.",
     "mssql.format.alignColumnDefinitionsInColumns": "Should column definitions be aligned?",
+    "mssql.format.enablePreviewFormatter": "Use the preview SQL formatter.",
     "mssql.format.datatypeCasing": "Should data types be formatted as UPPERCASE, lowercase, or none (not formatted)",
     "mssql.format.keywordCasing": "Should keywords be formatted as UPPERCASE, lowercase, or none (not formatted)",
     "mssql.format.placeCommasBeforeNextStatement": "should commas be placed at the beginning of each statement in a list e.g. ', mycolumn2' instead of at the end e.g. 'mycolumn1,'",

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260709.2",
+        version: "6.0.20260709.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260709.1",
+        version: "6.0.20260713.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9396,6 +9396,9 @@
     <trans-unit id="mssql.resultsGrid.useDataOnlyEnumDescription">
       <source xml:lang="en">Use only row data to size columns automatically</source>
     </trans-unit>
+    <trans-unit id="mssql.format.enablePreviewFormatter">
+      <source xml:lang="en">Use the preview SQL formatter.</source>
+    </trans-unit>
     <trans-unit id="mssql.preview.useVscodeAccountsForEntraMFA.description">
       <source xml:lang="en">Uses VS Code signed-in accounts for Microsoft Entra ID MFA authentication to SQL. Restart Visual Studio Code after changing this setting.</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Adds the opt-in `mssql.format.enablePreviewFormatter` setting, disabled by default, to let users enable the new ScriptDom-based SQL formatter.

This PR updates the SQL Tools Service dependency to `6.0.20260713.1`, which contains the formatter implementation. The existing formatter remains the default, so there is no behavior change until the preview setting is enabled.

STS diff:
https://github.com/microsoft/sqltoolsservice/compare/6.0.20260709.2...6.0.20260713.1
<img width="1328" height="628" alt="Screenshot 2026-07-13 at 1 42 53 PM" src="https://github.com/user-attachments/assets/5b476430-c22f-4efa-8457-ff01b9380a02" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
  - Formatter rollout telemetry is emitted by SQL Tools Service.
- [x] No regressions or UX breakage
  - The preview setting defaults to `false`.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)