### PR TITLE
Fix SQL Projects activation in bundled VSIX

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -359,13 +359,21 @@ export interface IPackageInfo {
     aiKey: string;
 }
 
+/**
+ * Returns candidate extension roots for runtime layouts that load this module.
+ *
+ * Supported examples:
+ * - Bundled VSIX entry: <extension>/dist/extension.js
+ * - Local build output: <extension>/out/src/common/utils.js
+ * - Bundled source output: <extension>/dist/src/common/utils.js
+ *
+ * We intentionally keep only the direct parent and the three-level ancestor,
+ * which map to extension roots for the supported layouts above.
+ */
 function getExtensionRootCandidates(moduleDirectory: string): string[] {
     return Array.from(
         new Set([
-            // Bundled VSIX layout: <extension>/dist/extension.js
             path.resolve(moduleDirectory, ".."),
-            // TypeScript output layouts used by local builds and tests.
-            path.resolve(moduleDirectory, "..", ".."),
             path.resolve(moduleDirectory, "..", "..", ".."),
         ]),
     );
@@ -386,6 +394,12 @@ function readJsonFromExtensionRoot(relativePath: string, moduleDirectory: string
     return undefined;
 }
 
+/**
+ * Returns extension package metadata.
+ *
+ * If `packageJson` is not provided, metadata is discovered from candidate
+ * extension roots derived from `moduleDirectory`.
+ */
 export function getPackageInfo(
     packageJson?: any,
     moduleDirectory: string = __dirname,

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -359,12 +359,20 @@ export interface IPackageInfo {
     aiKey: string;
 }
 
-const extensionRootCandidates = Array.from(
-    new Set([path.resolve(__dirname, "..", ".."), path.resolve(__dirname, "..", "..", "..")]),
-);
+function getExtensionRootCandidates(moduleDirectory: string): string[] {
+    return Array.from(
+        new Set([
+            // Bundled VSIX layout: <extension>/dist/extension.js
+            path.resolve(moduleDirectory, ".."),
+            // TypeScript output layouts used by local builds and tests.
+            path.resolve(moduleDirectory, "..", ".."),
+            path.resolve(moduleDirectory, "..", "..", ".."),
+        ]),
+    );
+}
 
-function readJsonFromExtensionRoot(relativePath: string): any {
-    for (const candidateRoot of extensionRootCandidates) {
+function readJsonFromExtensionRoot(relativePath: string, moduleDirectory: string): any {
+    for (const candidateRoot of getExtensionRootCandidates(moduleDirectory)) {
         const candidate = path.join(candidateRoot, relativePath);
         if (fse.pathExistsSync(candidate)) {
             try {
@@ -378,9 +386,12 @@ function readJsonFromExtensionRoot(relativePath: string): any {
     return undefined;
 }
 
-export function getPackageInfo(packageJson?: any): IPackageInfo | undefined {
+export function getPackageInfo(
+    packageJson?: any,
+    moduleDirectory: string = __dirname,
+): IPackageInfo | undefined {
     if (!packageJson) {
-        packageJson = readJsonFromExtensionRoot("package.json");
+        packageJson = readJsonFromExtensionRoot("package.json", moduleDirectory);
     }
 
     if (!packageJson) {

--- a/extensions/sql-database-projects/test/utils.test.ts
+++ b/extensions/sql-database-projects/test/utils.test.ts
@@ -203,4 +203,26 @@ suite("Tests to verify utils functions", function (): void {
             await fs.rm(root, { recursive: true, force: true });
         }
     });
+
+    test("Should read package info from the bundled extension layout", async () => {
+        const extensionRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sqlproj-bundle-"));
+        const bundleDirectory = path.join(extensionRoot, "dist");
+        const packageInfo = {
+            name: "sql-database-projects-vscode",
+            version: "1.2.3",
+            aiKey: "test-key",
+        };
+
+        try {
+            await fs.mkdir(bundleDirectory);
+            await fs.writeFile(
+                path.join(extensionRoot, "package.json"),
+                JSON.stringify(packageInfo),
+            );
+
+            expect(utils.getPackageInfo(undefined, bundleDirectory)).to.deep.equal(packageInfo);
+        } finally {
+            await fs.rm(extensionRoot, { recursive: true, force: true });
+        }
+    });
 });


### PR DESCRIPTION
## Description

Fix SQL Database Projects activation from its bundled VSIX by resolving package metadata from the `<extension>/dist` layout. Adds a regression test for the packaged directory structure.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant (no event changes required)
- [x] No regressions or UX breakage

## Validation

- `npm run build:extension`
- `npx vscode-test --grep "bundled extension layout" --skip-extension-dependencies`
- Production VSIX activation smoke test with an isolated four-extension profile

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)