### PR TITLE
Forward STS language service telemetry to vscode-mssql

### DIFF
--- a/extensions/mssql/src/languageservice/serviceclient.ts
+++ b/extensions/mssql/src/languageservice/serviceclient.ts
@@ -451,6 +451,10 @@ export default class SqlToolsServiceClient {
             LanguageServiceContracts.StatusChangedNotification.type,
             this.handleLanguageServiceStatusNotification(),
         );
+        client.onNotification(
+            LanguageServiceContracts.SqlToolsServiceTelemetryNotification.type,
+            this.handleSqlToolsServiceTelemetryNotification(),
+        );
 
         return client;
     }
@@ -487,6 +491,20 @@ export default class SqlToolsServiceClient {
                 );
             }
             this._statusView.languageServiceStatusChanged(event.ownerUri, event.status);
+        };
+    }
+
+    /**
+     * Public for testing purposes only.
+     */
+    public handleSqlToolsServiceTelemetryNotification(): NotificationHandler<LanguageServiceContracts.SqlToolsServiceTelemetryParams> {
+        return (event: LanguageServiceContracts.SqlToolsServiceTelemetryParams): void => {
+            sendActionEvent(
+                TelemetryViews.QueryEditor,
+                event.params.eventName,
+                event.params.properties ?? {},
+                event.params.measures ?? {},
+            );
         };
     }
 

--- a/extensions/mssql/src/models/contracts/languageService.ts
+++ b/extensions/mssql/src/models/contracts/languageService.ts
@@ -4,6 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NotificationType, RequestType } from "vscode-languageclient";
+import { TelemetryActions } from "../../sharedInterfaces/telemetry";
+
+// ------------------------------- < SQL Tools Service Telemetry Event > --------------------------
+
+export interface SqlToolsServiceTelemetryParams {
+    params: {
+        eventName: TelemetryActions;
+        properties?: Record<string, string>;
+        measures?: Record<string, number>;
+    };
+}
+
+/**
+ * Event sent when SQL Tools Service emits a telemetry event.
+ */
+export namespace SqlToolsServiceTelemetryNotification {
+    export const type = new NotificationType<SqlToolsServiceTelemetryParams>("telemetry/sqlevent");
+}
+
+// ------------------------------- </ SQL Tools Service Telemetry Event > -------------------------
 
 // ------------------------------- < IntelliSense Ready Event > ------------------------------------
 

--- a/extensions/mssql/src/sharedInterfaces/telemetry.ts
+++ b/extensions/mssql/src/sharedInterfaces/telemetry.ts
@@ -290,6 +290,11 @@ export enum TelemetryActions {
     CancelCellExecution = "CancelCellExecution",
     KernelSelected = "KernelSelected",
     Stats = "Stats",
+    // ------------------------------- < SQL Tools Service > ------------------------------------
+    FormatCode = "FormatCode",
+    PeekDefinitionRequested = "PeekDefinitionRequested",
+    IntellisenseQuantile = "IntellisenseQuantile",
+    // ------------------------------- </ SQL Tools Service > -----------------------------------
 }
 
 /**

--- a/extensions/mssql/test/unit/serviceClient.test.ts
+++ b/extensions/mssql/test/unit/serviceClient.test.ts
@@ -125,7 +125,7 @@ suite("Service Client tests", () => {
 
         serviceClient.handleSqlToolsServiceTelemetryNotification()(event);
 
-        expect(sendActionEvent).to.have.been.calledOnceWithExactly(
+        expect(sendActionEvent).to.have.been.calledWithExactly(
             TelemetryViews.QueryEditor,
             TelemetryActions.FormatCode,
             event.params.properties,
@@ -140,7 +140,7 @@ suite("Service Client tests", () => {
             params: { eventName: TelemetryActions.PeekDefinitionRequested },
         });
 
-        expect(sendActionEvent).to.have.been.calledOnceWithExactly(
+        expect(sendActionEvent).to.have.been.calledWithExactly(
             TelemetryViews.QueryEditor,
             TelemetryActions.PeekDefinitionRequested,
             {},

--- a/extensions/mssql/test/unit/serviceClient.test.ts
+++ b/extensions/mssql/test/unit/serviceClient.test.ts
@@ -17,6 +17,7 @@ import { PlatformInformation, Runtime } from "../../src/models/platform";
 import StatusView from "../../src/views/statusView";
 import * as LanguageServiceContracts from "../../src/models/contracts/languageService";
 import { Logger } from "../../src/models/logger";
+import { TelemetryActions, TelemetryViews } from "../../src/sharedInterfaces/telemetry";
 import { stubTelemetry, stubVscodeEnv } from "./utils";
 
 chai.use(sinonChai);
@@ -41,6 +42,7 @@ suite("Service Client tests", () => {
     let testStatusView: sinon.SinonStubbedInstance<StatusView>;
     let loggerShowStub: sinon.SinonStub;
     let dotnetRuntimeProvider: sinon.SinonStubbedInstance<DotnetRuntimeProvider>;
+    let sendActionEvent: sinon.SinonStub;
     let originalStsOverride: string | undefined;
 
     setup(() => {
@@ -49,7 +51,7 @@ suite("Service Client tests", () => {
         testStatusView = sandbox.createStubInstance(StatusView);
         loggerShowStub = sandbox.stub(Logger.prototype, "show");
         dotnetRuntimeProvider = sandbox.createStubInstance(DotnetRuntimeProvider);
-        stubTelemetry(sandbox);
+        ({ sendActionEvent } = stubTelemetry(sandbox));
         originalStsOverride = process.env.MSSQL_SQLTOOLSSERVICE;
         delete process.env.MSSQL_SQLTOOLSSERVICE;
     });
@@ -110,6 +112,41 @@ suite("Service Client tests", () => {
             },
         );
     }
+
+    test("forwards SQL Tools Service telemetry", () => {
+        const serviceClient = createServiceClient();
+        const event: LanguageServiceContracts.SqlToolsServiceTelemetryParams = {
+            params: {
+                eventName: TelemetryActions.FormatCode,
+                properties: { FormatterImplementation: "ScriptDom" },
+                measures: { FormatterDurationMs: 12.5 },
+            },
+        };
+
+        serviceClient.handleSqlToolsServiceTelemetryNotification()(event);
+
+        expect(sendActionEvent).to.have.been.calledOnceWithExactly(
+            TelemetryViews.QueryEditor,
+            TelemetryActions.FormatCode,
+            event.params.properties,
+            event.params.measures,
+        );
+    });
+
+    test("forwards SQL Tools Service telemetry without optional data", () => {
+        const serviceClient = createServiceClient();
+
+        serviceClient.handleSqlToolsServiceTelemetryNotification()({
+            params: { eventName: TelemetryActions.PeekDefinitionRequested },
+        });
+
+        expect(sendActionEvent).to.have.been.calledOnceWithExactly(
+            TelemetryViews.QueryEditor,
+            TelemetryActions.PeekDefinitionRequested,
+            {},
+            {},
+        );
+    });
 
     function stubLaunches(
         serviceClient: SqlToolsServiceClient,


### PR DESCRIPTION
## Description

STS emits language-service telemetry through the custom `telemetry/sqlevent` notification, but vscode-mssql did not register a handler for it. As a result, formatter, definition, and IntelliSense telemetry was dropped.

This PR forwards STS telemetry/sqlevent notifications through vscode-mssql telemetry, matching the existing Azure Data Studio handling.

STS code references:

- [Telemetry contract and event names](https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/TelemetryNotification.cs#L39-L64)
- [Formatter telemetry emission](https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs#L78-L111)
- [Definition telemetry emission](https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs#L631-L651)
- [IntelliSense telemetry emission](https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs#L1864-L1874)


## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)