### PR TITLE
Fix Add Firewall Rule webview bundle casing

### DIFF
--- a/extensions/mssql/src/controllers/addFirewallRuleWebviewController.ts
+++ b/extensions/mssql/src/controllers/addFirewallRuleWebviewController.ts
@@ -40,7 +40,7 @@ export class AddFirewallRuleWebviewController extends WebviewPanelController<
     ) {
         super(
             context,
-            "AddFirewallRule",
+            "addFirewallRule",
             "addFirewallRule",
             {
                 serverName: initializationProps.serverName,

--- a/extensions/mssql/src/controllers/connectionGroupWebviewController.ts
+++ b/extensions/mssql/src/controllers/connectionGroupWebviewController.ts
@@ -37,7 +37,7 @@ export class ConnectionGroupWebviewController extends WebviewPanelController<
     ) {
         super(
             context,
-            "ConnectionGroup",
+            "connectionGroup",
             "ConnectionGroup",
             {
                 existingGroupName: connectionGroupToEdit?.name,

--- a/extensions/mssql/test/unit/addFirewallRuleWebviewController.test.ts
+++ b/extensions/mssql/test/unit/addFirewallRuleWebviewController.test.ts
@@ -42,6 +42,13 @@ suite("AddFirewallRuleWebviewController Tests", () => {
     });
 
     suite("Initialization Tests", () => {
+        test("uses the lowercase bundle name for webview resources", async () => {
+            await finishSetup(false);
+
+            expect(controller.panel.webview.html).to.contain('href="addFirewallRule.css"');
+            expect(controller.panel.webview.html).to.contain('src="addFirewallRule.js"');
+        });
+
         test("Should initialize correctly for not signed into Azure", async () => {
             await finishSetup(false);
 

--- a/extensions/mssql/test/unit/connectionGroupWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionGroupWebviewController.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import { expect } from "chai";
+
+import { ConnectionGroupWebviewController } from "../../src/controllers/connectionGroupWebviewController";
+import { ConnectionConfig } from "../../src/connectionconfig/connectionconfig";
+
+suite("ConnectionGroupWebviewController Tests", () => {
+    let controller: ConnectionGroupWebviewController;
+
+    setup(() => {
+        const mockContext = {
+            extensionUri: vscode.Uri.parse("file://fakePath"),
+            extensionPath: "fakePath",
+            subscriptions: [],
+        } as vscode.ExtensionContext;
+
+        controller = new ConnectionGroupWebviewController(mockContext, {} as ConnectionConfig);
+    });
+
+    test("uses the lowercase bundle name for webview resources", () => {
+        expect(controller.panel.webview.html).to.contain('href="connectionGroup.css"');
+        expect(controller.panel.webview.html).to.contain('src="connectionGroup.js"');
+    });
+});


### PR DESCRIPTION
Issue #22509.

Uses the lowercase `addFirewallRule` and `connectionGroup` bundle entry-point names when generating webview HTML, matching the emitted JavaScript and stylesheet filenames on case-sensitive filesystems.

An audit of all concrete webview controllers found Connection Group as the only additional casing mismatch. Both affected webviews now have regression tests for their generated resource URLs.

Validation:
- Targeted AddFirewallRuleWebviewController unit tests
- ESLint on the Connection Group controller and unit test
- Webview bundle-name audit: 28 concrete controllers checked, with no remaining exact-case mismatches
- `npm run build -- --target mssql`
- `npm run lint -- --target mssql`