### PR TITLE
Use stable VS Code for extension tests

### DIFF
--- a/extensions/mssql/.vscode-test.mjs
+++ b/extensions/mssql/.vscode-test.mjs
@@ -20,7 +20,8 @@ export default defineConfig({
         {
             label: "Unit Tests",
             files: "out/test/unit/**/*.test.js",
-            version: "insiders",
+            // TODO: Switch back to Insiders after https://github.com/microsoft/vscode-test/issues/349.
+            version: "stable",
             launchArgs: ["--user-data-dir", userDataDir],
             env: {
                 VSCODE_LOG_LEVEL: "error",

--- a/extensions/sql-database-projects/.vscode-test.mjs
+++ b/extensions/sql-database-projects/.vscode-test.mjs
@@ -24,7 +24,8 @@ export default defineConfig({
     tests: [
         {
             files: "out/test/**/*.test.js",
-            version: "insiders",
+            // TODO: Switch back to Insiders after https://github.com/microsoft/vscode-test/issues/349.
+            version: "stable",
             launchArgs: ["--disable-gpu", "--user-data-dir", userDataDir],
             env: {
                 SQLPROJ_TEST_MODE: "1",


### PR DESCRIPTION
Switch the MSSQL and SQL Database Projects test configurations from VS Code Insiders to Stable as a temporary workaround for the removed macOS `Electron` compatibility path.

Upstream issue: https://github.com/microsoft/vscode-test/issues/349

Validation:
- Both `.vscode-test.mjs` configurations load successfully
- `npm run lint -- --target mssql`
- `npm run lint -- --target sql-database-projects` (existing warnings only)
- `git diff --check`