### PR TITLE
Adding Sql-projects changelog entry for alias rename fix

### DIFF
--- a/extensions/sql-database-projects/CHANGELOG.md
+++ b/extensions/sql-database-projects/CHANGELOG.md
@@ -6,6 +6,10 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-08-19
+
+- Fixed an issue where the **Rename Symbol** feature was incorrectly enabled on SQL alias identifiers (column aliases, table aliases, subquery aliases, and CTE names), which could generate an invalid `.refactorlog` entry.
+
 ## [1.6.2] - 2026-07-15
 
 - Added **Rename Symbol** refactoring support for SQL project files.


### PR DESCRIPTION
## Changes

- **SQL Database Projects CHANGELOG** — added entry for the Rename Symbol fix on alias identifiers

> Fixed an issue where the **Rename Symbol** feature was incorrectly enabled on SQL alias identifiers (column aliases, table aliases, subquery aliases, and CTE names), which could generate an invalid `.refactorlog` entry. Rename is now properly rejected for non-renameable alias identifiers.

## Related

- STS fix PR: https://github.com/microsoft/sqltoolsservice/pull/2766
- Fixes: #22379