### PR TITLE
Bound Electron shutdown in smoke tests

### DIFF
--- a/extensions/mssql/test/e2e/utils/testLifecycle.ts
+++ b/extensions/mssql/test/e2e/utils/testLifecycle.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Page, TestInfo } from "@playwright/test";
+import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { test } from "../baseFixtures";
@@ -41,6 +42,9 @@ type VideoArtifactDestination = {
     outputDir: string;
     testInfo?: TestInfo;
 };
+
+const ELECTRON_CLOSE_TIMEOUT_MS = 30_000;
+const ELECTRON_KILL_TIMEOUT_MS = 10_000;
 
 export function useSharedVsCodeLifecycle(
     hooks: SharedLifecycleHooks = {},
@@ -82,7 +86,7 @@ export function useSharedVsCodeLifecycle(
         }
         const currentContext = getContext();
         await hooks.beforeClose?.(currentContext);
-        await currentContext.electronApp.close();
+        await closeElectronApp(currentContext.electronApp);
         if (failedTests.length === 0) {
             await cleanupDirectories(currentContext.videoDir);
         } else {
@@ -119,7 +123,7 @@ export function usePerTestVsCodeLifecycle(
 
         await screenshotOnFailure(currentContext.page, testInfo);
         await hooks.beforeClose?.(currentContext, testInfo);
-        await currentContext.electronApp.close();
+        await closeElectronApp(currentContext.electronApp);
 
         if (!shouldKeepVideo) {
             await cleanupDirectories(currentContext.videoDir);
@@ -136,6 +140,73 @@ export function usePerTestVsCodeLifecycle(
     });
 
     return getContext;
+}
+
+async function closeElectronApp(electronApp: VsCodeAppHandle): Promise<void> {
+    const closeResult = electronApp.close().then(
+        () => ({ state: "closed" as const }),
+        (error: unknown) => ({ state: "failed" as const, error }),
+    );
+    let timeoutHandle: NodeJS.Timeout;
+    const timeoutResult = new Promise<{ state: "timedOut" }>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve({ state: "timedOut" }), ELECTRON_CLOSE_TIMEOUT_MS);
+    });
+    const result = await Promise.race([closeResult, timeoutResult]);
+    clearTimeout(timeoutHandle!);
+
+    if (result.state === "failed") {
+        throw result.error;
+    }
+
+    if (result.state === "closed") {
+        return;
+    }
+
+    console.warn(
+        `VS Code did not close within ${ELECTRON_CLOSE_TIMEOUT_MS / 1000} seconds; terminating it.`,
+    );
+    const electronProcess = electronApp.process();
+    const processExit = new Promise<void>((resolve) => {
+        electronProcess.once("close", () => resolve());
+    });
+    killProcessTree(electronProcess);
+
+    let killTimeoutHandle: NodeJS.Timeout;
+    await Promise.race([
+        processExit,
+        new Promise<never>((_, reject) => {
+            killTimeoutHandle = setTimeout(
+                () => reject(new Error("Timed out waiting for the VS Code process tree to exit.")),
+                ELECTRON_KILL_TIMEOUT_MS,
+            );
+        }),
+    ]).finally(() => clearTimeout(killTimeoutHandle!));
+}
+
+function killProcessTree(electronProcess: cp.ChildProcess): void {
+    if (!electronProcess.pid) {
+        throw new Error("Cannot terminate VS Code because its process ID is unavailable.");
+    }
+
+    if (process.platform === "win32") {
+        const result = cp.spawnSync(
+            "taskkill",
+            ["/pid", electronProcess.pid.toString(), "/T", "/F"],
+            {
+                encoding: "utf8",
+                windowsHide: true,
+            },
+        );
+        if (result.error) {
+            throw result.error;
+        }
+        if (result.status !== 0) {
+            throw new Error(`Failed to terminate the VS Code process tree: ${result.stderr}`);
+        }
+        return;
+    }
+
+    process.kill(-electronProcess.pid, "SIGKILL");
 }
 
 async function storeRecordedVideos(


### PR DESCRIPTION
## Summary
- bound graceful VS Code Electron shutdown in Playwright smoke-test teardown to 30 seconds
- force-terminate the complete Electron process tree when graceful shutdown hangs, then wait for the process to exit
- prevent orphaned Electron processes from causing Playwright's five-minute worker teardown timeout
- preserve CI video recording and normal graceful shutdown behavior

## Root cause
The previous fallback called `electronApp.process().kill()`, which only signaled the immediate process and returned without waiting for it to exit. Playwright still tracked the surviving process tree during worker cleanup, so all 14 tests passed but the smoke command exited with a worker teardown timeout.

## Validation
- `npm run build:extension:typecheck`
- `npx eslint --quiet test/e2e/utils/testLifecycle.ts`
- Prettier and `git diff --check`
- [Build and Test (Unit + E2E)](https://github.com/microsoft/vscode-mssql/actions/runs/30311179979): passed; 14/14 smoke tests passed with exit code 0
- [MSSQL VSIX Launch Verification](https://github.com/microsoft/vscode-mssql/actions/runs/30311179983): passed on all platforms