### PR TITLE
Improve local DAB container configuration generation

### DIFF
--- a/extensions/mssql/src/dab/dabConfigFileBuilder.ts
+++ b/extensions/mssql/src/dab/dabConfigFileBuilder.ts
@@ -28,7 +28,6 @@ interface DabRuntimeConfig {
     mcp: { enabled: boolean };
     host: {
         mode: string;
-        cors: { origins: string[] };
     };
 }
 
@@ -43,12 +42,7 @@ interface DabEntityOutput {
         "key-fields"?: string[];
         parameters?: DabParameterOutput[];
     };
-    fields?: Array<{
-        name: string;
-        alias?: string;
-        description?: string;
-        "primary-key"?: boolean;
-    }>;
+    fields?: DabFieldOutput[];
     rest: boolean | { path?: string; methods?: string[] } | undefined;
     graphql: boolean | { type?: DabGraphQLTypeOutput; operation?: string } | undefined;
     permissions: DabPermissionEntry[];
@@ -56,6 +50,13 @@ interface DabEntityOutput {
 }
 
 type DabGraphQLTypeOutput = string | { singular: string; plural?: string };
+
+interface DabFieldOutput {
+    name: string;
+    alias?: string;
+    description?: string;
+    "primary-key"?: boolean;
+}
 
 interface DabPermissionEntry {
     role: string;
@@ -121,7 +122,7 @@ export class DabConfigFileBuilder {
      *
      * The paths for REST and GraphQL APIs are set to default values.
      * Mode is set to 'development'.
-     * CORS is configured to allow all origins.
+     * CORS is not configured so cross-origin browser access is denied by default.
      *
      * @param apiTypes The API types to enable in the runtime section.
      * @returns The runtime configuration object.
@@ -141,9 +142,6 @@ export class DabConfigFileBuilder {
             },
             host: {
                 mode: "development",
-                cors: {
-                    origins: ["*"],
-                },
             },
         };
     }
@@ -199,6 +197,8 @@ export class DabConfigFileBuilder {
             isGraphQLEnabled && entity.advancedSettings.graphQLEnabled !== false
                 ? this.buildGraphQLProperty(entity)
                 : false;
+        const isEntityGraphQLEnabled =
+            isGraphQLEnabled && entity.advancedSettings.graphQLEnabled !== false;
         const output: DabEntityOutput = {
             source: {
                 type: entity.sourceType ?? Dab.EntitySourceType.Table,
@@ -218,13 +218,9 @@ export class DabConfigFileBuilder {
             permissions: this.buildPermissions(entity),
         };
 
-        if (entity.fields?.length) {
-            output.fields = entity.fields.map((field) => ({
-                name: field.name,
-                ...(field.alias ? { alias: field.alias } : {}),
-                ...(field.description ? { description: field.description } : {}),
-                ...(field.isPrimaryKey ? { "primary-key": true } : {}),
-            }));
+        const fields = this.buildFieldsProperty(entity, isEntityGraphQLEnabled);
+        if (fields.length > 0) {
+            output.fields = fields;
         }
 
         const mcpConfig = this.buildMcpProperty(entity, isMcpEnabled);
@@ -233,6 +229,91 @@ export class DabConfigFileBuilder {
         }
 
         return output;
+    }
+
+    /**
+     * Builds field mappings and assigns collision-free aliases to SQL column names
+     * that cannot be represented as GraphQL names.
+     */
+    private buildFieldsProperty(
+        entity: Dab.DabEntityConfig,
+        isGraphQLEnabled: boolean,
+    ): DabFieldOutput[] {
+        const fields: DabFieldOutput[] = (entity.fields ?? []).map((field) => ({
+            name: field.name,
+            ...(field.alias ? { alias: field.alias } : {}),
+            ...(field.description ? { description: field.description } : {}),
+            ...(field.isPrimaryKey ? { "primary-key": true } : {}),
+        }));
+
+        if (!isGraphQLEnabled) {
+            return fields;
+        }
+
+        const fieldIndexesByName = new Map(fields.map((field, index) => [field.name, index]));
+        const usedGraphQLNames = new Set<string>();
+
+        for (const column of entity.columns) {
+            const configuredField = fields[fieldIndexesByName.get(column.name) ?? -1];
+            const exposedName = configuredField?.alias ?? column.name;
+            if (this.isValidGraphQLName(exposedName)) {
+                usedGraphQLNames.add(exposedName);
+            }
+        }
+
+        for (const field of fields) {
+            const exposedName = field.alias ?? field.name;
+            if (this.isValidGraphQLName(exposedName)) {
+                usedGraphQLNames.add(exposedName);
+            }
+        }
+
+        for (const field of fields) {
+            const exposedName = field.alias ?? field.name;
+            if (!this.isValidGraphQLName(exposedName)) {
+                field.alias = this.createUniqueGraphQLName(exposedName, usedGraphQLNames);
+                usedGraphQLNames.add(field.alias);
+            }
+        }
+
+        for (const column of entity.columns) {
+            const existingIndex = fieldIndexesByName.get(column.name);
+            const existingField = existingIndex !== undefined ? fields[existingIndex] : undefined;
+            const exposedName = existingField?.alias ?? column.name;
+            if (this.isValidGraphQLName(exposedName)) {
+                continue;
+            }
+
+            const alias = this.createUniqueGraphQLName(exposedName, usedGraphQLNames);
+            if (existingField) {
+                existingField.alias = alias;
+            } else {
+                fieldIndexesByName.set(column.name, fields.length);
+                fields.push({ name: column.name, alias });
+            }
+            usedGraphQLNames.add(alias);
+        }
+
+        return fields;
+    }
+
+    private isValidGraphQLName(value: string): boolean {
+        return /^[_A-Za-z][_0-9A-Za-z]*$/.test(value);
+    }
+
+    private createUniqueGraphQLName(value: string, usedNames: Set<string>): string {
+        let baseName = value.replace(/[^_0-9A-Za-z]/g, "_");
+        if (!/^[_A-Za-z]/.test(baseName)) {
+            baseName = `_${baseName}`;
+        }
+
+        let candidate = baseName;
+        let suffix = 2;
+        while (usedNames.has(candidate)) {
+            candidate = `${baseName}_${suffix}`;
+            suffix++;
+        }
+        return candidate;
     }
 
     private buildMcpProperty(

--- a/extensions/mssql/src/dab/dabContainer.ts
+++ b/extensions/mssql/src/dab/dabContainer.ts
@@ -163,7 +163,7 @@ export async function startDabDockerContainer(
             },
             HostConfig: {
                 PortBindings: {
-                    [dabContainerPort]: [{ HostPort: hostPort }],
+                    [dabContainerPort]: [{ HostIp: "127.0.0.1", HostPort: hostPort }],
                 },
                 ExtraHosts: ["host.docker.internal:host-gateway"],
             },

--- a/extensions/mssql/src/services/dabService.ts
+++ b/extensions/mssql/src/services/dabService.ts
@@ -340,17 +340,19 @@ export class DabService implements Dab.IDabService {
 
         const serverPropertyPrefix = serverMatch[1];
         const serverValue = this.stripConnectionStringValueQuotes(serverMatch[2].trim());
+        const protocolPrefix = serverValue.match(/^tcp:\s*/i)?.[0] ?? "";
+        const serverAddress = serverValue.substring(protocolPrefix.length);
 
         // Parse the server address to check if it's localhost
-        const host = this.parseHostFromServerValue(serverValue);
+        const host = this.parseHostFromServerValue(serverAddress);
 
         // Check if this is a localhost address
         if (!this.isLocalhostAddress(host)) {
             return connectionInfo;
         }
 
-        const hasPort = serverValue.includes(",");
-        let newServerValue = serverValue.replace(
+        const hasPort = serverAddress.includes(",");
+        let newServerValue = serverAddress.replace(
             new RegExp(`^${this.escapeRegex(host)}`, "i"),
             "host.docker.internal",
         );
@@ -361,8 +363,8 @@ export class DabService implements Dab.IDabService {
             // a host port. DAB runs in a separate container, so it must connect to that
             // published port through host.docker.internal instead of treating the
             // container name as a SQL Server named instance.
-            const commaIndex = serverValue.indexOf(",");
-            const port = commaIndex !== -1 ? this.normalizeSqlServerPort(serverValue) : "";
+            const commaIndex = serverAddress.indexOf(",");
+            const port = commaIndex !== -1 ? this.normalizeSqlServerPort(serverAddress) : "";
             newServerValue = `host.docker.internal${port}`;
         }
 
@@ -371,6 +373,7 @@ export class DabService implements Dab.IDabService {
         if (!hasPort) {
             newServerValue += `,${DefaultSqlPortNumber}`;
         }
+        newServerValue = `${protocolPrefix}${newServerValue}`;
 
         // Replace in connection string
         const transformedConnectionString = connectionString.replace(

--- a/extensions/mssql/test/unit/dab/dabConfigFileBuilder.test.ts
+++ b/extensions/mssql/test/unit/dab/dabConfigFileBuilder.test.ts
@@ -200,10 +200,10 @@ suite("DabConfigFileBuilder Tests", () => {
                 expect(parsed.runtime.host.mode).to.equal("development");
             });
 
-            test("should set CORS origins to wildcard", () => {
+            test("should not allow cross-origin browser access by default", () => {
                 const result = builder.build(createTestConfig(), defaultConnectionInfo);
                 const parsed = JSON.parse(result);
-                expect(parsed.runtime.host.cors.origins).to.deep.equal(["*"]);
+                expect(parsed.runtime.host).not.to.have.property("cors");
             });
         });
 
@@ -392,6 +392,68 @@ suite("DabConfigFileBuilder Tests", () => {
                     { name: "Id", "primary-key": true },
                     { name: "Name" },
                 ]);
+            });
+
+            test("should alias GraphQL-invalid column names without colliding", () => {
+                const config = createTestConfig({
+                    apiTypes: [Dab.ApiType.GraphQL],
+                    entities: [
+                        createTestEntity({
+                            columns: [
+                                {
+                                    id: "database-version",
+                                    name: "Database Version",
+                                    dataType: "nvarchar",
+                                    isSupported: true,
+                                    isExposed: true,
+                                    isPrimaryKey: false,
+                                },
+                                {
+                                    id: "database-version-alias",
+                                    name: "Database_Version",
+                                    dataType: "nvarchar",
+                                    isSupported: true,
+                                    isExposed: true,
+                                    isPrimaryKey: false,
+                                },
+                            ],
+                        }),
+                    ],
+                });
+
+                const result = builder.build(config, defaultConnectionInfo);
+                const parsed = JSON.parse(result);
+
+                expect(parsed.entities["Users"].fields).to.deep.equal([
+                    {
+                        name: "Database Version",
+                        alias: "Database_Version_2",
+                    },
+                ]);
+            });
+
+            test("should not alias GraphQL-invalid column names when GraphQL is disabled", () => {
+                const config = createTestConfig({
+                    entities: [
+                        createTestEntity({
+                            columns: [
+                                {
+                                    id: "database-version",
+                                    name: "Database Version",
+                                    dataType: "nvarchar",
+                                    isSupported: true,
+                                    isExposed: true,
+                                    isPrimaryKey: false,
+                                },
+                            ],
+                        }),
+                    ],
+                });
+
+                const result = builder.build(config, defaultConnectionInfo);
+                const parsed = JSON.parse(result);
+
+                expect(parsed.entities["Users"]).not.to.have.property("fields");
             });
 
             test("should emit stored procedure execute permissions and MCP custom tool", () => {

--- a/extensions/mssql/test/unit/dab/dabContainer.test.ts
+++ b/extensions/mssql/test/unit/dab/dabContainer.test.ts
@@ -139,6 +139,9 @@ suite("DAB Container", () => {
             const createOptions = createContainerStub.firstCall.args[0];
             expect(createOptions.name).to.equal("test-dab-container");
             expect(createOptions.Cmd).to.deep.equal(["--ConfigFileName", "/App/dab-config.json"]);
+            expect(createOptions.HostConfig.PortBindings).to.deep.equal({
+                "5000/tcp": [{ HostIp: "127.0.0.1", HostPort: "5000" }],
+            });
         } finally {
             // Cleanup temp files
             fs.unlinkSync(configFilePath);

--- a/extensions/mssql/test/unit/dab/dabService.test.ts
+++ b/extensions/mssql/test/unit/dab/dabService.test.ts
@@ -189,6 +189,14 @@ suite("DabService Tests", () => {
                 expect(result.connectionString).to.include("Data Source=host.docker.internal,1433");
             });
 
+            test("Data Source=tcp:localhost with port", () => {
+                const result = transform("Data Source=tcp:localhost,1433;Database=TestDb;");
+                expect(result.connectionString).to.include(
+                    "Data Source=tcp:host.docker.internal,1433",
+                );
+                expect(result.connectionString).to.not.include("tcp:localhost");
+            });
+
             test("case-insensitive data source", () => {
                 const result = transform("data source=127.0.0.1;Database=TestDb;");
                 expect(result.connectionString).to.include("host.docker.internal");


### PR DESCRIPTION
## Description

Improves local Data API Builder deployment reliability and generated configuration defaults.

- Bind the locally published DAB endpoint to the loopback interface.
- Leave cross-origin access unconfigured by default.
- Handle `tcp:`-prefixed localhost SQL connection strings when translating addresses for Docker.
- Generate valid, collision-free GraphQL aliases for SQL column names that cannot be used directly as GraphQL fields.
- Add regression coverage for container bindings, runtime configuration, connection-string translation, and GraphQL field aliases.

## Validation

- `npm run test -- --target mssql --grep DabConfigFileBuilder`
- `npm run test -- --target mssql --grep transformConnectionInfoForDocker`
- `npm run build -- --target mssql`
- `npm run lint -- --target mssql`

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant — not applicable
- [x] No regressions or UX breakage identified

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)