### PR TITLE
Update azdataGraph and refine webview action handling

### DIFF
--- a/extensions/mssql/package-lock.json
+++ b/extensions/mssql/package-lock.json
@@ -85,7 +85,7 @@
                 "@vscode/vsce": "^3.9.1",
                 "@xyflow/react": "^12.4.4",
                 "assert": "^1.4.1",
-                "azdataGraph": "github:Microsoft/azdataGraph#0.0.139",
+                "azdataGraph": "github:Microsoft/azdataGraph#0.0.140",
                 "chai": "^5.3.3",
                 "cli-color": "^2.0.4",
                 "esbuild": "^0.28.1",
@@ -5305,8 +5305,8 @@
             }
         },
         "node_modules/azdataGraph": {
-            "version": "0.0.139",
-            "resolved": "git+ssh://git@github.com/Microsoft/azdataGraph.git#0a3ea27e4e2b10274d9a141ddb48cb76b461216a",
+            "version": "0.0.140",
+            "resolved": "git+ssh://git@github.com/Microsoft/azdataGraph.git#d1e8ab12edc9a4b0b7c79a1103c5533e35d16d1d",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -117,7 +117,7 @@
         "@vscode/vsce": "^3.9.1",
         "@xyflow/react": "^12.4.4",
         "assert": "^1.4.1",
-        "azdataGraph": "github:Microsoft/azdataGraph#0.0.139",
+        "azdataGraph": "github:Microsoft/azdataGraph#0.0.140",
         "chai": "^5.3.3",
         "cli-color": "^2.0.4",
         "esbuild": "^0.28.1",

--- a/extensions/mssql/src/configurations/changelog.ts
+++ b/extensions/mssql/src/configurations/changelog.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChangelogWebviewState } from "../sharedInterfaces/changelog";
+import { ChangelogActionId, ChangelogWebviewState } from "../sharedInterfaces/changelog";
 import * as vscode from "vscode";
 import * as constants from "../constants/constants";
 import * as locConstants from "../constants/locConstants";
@@ -20,7 +20,7 @@ export const changelogConfig: ChangelogWebviewState = {
                     {
                         label: locConstants.Changelog.tryIt,
                         type: "command",
-                        value: constants.cmdOpenShortcutsConfiguration,
+                        value: ChangelogActionId.OpenShortcutsConfiguration,
                     },
                     {
                         label: locConstants.Changelog.learnMore,
@@ -37,7 +37,7 @@ export const changelogConfig: ChangelogWebviewState = {
                     {
                         label: locConstants.Changelog.tryIt,
                         type: "command",
-                        value: constants.cmdDeployNewDatabase,
+                        value: ChangelogActionId.DeployNewDatabase,
                     },
                     {
                         label: locConstants.Changelog.learnMore,
@@ -75,7 +75,7 @@ export const changelogConfig: ChangelogWebviewState = {
                     {
                         label: locConstants.Changelog.tryIt,
                         type: "command",
-                        value: constants.cmdNotebooksCreate,
+                        value: ChangelogActionId.CreateNotebook,
                     },
                     {
                         label: locConstants.Changelog.learnMore,
@@ -92,7 +92,7 @@ export const changelogConfig: ChangelogWebviewState = {
                     {
                         label: locConstants.Changelog.tryIt,
                         type: "command",
-                        value: constants.cmdOpenAzureDataStudioMigration,
+                        value: ChangelogActionId.OpenAzureDataStudioMigration,
                     },
                     {
                         label: locConstants.Changelog.watchDemo,
@@ -147,7 +147,7 @@ export const changelogConfig: ChangelogWebviewState = {
                     {
                         label: locConstants.Changelog.tryIt,
                         type: "command",
-                        value: constants.cmdDacpacDialog,
+                        value: ChangelogActionId.OpenDacpacDialog,
                     },
                     {
                         label: locConstants.Changelog.watchDemo,
@@ -251,12 +251,12 @@ export const changelogConfig: ChangelogWebviewState = {
                 {
                     type: "walkthrough",
                     label: locConstants.Changelog.mssqlWalkthrough,
-                    value: `${constants.extensionId}#mssql.getStarted`,
+                    value: ChangelogActionId.OpenMssqlWalkthrough,
                 },
                 {
                     type: "walkthrough",
                     label: locConstants.Changelog.copilotWalkthrough,
-                    value: `GitHub.copilot-chat#copilotWelcome`,
+                    value: ChangelogActionId.OpenCopilotWalkthrough,
                 },
                 {
                     type: "link",

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -26,6 +26,7 @@ import {
     GetSqlAnalyticsEndpointUriFromFabricRequest,
     ChangePasswordDialogProps,
     ConnectionSubmitAction,
+    OpenAzureDataStudioMigrationRequest,
 } from "../sharedInterfaces/connectionDialog";
 import { FormItemActionButton, FormItemOptions } from "../sharedInterfaces/form";
 import { ApiStatus } from "../sharedInterfaces/webview";
@@ -50,7 +51,11 @@ import { generateConnectionComponents, groupAdvancedOptions } from "./formCompon
 import { FormWebviewController } from "../forms/formWebviewController";
 import { ConnectionCredentials } from "../models/connectionCredentials";
 import { Deferred } from "../protocol";
-import { defaultDatabase, systemDatabases } from "../constants/constants";
+import {
+    cmdOpenAzureDataStudioMigration,
+    defaultDatabase,
+    systemDatabases,
+} from "../constants/constants";
 import * as AzureConstants from "../azure/constants";
 import { AddFirewallRuleState } from "../sharedInterfaces/addFirewallRule";
 import * as Utils from "../models/utils";
@@ -321,6 +326,10 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     }
 
     private registerRpcHandlers() {
+        this.onRequest(OpenAzureDataStudioMigrationRequest.type, async () => {
+            await vscode.commands.executeCommand(cmdOpenAzureDataStudioMigration);
+        });
+
         this.registerReducer("setConnectionInputType", async (state, payload) => {
             this.state.selectedInputMode = payload.inputMode;
             await this.updateItemVisibility();

--- a/extensions/mssql/src/controllers/changelogWebviewController.ts
+++ b/extensions/mssql/src/controllers/changelogWebviewController.ts
@@ -5,13 +5,13 @@
 
 import { Changelog } from "../constants/locConstants";
 import {
-    ChangelogCommandRequest,
-    ChangelogCommandRequestParams,
+    ChangelogActionId,
     ChangelogDontShowAgainRequest,
     ChangelogLinkRequest,
     ChangelogLinkRequestParams,
     ChangelogWebviewState,
     CloseChangelogRequest,
+    RunChangelogActionRequest,
 } from "../sharedInterfaces/changelog";
 import { WebviewPanelController } from "./webviewPanelController";
 import * as vscode from "vscode";
@@ -52,15 +52,42 @@ export class ChangelogWebviewController extends WebviewPanelController<
             });
         });
 
-        this.onRequest(
-            ChangelogCommandRequest.type,
-            async (params: ChangelogCommandRequestParams) => {
-                vscode.commands.executeCommand(params.commandId, ...(params.args || []));
-                sendActionEvent(TelemetryViews.ChangelogPage, TelemetryActions.ExecuteCommand, {
-                    command: params.commandId,
-                });
-            },
-        );
+        this.onRequest(RunChangelogActionRequest.type, async (action) => {
+            let command: string;
+            let args: unknown[] = [];
+            switch (action) {
+                case ChangelogActionId.OpenShortcutsConfiguration:
+                    command = constants.cmdOpenShortcutsConfiguration;
+                    break;
+                case ChangelogActionId.DeployNewDatabase:
+                    command = constants.cmdDeployNewDatabase;
+                    break;
+                case ChangelogActionId.CreateNotebook:
+                    command = constants.cmdNotebooksCreate;
+                    break;
+                case ChangelogActionId.OpenAzureDataStudioMigration:
+                    command = constants.cmdOpenAzureDataStudioMigration;
+                    break;
+                case ChangelogActionId.OpenDacpacDialog:
+                    command = constants.cmdDacpacDialog;
+                    break;
+                case ChangelogActionId.OpenMssqlWalkthrough:
+                    command = "workbench.action.openWalkthrough";
+                    args = [`${constants.extensionId}#mssql.getStarted`];
+                    break;
+                case ChangelogActionId.OpenCopilotWalkthrough:
+                    command = "workbench.action.openWalkthrough";
+                    args = ["GitHub.copilot-chat#copilotWelcome"];
+                    break;
+                default:
+                    throw new Error("Unknown changelog action");
+            }
+
+            await vscode.commands.executeCommand(command, ...args);
+            sendActionEvent(TelemetryViews.ChangelogPage, TelemetryActions.ExecuteCommand, {
+                command,
+            });
+        });
 
         this.onRequest(CloseChangelogRequest.type, async () => {
             this.panel.dispose();

--- a/extensions/mssql/src/controllers/webviewBaseController.ts
+++ b/extensions/mssql/src/controllers/webviewBaseController.ts
@@ -8,8 +8,6 @@ import * as vscode from "vscode";
 import { ActivityStatus, TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
 import {
     ColorThemeChangeNotification,
-    ExecuteCommandParams,
-    ExecuteCommandRequest,
     GetEOLRequest,
     GetKeyBindingsConfigRequest,
     GetLocalizationRequest,
@@ -362,15 +360,6 @@ export abstract class WebviewBaseController<State, Reducers> implements vscode.D
                 );
                 return undefined;
             }
-        });
-
-        this.onRequest(ExecuteCommandRequest.type, async (params: ExecuteCommandParams) => {
-            if (!params?.command) {
-                this.logger.trace("No command provided to execute");
-                return;
-            }
-            const args = params?.args ?? [];
-            return await vscode.commands.executeCommand(params.command, ...args);
         });
 
         this.onRequest(GetPlatformRequest.type, async () => {

--- a/extensions/mssql/src/queryResult/queryResultWebViewController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebViewController.ts
@@ -171,13 +171,16 @@ export class QueryResultWebviewController extends WebviewViewController<
 
         context.subscriptions.push(
             vscode.commands.registerCommand(Constants.cmdHandleSummaryOperation, async (uri) => {
-                const state = this._queryResultStateMap.get(uri);
-                if (!state) {
-                    return;
-                }
-                this._selectionSummaryContinuations.get(uri)?.resolve();
+                this.handleSelectionSummary(uri);
             }),
         );
+    }
+
+    public handleSelectionSummary(uri: string): void {
+        if (!this._queryResultStateMap.has(uri)) {
+            return;
+        }
+        this._selectionSummaryContinuations.get(uri)?.resolve();
     }
 
     private get shouldAutoRevealResultsPanel(): boolean {

--- a/extensions/mssql/src/queryResult/utils.ts
+++ b/extensions/mssql/src/queryResult/utils.ts
@@ -71,6 +71,14 @@ export function registerCommonRequestHandlers(
             ? webviewController
             : webviewController.getQueryResultWebviewViewController();
 
+    webviewController.onRequest(qr.CloseResultsPanelRequest.type, async () => {
+        await vscode.commands.executeCommand("workbench.action.closePanel");
+    });
+
+    webviewController.onRequest(qr.HandleSelectionSummaryRequest.type, async (uri) => {
+        webviewViewController.handleSelectionSummary(uri);
+    });
+
     webviewController.onRequest(qr.GetRowsRequest.type, async (message) => {
         const result = await webviewViewController
             .getSqlOutputContentProvider()

--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -173,6 +173,10 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
     }
 
     private setupRequestHandlers() {
+        this.onRequest(CopilotChat.OpenFromUiRequest.type, async (payload) => {
+            await vscode.commands.executeCommand(CopilotChat.openFromUiCommand, payload);
+        });
+
         this.onRequest(SchemaDesigner.InitializeSchemaDesignerRequest.type, async () => {
             if (!this._initializeSchemaDesignerPromise) {
                 this._initializeSchemaDesignerPromise = this.initializeSchemaDesignerSession();

--- a/extensions/mssql/src/sharedInterfaces/changelog.ts
+++ b/extensions/mssql/src/sharedInterfaces/changelog.ts
@@ -53,13 +53,32 @@ export interface ContentEntry {
     actions?: ChangelogAction[];
 }
 
-export interface ChangelogAction {
+interface ChangelogActionBase {
     label: string;
-    type: "command" | "link" | "walkthrough";
-    value: string;
-    args?: unknown[];
     icon?: keyof Icons;
 }
+
+export enum ChangelogActionId {
+    OpenShortcutsConfiguration = "openShortcutsConfiguration",
+    DeployNewDatabase = "deployNewDatabase",
+    CreateNotebook = "createNotebook",
+    OpenAzureDataStudioMigration = "openAzureDataStudioMigration",
+    OpenDacpacDialog = "openDacpacDialog",
+    OpenMssqlWalkthrough = "openMssqlWalkthrough",
+    OpenCopilotWalkthrough = "openCopilotWalkthrough",
+}
+
+export type ChangelogAction = ChangelogActionBase &
+    (
+        | {
+              type: "link";
+              value: string;
+          }
+        | {
+              type: "command" | "walkthrough";
+              value: ChangelogActionId;
+          }
+    );
 
 export interface ChangelogLinkRequestParams {
     url: string;
@@ -71,15 +90,8 @@ export namespace ChangelogLinkRequest {
     );
 }
 
-export interface ChangelogCommandRequestParams {
-    commandId: string;
-    args?: unknown[];
-}
-
-export namespace ChangelogCommandRequest {
-    export const type = new RequestType<ChangelogCommandRequestParams, void, void>(
-        "executeChangelogCommand",
-    );
+export namespace RunChangelogActionRequest {
+    export const type = new RequestType<ChangelogActionId, void, void>("runChangelogAction");
 }
 
 export namespace CloseChangelogRequest {

--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -317,6 +317,12 @@ export namespace OpenOptionInfoLinkNotification {
     );
 }
 
+export namespace OpenAzureDataStudioMigrationRequest {
+    export const type = new RequestType<void, void, void>(
+        "connectionDialog/openAzureDataStudioMigration",
+    );
+}
+
 export namespace GetConnectionDisplayNameRequest {
     export const type = new RequestType<IConnectionDialogProfile, string, void>(
         "getConnectionDisplayName",

--- a/extensions/mssql/src/sharedInterfaces/copilotChat.ts
+++ b/extensions/mssql/src/sharedInterfaces/copilotChat.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { RequestType } from "vscode-jsonrpc";
+
 export namespace CopilotChat {
     export const openFromUiCommand = "mssql.openCopilotChatFromUi";
     const discoveryDismissedStateKeyPrefix = "mssql.copilotChatDiscoveryDismissed";
@@ -17,6 +19,10 @@ export namespace CopilotChat {
         scenario: Scenario;
         entryPoint: EntryPoint;
         prompt?: string;
+    }
+
+    export namespace OpenFromUiRequest {
+        export const type = new RequestType<OpenFromUiArgs, void, void>("copilotChat/openFromUi");
     }
 
     export type DiscoveryDismissedState = Partial<Record<Scenario, boolean>>;

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -398,6 +398,14 @@ export namespace SetSelectionSummaryRequest {
     export const type = new NotificationType<SetSelectionSummary>("setSelectionSummary");
 }
 
+export namespace HandleSelectionSummaryRequest {
+    export const type = new RequestType<string, void, void>("queryResult/handleSelectionSummary");
+}
+
+export namespace CloseResultsPanelRequest {
+    export const type = new RequestType<void, void, void>("queryResult/closePanel");
+}
+
 export interface OpenInNewTabParams {
     uri: string;
 }

--- a/extensions/mssql/src/sharedInterfaces/webview.ts
+++ b/extensions/mssql/src/sharedInterfaces/webview.ts
@@ -260,21 +260,6 @@ export namespace GetLocalizationRequest {
 }
 
 /**
- * Parameters for executing a command in the extension host from the webview.
- */
-export interface ExecuteCommandParams {
-    command: string;
-    args?: any[];
-}
-
-/**
- * Request to execute a command in the extension host from the webview.
- */
-export namespace ExecuteCommandRequest {
-    export const type = new RequestType<ExecuteCommandParams, void, void>("executeCommand");
-}
-
-/**
  * Request from the webview to get the platform information.
  */
 export namespace GetPlatformRequest {

--- a/extensions/mssql/src/webviews/pages/Changelog/changelogPage.tsx
+++ b/extensions/mssql/src/webviews/pages/Changelog/changelogPage.tsx
@@ -20,13 +20,12 @@ import React, { useCallback, useState } from "react";
 
 import {
     ChangelogAction,
-    ChangelogCommandRequest,
-    ChangelogCommandRequestParams,
     ChangelogDontShowAgainRequest,
     ChangelogEvent,
     ChangelogLinkRequest,
     CloseChangelogRequest,
     ContentEntry,
+    RunChangelogActionRequest,
 } from "../../../sharedInterfaces/changelog";
 import { getActionIcon } from "../../common/icons/iconUtils";
 import { locConstants } from "../../common/locConstants";
@@ -499,15 +498,8 @@ export const ChangelogPage = () => {
         await extensionRpc.sendRequest(ChangelogLinkRequest.type, { url });
     };
 
-    const handleAction = async (params: ChangelogCommandRequestParams) => {
-        await extensionRpc.sendRequest(ChangelogCommandRequest.type, params);
-    };
-
-    const openWalkthrough = async (walkthroughId: string, args: unknown[] = []) => {
-        await extensionRpc.sendRequest(ChangelogCommandRequest.type, {
-            commandId: "workbench.action.openWalkthrough",
-            args: [walkthroughId, ...args],
-        });
+    const runAction = async (action: Exclude<ChangelogAction, { type: "link" }>) => {
+        await extensionRpc.sendRequest(RunChangelogActionRequest.type, action.value);
     };
 
     const handleSecondaryToggle = (_event: unknown, data: { openItems: Iterable<unknown> }) => {
@@ -587,27 +579,8 @@ export const ChangelogPage = () => {
             );
         }
 
-        if (action.type === "walkthrough") {
-            return (
-                <Link
-                    key={key}
-                    className={className}
-                    onClick={() => openWalkthrough(action.value, action.args)}>
-                    {content}
-                </Link>
-            );
-        }
-
         return (
-            <Link
-                key={key}
-                className={className}
-                onClick={() =>
-                    handleAction({
-                        commandId: action.value,
-                        args: action.args,
-                    })
-                }>
+            <Link key={key} className={className} onClick={() => runAction(action)}>
                 {content}
             </Link>
         );

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionsListContainer.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionsListContainer.tsx
@@ -31,11 +31,11 @@ import {
     ConnectionDialogReducers,
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
+    OpenAzureDataStudioMigrationRequest,
 } from "../../../sharedInterfaces/connectionDialog";
 import { locConstants } from "../../common/locConstants";
 import { KeyCode } from "../../common/keys";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
-import { ExecuteCommandRequest } from "../../../sharedInterfaces/webview";
 
 const buttonContainer = "buttonContainer";
 
@@ -143,9 +143,7 @@ export const ConnectionsListContainer = () => {
                         />
                     }
                     onClick={async () => {
-                        await extensionRpc.sendRequest(ExecuteCommandRequest.type, {
-                            command: "mssql.openAzureDataStudioMigration",
-                        });
+                        await extensionRpc.sendRequest(OpenAzureDataStudioMigrationRequest.type);
                     }}>
                     {locConstants.connectionDialog.importFromAzureDataStudio}
                 </Button>

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultPane.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultPane.tsx
@@ -21,7 +21,7 @@ import { locConstants } from "../../common/locConstants";
 import { hasResultsOrMessages } from "./queryResultUtils";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
 import { useQueryResultSelector } from "./queryResultSelector";
-import { ExecuteCommandRequest, WebviewAction } from "../../../sharedInterfaces/webview";
+import { WebviewAction } from "../../../sharedInterfaces/webview";
 import { ExecutionPlanGraph } from "../../../sharedInterfaces/executionPlan";
 import { getGridCount } from "./table/utils";
 import { QueryMessageTab } from "./queryMessageTab";
@@ -245,10 +245,7 @@ export const QueryResultPane = () => {
                                     className={classes.hidePanelLink}
                                     onClick={async () => {
                                         await context.extensionRpc.sendRequest(
-                                            ExecuteCommandRequest.type,
-                                            {
-                                                command: "workbench.action.closePanel",
-                                            },
+                                            qr.CloseResultsPanelRequest.type,
                                         );
                                     }}>
                                     {locConstants.queryResult.clickHereToHideThisPanel}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
@@ -5,7 +5,6 @@
 
 import { Tooltip, makeStyles } from "@fluentui/react-components";
 import { Fragment, useContext, useEffect, useMemo, useState } from "react";
-import { ExecuteCommandRequest } from "../../../sharedInterfaces/webview";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { locConstants } from "../../common/locConstants";
 import { getDisplayedRowsCount } from "./queryResultUtils";
@@ -404,6 +403,7 @@ export const QueryResultSummaryFooter = ({
             : compactExecutionText;
     const selectionStats = selectionSummary?.stats;
     const selectionCommand = selectionSummary?.command;
+    const selectionActionUri = selectionCommand?.arguments[0];
     const selectionStatusText = selectionSummary?.displayText ?? selectionSummary?.text ?? "";
     const selectionDisplayContent = selectionStats
         ? renderSelectionMetricsInline(selectionStats, classes)
@@ -466,17 +466,14 @@ export const QueryResultSummaryFooter = ({
                     relationship="description"
                     positioning={SELECTION_TOOLTIP_POSITIONING}
                     content={selectionTooltipContent}>
-                    {selectionCommand?.command ? (
+                    {typeof selectionActionUri === "string" ? (
                         <button
                             type="button"
                             className={classes.selectionValueButton}
                             onClick={async () => {
                                 await context?.extensionRpc.sendRequest(
-                                    ExecuteCommandRequest.type,
-                                    {
-                                        command: selectionCommand.command,
-                                        args: selectionCommand.arguments,
-                                    },
+                                    qr.HandleSelectionSummaryRequest.type,
+                                    selectionActionUri,
                                 );
                             }}>
                             {selectionDisplayContent}

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/copilot/schemaDesignerWebviewCopilotChatEntry.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/copilot/schemaDesignerWebviewCopilotChatEntry.tsx
@@ -5,7 +5,6 @@
 
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { CopilotChat } from "../../../../sharedInterfaces/copilotChat";
-import { ExecuteCommandRequest } from "../../../../sharedInterfaces/webview";
 import { CopilotChatEntry } from "../../../common/copilot/copilotChatEntry";
 import { locConstants } from "../../../common/locConstants";
 import { SchemaDesignerContext } from "../schemaDesignerStateProvider";
@@ -58,9 +57,9 @@ export function SchemaDesignerWebviewCopilotChatEntry({
     }, [context.extensionRpc, scenario]);
 
     const openChat = useCallback(async () => {
-        await context.extensionRpc.sendRequest(ExecuteCommandRequest.type, {
-            command: CopilotChat.openFromUiCommand,
-            args: [{ scenario, entryPoint }],
+        await context.extensionRpc.sendRequest(CopilotChat.OpenFromUiRequest.type, {
+            scenario,
+            entryPoint,
         });
     }, [context.extensionRpc, entryPoint, scenario]);
 

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/toolbar/publishChangesDialogButton.tsx
@@ -12,7 +12,7 @@ import { SchemaDesigner } from "../../../../sharedInterfaces/schemaDesigner";
 import { useSchemaDesignerChangeContext } from "../definition/changes/schemaDesignerChangeContext";
 import { useSchemaDesignerSelector } from "../schemaDesignerSelector";
 import { CopilotChat } from "../../../../sharedInterfaces/copilotChat";
-import { ExecuteCommandRequest, LoadingLogEntry } from "../../../../sharedInterfaces/webview";
+import { LoadingLogEntry } from "../../../../sharedInterfaces/webview";
 import { GithubCopilot16Regular } from "../../../common/icons/fluentIcons";
 import {
     schemaDesignerPublishErrorDetailsLabel,
@@ -294,15 +294,10 @@ export function PublishChangesDialogButton() {
             isConfirmationChecked: false,
         });
 
-        await context.extensionRpc.sendRequest(ExecuteCommandRequest.type, {
-            command: CopilotChat.openFromUiCommand,
-            args: [
-                {
-                    scenario: "schemaDesigner",
-                    entryPoint: "schemaDesignerPublishDialogError",
-                    prompt,
-                },
-            ],
+        await context.extensionRpc.sendRequest(CopilotChat.OpenFromUiRequest.type, {
+            scenario: "schemaDesigner",
+            entryPoint: "schemaDesignerPublishDialogError",
+            prompt,
         });
     };
 

--- a/extensions/mssql/test/unit/queryResultWebViewController.test.ts
+++ b/extensions/mssql/test/unit/queryResultWebViewController.test.ts
@@ -97,6 +97,28 @@ suite("QueryResultWebviewController", () => {
         sandbox.restore();
     });
 
+    test("resolves the selection summary continuation for a known result", () => {
+        const resolve = sandbox.stub();
+        controller["_selectionSummaryContinuations"].set(testUri, {
+            resolve,
+        } as any);
+
+        controller.handleSelectionSummary(testUri);
+
+        expect(resolve).to.have.been.calledOnce;
+    });
+
+    test("ignores a selection summary request for an unknown result", () => {
+        const resolve = sandbox.stub();
+        controller["_selectionSummaryContinuations"].set("file:///unknown.sql", {
+            resolve,
+        } as any);
+
+        controller.handleSelectionSummary("file:///unknown.sql");
+
+        expect(resolve).to.not.have.been.called;
+    });
+
     test("moves current result to a tab when the setting is enabled through configuration change", async () => {
         openResultsInTabByDefault = true;
         const createPanelControllerStub = sandbox

--- a/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
+++ b/extensions/mssql/test/unit/schemaDesignerWebviewController.test.ts
@@ -208,6 +208,7 @@ suite("SchemaDesignerWebviewController tests", () => {
         test("should register all request handlers", () => {
             createController();
 
+            expect(requestHandlers.has(CopilotChat.OpenFromUiRequest.type.method)).to.be.true;
             expect(requestHandlers.has(SchemaDesigner.InitializeSchemaDesignerRequest.type.method))
                 .to.be.true;
             expect(requestHandlers.has(SchemaDesigner.GetDefinitionRequest.type.method)).to.be.true;
@@ -215,6 +216,22 @@ suite("SchemaDesignerWebviewController tests", () => {
                 .true;
             expect(requestHandlers.has(SchemaDesigner.PublishSessionRequest.type.method)).to.be
                 .true;
+        });
+
+        test("should map the Copilot entry request to the fixed extension command", async () => {
+            const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+            createController();
+            const payload: CopilotChat.OpenFromUiArgs = {
+                scenario: "schemaDesigner",
+                entryPoint: "schemaDesignerToolbar",
+            };
+
+            await requestHandlers.get(CopilotChat.OpenFromUiRequest.type.method)!(payload);
+
+            expect(executeCommandStub).to.have.been.calledOnceWithExactly(
+                CopilotChat.openFromUiCommand,
+                payload,
+            );
         });
 
         test("should register all notification handlers", () => {

--- a/extensions/mssql/test/unit/webviewBaseController.test.ts
+++ b/extensions/mssql/test/unit/webviewBaseController.test.ts
@@ -14,7 +14,6 @@ import { WebviewBaseController } from "../../src/controllers/webviewBaseControll
 import { stubTelemetry } from "./utils";
 import {
     ColorThemeChangeNotification,
-    ExecuteCommandRequest,
     GetKeyBindingsConfigRequest,
     GetLocalizationRequest,
     GetStateRequest,
@@ -117,10 +116,6 @@ suite("WebviewController Tests", () => {
             onRequestStub,
             "GetLocalizationRequest handler is not registered",
         ).to.have.been.calledWith(GetLocalizationRequest.type, sinon.match.any);
-        expect(
-            onRequestStub,
-            "ExecuteCommandRequest handler is not registered",
-        ).to.have.been.calledWith(ExecuteCommandRequest.type, sinon.match.any);
         expect(
             onNotificationStub,
             "LoadStatsNotification handler is not registered",


### PR DESCRIPTION
## Summary

- Update azdataGraph to version 0.0.140 with improved tooltip content sanitization.
- Replace the shared webview command dispatcher with feature-specific typed requests.
- Keep command routing within the controllers that own each webview action.
- Update changelog, connection dialog, query results, and schema designer callers.
- Add focused coverage for the updated request handling.

## Validation

- `npm run build -- --target mssql`
- `npm run lint -- --target mssql`
- Focused webview and request-handler unit tests