### PR TITLE
Fix: DAB GHCP does not deselect columns when table is deselected (#22549)

### DIFF
--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/schemaDesignerRpcHandlers.ts
@@ -2042,18 +2042,32 @@ function applyDabToolChange(
                 selectedEntityIds.add(resolvedEntity.entity.id);
             }
 
-            config.entities = config.entities.map((entity) => ({
-                ...entity,
-                isEnabled: selectedEntityIds.has(entity.id),
-            }));
+            config.entities = config.entities.map((entity) => {
+                const isEnabled = selectedEntityIds.has(entity.id);
+                return {
+                    ...entity,
+                    isEnabled,
+                    columns: entity.columns.map((column) => ({
+                        ...column,
+                        isExposed: isEnabled,
+                    })),
+                };
+            });
             return { success: true };
         }
 
         case "set_all_entities_enabled": {
-            config.entities = config.entities.map((entity) => ({
-                ...entity,
-                isEnabled: change.isEnabled ? entity.isSupported : false,
-            }));
+            config.entities = config.entities.map((entity) => {
+                const isEnabled = change.isEnabled ? entity.isSupported : false;
+                return {
+                    ...entity,
+                    isEnabled,
+                    columns: entity.columns.map((column) => ({
+                        ...column,
+                        isExposed: isEnabled,
+                    })),
+                };
+            });
             return { success: true };
         }
 

--- a/extensions/mssql/test/unit/dabTool.test.ts
+++ b/extensions/mssql/test/unit/dabTool.test.ts
@@ -2222,7 +2222,7 @@ suite("DabTool Tests", () => {
                 ],
             };
             const harness = createDabHandlerHarness({
-                tables: [table],
+                tables: [table, createTable("t2", "dbo", "Accounts")],
                 dabConfig: null,
             });
 
@@ -2240,7 +2240,7 @@ suite("DabTool Tests", () => {
 
             const disableResult = await harness.applyChanges({
                 expectedVersion: enableResult.version,
-                changes: [{ type: "set_only_enabled_entities", entities: [] }],
+                changes: [{ type: "set_only_enabled_entities", entities: [{ id: "t2" }] }],
             });
             expect(disableResult.success).to.equal(true);
             expect(disableResult.config?.entities[0].isEnabled).to.equal(false);

--- a/extensions/mssql/test/unit/dabTool.test.ts
+++ b/extensions/mssql/test/unit/dabTool.test.ts
@@ -2203,6 +2203,53 @@ suite("DabTool Tests", () => {
             expect(summaryResult).to.not.have.property("config");
         });
 
+        test("apply_changes set_all_entities_enabled and set_only_enabled_entities synchronizes column isExposed", async () => {
+            const table = {
+                ...createTable("t1", "dbo", "Users"),
+                columns: [
+                    {
+                        id: "t1-id",
+                        name: "Id",
+                        dataType: "int",
+                        isPrimaryKey: true,
+                    } as SchemaDesigner.Column,
+                    {
+                        id: "t1-name",
+                        name: "Name",
+                        dataType: "nvarchar",
+                        isPrimaryKey: false,
+                    } as SchemaDesigner.Column,
+                ],
+            };
+            const harness = createDabHandlerHarness({
+                tables: [table],
+                dabConfig: null,
+            });
+
+            const state1 = await harness.getState();
+            const enableResult = await harness.applyChanges({
+                expectedVersion: state1.version,
+                changes: [{ type: "set_all_entities_enabled", isEnabled: true }],
+            });
+            expect(enableResult.success).to.equal(true);
+            expect(enableResult.config?.entities[0].isEnabled).to.equal(true);
+            expect(
+                enableResult.config?.entities[0].columns.find((c: any) => c.name === "Name")
+                    ?.isExposed,
+            ).to.equal(true);
+
+            const disableResult = await harness.applyChanges({
+                expectedVersion: enableResult.version,
+                changes: [{ type: "set_only_enabled_entities", entities: [] }],
+            });
+            expect(disableResult.success).to.equal(true);
+            expect(disableResult.config?.entities[0].isEnabled).to.equal(false);
+            expect(
+                disableResult.config?.entities[0].columns.find((c: any) => c.name === "Name")
+                    ?.isExposed,
+            ).to.equal(false);
+        });
+
         test("apply_changes set_only_enabled_entities updates enabled flags by selected ids", async () => {
             const harness = createDabHandlerHarness({
                 tables: [


### PR DESCRIPTION
### Description
This PR fixes issue #22549 where deselecting a table using the GitHub Copilot (GHCP) integration for Data API builder (DAB) did not automatically deselect all of the columns in that table.

### Fix Details
The fix aligns the backend `applyDabToolChange` logic for the `"set_only_enabled_entities"` and `"set_all_entities_enabled"` operations with the frontend UI logic. It now maps through the entity columns and correctly updates their `isExposed` state to match the table's new `isEnabled` state.
