### PR TITLE
Improve and trace connection startup performance

### DIFF
--- a/extensions/mssql/src/azure/vscodeEntraMfaUtils.ts
+++ b/extensions/mssql/src/azure/vscodeEntraMfaUtils.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { AzureTenant, getSessionFromVSCode } from "@microsoft/vscode-azext-azureauth";
 
 import { FormItemOptions } from "../sharedInterfaces/form";
+import { ILogger } from "../sharedInterfaces/logger";
 import { IProviderResources, IToken } from "../models/contracts/azure";
 import { getCloudProviderSettings } from "./providerSettings";
 import { VsCodeAzureHelper, getDefaultTenantId } from "../connectionconfig/azureHelpers";
@@ -17,6 +18,11 @@ export interface VscodeEntraSqlTokenInfo {
     session: vscode.AuthenticationSession;
     tenantId: string;
     token: IToken;
+}
+
+export interface VscodeEntraTokenTrace {
+    logger: ILogger;
+    requestId: string;
 }
 
 /**
@@ -100,8 +106,14 @@ export async function acquireTokenFromVscodeAccountForResource(
     accountId?: string,
     tenantId?: string,
     accountLabel?: string,
+    trace?: VscodeEntraTokenTrace,
 ): Promise<VscodeEntraSqlTokenInfo> {
-    const account = await resolveVscodeEntraAccount(accountId, accountLabel);
+    const account = await traceTokenPhase(
+        trace,
+        "account resolution",
+        () => resolveVscodeEntraAccount(accountId, accountLabel),
+        (resolvedAccount) => `accountResolved=${resolvedAccount !== undefined}`,
+    );
     if (!account) {
         throw new MissingEntraAuthAccountError(
             locConstants.Accounts.accountNotAvailableThroughVsCode(
@@ -111,7 +123,12 @@ export async function acquireTokenFromVscodeAccountForResource(
         );
     }
 
-    const tenants = await VsCodeAzureHelper.getTenantsForAccount(account);
+    const tenants = await traceTokenPhase(
+        trace,
+        "tenant resolution",
+        () => VsCodeAzureHelper.getTenantsForAccount(account),
+        (resolvedTenants) => `tenantCount=${resolvedTenants.length}`,
+    );
     const resolvedTenantId =
         tenantId && tenants.some((tenant) => tenant.tenantId === tenantId)
             ? tenantId
@@ -126,16 +143,29 @@ export async function acquireTokenFromVscodeAccountForResource(
         );
     }
 
+    const silentSession = await traceTokenPhase(
+        trace,
+        "silent token session request",
+        () =>
+            getSessionFromVSCode(resourceEndpoint, resolvedTenantId, {
+                createIfNone: false,
+                silent: true,
+                account,
+            }),
+        (session) => `sessionPresent=${session !== undefined}`,
+    );
     const session =
-        (await getSessionFromVSCode(resourceEndpoint, resolvedTenantId, {
-            createIfNone: false,
-            silent: true,
-            account,
-        })) ??
-        (await getSessionFromVSCode(resourceEndpoint, resolvedTenantId, {
-            createIfNone: true,
-            account,
-        }));
+        silentSession ??
+        (await traceTokenPhase(
+            trace,
+            "interactive token session request",
+            () =>
+                getSessionFromVSCode(resourceEndpoint, resolvedTenantId, {
+                    createIfNone: true,
+                    account,
+                }),
+            (session) => `sessionPresent=${session !== undefined}`,
+        ));
 
     if (!session) {
         throw new Error(
@@ -154,6 +184,31 @@ export async function acquireTokenFromVscodeAccountForResource(
             expiresOn: getTokenExpiration(session.accessToken),
         },
     };
+}
+
+async function traceTokenPhase<T>(
+    trace: VscodeEntraTokenTrace | undefined,
+    phase: string,
+    operation: () => Promise<T>,
+    describeResult?: (result: T) => string,
+): Promise<T> {
+    const startedAt = Date.now();
+    trace?.logger.debug(
+        `[ConnectionTrace] VS Code accounts ${phase} started requestId=${trace.requestId}`,
+    );
+
+    try {
+        const result = await operation();
+        trace?.logger.debug(
+            `[ConnectionTrace] VS Code accounts ${phase} completed requestId=${trace.requestId} durationMs=${Date.now() - startedAt}${describeResult ? ` ${describeResult(result)}` : ""}`,
+        );
+        return result;
+    } catch (error) {
+        trace?.logger.debug(
+            `[ConnectionTrace] VS Code accounts ${phase} failed requestId=${trace.requestId} durationMs=${Date.now() - startedAt}`,
+        );
+        throw error;
+    }
 }
 
 export function getCloudResourceEndpoint(endpoint: keyof IProviderResources): string {

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -387,8 +387,29 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             return state;
         });
 
-        this.registerReducer("connect", async (state) => {
-            return this.submitConnectionAction(state, ConnectionSubmitAction.Connect);
+        this.registerReducer("connect", async (state, payload = {}) => {
+            const now = Date.now();
+            const correlationId =
+                typeof payload.clickId === "string" &&
+                payload.clickId.length <= 64 &&
+                /^\d{13}-[a-z0-9]+$/.test(payload.clickId)
+                    ? payload.clickId
+                    : uuid();
+            const transportDurationMs =
+                typeof payload.clickTimestamp === "number" &&
+                Number.isFinite(payload.clickTimestamp) &&
+                payload.clickTimestamp >= 0 &&
+                payload.clickTimestamp <= now
+                    ? now - payload.clickTimestamp
+                    : undefined;
+            this.logger.debug(
+                `[ConnectionTrace] Connection attempt started correlationId=${correlationId}${transportDurationMs === undefined ? "" : ` transportDurationMs=${transportDurationMs}`}`,
+            );
+            return this.submitConnectionAction(
+                state,
+                ConnectionSubmitAction.Connect,
+                correlationId,
+            );
         });
 
         this.registerReducer("testConnection", async (state) => {
@@ -1353,18 +1374,27 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private async submitConnectionAction(
         state: ConnectionDialogWebviewState,
         action: ConnectionSubmitAction,
+        correlationId: string = uuid(),
     ): Promise<ConnectionDialogWebviewState> {
         this._lastSubmittedAction = action;
         this.state.connectionAction = action;
 
-        const cleanedConnection = await this.prepareConnectionForSubmit(state);
+        this.logger.debug(
+            `[ConnectionTrace] Submit action started correlationId=${correlationId} action=${action}`,
+        );
+
+        const cleanedConnection = await this.prepareConnectionForSubmit(state, correlationId);
         if (!cleanedConnection) {
             return state;
         }
 
         try {
             if (action === ConnectionSubmitAction.TestConnection) {
-                const testSucceeded = await this.testConnectionStep(cleanedConnection, state);
+                const testSucceeded = await this.testConnectionStep(
+                    cleanedConnection,
+                    state,
+                    correlationId,
+                );
                 if (!testSucceeded) {
                     return state;
                 }
@@ -1386,7 +1416,11 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 return state;
             }
 
-            const testSucceeded = await this.testConnectionStep(cleanedConnection, state);
+            const testSucceeded = await this.testConnectionStep(
+                cleanedConnection,
+                state,
+                correlationId,
+            );
             if (!testSucceeded) {
                 return state;
             }
@@ -1394,7 +1428,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             const preparedConnection = await this.prepareConnectionForSave(cleanedConnection);
             await this.removeEditedConnectionIfNeeded();
             await this.saveProfileStep(preparedConnection, state);
-            await this.connectAndRevealStep(preparedConnection, state);
+            await this.connectAndRevealStep(preparedConnection, state, correlationId);
 
             this.state.connectionStatus = ApiStatus.Loaded;
             this.updateState();
@@ -1439,7 +1473,11 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
     private async prepareConnectionForSubmit(
         state: ConnectionDialogWebviewState,
+        correlationId: string,
     ): Promise<IConnectionDialogProfile | undefined> {
+        this.logger.debug(
+            `[ConnectionTrace] Connection form preparation started correlationId=${correlationId}`,
+        );
         this.clearFormError();
         this.state.connectionStatus = ApiStatus.Loading;
         this.updateState();
@@ -1456,6 +1494,10 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
         this.combineServerAndPort(cleanedConnection);
 
+        this.logger.debug(
+            `[ConnectionTrace] Connection form preparation completed correlationId=${correlationId}`,
+        );
+
         return cleanedConnection;
     }
 
@@ -1471,8 +1513,13 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private async testConnectionStep(
         connection: IConnectionDialogProfile,
         state: ConnectionDialogWebviewState,
+        correlationId: string,
     ): Promise<boolean> {
         const tempConnectionUri = uuid();
+        const startedAt = Date.now();
+        this.logger.debug(
+            `[ConnectionTrace] Test connection started correlationId=${correlationId} durationMs=0`,
+        );
 
         try {
             const result = await this._mainController.connectionManager.connect(
@@ -1492,6 +1539,10 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 this.updateState(state);
                 return false;
             }
+
+            this.logger.debug(
+                `[ConnectionTrace] Test connection completed correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+            );
 
             return true;
         } catch (error) {
@@ -1737,8 +1788,20 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     private async connectAndRevealStep(
         connection: IConnectionDialogProfile,
         state: ConnectionDialogWebviewState,
+        correlationId: string,
     ): Promise<void> {
-        let node = await this._mainController.createObjectExplorerSession(connection);
+        const startedAt = Date.now();
+        this.logger.debug(
+            `[ConnectionTrace] Object Explorer session creation started correlationId=${correlationId}`,
+        );
+        let node = await this._mainController.createObjectExplorerSession(
+            connection,
+            correlationId,
+            startedAt,
+        );
+        this.logger.debug(
+            `[ConnectionTrace] Object Explorer session created correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+        );
 
         try {
             await this._mainController.objectExplorerTree.reveal(node, {
@@ -1746,10 +1809,17 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 select: true,
                 expand: true,
             });
+            this.logger.debug(
+                `[ConnectionTrace] Connection reveal completed correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+            );
         } catch {
             // If revealing the node fails, we've hit an event-based race condition; re-saving and creating the profile should fix it.
             await this.saveProfileStep(connection, state);
-            node = await this._mainController.createObjectExplorerSession(connection);
+            node = await this._mainController.createObjectExplorerSession(
+                connection,
+                correlationId,
+                startedAt,
+            );
             await this._mainController.objectExplorerTree.reveal(node, {
                 focus: true,
                 select: true,

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -1454,6 +1454,19 @@ export default class ConnectionManager {
             serverlessWakeFailedAttempts = 0,
         } = options;
 
+        const connectionAttemptId = uuid();
+        const connectionStartedAt = Date.now();
+        const logConnectionPhase = (phase: string, details = "") => {
+            this._logger.debug(
+                `[ConnectionTrace] ${phase} correlationId=${connectionAttemptId} durationMs=${Date.now() - connectionStartedAt}${details ? ` ${details}` : ""}`,
+            );
+        };
+
+        logConnectionPhase(
+            "Connection manager entered",
+            `connectionSource=${connectionSource} authenticationType=${credentials.authenticationType ?? "unknown"}`,
+        );
+
         const connectionActivity = startActivity(
             TelemetryViews.ConnectionManager,
             TelemetryActions.Connect,
@@ -1473,7 +1486,12 @@ export default class ConnectionManager {
             fileUri = `${ObjectExplorerUtils.getNodeUriFromProfile(credentials as IConnectionProfile)}_${uuid()}`;
         }
 
-        credentials = await this.prepareConnectionInfo(credentials, connectionActivity);
+        credentials = await this.prepareConnectionInfo(
+            credentials,
+            connectionActivity,
+            logConnectionPhase,
+        );
+        logConnectionPhase("Connection information prepared");
 
         // Check if the connection is one that we can check for pause status (i.e., a Azure SQL database using Entra MFA auth)
         const isPauseAwareConnection =
@@ -1501,6 +1519,7 @@ export default class ConnectionManager {
         }
 
         this._logger.info(LocalizedConstants.msgConnecting(credentials.server, fileUri));
+        logConnectionPhase("SQL Tools Service connection request sending");
 
         // Create connection request params
         const connectionDetails = ConnectionCredentials.createConnectionDetails(credentials);
@@ -1530,6 +1549,10 @@ export default class ConnectionManager {
                 connectParams,
             );
             initRequestCompleted = true;
+            logConnectionPhase(
+                "SQL Tools Service connection request accepted",
+                `initResponse=${String(initResponse)}`,
+            );
         } catch (error) {
             initRequestCompleted = true;
             this.removeActiveConnection(fileUri);
@@ -1573,6 +1596,10 @@ export default class ConnectionManager {
         });
 
         const result = await connectionCompletePromise.promise;
+        logConnectionPhase(
+            "SQL Tools Service connection completed",
+            `connectionIdPresent=${String(Utils.isNotEmpty(result.connectionId))}`,
+        );
 
         connectionInfo.connecting = false;
 
@@ -1585,6 +1612,7 @@ export default class ConnectionManager {
              */
 
             await this.handleConnectionSuccess(fileUri, connectionInfo, result);
+            logConnectionPhase("Connection manager completed successfully");
             connectionActivity.end(
                 ActivityStatus.Succeeded,
                 undefined,
@@ -1749,8 +1777,10 @@ export default class ConnectionManager {
     public async prepareConnectionInfo(
         credentials: IConnectionInfo,
         telemetryActivity?: ActivityObject,
+        logConnectionPhase?: (phase: string, details?: string) => void,
     ): Promise<IConnectionInfo> {
         const telemetryActivityErrorType = "ConnectionPreparationError";
+        logConnectionPhase?.("Connection preparation entered");
         // Verify that the connection info has server or connection string
         if (!credentials.server && !credentials.connectionString) {
             const error = new Error(LocalizedConstants.serverNameMissing);
@@ -1768,6 +1798,7 @@ export default class ConnectionManager {
         if (credentials.authenticationType === Constants.azureMfa) {
             try {
                 await this.refreshEntraTokenIfNeeded(credentials);
+                logConnectionPhase?.("Entra token preparation completed");
             } catch (error) {
                 telemetryActivity?.endFailed(
                     error,
@@ -1782,6 +1813,7 @@ export default class ConnectionManager {
 
         // Handle password-based credentials
         const passwordResult = await this.handlePasswordBasedCredentials(credentials);
+        logConnectionPhase?.("Password credential preparation completed");
         if (!passwordResult) {
             // User cancelled the password prompt
             const passwordError = new Error(LocalizedConstants.cannotConnect);
@@ -1802,6 +1834,7 @@ export default class ConnectionManager {
         ) {
             let connectionString = await this.connectionStore.lookupPassword(credentials, true);
             credentials.connectionString = connectionString;
+            logConnectionPhase?.("Connection string credential resolved");
         }
 
         if (
@@ -1814,6 +1847,7 @@ export default class ConnectionManager {
         telemetryActivity?.update({
             connectionPrepared: "true",
         });
+        logConnectionPhase?.("Connection preparation exited");
         return credentials;
     }
 
@@ -2266,10 +2300,11 @@ export default class ConnectionManager {
     private async performConnectionStartupChecks(): Promise<void> {
         this._logger.trace("Beginning connection startup checks");
 
-        const connections: IConnectionProfile[] =
-            await this.connectionStore.readAllConnections(false);
-        const connectionGroups: IConnectionGroup[] =
-            await this.connectionStore.readAllConnectionGroups();
+        const [connections, connectionGroups]: [IConnectionProfile[], IConnectionGroup[]] =
+            await Promise.all([
+                this.connectionStore.readAllConnections(false),
+                this.connectionStore.readAllConnectionGroups(),
+            ]);
 
         const migrationTally = {
             migrated: 0,
@@ -2423,8 +2458,10 @@ export default class ConnectionManager {
         params: RequestSecurityTokenParams,
     ): Promise<RequestSecurityTokenResponse> {
         if (params.accountId) {
-            this._entraLogger.info(
-                `VS Code accounts token request received for ${params.resource} with accountId '${params.accountId}' and tenantId '${params.tenantId}'`,
+            const tokenRequestId = uuid();
+            const tokenRequestStartedAt = Date.now();
+            this._entraLogger.debug(
+                `[ConnectionTrace] VS Code accounts token request received requestId=${tokenRequestId}`,
             );
             try {
                 const resourceEndpoint = params.resource || getCloudResourceEndpoint("sqlResource");
@@ -2432,13 +2469,12 @@ export default class ConnectionManager {
                     resourceEndpoint,
                     params.accountId,
                     params.tenantId,
+                    undefined,
+                    { logger: this._entraLogger, requestId: tokenRequestId },
                 );
 
-                const expiry = Utils.epochToDisplay(
-                    tokenInfo.token.expiresOn ? tokenInfo.token.expiresOn * 1000 : undefined,
-                );
-                this._entraLogger.info(
-                    `VS Code accounts token acquired successfully for ${resourceEndpoint} with accountId '${params.accountId}' and tenantId '${params.tenantId}'; expires on ${tokenInfo.token.expiresOn} (${expiry.iso}, ${expiry.relative})`,
+                this._entraLogger.debug(
+                    `[ConnectionTrace] VS Code accounts token acquired successfully requestId=${tokenRequestId} durationMs=${Date.now() - tokenRequestStartedAt}`,
                 );
 
                 return {
@@ -2447,6 +2483,9 @@ export default class ConnectionManager {
                     expiresOn: tokenInfo.token.expiresOn,
                 };
             } catch (error) {
+                this._entraLogger.error(
+                    `[ConnectionTrace] VS Code accounts token acquisition failed requestId=${tokenRequestId} durationMs=${Date.now() - tokenRequestStartedAt}`,
+                );
                 this._logger.error(
                     `VS Code accounts token acquisition failed: ${getErrorMessage(error)}`,
                 );

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -1550,7 +1550,9 @@ export default class ConnectionManager {
             );
             initRequestCompleted = true;
             logConnectionPhase(
-                "SQL Tools Service connection request accepted",
+                initResponse
+                    ? "SQL Tools Service connection request accepted"
+                    : "SQL Tools Service connection request rejected",
                 `initResponse=${String(initResponse)}`,
             );
         } catch (error) {

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -62,7 +62,7 @@ import {
 import { ObjectExplorerFilter } from "../objectExplorer/objectExplorerFilter";
 import { ExecutionPlanService } from "../services/executionPlanService";
 import { MssqlProtocolHandler } from "../mssqlProtocolHandler";
-import { getErrorMessage, getUriKey, isIConnectionInfo } from "../utils/utils";
+import { getErrorMessage, getUriKey, isIConnectionInfo, uuid } from "../utils/utils";
 import { getStandardNPSQuestions, UserSurvey } from "../nps/userSurvey";
 import { ExecutionPlanOptions } from "../models/contracts/queryExecute";
 import { ObjectExplorerDragAndDropController } from "../objectExplorer/objectExplorerDragAndDropController";
@@ -1207,6 +1207,8 @@ export default class MainController implements vscode.Disposable {
      */
     public async createObjectExplorerSession(
         connectionCredentials?: IConnectionInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
     ): Promise<TreeNodeInfo> {
         let retry = true;
         // There can be many reasons for the session creation to fail, so we will retry until we get a successful result or the user cancels the operation.
@@ -1214,7 +1216,11 @@ export default class MainController implements vscode.Disposable {
         while (retry) {
             retry = false;
             sessionCreationResult =
-                await this._objectExplorerProvider.createSession(connectionCredentials);
+                await this._objectExplorerProvider.createSession(
+                    connectionCredentials,
+                    correlationId,
+                    startedAt,
+                );
             if (sessionCreationResult?.shouldRetryOnFailure) {
                 retry = true;
             }
@@ -1249,6 +1255,20 @@ export default class MainController implements vscode.Disposable {
             ),
         });
         this._context.subscriptions.push(this.objectExplorerTree);
+        this._context.subscriptions.push(
+            this.objectExplorerTree.onDidChangeSelection((event) => {
+                const node = event.selection[0];
+                if (!(node instanceof ConnectionNode)) {
+                    return;
+                }
+
+                const correlationId = uuid();
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer connection selected correlationId=${correlationId} durationMs=0`,
+                );
+                this._objectExplorerProvider.recordConnectionClick(node, correlationId);
+            }),
+        );
 
         // Register command for table node double-click action
         let lastTableClickTime = 0;

--- a/extensions/mssql/src/objectExplorer/objectExplorerProvider.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerProvider.ts
@@ -72,8 +72,18 @@ export class ObjectExplorerProvider implements vscode.TreeDataProvider<any> {
 
     public async createSession(
         connectionCredentials?: IConnectionInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
     ): Promise<CreateSessionResult> {
-        return this._objectExplorerService.createSession(connectionCredentials);
+        return this._objectExplorerService.createSession(
+            connectionCredentials,
+            correlationId,
+            startedAt,
+        );
+    }
+
+    public recordConnectionClick(node: TreeNodeInfo, correlationId: string): void {
+        this._objectExplorerService.recordConnectionClick(node, correlationId);
     }
 
     public async expandNode(

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -70,6 +70,11 @@ export interface CreateSessionResult {
     shouldRetryOnFailure?: boolean;
 }
 
+interface ConnectionClickTrace {
+    correlationId: string;
+    startedAt: number;
+}
+
 export class ObjectExplorerService {
     private _client: SqlToolsServiceClient;
     private _logger: ILogger;
@@ -126,6 +131,8 @@ export class ObjectExplorerService {
      * Nodes that need another refresh as soon as their current load finishes.
      */
     private _refreshQueuedAfterInFlight: Set<TreeNodeInfo> = new Set();
+
+    private _connectionClickTraces = new WeakMap<TreeNodeInfo, ConnectionClickTrace>();
 
     constructor(
         private _connectionManager: ConnectionManager,
@@ -436,8 +443,24 @@ export class ObjectExplorerService {
 
     // Main method that routes to the appropriate handler
     public async getChildren(element?: TreeNodeInfo): Promise<vscode.TreeItem[]> {
+        const clickTrace = element ? this._connectionClickTraces.get(element) : undefined;
+        const correlationId = clickTrace?.correlationId;
+        const startedAt = clickTrace?.startedAt ?? Date.now();
+        if (element) {
+            this._connectionClickTraces.delete(element);
+        }
+        const logConnectionPhase = (phase: string) => {
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer ${phase} correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+                );
+            }
+        };
+
         this._logger.trace(`getChildren called for ${getNodeDescriptor(element)}`);
+        logConnectionPhase("getChildren entered");
         await this.initialized;
+        logConnectionPhase("initialization completed");
         if (!element) {
             return this.getRootNodes();
         }
@@ -452,7 +475,14 @@ export class ObjectExplorerService {
             return element.children;
         }
 
-        return this.getNodeChildren(element);
+        return this.getNodeChildren(element, correlationId, startedAt);
+    }
+
+    public recordConnectionClick(node: TreeNodeInfo, correlationId: string): void {
+        this._connectionClickTraces.set(node, {
+            correlationId,
+            startedAt: Date.now(),
+        });
     }
 
     /**
@@ -590,7 +620,11 @@ export class ObjectExplorerService {
      * @param element The node to get children for
      * @returns The children of the node
      */
-    private async getNodeChildren(element: TreeNodeInfo): Promise<vscode.TreeItem[]> {
+    private async getNodeChildren(
+        element: TreeNodeInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
+    ): Promise<vscode.TreeItem[]> {
         const wasRefresh = element.shouldRefresh;
         const hadCache = this._treeNodeToChildrenMap.has(element);
         const hasInFlight = this._inFlightChildrenFetches.has(element);
@@ -621,7 +655,7 @@ export class ObjectExplorerService {
          * Tree expansion is queued, so without this if multiple connections are expanding,
          * one blocked operation can delay the other.
          */
-        void this.getOrCreateNodeChildrenWithSession(element);
+        void this.getOrCreateNodeChildrenWithSession(element, correlationId, startedAt);
         return this.setLoadingUiForNode(element);
     }
 
@@ -689,7 +723,11 @@ export class ObjectExplorerService {
      * If it doesn't, create a new session and expand it.
      * @param element The node to get or create children for
      */
-    private async getOrCreateNodeChildrenWithSession(element: TreeNodeInfo): Promise<void> {
+    private async getOrCreateNodeChildrenWithSession(
+        element: TreeNodeInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
+    ): Promise<void> {
         const existing = this._inFlightChildrenFetches.get(element);
 
         this._logger.trace(
@@ -705,7 +743,7 @@ export class ObjectExplorerService {
                 if (element.sessionId) {
                     await this.expandExistingNode(element);
                 } else {
-                    await this.createSessionAndExpandNode(element);
+                    await this.createSessionAndExpandNode(element, correlationId, startedAt);
                 }
             } finally {
                 this._inFlightChildrenFetches.delete(element);
@@ -756,8 +794,21 @@ export class ObjectExplorerService {
      * @param element The node to create a session for and expand
      * @returns The children of the node
      */
-    private async createSessionAndExpandNode(element: TreeNodeInfo): Promise<vscode.TreeItem[]> {
-        const sessionResult = await this.createSession(element.connectionProfile);
+    private async createSessionAndExpandNode(
+        element: TreeNodeInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
+    ): Promise<vscode.TreeItem[]> {
+        if (correlationId) {
+            this._logger.debug(
+                `[ConnectionTrace] Object Explorer session creation started correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+            );
+        }
+        const sessionResult = await this.createSession(
+            element.connectionProfile,
+            correlationId,
+            startedAt,
+        );
 
         if (sessionResult?.shouldRetryOnFailure) {
             setTimeout(() => void this.reconnectProfile(element.connectionProfile), 0);
@@ -794,6 +845,8 @@ export class ObjectExplorerService {
      */
     public async createSession(
         connectionInfo?: IConnectionInfo,
+        correlationId?: string,
+        startedAt = Date.now(),
     ): Promise<CreateSessionResult | undefined> {
         await this.initialized;
         if (!this._rootTreeNodeArray) {
@@ -813,6 +866,11 @@ export class ObjectExplorerService {
             undefined,
         );
 
+        if (correlationId) {
+            this._logger.debug(
+                `[ConnectionTrace] Object Explorer preparing connection profile correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+            );
+        }
         const connectionProfile = await this.prepareConnectionProfile(connectionInfo);
 
         if (!connectionProfile) {
@@ -821,6 +879,12 @@ export class ObjectExplorerService {
         }
 
         const connectionDetails = ConnectionCredentials.createConnectionDetails(connectionProfile);
+
+        if (correlationId) {
+            this._logger.debug(
+                `[ConnectionTrace] Object Explorer connection profile prepared correlationId=${correlationId} durationMs=${Date.now() - startedAt}`,
+            );
+        }
 
         let sessionCompleted = false;
 
@@ -851,22 +915,44 @@ export class ObjectExplorerService {
                 () => !sessionCompleted,
             );
 
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer GetSessionId request started correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                );
+            }
             const sessionIdResponse: GetSessionIdResponse =
                 await this._connectionManager.client.sendRequest(
                     GetSessionIdRequest.type,
                     connectionDetails,
                 );
 
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer GetSessionId request completed correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                );
+            }
+
             const sessionCreatedResponse: Deferred<SessionCreatedParameters> =
                 new Deferred<SessionCreatedParameters>();
 
             this._pendingSessionCreations.set(sessionIdResponse.sessionId, sessionCreatedResponse);
 
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer CreateSession request started correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                );
+            }
             const createSessionResponse: CreateSessionResponse =
                 await this._connectionManager.client.sendRequest(
                     CreateSessionRequest.type,
                     connectionDetails,
                 );
+
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer CreateSession request completed correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                );
+            }
 
             if (!createSessionResponse) {
                 this._pendingSessionCreations.delete(sessionIdResponse.sessionId);
@@ -877,6 +963,12 @@ export class ObjectExplorerService {
             const sessionCreationResult = await sessionCreatedResponse;
             this._pendingSessionCreations.delete(sessionIdResponse.sessionId);
 
+            if (correlationId) {
+                this._logger.debug(
+                    `[ConnectionTrace] Object Explorer session creation notification received correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                );
+            }
+
             if (sessionCreationResult.success) {
                 this._logger.debug(
                     `Session created successfully with session ID ${sessionCreationResult.sessionId}`,
@@ -885,6 +977,11 @@ export class ObjectExplorerService {
                     sessionCreationResult,
                     connectionProfile,
                 );
+                if (correlationId) {
+                    this._logger.debug(
+                        `[ConnectionTrace] Object Explorer session creation completed correlationId=${correlationId} durationMs=${Date.now() - startedAt} attempt=${attempt + 1}`,
+                    );
+                }
                 createSessionActivity.end(ActivityStatus.Succeeded, {
                     connectionType: connectionProfile.authenticationType,
                 });

--- a/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
+++ b/extensions/mssql/src/sharedInterfaces/connectionDialog.ts
@@ -277,7 +277,10 @@ export interface ConnectionDialogReducers extends FormReducers<IConnectionDialog
     loadConnectionAsNewDraft: {
         connection: IConnectionDialogProfile;
     };
-    connect: {};
+    connect: {
+        clickId?: string;
+        clickTimestamp?: number;
+    };
     testConnection: {};
     saveWithoutConnecting: {};
     retryLastSubmitAction: {};

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
@@ -16,7 +16,7 @@ import {
 } from "../../../sharedInterfaces/connectionDialog";
 import { FirewallRuleSpec } from "../../../sharedInterfaces/firewallRule";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
-import { getCoreRPCs } from "../../common/utils";
+import { getCoreRPCs, uuid } from "../../common/utils";
 import { ConnectionGroupSpec } from "../../../sharedInterfaces/connectionGroup";
 import { SqlDbInfo } from "../../../sharedInterfaces/fabric";
 import {
@@ -62,7 +62,7 @@ const ConnectionDialogStateProvider: React.FC<ConnectionDialogProviderProps> = (
             },
             connect: function (): void {
                 const clickTimestamp = Date.now();
-                const clickId = `${clickTimestamp}-${Math.random().toString(36).slice(2)}`;
+                const clickId = `${clickTimestamp}-${uuid().replace(/-/g, "")}`;
                 extensionRpc.log.debug(
                     `[ConnectionTrace] Connect button clicked clickId=${clickId}`,
                 );

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionDialogStateProvider.tsx
@@ -61,7 +61,12 @@ const ConnectionDialogStateProvider: React.FC<ConnectionDialogProviderProps> = (
                 });
             },
             connect: function (): void {
-                extensionRpc.action("connect");
+                const clickTimestamp = Date.now();
+                const clickId = `${clickTimestamp}-${Math.random().toString(36).slice(2)}`;
+                extensionRpc.log.debug(
+                    `[ConnectionTrace] Connect button clicked clickId=${clickId}`,
+                );
+                extensionRpc.action("connect", { clickId, clickTimestamp });
             },
             testConnection: function (): void {
                 extensionRpc.action("testConnection");

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -1024,6 +1024,45 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 } as IConnectionDialogProfile;
             });
 
+            test("logs when the connection action reaches the extension host", async () => {
+                const loggerDebug = sandbox.stub(controller["logger"], "debug");
+                connectionManager.connect.resolves(true);
+                controller.state.formState = testFormState;
+
+                await controller["_reducerHandlers"].get("connect")(controller.state, {});
+
+                expect(loggerDebug).to.have.been.calledWithMatch(
+                    /Connection attempt started.*correlationId=/,
+                );
+            });
+
+            test("handles a connect action without a payload", async () => {
+                connectionManager.connect.resolves(true);
+                controller.state.formState = testFormState;
+
+                await controller["_reducerHandlers"].get("connect")(
+                    controller.state,
+                    undefined,
+                );
+            });
+
+            test("does not log an invalid webview correlation payload", async () => {
+                const loggerDebug = sandbox.stub(controller["logger"], "debug");
+                connectionManager.connect.resolves(true);
+                controller.state.formState = testFormState;
+
+                await controller["_reducerHandlers"].get("connect")(controller.state, {
+                    clickId: "forged\r\nlog-entry",
+                    clickTimestamp: -1,
+                });
+
+                const connectionAttemptLog = loggerDebug.args
+                    .map(([message]) => String(message))
+                    .find((message) => message.includes("Connection attempt started"));
+                expect(connectionAttemptLog).to.not.include("forged");
+                expect(connectionAttemptLog).to.not.include("transportDurationMs");
+            });
+
             test("connect happy path", async () => {
                 mockObjectExplorerProvider.createSession.resolves({
                     sessionId: "testSessionId",
@@ -1047,6 +1086,33 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 expect(connectionManager.connect.calledOnce).to.be.true;
                 expect(connectionStore.saveProfile.calledOnce).to.be.true;
                 expect(mockObjectExplorerProvider.createSession.calledOnce).to.be.true;
+            });
+
+            test("passes the connection correlation ID to Object Explorer session creation", async () => {
+                const clickId = "1234567890123-test";
+                mockObjectExplorerProvider.createSession.resolves({
+                    sessionId: "testSessionId",
+                    rootNode: mockConnectionNode,
+                    success: true,
+                } as CreateSessionResponse);
+                connectionManager.connect.resolves(true);
+
+                const mockObjectExplorerTree = {
+                    reveal: sandbox.stub().resolves(),
+                } as unknown as vscode.TreeView<TreeNodeInfo>;
+
+                mainController.objectExplorerTree = mockObjectExplorerTree;
+                controller.state.formState = testFormState;
+
+                await controller["_reducerHandlers"].get("connect")(controller.state, {
+                    clickId,
+                    clickTimestamp: Date.now(),
+                });
+
+                expect(mockObjectExplorerProvider.createSession).to.have.been.calledWith(
+                    sinon.match.any,
+                    clickId,
+                );
             });
 
             test("testConnection only validates connectivity without saving or creating session", async () => {

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -17,7 +17,11 @@ import ConnectionManager, {
 import SqlToolsServerClient from "../../src/languageservice/serviceclient";
 import StatusView from "../../src/views/statusView";
 import { CredentialStore } from "../../src/credentialstore/credentialstore";
-import { IConnectionProfile, IConnectionProfileWithSource } from "../../src/models/interfaces";
+import {
+    IConnectionGroup,
+    IConnectionProfile,
+    IConnectionProfileWithSource,
+} from "../../src/models/interfaces";
 import { ParseConnectionStringRequest } from "../../src/models/contracts/connection";
 import * as ConnectionContracts from "../../src/models/contracts/connection";
 import * as Constants from "../../src/constants/constants";
@@ -103,6 +107,33 @@ suite("ConnectionManager Tests", () => {
             }).to.not.throw();
 
             await connectionManager.initialized; // Wait for initialization to complete
+        });
+
+        test("starts loading connections and groups concurrently", async () => {
+            const connectionsReady = new Deferred<IConnectionProfileWithSource[]>();
+            const groupsReady = new Deferred<IConnectionGroup[]>();
+            mockConnectionStore.readAllConnections.callsFake(() => connectionsReady.promise);
+            mockConnectionStore.readAllConnectionGroups.callsFake(() => groupsReady.promise);
+
+            connectionManager = new ConnectionManager(
+                mockContext,
+                mockStatusView,
+                undefined, // prompter
+                mockLogger,
+                mockServiceClient,
+                mockConnectionStore,
+                mockCredentialStore,
+                undefined, // connectionUI
+                mockAccountStore,
+            );
+
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            expect(mockConnectionStore.readAllConnections).to.have.been.called;
+            expect(mockConnectionStore.readAllConnectionGroups).to.have.been.called;
+
+            connectionsReady.resolve([]);
+            groupsReady.resolve([]);
+            await connectionManager.initialized;
         });
 
         test("Initialization migrates legacy Connection String connections in credential store", async () => {

--- a/extensions/mssql/test/unit/vscodeEntraMfaUtils.test.ts
+++ b/extensions/mssql/test/unit/vscodeEntraMfaUtils.test.ts
@@ -4,9 +4,76 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { areCompatibleEntraAccountIds } from "../../src/azure/vscodeEntraMfaUtils";
+import * as vscode from "vscode";
+import {
+    areCompatibleEntraAccountIds,
+    acquireTokenFromVscodeAccountForResource,
+} from "../../src/azure/vscodeEntraMfaUtils";
+import * as sinon from "sinon";
+import * as AzureHelpers from "../../src/connectionconfig/azureHelpers";
+import { mockAccounts, mockTenants } from "./azureHelperStubs";
+import { createStubLogger } from "./utils";
 
 suite("vscodeEntraMfaUtils", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test("traces silent and interactive token session acquisition separately", async () => {
+        const traceLogger = createStubLogger(sandbox);
+        const selectedTenantId = mockTenants[0].tenantId;
+        const session = {
+            id: "session-id",
+            accessToken: "access-token",
+            account: mockAccounts.signedInAccount,
+            scopes: [],
+        };
+
+        sandbox
+            .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
+            .resolves([mockAccounts.signedInAccount]);
+        sandbox
+            .stub(AzureHelpers.VsCodeAzureHelper, "getTenantsForAccount")
+            .resolves(
+                mockTenants.filter(
+                    (tenant) => tenant.account.id === mockAccounts.signedInAccount.id,
+                ),
+            );
+        sandbox
+            .stub(vscode.authentication, "getSession")
+            .onFirstCall()
+            .resolves(undefined)
+            .onSecondCall()
+            .resolves(session);
+
+        await acquireTokenFromVscodeAccountForResource(
+            "https://database.windows.net/",
+            mockAccounts.signedInAccount.id,
+            selectedTenantId,
+            undefined,
+            { logger: traceLogger, requestId: "token-request" },
+        );
+
+        expect(traceLogger.debug).to.have.been.calledWithMatch(
+            "silent token session request started requestId=token-request",
+        );
+        expect(traceLogger.debug).to.have.been.calledWithMatch(
+            "silent token session request completed requestId=token-request",
+        );
+        expect(traceLogger.debug).to.have.been.calledWithMatch(
+            "interactive token session request started requestId=token-request",
+        );
+        expect(traceLogger.debug).to.have.been.calledWithMatch(
+            "interactive token session request completed requestId=token-request",
+        );
+    });
+
     suite("areCompatibleEntraAccountIds", () => {
         test("returns true for exact match", () => {
             expect(areCompatibleEntraAccountIds("user@example.com", "user@example.com")).to.be.true;


### PR DESCRIPTION
## Description

This PR extracts the connection-startup and diagnostic improvements from #22614 into a focused change.

It improves startup performance and makes slow connection phases easier to diagnose by:

- Loading saved connections and connection groups concurrently.
- Carrying correlation IDs and timestamps from the connection dialog and Object Explorer through connection setup.
- Adding phase-level debug traces for credential preparation, Entra token acquisition, Object Explorer initialization, and SQL Tools Service connection requests.
- Replacing verbose Entra information logs containing account, tenant, resource, or token-expiry details with privacy-conscious timing traces.
- Validating connection-dialog timing payloads before using them.

The traces contain timings, correlation identifiers, authentication type, and boolean state only. They do not include server names, database names, account IDs, tenant IDs, resource endpoints, or credentials.

Validation performed:

- `npm run build -- --target mssql`
- `npm run test -- --target mssql --coverage=false`
- `npm run package -- --target mssql --online`
- Manual VSIX installation and connection testing

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)