### PR TITLE
Coalesce concurrent connection-sharing permission prompts

### DIFF
--- a/extensions/mssql/src/connectionSharing/connectionSharingService.ts
+++ b/extensions/mssql/src/connectionSharing/connectionSharingService.ts
@@ -49,6 +49,8 @@ export class ConnectionSharingError extends Error {
 
 export class ConnectionSharingService implements mssql.IConnectionSharingService {
     private _logger: ILogger;
+    private readonly _permissionRequests = new Map<string, Promise<boolean>>();
+
     constructor(
         private readonly _context: vscode.ExtensionContext,
         private readonly _client: SqlToolsServiceClient,
@@ -230,6 +232,26 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
     }
 
     private async requestConnectionSharingPermission(extensionId: string): Promise<boolean> {
+        const pendingRequest = this._permissionRequests.get(extensionId);
+        if (pendingRequest) {
+            return pendingRequest;
+        }
+
+        const permissionRequest = this.requestConnectionSharingPermissionCore(extensionId);
+        this._permissionRequests.set(extensionId, permissionRequest);
+
+        try {
+            return await permissionRequest;
+        } finally {
+            if (this._permissionRequests.get(extensionId) === permissionRequest) {
+                this._permissionRequests.delete(extensionId);
+            }
+        }
+    }
+
+    private async requestConnectionSharingPermissionCore(
+        extensionId: string,
+    ): Promise<boolean> {
         this._logger.info(`Requesting connection sharing permission for extension: ${extensionId}`);
 
         const currentPermission = await this.getExtensionPermission(extensionId);

--- a/extensions/mssql/test/unit/connectionSharingService.test.ts
+++ b/extensions/mssql/test/unit/connectionSharingService.test.ts
@@ -299,6 +299,7 @@ suite("ConnectionSharingService Tests", () => {
 
             await new Promise<void>((resolve) => setImmediate(resolve));
 
+            expect(showInformationMessageStub).to.have.been.calledOnce;
             resolvePrompt!(LocalizedConstants.ConnectionSharing.Approve);
             await Promise.all([firstRequest, secondRequest]);
         });

--- a/extensions/mssql/test/unit/connectionSharingService.test.ts
+++ b/extensions/mssql/test/unit/connectionSharingService.test.ts
@@ -272,6 +272,37 @@ suite("ConnectionSharingService Tests", () => {
             expect(showInformationMessageStub).to.not.have.been.called;
         });
 
+        test("should share an in-flight permission request for the same extension", async () => {
+            secretStorage.get.resolves(undefined);
+            let resolvePrompt: (value: string) => void;
+            const promptResult = new Promise<string>((resolve) => {
+                resolvePrompt = resolve;
+            });
+            let promptInvocationCount = 0;
+            showInformationMessageStub.callsFake(() => {
+                promptInvocationCount++;
+                if (promptInvocationCount > 1) {
+                    throw new Error("Connection sharing permission prompt was shown twice");
+                }
+                return promptResult;
+            });
+
+            sandbox.stub(vscode.window, "activeTextEditor").get(() => ({
+                document: { uri: vscode.Uri.parse("file:///test.sql") },
+            }));
+
+            const command = registeredCommands.get(
+                "mssql.connectionSharing.getActiveEditorConnectionId",
+            );
+            const firstRequest = command!(testExtensionId);
+            const secondRequest = command!(testExtensionId);
+
+            await new Promise<void>((resolve) => setImmediate(resolve));
+
+            resolvePrompt!(LocalizedConstants.ConnectionSharing.Approve);
+            await Promise.all([firstRequest, secondRequest]);
+        });
+
         test("should reject denied extension without prompting", async () => {
             secretStorage.get.resolves(JSON.stringify({ [testExtensionId]: "denied" }));
 


### PR DESCRIPTION
## Description

This PR extracts the connection-sharing prompt improvement from #22614 into a focused change.

Concurrent connection-sharing requests from the same extension can arrive before the user's permission choice has been persisted. Previously, each request could display its own permission prompt.

This change tracks the in-flight permission request for each extension and shares its result with concurrent callers. The request is removed after completion so later permission checks and retries continue to work normally. Requests from different extensions remain independent.

A regression test verifies that two concurrent requests from the same extension display only one permission prompt.

Validation performed:

- `npm run build -- --target mssql`
- `npm run test -- --target mssql --coverage=false`
- `npm run package -- --target mssql --online`
- Manual VSIX installation and connection-sharing testing

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant — existing logging retained
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)