### PR TITLE
Update FirewallService to use VsCodeAzureHelper for firewall rules

### DIFF
--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -1255,6 +1255,14 @@ export class Azure {
         });
     };
 
+    public static unableToLocateSqlServer = (serverName: string) => {
+        return l10n.t({
+            message: "Unable to locate Azure SQL server '{0}' in the selected Azure account.",
+            args: [serverName],
+            comment: ["{0} is the server name"],
+        });
+    };
+
     public static failedToGetTenantForAccount = (tenantId: string, accountName: string) => {
         return l10n.t({
             message: "Failed to get tenant '{0}' for account '{1}'.",

--- a/extensions/mssql/src/firewall/firewallService.ts
+++ b/extensions/mssql/src/firewall/firewallService.ts
@@ -4,33 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-    CreateFirewallRuleRequest,
     HandleFirewallRuleRequest,
     IHandleFirewallRuleParams,
     IHandleFirewallRuleResponse,
-    ICreateFirewallRuleResponse,
-    ICreateFirewallRuleParams,
 } from "../models/contracts/firewall/firewallRequest";
 import * as Constants from "../constants/constants";
 import { AccountService } from "../azure/accountService";
 import { FirewallRuleSpec } from "../sharedInterfaces/firewallRule";
-import { constructAzureAccountForTenant } from "../connectionconfig/azureHelpers";
+import { VsCodeAzureHelper } from "../connectionconfig/azureHelpers";
 import { getErrorMessage } from "../utils/utils";
 import { Azure as LocAzure } from "../constants/locConstants";
-import { IAccount } from "../models/contracts/azure";
 
 export class FirewallService {
     constructor(private accountService: AccountService) {}
-
-    public async createFirewallRule(
-        params: ICreateFirewallRuleParams,
-    ): Promise<ICreateFirewallRuleResponse> {
-        let result = await this.accountService.client.sendResourceRequest(
-            CreateFirewallRuleRequest.type,
-            params,
-        );
-        return result;
-    }
 
     public async handleFirewallRule(
         errorCode: number,
@@ -57,36 +43,32 @@ export class FirewallService {
                 ? [firewallRuleSpec.ip, firewallRuleSpec.ip]
                 : [firewallRuleSpec.ip.startIp, firewallRuleSpec.ip.endIp];
 
-        let account: IAccount, tokenMappings: {};
-
         try {
-            ({ account, tokenMappings } = await constructAzureAccountForTenant(
-                firewallRuleSpec.azureAccountInfo,
-            ));
-        } catch (err) {
-            const error = new Error(
-                LocAzure.errorCreatingFirewallRule(
-                    `"${firewallRuleSpec.name}" (${startIp} - ${endIp})`,
-                    getErrorMessage(err),
-                ),
-            );
-            error.name = "constructAzureAccountForTenant";
-            throw error;
-        }
+            const { accountId, tenantId } = firewallRuleSpec.azureAccountInfo;
+            const resource = await VsCodeAzureHelper.findSqlResource(accountId, serverName);
 
-        try {
-            const result = await this.createFirewallRule({
-                account: account,
-                firewallRuleName: firewallRuleSpec.name,
-                startIpAddress: startIp,
-                endIpAddress: endIp,
-                serverName: serverName,
-                securityTokenMappings: tokenMappings,
-            });
-
-            if (!result.result) {
-                throw result.errorMessage;
+            if (resource === "UnableToCheck") {
+                throw new Error(LocAzure.unableToLocateSqlServer(serverName));
             }
+
+            const subscriptions = await VsCodeAzureHelper.getSubscriptionsForAccount(accountId);
+            const subscription = subscriptions.find(
+                (sub) =>
+                    sub.subscriptionId === resource.subscriptionId && sub.tenantId === tenantId,
+            );
+
+            if (!subscription) {
+                throw new Error(LocAzure.errorLoadingAzureAccountInfoForTenantId(tenantId));
+            }
+
+            await VsCodeAzureHelper.createFirewallRule(
+                subscription,
+                resource.resourceGroup,
+                serverName,
+                firewallRuleSpec.name,
+                startIp,
+                endIp,
+            );
         } catch (err) {
             const error = new Error(
                 LocAzure.errorCreatingFirewallRule(

--- a/extensions/mssql/test/unit/firewallService.test.ts
+++ b/extensions/mssql/test/unit/firewallService.test.ts
@@ -13,11 +13,10 @@ import { AccountService } from "../../src/azure/accountService";
 import {
     HandleFirewallRuleRequest,
     IHandleFirewallRuleResponse,
-    CreateFirewallRuleRequest,
-    ICreateFirewallRuleResponse,
-    ICreateFirewallRuleParams,
 } from "../../src/models/contracts/firewall/firewallRequest";
 import * as Constants from "../../src/constants/constants";
+import { VsCodeAzureHelper } from "../../src/connectionconfig/azureHelpers";
+import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
 
 chai.use(sinonChai);
 
@@ -60,28 +59,76 @@ suite("Firewall Service Tests", () => {
         );
     });
 
-    test("Create Firewall Rule Test", async () => {
-        const mockResponse: ICreateFirewallRuleResponse = {
-            result: true,
-            errorMessage: "",
+    test("creates firewall rule using the matching Azure subscription", async () => {
+        const subscription = {
+            subscriptionId: "subscription-id",
+            tenantId: "tenant-id",
+        } as AzureSubscription;
+        const firewallRuleSpec = {
+            name: "Test Rule",
+            azureAccountInfo: {
+                accountId: "account-id",
+                tenantId: "tenant-id",
+            },
+            ip: {
+                startIp: "1.2.3.1",
+                endIp: "1.2.3.255",
+            },
         };
-        client.sendResourceRequest.resolves(mockResponse);
+        sandbox.stub(VsCodeAzureHelper, "findSqlResource").resolves({
+            accountId: "account-id",
+            subscriptionId: "subscription-id",
+            resourceGroup: "resource-group",
+        });
+        sandbox.stub(VsCodeAzureHelper, "getSubscriptionsForAccount").resolves([subscription]);
+        const createFirewallRule = sandbox.stub(VsCodeAzureHelper, "createFirewallRule").resolves();
 
-        const request = {
-            account: { properties: { tenants: [] } },
-            firewallRuleName: "Test Rule",
-            startIpAddress: "1.2.3.1",
-            endIpAddress: "1.2.3.255",
-            serverName: "test_server",
-            securityTokenMappings: {},
-        } as ICreateFirewallRuleParams;
+        await firewallService.createFirewallRuleWithVscodeAccount(firewallRuleSpec, "test-server");
 
-        const result = await firewallService.createFirewallRule(request);
-
-        expect(result).to.deep.equal(mockResponse);
-        expect(client.sendResourceRequest).to.have.been.calledOnceWithExactly(
-            CreateFirewallRuleRequest.type,
-            request,
+        expect(VsCodeAzureHelper.findSqlResource).to.have.been.calledWithExactly(
+            "account-id",
+            "test-server",
         );
+        expect(VsCodeAzureHelper.getSubscriptionsForAccount).to.have.been.calledWithExactly(
+            "account-id",
+        );
+        expect(createFirewallRule).to.have.been.calledWithExactly(
+            subscription,
+            "resource-group",
+            "test-server",
+            "Test Rule",
+            "1.2.3.1",
+            "1.2.3.255",
+        );
+    });
+
+    test("reports an error when the Azure SQL server cannot be located", async () => {
+        sandbox.stub(VsCodeAzureHelper, "findSqlResource").resolves("UnableToCheck");
+        const getSubscriptions = sandbox.stub(VsCodeAzureHelper, "getSubscriptionsForAccount");
+        const createFirewallRule = sandbox.stub(VsCodeAzureHelper, "createFirewallRule");
+
+        const firewallRuleSpec = {
+            name: "Test Rule",
+            azureAccountInfo: {
+                accountId: "account-id",
+                tenantId: "tenant-id",
+            },
+            ip: "1.2.3.4",
+        };
+
+        try {
+            await firewallService.createFirewallRuleWithVscodeAccount(
+                firewallRuleSpec,
+                "missing-server",
+            );
+            expect.fail("Expected firewall rule creation to throw");
+        } catch (error) {
+            if (!(error instanceof Error)) {
+                throw error;
+            }
+            expect(error.message).to.contain("Unable to locate Azure SQL server 'missing-server'");
+        }
+        expect(getSubscriptions).not.to.have.been.called;
+        expect(createFirewallRule).not.to.have.been.called;
     });
 });


### PR DESCRIPTION
This pull request refactors the `FirewallService` to utilize the `VsCodeAzureHelper` for creating firewall rules instead of relying on the SQL Tools Service (STS). The changes include:

- **Refactoring**: The `firewallService.ts` now calls `VsCodeAzureHelper.findSqlResource()` and `createFirewallRule()` for firewall operations.
- **Removal of STS Dependency**: The direct call to the SQL Tools Service for firewall creation has been eliminated, retaining STS only for parsing firewall errors and client IPs.
- **Localization**: Added localized messaging for lookup failures.
- **Testing**: Updated unit tests in `firewallService.test.ts` to cover the new implementation, ensuring all tests pass.

Validation has confirmed that the build, linting, and all targeted tests are successful.