### PR TITLE
Redact secrets from proxy warnings

### DIFF
--- a/packages/extension-toolkit/src/base/http/httpClient.ts
+++ b/packages/extension-toolkit/src/base/http/httpClient.ts
@@ -498,6 +498,17 @@ interface ProxyAgentOptions {
     rejectUnauthorized: boolean;
 }
 
+/**
+ * Redacts credentials and query or fragment values from proxy URL-like strings.
+ *
+ * Examples:
+ * - `http://user:password@proxy.example.com:8080` becomes
+ *   `http://<redacted>@proxy.example.com:8080`.
+ * - `http://proxy.example.com:8080?token=secret#fragment` becomes
+ *   `http://proxy.example.com:8080<redacted>`.
+ * - `proxy.example.com:8080` remains usable as a protocol-less proxy value while
+ *   still redacting any credentials or query and fragment values.
+ */
 function redactProxySecrets(proxy: string): string {
     const schemeSeparatorIndex = proxy.indexOf("://");
     const authorityStart = schemeSeparatorIndex >= 0 ? schemeSeparatorIndex + 3 : 0;

--- a/packages/extension-toolkit/src/base/http/httpClient.ts
+++ b/packages/extension-toolkit/src/base/http/httpClient.ts
@@ -200,6 +200,7 @@ export class HttpClient {
 
         let message: string | undefined;
         let localizedMessage: string | undefined;
+        const redactedProxy = redactProxySecrets(proxy);
 
         try {
             const scheme = this.dependencies.parseUriScheme
@@ -207,13 +208,15 @@ export class HttpClient {
                 : new URL(proxy).protocol;
 
             if (!scheme) {
-                message = `Proxy settings found, but without a protocol (e.g. http://): '${proxy}'.  You may encounter connection issues while using this extension.`;
-                localizedMessage = ProxyMessages.missingProtocolWarning(proxy);
+                message = `Proxy settings found, but without a protocol (e.g. http://): '${redactedProxy}'.  You may encounter connection issues while using this extension.`;
+                localizedMessage = ProxyMessages.missingProtocolWarning(redactedProxy);
             }
         } catch (error) {
-            const errorMessage = getErrorMessage(error);
-            message = `Proxy settings found, but encountered an error while parsing the URL: '${proxy}'.  You may encounter connection issues while using this extension.  Error: ${errorMessage}`;
-            localizedMessage = ProxyMessages.unparseableWarning(proxy, errorMessage);
+            const errorMessage = redactProxySecrets(
+                getErrorMessage(error).replaceAll(proxy, redactedProxy),
+            );
+            message = `Proxy settings found, but encountered an error while parsing the URL: '${redactedProxy}'.  You may encounter connection issues while using this extension.  Error: ${errorMessage}`;
+            localizedMessage = ProxyMessages.unparseableWarning(redactedProxy, errorMessage);
         }
 
         if (message) {
@@ -493,6 +496,29 @@ interface ProxyAgentOptions {
     port?: string | number | null;
     protocol: string;
     rejectUnauthorized: boolean;
+}
+
+function redactProxySecrets(proxy: string): string {
+    const schemeSeparatorIndex = proxy.indexOf("://");
+    const authorityStart = schemeSeparatorIndex >= 0 ? schemeSeparatorIndex + 3 : 0;
+    const authorityEnd = ["/", "?", "#"]
+        .map((separator) => proxy.indexOf(separator, authorityStart))
+        .filter((index) => index >= 0)
+        .reduce((first, index) => Math.min(first, index), proxy.length);
+    const credentialSeparatorIndex = proxy.lastIndexOf("@", authorityEnd - 1);
+
+    let redacted =
+        credentialSeparatorIndex >= authorityStart
+            ? `${proxy.slice(0, authorityStart)}<redacted>@${proxy.slice(credentialSeparatorIndex + 1)}`
+            : proxy;
+    const sensitiveSuffixIndex = [redacted.indexOf("?"), redacted.indexOf("#")]
+        .filter((index) => index >= 0)
+        .reduce((first, index) => Math.min(first, index), redacted.length);
+    if (sensitiveSuffixIndex < redacted.length) {
+        redacted = `${redacted.slice(0, sensitiveSuffixIndex)}<redacted>`;
+    }
+
+    return redacted;
 }
 
 /** Error raised by a download when request or response streaming fails. */

--- a/packages/extension-toolkit/test/httpClient.test.js
+++ b/packages/extension-toolkit/test/httpClient.test.js
@@ -295,6 +295,23 @@ describe("HttpClient", () => {
             assert.equal(logger.warn.mock.callCount(), 1);
         });
 
+        it("redacts proxy credentials and query values from warnings", () => {
+            proxyValue = "http://user:super-secret@[invalid-host]?token=also-secret";
+            parseUriScheme = () => {
+                throw new Error(`Invalid URL: ${proxyValue}`);
+            };
+
+            const warning = httpClient.getInvalidProxySettingsWarning();
+            const loggedWarning = logger.warn.mock.calls[0].arguments[0];
+
+            for (const exposedValue of ["user", "super-secret", "token", "also-secret"]) {
+                assert.equal(warning.includes(exposedValue), false);
+                assert.equal(loggedWarning.includes(exposedValue), false);
+            }
+            assert.ok(warning.includes("<redacted>"));
+            assert.ok(loggedWarning.includes("<redacted>"));
+        });
+
         it("does not warn when the proxy is valid", () => {
             for (const validProxyValue of [
                 "http://valid-proxy.test:8080",


### PR DESCRIPTION
## Summary

- Redacts proxy URL credentials and query or fragment values before warnings reach UI or logs.
- Sanitizes parser error details that repeat the configured proxy value.
- Adds regression coverage ensuring proxy secrets are absent from both warning channels.

## Validation

- TypeScript compilation
- Focused HTTP client tests
- ESLint and Prettier
