### PR TITLE
Added ability to favorite azure/fabric resources within the Azure and Fabric Provisioning Experiences

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1887,6 +1887,20 @@
                         "type": "string"
                     }
                 },
+                "mssql.favoriteAzureResourceGroups": {
+                    "type": "array",
+                    "description": "%mssql.favoriteAzureResourceGroups%",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "mssql.favoriteAzureServers": {
+                    "type": "array",
+                    "description": "%mssql.favoriteAzureServers%",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "mssql.azureActiveDirectory": {
                     "type": "string",
                     "default": "AuthCodeGrant",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -288,6 +288,8 @@
     "mssql.userFeedback": "Send Feedback",
     "mssql.selectedAzureSubscriptions": "Selected Azure subscriptions for browsing and managing servers and databases",
     "mssql.selectedFabricWorkspaces": "Selected Microsoft Fabric workspaces for browsing and managing SQL databases",
+    "mssql.favoriteAzureResourceGroups": "Favorite Azure resource groups used during database provisioning",
+    "mssql.favoriteAzureServers": "Favorite Azure SQL servers used during database provisioning",
     "mssql.schemaDesigner": "Visualize and Design Schema...",
     "mssql.buildDataApi": "Build Data API...",
     "mssql.newDeployment": "New Deployment",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -326,6 +326,8 @@ export const configAutoDisableNonTSqlLanguageService = "mssql.autoDisableNonTSql
 export const copilotDebugLogging = "mssql.copilotDebugLogging";
 export const configSelectedAzureSubscriptions = "mssql.selectedAzureSubscriptions";
 export const configSelectedFabricWorkspaces = "mssql.selectedFabricWorkspaces";
+export const configFavoriteAzureResourceGroups = "mssql.favoriteAzureResourceGroups";
+export const configFavoriteAzureServers = "mssql.favoriteAzureServers";
 export const configShowActiveConnectionAsCodeLensSuggestion =
     "mssql.query.showActiveConnectionAsCodeLensSuggestion";
 export const configStatusBarConnectionInfoMaxLength = "statusBar.connectionInfoMaxLength";

--- a/extensions/mssql/src/deployment/azureSqlDatabaseHelpers.ts
+++ b/extensions/mssql/src/deployment/azureSqlDatabaseHelpers.ts
@@ -16,7 +16,12 @@ import { AzureSqlDatabase, ConnectionDialog } from "../constants/locConstants";
 import { ILogger } from "../sharedInterfaces/logger";
 import * as asd from "../sharedInterfaces/azureSqlDatabase";
 import { AuthenticationType, IConnectionDialogProfile } from "../sharedInterfaces/connectionDialog";
-import { FormItemActionButton, FormItemOptions, FormItemType } from "../sharedInterfaces/form";
+import {
+    FavoriteResourceType,
+    FormItemActionButton,
+    FormItemOptions,
+    FormItemType,
+} from "../sharedInterfaces/form";
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
 import { sendActionEvent, sendErrorEvent } from "extension-toolkit/vscode";
@@ -31,6 +36,7 @@ import {
     getCloudResourceEndpoint,
 } from "../azure/vscodeEntraMfaUtils";
 import { getErrorMessage } from "../utils/utils";
+import { applyFavorites } from "./deploymentFavorites";
 
 // Cached logger reference for use in helper functions that don't have
 // direct access to the controller's protected logger.
@@ -905,8 +911,7 @@ async function loadAccountComponent(
         accountComponent.placeholder = AzureSqlDatabase.noAzureAccountsFound;
     }
 
-    azureSqlState.formState.accountId =
-        azureSqlState.accounts.length > 0 ? azureSqlState.accounts[0].id : "";
+    azureSqlState.formState.accountId = accountComponent.options[0]?.value ?? "";
 }
 
 async function loadTenantComponent(azureSqlState: asd.AzureSqlDatabaseState): Promise<void> {
@@ -924,9 +929,9 @@ async function loadTenantComponent(azureSqlState: asd.AzureSqlDatabaseState): Pr
     );
     clearCacheDownstream(azureSqlState, "tenantId");
 
-    tenantComponent.options = azureSqlState.tenants.map((t) => ({
-        displayName: t.displayName,
-        value: t.tenantId,
+    tenantComponent.options = azureSqlState.tenants.map((tenant) => ({
+        displayName: tenant.displayName,
+        value: tenant.tenantId,
     }));
     tenantComponent.placeholder =
         azureSqlState.tenants.length > 0
@@ -959,17 +964,19 @@ async function loadSubscriptionComponent(azureSqlState: asd.AzureSqlDatabaseStat
     azureSqlState.subscriptions = await VsCodeAzureHelper.getSubscriptionsForTenant(tenant);
     clearCacheDownstream(azureSqlState, "subscriptionId");
 
-    subscriptionComponent.options = azureSqlState.subscriptions.map((sub) => ({
-        displayName: `${sub.name} (${sub.subscriptionId})`,
-        value: sub.subscriptionId,
-    }));
+    subscriptionComponent.options = applyFavorites(
+        azureSqlState.subscriptions.map((sub) => ({
+            displayName: `${sub.name} (${sub.subscriptionId})`,
+            value: sub.subscriptionId,
+        })),
+        FavoriteResourceType.AzureSubscription,
+    );
     subscriptionComponent.placeholder =
         azureSqlState.subscriptions.length > 0
             ? AzureSqlDatabase.selectASubscription
             : AzureSqlDatabase.noSubscriptionsFound;
 
-    azureSqlState.formState.subscriptionId =
-        azureSqlState.subscriptions.length > 0 ? azureSqlState.subscriptions[0].subscriptionId : "";
+    azureSqlState.formState.subscriptionId = subscriptionComponent.options[0]?.value ?? "";
 
     // Load maintenance configurations for the selected subscription
     void loadMaintenanceConfigs(azureSqlState);
@@ -1034,10 +1041,14 @@ async function loadResourceGroupComponent(azureSqlState: asd.AzureSqlDatabaseSta
         await VsCodeAzureHelper.getResourceGroupsForSubscription(subscription);
     clearCacheDownstream(azureSqlState, "resourceGroup");
 
-    resourceGroupComponent.options = azureSqlState.resourceGroups.map((name) => ({
-        displayName: name,
-        value: name,
-    }));
+    resourceGroupComponent.options = applyFavorites(
+        azureSqlState.resourceGroups.map((name) => ({
+            displayName: name,
+            value: name,
+        })),
+        FavoriteResourceType.AzureResourceGroup,
+        (option) => `${azureSqlState.formState.subscriptionId}/${option.value}`,
+    );
     resourceGroupComponent.placeholder =
         azureSqlState.resourceGroups.length > 0
             ? AzureSqlDatabase.selectAResourceGroup
@@ -1048,8 +1059,7 @@ async function loadResourceGroupComponent(azureSqlState: asd.AzureSqlDatabaseSta
     if (currentRg && azureSqlState.resourceGroups.includes(currentRg)) {
         azureSqlState.formState.resourceGroup = currentRg;
     } else {
-        azureSqlState.formState.resourceGroup =
-            azureSqlState.resourceGroups.length > 0 ? azureSqlState.resourceGroups[0] : "";
+        azureSqlState.formState.resourceGroup = resourceGroupComponent.options[0]?.value ?? "";
     }
 }
 
@@ -1082,10 +1092,17 @@ async function loadServerComponent(azureSqlState: asd.AzureSqlDatabaseState): Pr
         azureSqlState.formState.resourceGroup,
     );
 
-    serverComponent.options = azureSqlState.servers.map((s) => ({
-        displayName: s.name ?? "",
-        value: s.name ?? "",
-    }));
+    serverComponent.options = applyFavorites(
+        azureSqlState.servers.map((s) => ({
+            displayName: s.name ?? "",
+            value: s.name ?? "",
+            favoriteId:
+                s.id ??
+                `${azureSqlState.formState.subscriptionId}/${azureSqlState.formState.resourceGroup}/${s.name ?? ""}`,
+        })),
+        FavoriteResourceType.AzureServer,
+        (option) => option.favoriteId!,
+    );
     serverComponent.placeholder =
         azureSqlState.servers.length > 0
             ? AzureSqlDatabase.selectAServer
@@ -1099,8 +1116,7 @@ async function loadServerComponent(azureSqlState: asd.AzureSqlDatabaseState): Pr
     if (matchedServer) {
         azureSqlState.formState.serverName = currentServer;
     } else {
-        azureSqlState.formState.serverName =
-            azureSqlState.servers.length > 0 ? (azureSqlState.servers[0].name ?? "") : "";
+        azureSqlState.formState.serverName = serverComponent.options[0]?.value ?? "";
     }
 
     // Auto-detect auth type based on the selected server's properties
@@ -1149,8 +1165,7 @@ async function getAzureActionButton(
             // Auto-select the newly added account, or keep the first one
             const newAccount = currentState.accounts.find((a) => !previousAccountIds.has(a.id));
             currentState.formState.accountId =
-                newAccount?.id ??
-                (currentState.accounts.length > 0 ? currentState.accounts[0].id : "");
+                newAccount?.id ?? accountsComponent.options[0]?.value ?? "";
 
             // Reset downstream components so they reload with the new account
             reloadAzureComponentsDownstream(currentState, "accountId");

--- a/extensions/mssql/src/deployment/deploymentFavorites.ts
+++ b/extensions/mssql/src/deployment/deploymentFavorites.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import {
+    configFavoriteAzureResourceGroups,
+    configFavoriteAzureServers,
+    configSelectedAzureSubscriptions,
+    configSelectedFabricWorkspaces,
+} from "../constants/constants";
+import {
+    FavoriteResourceType,
+    FormItemOptions,
+    sortOptionsByFavoriteOrder,
+} from "../sharedInterfaces/form";
+
+const favoriteConfigKeys: Record<FavoriteResourceType, string> = {
+    [FavoriteResourceType.AzureSubscription]: configSelectedAzureSubscriptions,
+    [FavoriteResourceType.AzureResourceGroup]: configFavoriteAzureResourceGroups,
+    [FavoriteResourceType.AzureServer]: configFavoriteAzureServers,
+    [FavoriteResourceType.FabricWorkspace]: configSelectedFabricWorkspaces,
+};
+
+export function getFavoriteIds(resourceType: FavoriteResourceType): string[] {
+    const favoriteIds = vscode.workspace
+        .getConfiguration()
+        .get<string[]>(favoriteConfigKeys[resourceType], []);
+    return resourceType === FavoriteResourceType.AzureSubscription
+        ? favoriteIds.map((id) => id.slice(id.lastIndexOf("/") + 1))
+        : favoriteIds;
+}
+
+export function applyFavorites(
+    options: FormItemOptions[],
+    resourceType: FavoriteResourceType,
+    getFavoriteId: (option: FormItemOptions) => string = (option) => option.value,
+): FormItemOptions[] {
+    const favoriteIds = getFavoriteIds(resourceType);
+    const favoriteOrderById = new Map(favoriteIds.map((id, index) => [id, index]));
+    return sortOptionsByFavoriteOrder(
+        options.map((option) => {
+            const favoriteId = getFavoriteId(option);
+            const favoriteOrder = favoriteOrderById.get(favoriteId);
+            return {
+                ...option,
+                favoriteResourceType: resourceType,
+                favoriteId,
+                isFavorite: favoriteOrder !== undefined,
+                favoriteOrder,
+            };
+        }),
+    );
+}
+
+export async function toggleFavorite(
+    resourceType: FavoriteResourceType,
+    favoriteId: string,
+): Promise<string[]> {
+    const configKey = favoriteConfigKeys[resourceType];
+    const config = vscode.workspace.getConfiguration();
+    const rawFavoriteIds = config.get<string[]>(configKey, []);
+    const favoriteIds =
+        resourceType === FavoriteResourceType.AzureSubscription
+            ? rawFavoriteIds.map((id) => id.slice(id.lastIndexOf("/") + 1))
+            : rawFavoriteIds;
+    const nextIds = favoriteIds.includes(favoriteId)
+        ? favoriteIds.filter((id) => id !== favoriteId)
+        : [...favoriteIds, favoriteId];
+    await config.update(configKey, nextIds, vscode.ConfigurationTarget.Global);
+    return nextIds;
+}

--- a/extensions/mssql/src/deployment/deploymentWebviewController.ts
+++ b/extensions/mssql/src/deployment/deploymentWebviewController.ts
@@ -31,6 +31,7 @@ import {
     AzureSqlDatabaseState,
     AZURE_SQL_DB_COMPONENT_ORDER,
 } from "../sharedInterfaces/azureSqlDatabase";
+import { toggleFavorite } from "./deploymentFavorites";
 
 export const DEPLOYMENT_VIEW_ID = "deployment";
 
@@ -164,6 +165,33 @@ export class DeploymentWebviewController extends FormWebviewController<
                 state.dialog = undefined;
             }
             state.deploymentTypeState.dialog = state.dialog;
+            return state;
+        });
+
+        this.registerReducer("toggleFavoriteOption", async (state, payload) => {
+            const favoriteIds = await toggleFavorite(payload.resourceType, payload.favoriteId);
+            const favoriteOrderById = new Map(
+                favoriteIds.map((favoriteId, index) => [favoriteId, index]),
+            );
+            for (const component of Object.values(state.deploymentTypeState.formComponents)) {
+                if (!component?.options) {
+                    continue;
+                }
+                component.options = component.options.map((option) => {
+                    if (
+                        option.favoriteResourceType !== payload.resourceType ||
+                        !option.favoriteId
+                    ) {
+                        return option;
+                    }
+                    const favoriteOrder = favoriteOrderById.get(option.favoriteId);
+                    return {
+                        ...option,
+                        isFavorite: favoriteOrder !== undefined,
+                        favoriteOrder,
+                    };
+                });
+            }
             return state;
         });
 

--- a/extensions/mssql/src/deployment/fabricProvisioningHelpers.ts
+++ b/extensions/mssql/src/deployment/fabricProvisioningHelpers.ts
@@ -16,6 +16,7 @@ import {
 } from "../sharedInterfaces/fabric";
 import * as fp from "../sharedInterfaces/fabricProvisioning";
 import {
+    FavoriteResourceType,
     FormItemActionButton,
     FormItemOptions,
     FormItemSpec,
@@ -31,6 +32,7 @@ import { IConnectionProfile } from "../models/interfaces";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
 import { sendActionEvent, sendErrorEvent } from "extension-toolkit/vscode";
 import { UserSurvey } from "../nps/userSurvey";
+import { applyFavorites } from "./deploymentFavorites";
 
 export const WORKSPACE_ROLE_REQUEST_LIMIT = 20;
 
@@ -328,8 +330,8 @@ export async function getAzureActionButton(
 
             // There should always be at least one account, because the user just went through the sign in workflow
             if (azureAccounts.length > 0) {
-                state.formState.accountId = azureAccounts[0].id;
-                logger.debug(`Selecting '${azureAccounts[0].id}'`);
+                state.formState.accountId = accountsComponent.options[0].value;
+                logger.debug(`Selecting '${accountsComponent.options[0].value}'`);
             }
 
             updateFabricProvisioningState(deploymentController, state);
@@ -402,17 +404,20 @@ export function getWorkspaceOptions(state: fp.FabricProvisioningState): FormItem
         ...Object.values(state.workspacesWithPermissions),
         ...Object.values(state.workspacesWithoutPermissions),
     ];
-    return orderedWorkspaces.map((workspace) => {
-        const hasPermission = workspace.id in state.workspacesWithPermissions;
+    return applyFavorites(
+        orderedWorkspaces.map((workspace) => {
+            const hasPermission = workspace.id in state.workspacesWithPermissions;
 
-        return {
-            displayName: workspace.displayName,
-            value: workspace.id,
-            color: hasPermission ? "" : "colorNeutralForegroundDisabled",
-            description: hasPermission ? "" : Fabric.insufficientWorkspacePermissions,
-            icon: hasPermission ? undefined : "Warning20Regular",
-        };
-    });
+            return {
+                displayName: workspace.displayName,
+                value: workspace.id,
+                color: hasPermission ? "" : "colorNeutralForegroundDisabled",
+                description: hasPermission ? "" : Fabric.insufficientWorkspacePermissions,
+                icon: hasPermission ? undefined : "Warning20Regular",
+            };
+        }),
+        FavoriteResourceType.FabricWorkspace,
+    );
 }
 
 export async function getWorkspaces(
@@ -435,7 +440,9 @@ export async function getWorkspaces(
         // Handle workspace state updates
         const workspaceOptions = getWorkspaceOptions(state);
         state.formComponents.workspace.options = workspaceOptions;
-        state.formState.workspace = workspaceOptions.length > 0 ? workspaceOptions[0].value : "";
+        state.formState.workspace =
+            workspaceOptions.find((option) => option.value in state.workspacesWithPermissions)
+                ?.value ?? "";
         updateFabricProvisioningState(deploymentController, state);
         sendActionEvent(
             TelemetryViews.FabricProvisioning,

--- a/extensions/mssql/src/sharedInterfaces/deployment.ts
+++ b/extensions/mssql/src/sharedInterfaces/deployment.ts
@@ -3,7 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { FormContextProps, FormEvent, FormItemOptions, FormItemSpec, FormState } from "./form";
+import {
+    FavoriteResourceType,
+    FormContextProps,
+    FormEvent,
+    FormItemOptions,
+    FormItemSpec,
+    FormState,
+} from "./form";
 import {
     LocalContainersContextProps,
     DockerConnectionProfile as LocalContainersFormState,
@@ -66,6 +73,9 @@ export interface DeploymentCommonReducers {
      */
     setConnectionGroupDialogState: { shouldOpen: boolean };
 
+    /** Toggles a provisioning resource favorite. */
+    toggleFavoriteOption: { resourceType: FavoriteResourceType; favoriteId: string };
+
     /**
      * Reducer for cleanup and disposal logic.
      */
@@ -95,6 +105,9 @@ export interface DeploymentCommonContextProps extends FormContextProps<Deploymen
      * @param shouldOpen - A boolean indicating whether the dialog should be open or closed.
      */
     setConnectionGroupDialogState(shouldOpen: boolean): void;
+
+    /** Toggles a provisioning resource favorite. */
+    toggleFavoriteOption(resourceType: FavoriteResourceType, favoriteId: string): void;
 
     /**
      * Cleans up and disposes of resources used by the deployment context.

--- a/extensions/mssql/src/sharedInterfaces/form.ts
+++ b/extensions/mssql/src/sharedInterfaces/form.ts
@@ -163,11 +163,7 @@ export function sortOptionsByFavoriteOrder<T extends FormItemOptions>(options: r
         .sort((a, b) => {
             const aFavoriteOrder = a.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
             const bFavoriteOrder = b.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
-            return (
-                aFavoriteOrder - bFavoriteOrder ||
-                a.option.displayName.localeCompare(b.option.displayName) ||
-                a.index - b.index
-            );
+            return aFavoriteOrder - bFavoriteOrder || a.index - b.index;
         })
         .map(({ option }) => option);
 }

--- a/extensions/mssql/src/sharedInterfaces/form.ts
+++ b/extensions/mssql/src/sharedInterfaces/form.ts
@@ -20,6 +20,7 @@ export interface FormState<
 export interface FormContextProps<TForm> extends CoreRPCs {
     formAction: (event: FormEvent<TForm>) => void;
     openInfoLink?: (option: FormItemOptions) => void;
+    toggleFavoriteOption?: (resourceType: FavoriteResourceType, favoriteId: string) => void;
 }
 
 export interface FormReducers<TForm> {
@@ -146,6 +147,36 @@ export interface FormItemOptions {
      * then all options are rendered in a flat list.
      */
     groupName?: string;
+    /** Resource type used to persist this option as a favorite. */
+    favoriteResourceType?: FavoriteResourceType;
+    /** Stable, globally unique identifier persisted for this favorite. */
+    favoriteId?: string;
+    /** Whether this option is currently favorited. */
+    isFavorite?: boolean;
+    /** Zero-based order in which this option was favorited. */
+    favoriteOrder?: number;
+}
+
+export function sortOptionsByFavoriteOrder<T extends FormItemOptions>(options: readonly T[]): T[] {
+    return options
+        .map((option, index) => ({ option, index }))
+        .sort((a, b) => {
+            const aFavoriteOrder = a.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
+            const bFavoriteOrder = b.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
+            return (
+                aFavoriteOrder - bFavoriteOrder ||
+                a.option.displayName.localeCompare(b.option.displayName) ||
+                a.index - b.index
+            );
+        })
+        .map(({ option }) => option);
+}
+
+export enum FavoriteResourceType {
+    AzureSubscription = "azureSubscription",
+    AzureResourceGroup = "azureResourceGroup",
+    AzureServer = "azureServer",
+    FabricWorkspace = "fabricWorkspace",
 }
 
 /**

--- a/extensions/mssql/src/webviews/common/forms/form.component.tsx
+++ b/extensions/mssql/src/webviews/common/forms/form.component.tsx
@@ -8,6 +8,7 @@ import {
     Checkbox,
     Combobox,
     Dropdown,
+    DropdownProps,
     Field,
     FieldProps,
     InfoLabel,
@@ -29,6 +30,8 @@ import {
     Eye16Regular,
     EyeOff16Regular,
     Info16Regular,
+    Star16Filled,
+    Star16Regular,
 } from "@fluentui/react-icons";
 import {
     FormContextProps,
@@ -36,6 +39,7 @@ import {
     FormItemSpec,
     FormItemType,
     FormState,
+    sortOptionsByFavoriteOrder,
 } from "../../../sharedInterfaces/form";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
 import { useEffect, useState } from "react";
@@ -91,6 +95,181 @@ export const useFormStyles = makeStyles({
         gap: "4px",
     },
 });
+
+function FavoriteDropdownOption({
+    option,
+    onToggleFavorite,
+    onOpenInfoLink,
+}: {
+    option: FormItemOptions;
+    onToggleFavorite?: FormContextProps<unknown>["toggleFavoriteOption"];
+    onOpenInfoLink?: (option: FormItemOptions) => void;
+}) {
+    const [isHovered, setIsHovered] = useState(false);
+    const showFavorite = option.isFavorite || isHovered;
+
+    return (
+        <div
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            style={{
+                width: "100%",
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+                ...(option.color ? { color: tokens[option.color as keyof typeof tokens] } : {}),
+            }}>
+            {option.displayName}
+            <span style={{ display: "flex", gap: "4px", marginRight: "12px" }}>
+                {option.description && <Text>{option.description}</Text>}
+                {option.icon && FluentOptionIcons[option.icon]}
+                {option.favoriteResourceType && option.favoriteId && onToggleFavorite && (
+                    <Tooltip
+                        content={
+                            option.isFavorite
+                                ? locConstants.connectionDialog.removeFromFavorites
+                                : locConstants.connectionDialog.addToFavorites
+                        }
+                        relationship="label">
+                        <button
+                            type="button"
+                            aria-label={
+                                option.isFavorite
+                                    ? locConstants.connectionDialog.removeFromFavorites
+                                    : locConstants.connectionDialog.addToFavorites
+                            }
+                            aria-pressed={option.isFavorite}
+                            onFocus={() => setIsHovered(true)}
+                            onBlur={() => setIsHovered(false)}
+                            onMouseDown={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                            }}
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                onToggleFavorite(option.favoriteResourceType!, option.favoriteId!);
+                            }}
+                            style={{
+                                opacity: showFavorite ? 1 : 0,
+                                display: "flex",
+                                alignItems: "center",
+                                padding: 0,
+                                border: "none",
+                                background: "transparent",
+                                color: "inherit",
+                                cursor: "pointer",
+                            }}>
+                            {option.isFavorite ? <Star16Filled /> : <Star16Regular />}
+                        </button>
+                    </Tooltip>
+                )}
+                {option.infoTooltip && (
+                    <Tooltip
+                        content={option.infoTooltip}
+                        relationship="description"
+                        positioning="after"
+                        withArrow>
+                        <button
+                            type="button"
+                            aria-label={locConstants.common.learnMore}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                event.preventDefault();
+                                onOpenInfoLink?.(option);
+                            }}
+                            style={{
+                                background: "none",
+                                border: "none",
+                                cursor: "pointer",
+                                padding: 0,
+                                minWidth: 0,
+                                display: "flex",
+                                alignItems: "center",
+                                color: "inherit",
+                            }}>
+                            <Info16Regular />
+                        </button>
+                    </Tooltip>
+                )}
+            </span>
+        </div>
+    );
+}
+
+function FormDropdown<TForm>({
+    context,
+    formState,
+    component,
+    props,
+}: {
+    context: FormContextProps<TForm>;
+    formState: TForm;
+    component: {
+        propertyName: keyof TForm;
+        options: FormItemOptions[];
+        placeholder?: string;
+    };
+    props?: DropdownProps;
+}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [displayedOptions, setDisplayedOptions] = useState(() =>
+        sortOptionsByFavoriteOrder(component.options),
+    );
+
+    useEffect(() => {
+        if (isOpen) {
+            setDisplayedOptions((currentOptions) =>
+                currentOptions.map(
+                    (currentOption) =>
+                        component.options.find((option) => option.value === currentOption.value) ??
+                        currentOption,
+                ),
+            );
+        } else {
+            setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+        }
+    }, [component.options, isOpen]);
+
+    return (
+        <Dropdown
+            {...props}
+            size="small"
+            placeholder={component.placeholder ?? ""}
+            value={
+                component.options.find(
+                    (option) => option.value === formState[component.propertyName],
+                )?.displayName ?? ""
+            }
+            selectedOptions={[formState[component.propertyName] as string]}
+            onOpenChange={(event, data) => {
+                props?.onOpenChange?.(event, data);
+                setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+                setIsOpen(data.open);
+            }}
+            onOptionSelect={(event, data) => {
+                if (props?.onOptionSelect) {
+                    props.onOptionSelect(event, data);
+                } else {
+                    context.formAction({
+                        propertyName: component.propertyName,
+                        isAction: false,
+                        value: data.optionValue as string,
+                    });
+                }
+            }}>
+            {displayedOptions.map((option) => (
+                <Option key={option.value} value={option.value} text={option.displayName}>
+                    <FavoriteDropdownOption
+                        option={option}
+                        onToggleFavorite={context.toggleFavoriteOption}
+                        onOpenInfoLink={context.openInfoLink}
+                    />
+                </Option>
+            ))}
+        </Dropdown>
+    );
+}
 
 export const FormInput = <
     TForm,
@@ -482,89 +661,16 @@ export function generateFormComponent<
                 throw new Error("Dropdown component must have options");
             }
             return (
-                <Dropdown
-                    size="small"
-                    placeholder={component.placeholder ?? ""}
-                    value={
-                        component.options.find(
-                            (option) => option.value === formState[component.propertyName],
-                        )?.displayName ?? ""
-                    }
-                    selectedOptions={[formState[component.propertyName] as string]}
-                    onOptionSelect={(event, data) => {
-                        if (props && props.onOptionSelect) {
-                            props.onOptionSelect(event, data);
-                        } else {
-                            context?.formAction({
-                                propertyName: component.propertyName,
-                                isAction: false,
-                                value: data.optionValue as string,
-                            });
-                        }
+                <FormDropdown
+                    context={context}
+                    formState={formState}
+                    component={{
+                        propertyName: component.propertyName,
+                        options: component.options,
+                        placeholder: component.placeholder,
                     }}
-                    {...props}>
-                    {component.options?.map((option, idx) => {
-                        return (
-                            <Option
-                                key={(component.propertyName as string) + idx}
-                                value={option.value}
-                                text={option.displayName}>
-                                <div
-                                    style={{
-                                        width: "100%",
-                                        display: "flex",
-                                        flexDirection: "row",
-                                        justifyContent: "space-between",
-                                        ...(option.color
-                                            ? { color: tokens[option.color as keyof typeof tokens] }
-                                            : {}),
-                                    }}>
-                                    {option.displayName}
-                                    <span
-                                        style={{
-                                            display: "flex",
-                                            gap: "4px",
-                                            marginRight: "12px",
-                                        }}>
-                                        {option.description && <Text>{option.description}</Text>}
-                                        {option.icon && FluentOptionIcons[option.icon]}
-                                        {option.infoTooltip && (
-                                            <span
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    e.preventDefault();
-                                                    context?.openInfoLink?.(option);
-                                                }}
-                                                style={{ display: "flex", alignItems: "center" }}>
-                                                <Tooltip
-                                                    content={option.infoTooltip}
-                                                    relationship="description"
-                                                    positioning="after"
-                                                    withArrow>
-                                                    <button
-                                                        type="button"
-                                                        aria-label={locConstants.common.learnMore}
-                                                        style={{
-                                                            background: "none",
-                                                            border: "none",
-                                                            cursor: "pointer",
-                                                            padding: 0,
-                                                            minWidth: 0,
-                                                            display: "flex",
-                                                            alignItems: "center",
-                                                            color: "inherit",
-                                                        }}>
-                                                        <Info16Regular />
-                                                    </button>
-                                                </Tooltip>
-                                            </span>
-                                        )}
-                                    </span>
-                                </div>
-                            </Option>
-                        );
-                    })}
-                </Dropdown>
+                    props={props}
+                />
             );
         case FormItemType.Combobox:
             if (component.options === undefined) {
@@ -588,6 +694,10 @@ export function generateFormComponent<
                 color: opt.color,
                 description: opt.description,
                 icon: opt.icon,
+                favoriteResourceType: opt.favoriteResourceType,
+                favoriteId: opt.favoriteId,
+                isFavorite: opt.isFavorite,
+                favoriteOrder: opt.favoriteOrder,
             }));
             const selectedOption = dropdownOptions.find(
                 (option) => option.value === formState[component.propertyName],
@@ -614,6 +724,7 @@ export function generateFormComponent<
                     clearable={true}
                     ariaLabel={component.label}
                     showPlaceholder={true}
+                    onToggleFavorite={context.toggleFavoriteOption}
                     {...props}
                 />
             );

--- a/extensions/mssql/src/webviews/common/forms/form.component.tsx
+++ b/extensions/mssql/src/webviews/common/forms/form.component.tsx
@@ -43,7 +43,12 @@ import {
 } from "../../../sharedInterfaces/form";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
 import { useEffect, useState } from "react";
-import { FluentOptionIcons, SearchableDropdown } from "../searchableDropdown.component";
+import {
+    FluentOptionIcons,
+    SearchableDropdown,
+    SearchableDropdownOptions,
+    SearchableDropdownProps,
+} from "../searchableDropdown.component";
 import { locConstants } from "../locConstants";
 import { EventType, KeyCode } from "../keys";
 
@@ -212,12 +217,18 @@ function FormDropdown<TForm>({
     };
     props?: DropdownProps;
 }) {
+    const hasFavoriteOptions = component.options.some(
+        (option) => option.favoriteResourceType && option.favoriteId,
+    );
     const [isOpen, setIsOpen] = useState(false);
     const [displayedOptions, setDisplayedOptions] = useState(() =>
         sortOptionsByFavoriteOrder(component.options),
     );
 
     useEffect(() => {
+        if (!hasFavoriteOptions) {
+            return;
+        }
         if (isOpen) {
             setDisplayedOptions((currentOptions) =>
                 currentOptions.map(
@@ -229,11 +240,12 @@ function FormDropdown<TForm>({
         } else {
             setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
         }
-    }, [component.options, isOpen]);
+    }, [component.options, hasFavoriteOptions, isOpen]);
+
+    const options = hasFavoriteOptions ? displayedOptions : component.options;
 
     return (
         <Dropdown
-            {...props}
             size="small"
             placeholder={component.placeholder ?? ""}
             value={
@@ -242,9 +254,12 @@ function FormDropdown<TForm>({
                 )?.displayName ?? ""
             }
             selectedOptions={[formState[component.propertyName] as string]}
+            {...props}
             onOpenChange={(event, data) => {
                 props?.onOpenChange?.(event, data);
-                setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+                if (hasFavoriteOptions) {
+                    setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+                }
                 setIsOpen(data.open);
             }}
             onOptionSelect={(event, data) => {
@@ -258,7 +273,7 @@ function FormDropdown<TForm>({
                     });
                 }
             }}>
-            {displayedOptions.map((option) => (
+            {options.map((option) => (
                 <Option key={option.value} value={option.value} text={option.displayName}>
                     <FavoriteDropdownOption
                         option={option}
@@ -268,6 +283,124 @@ function FormDropdown<TForm>({
                 </Option>
             ))}
         </Dropdown>
+    );
+}
+
+type FormSearchableDropdownProps = Omit<
+    Partial<SearchableDropdownProps>,
+    "options" | "selectedOption" | "onSelect" | "onOpenChange" | "getOptionAction"
+> & {
+    onSelect?: (value: string) => void;
+    onOpenChange?: (open: boolean) => void;
+};
+
+function FormSearchableDropdown<TForm>({
+    context,
+    formState,
+    component,
+    props,
+}: {
+    context: FormContextProps<TForm>;
+    formState: TForm;
+    component: {
+        propertyName: keyof TForm;
+        options: FormItemOptions[];
+        placeholder?: string;
+        searchBoxPlaceholder?: string;
+        label?: string;
+    };
+    props?: FormSearchableDropdownProps;
+}) {
+    const hasFavoriteOptions = component.options.some(
+        (option) => option.favoriteResourceType && option.favoriteId,
+    );
+    const [isOpen, setIsOpen] = useState(false);
+    const [displayedOptions, setDisplayedOptions] = useState(() =>
+        sortOptionsByFavoriteOrder(component.options),
+    );
+
+    useEffect(() => {
+        if (!hasFavoriteOptions) {
+            return;
+        }
+        if (isOpen) {
+            setDisplayedOptions((currentOptions) =>
+                currentOptions.map(
+                    (currentOption) =>
+                        component.options.find((option) => option.value === currentOption.value) ??
+                        currentOption,
+                ),
+            );
+        } else {
+            setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+        }
+    }, [component.options, hasFavoriteOptions, isOpen]);
+
+    const options = hasFavoriteOptions ? displayedOptions : component.options;
+    const dropdownOptions: SearchableDropdownOptions[] = options.map((option) => ({
+        value: option.value,
+        text: option.displayName,
+        color: option.color as keyof typeof tokens | undefined,
+        description: option.description,
+        icon: option.icon as keyof typeof FluentOptionIcons | undefined,
+    }));
+    const selectedOption = dropdownOptions.find(
+        (option) => option.value === formState[component.propertyName],
+    );
+
+    return (
+        <SearchableDropdown
+            options={dropdownOptions}
+            placeholder={component.placeholder}
+            searchBoxPlaceholder={component.searchBoxPlaceholder}
+            selectedOption={selectedOption}
+            size="small"
+            clearable={true}
+            ariaLabel={component.label}
+            showPlaceholder={true}
+            {...props}
+            onOpenChange={(open) => {
+                props?.onOpenChange?.(open);
+                if (hasFavoriteOptions) {
+                    setDisplayedOptions(sortOptionsByFavoriteOrder(component.options));
+                }
+                setIsOpen(open);
+            }}
+            getOptionAction={(option) => {
+                const formOption = options.find((candidate) => candidate.value === option.value);
+                if (
+                    !formOption?.favoriteResourceType ||
+                    !formOption.favoriteId ||
+                    !context.toggleFavoriteOption
+                ) {
+                    return undefined;
+                }
+
+                return {
+                    label: formOption.isFavorite
+                        ? locConstants.connectionDialog.removeFromFavorites
+                        : locConstants.connectionDialog.addToFavorites,
+                    icon: formOption.isFavorite ? <Star16Filled /> : <Star16Regular />,
+                    onActivate: () =>
+                        context.toggleFavoriteOption!(
+                            formOption.favoriteResourceType!,
+                            formOption.favoriteId!,
+                        ),
+                    pressed: formOption.isFavorite,
+                };
+            }}
+            onSelect={(option) => {
+                if (props?.onSelect) {
+                    props.onSelect(option.value);
+                } else {
+                    context.formAction({
+                        propertyName: component.propertyName,
+                        isAction: false,
+                        value: option.value,
+                    });
+                }
+            }}
+        />
     );
 }
 
@@ -688,44 +821,18 @@ export function generateFormComponent<
             if (component.options === undefined) {
                 throw new Error("Dropdown component must have options");
             }
-            const dropdownOptions = component.options.map((opt) => ({
-                value: opt.value,
-                text: opt.displayName,
-                color: opt.color,
-                description: opt.description,
-                icon: opt.icon,
-                favoriteResourceType: opt.favoriteResourceType,
-                favoriteId: opt.favoriteId,
-                isFavorite: opt.isFavorite,
-                favoriteOrder: opt.favoriteOrder,
-            }));
-            const selectedOption = dropdownOptions.find(
-                (option) => option.value === formState[component.propertyName],
-            );
             return (
-                <SearchableDropdown
-                    options={dropdownOptions}
-                    placeholder={component.placeholder}
-                    searchBoxPlaceholder={component.searchBoxPlaceholder}
-                    selectedOption={selectedOption}
-                    freeform={component.freeform}
-                    onSelect={(option) => {
-                        if (props && props.onSelect) {
-                            props.onSelect(option.value);
-                        } else {
-                            context?.formAction({
-                                propertyName: component.propertyName,
-                                isAction: false,
-                                value: option.value,
-                            });
-                        }
+                <FormSearchableDropdown
+                    context={context}
+                    formState={formState}
+                    component={{
+                        propertyName: component.propertyName,
+                        options: component.options,
+                        placeholder: component.placeholder,
+                        searchBoxPlaceholder: component.searchBoxPlaceholder,
+                        label: component.label,
                     }}
-                    size="small"
-                    clearable={true}
-                    ariaLabel={component.label}
-                    showPlaceholder={true}
-                    onToggleFavorite={context.toggleFavoriteOption}
-                    {...props}
+                    props={props}
                 />
             );
         case FormItemType.Checkbox:

--- a/extensions/mssql/src/webviews/common/searchableDropdown.component.tsx
+++ b/extensions/mssql/src/webviews/common/searchableDropdown.component.tsx
@@ -27,7 +27,6 @@ import React, {
     useState,
 } from "react";
 import { locConstants } from "./locConstants";
-import { FavoriteResourceType } from "../../sharedInterfaces/form";
 
 export interface SearchableDropdownOptions {
     /**
@@ -50,27 +49,14 @@ export interface SearchableDropdownOptions {
      * Optional text color for the option
      */
     color?: keyof typeof tokens;
-    favoriteResourceType?: FavoriteResourceType;
-    favoriteId?: string;
-    isFavorite?: boolean;
-    favoriteOrder?: number;
 }
 
-const sortOptionsByFavoriteOrder = (
-    options: readonly SearchableDropdownOptions[],
-): SearchableDropdownOptions[] =>
-    options
-        .map((option, index) => ({ option, index }))
-        .sort((a, b) => {
-            const aFavoriteOrder = a.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
-            const bFavoriteOrder = b.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
-            return (
-                aFavoriteOrder - bFavoriteOrder ||
-                getOptionDisplayText(a.option).localeCompare(getOptionDisplayText(b.option)) ||
-                a.index - b.index
-            );
-        })
-        .map(({ option }) => option);
+export interface SearchableDropdownOptionAction {
+    label: string;
+    icon: React.ReactNode;
+    onActivate: () => void;
+    pressed?: boolean;
+}
 
 export interface SearchableDropdownProps {
     /**
@@ -143,8 +129,13 @@ export interface SearchableDropdownProps {
      */
     renderDecoration?: (option: SearchableDropdownOptions) => React.JSX.Element | undefined;
 
-    /** Toggles a favorite without selecting or closing the dropdown. */
-    onToggleFavorite?: (resourceType: FavoriteResourceType, favoriteId: string) => void;
+    /** Returns a trailing action for an option. */
+    getOptionAction?: (
+        option: SearchableDropdownOptions,
+    ) => SearchableDropdownOptionAction | undefined;
+
+    /** Called when the dropdown opens or closes. */
+    onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -218,9 +209,6 @@ const sizeToFontSize: Record<string, string> = {
 
 export const SearchableDropdown = (props: SearchableDropdownProps) => {
     const [searchText, setSearchText] = useState("");
-    const [displayedOptions, setDisplayedOptions] = useState(() =>
-        sortOptionsByFavoriteOrder(props.options),
-    );
     const [selectedOption, setSelectedOption] = useState(
         props.selectedOption ?? {
             value: "",
@@ -236,8 +224,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
     const listboxId = `${id}-listbox`;
 
     const filteredOptions = useMemo(
-        () => searchOptions(searchText, displayedOptions),
-        [searchText, displayedOptions],
+        () => searchOptions(searchText, props.options),
+        [searchText, props.options],
     );
 
     const [popoverWidth, setPopoverWidth] = useState(0);
@@ -261,8 +249,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
             : "var(--vscode-settings-dropdownBorder, var(--vscode-input-border, transparent))";
 
     const selectedOptionIndex = useMemo(
-        () => displayedOptions.findIndex((opt) => opt.value === selectedOption.value),
-        [displayedOptions, selectedOption.value],
+        () => props.options.findIndex((opt) => opt.value === selectedOption.value),
+        [props.options, selectedOption.value],
     );
 
     const activeDescendantId = activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined;
@@ -276,13 +264,13 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
     const initActiveIndex = useCallback(
         (direction: "down" | "up" = "down") => {
-            const optionCount = displayedOptions.length;
+            const optionCount = props.options.length;
             if (optionCount === 0) {
                 setActiveIndex(-1);
                 return;
             }
 
-            const currentIndex = displayedOptions.findIndex(
+            const currentIndex = props.options.findIndex(
                 (opt) => opt.value === selectedOption.value,
             );
             const nextIndex =
@@ -290,26 +278,30 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
             setActiveIndex(nextIndex);
         },
-        [displayedOptions, selectedOption.value],
+        [props.options, selectedOption.value],
     );
 
-    const closePopup = useCallback((focusTrigger: boolean) => {
-        setIsOpen(false);
-        setSearchText("");
-        setActiveIndex(-1);
-        if (focusTrigger) {
-            requestAnimationFrame(() => buttonRef.current?.focus());
-        }
-    }, []);
+    const closePopup = useCallback(
+        (focusTrigger: boolean) => {
+            setIsOpen(false);
+            props.onOpenChange?.(false);
+            setSearchText("");
+            setActiveIndex(-1);
+            if (focusTrigger) {
+                requestAnimationFrame(() => buttonRef.current?.focus());
+            }
+        },
+        [props.onOpenChange],
+    );
 
     const updateOption = useCallback(
         (option: SearchableDropdownOptions) => {
-            const index = displayedOptions.findIndex((opt) => opt.value === option.value);
+            const index = props.options.findIndex((opt) => opt.value === option.value);
             setSelectedOption(option);
             props.onSelect(option, index);
             closePopup(true);
         },
-        [closePopup, displayedOptions, props],
+        [closePopup, props],
     );
 
     const openPopup = useCallback(
@@ -321,10 +313,11 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
             // Match existing behavior: opening clears any prior search
             setSearchText("");
             setIsOpen(true);
+            props.onOpenChange?.(true);
 
             initActiveIndex(direction);
         },
-        [initActiveIndex, props.disabled],
+        [initActiveIndex, props],
     );
 
     const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -446,13 +439,9 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
         if (e.key === "Tab") {
             const activeOption = filteredOptions[activeIndex];
-            if (
-                activeOption?.favoriteResourceType &&
-                activeOption.favoriteId &&
-                props.onToggleFavorite
-            ) {
+            if (activeOption && props.getOptionAction?.(activeOption)) {
                 e.preventDefault();
-                document.getElementById(`${id}-favorite-${activeIndex}`)?.focus();
+                document.getElementById(`${id}-action-${activeIndex}`)?.focus();
                 return;
             }
             // Allow normal focus traversal; just close the popup.
@@ -475,10 +464,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
         }
 
         // If search is cleared, restore active index to the current selection when possible.
-        const currentIndex = displayedOptions.findIndex(
-            (opt) => opt.value === selectedOption.value,
-        );
-        const nextIndex = currentIndex >= 0 ? currentIndex : displayedOptions.length > 0 ? 0 : -1;
+        const currentIndex = props.options.findIndex((opt) => opt.value === selectedOption.value);
+        const nextIndex = currentIndex >= 0 ? currentIndex : props.options.length > 0 ? 0 : -1;
         setActiveIndex(nextIndex);
         if (nextIndex >= 0) {
             virtualizer.scrollToIndex(nextIndex, { align: "auto" });
@@ -524,26 +511,12 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
     }, []);
 
     useEffect(() => {
-        if (isOpen) {
-            setDisplayedOptions((currentOptions) =>
-                currentOptions.map(
-                    (currentOption) =>
-                        props.options.find((option) => option.value === currentOption.value) ??
-                        currentOption,
-                ),
-            );
-        } else {
-            setDisplayedOptions(sortOptionsByFavoriteOrder(props.options));
-        }
-    }, [isOpen, props.options]);
-
-    useEffect(() => {
         // If showPlaceholder is true, use empty value to show placeholder; otherwise fall back to first option
         const fallbackOption = props.showPlaceholder
             ? { value: "" }
-            : (displayedOptions[0] ?? { value: "" });
+            : (props.options[0] ?? { value: "" });
         setSelectedOption(props.selectedOption ?? fallbackOption);
-    }, [displayedOptions, props.selectedOption, props.showPlaceholder]);
+    }, [props.options, props.selectedOption, props.showPlaceholder]);
 
     useEffect(() => {
         if (!isOpen) {
@@ -588,8 +561,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
             positioning={{ position: "below", align: "start" }}
             open={isOpen}
             onOpenChange={(_e, data) => {
-                setDisplayedOptions(sortOptionsByFavoriteOrder(props.options));
                 setIsOpen(data.open);
+                props.onOpenChange?.(data.open);
                 if (data.open) {
                     setSearchText("");
                     initActiveIndex("down");
@@ -714,6 +687,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
                                 const isSelected = option.value === selectedOption.value;
                                 const isActive = virtualRow.index === activeIndex;
+                                const optionAction = props.getOptionAction?.(option);
 
                                 return (
                                     <div
@@ -793,33 +767,17 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                                                     <Text>{option.description}</Text>
                                                 )}
                                                 {option.icon && FluentOptionIcons[option.icon]}
-                                                {option.favoriteResourceType &&
-                                                    option.favoriteId &&
-                                                    props.onToggleFavorite &&
-                                                    (option.isFavorite || isActive) && (
+                                                {optionAction &&
+                                                    (optionAction.pressed || isActive) && (
                                                         <Tooltip
-                                                            content={
-                                                                option.isFavorite
-                                                                    ? locConstants.connectionDialog
-                                                                          .removeFromFavorites
-                                                                    : locConstants.connectionDialog
-                                                                          .addToFavorites
-                                                            }
+                                                            content={optionAction.label}
                                                             relationship="label">
                                                             <button
-                                                                id={`${id}-favorite-${virtualRow.index}`}
+                                                                id={`${id}-action-${virtualRow.index}`}
                                                                 type="button"
                                                                 tabIndex={-1}
-                                                                aria-label={
-                                                                    option.isFavorite
-                                                                        ? locConstants
-                                                                              .connectionDialog
-                                                                              .removeFromFavorites
-                                                                        : locConstants
-                                                                              .connectionDialog
-                                                                              .addToFavorites
-                                                                }
-                                                                aria-pressed={option.isFavorite}
+                                                                aria-label={optionAction.label}
+                                                                aria-pressed={optionAction.pressed}
                                                                 onMouseDown={(event) => {
                                                                     event.preventDefault();
                                                                     event.stopPropagation();
@@ -827,10 +785,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                                                                 onClick={(event) => {
                                                                     event.preventDefault();
                                                                     event.stopPropagation();
-                                                                    props.onToggleFavorite!(
-                                                                        option.favoriteResourceType!,
-                                                                        option.favoriteId!,
-                                                                    );
+                                                                    optionAction.onActivate();
                                                                 }}
                                                                 onKeyDown={(event) => {
                                                                     if (event.key === "Escape") {
@@ -851,11 +806,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                                                                     color: "inherit",
                                                                     cursor: "pointer",
                                                                 }}>
-                                                                {option.isFavorite ? (
-                                                                    <FluentIcons.Star16Filled />
-                                                                ) : (
-                                                                    <FluentIcons.Star16Regular />
-                                                                )}
+                                                                {optionAction.icon}
                                                             </button>
                                                         </Tooltip>
                                                     )}

--- a/extensions/mssql/src/webviews/common/searchableDropdown.component.tsx
+++ b/extensions/mssql/src/webviews/common/searchableDropdown.component.tsx
@@ -12,6 +12,7 @@ import {
     SearchBox,
     SearchBoxChangeEvent,
     Text,
+    Tooltip,
     tokens,
 } from "@fluentui/react-components";
 import * as FluentIcons from "@fluentui/react-icons";
@@ -26,6 +27,7 @@ import React, {
     useState,
 } from "react";
 import { locConstants } from "./locConstants";
+import { FavoriteResourceType } from "../../sharedInterfaces/form";
 
 export interface SearchableDropdownOptions {
     /**
@@ -48,7 +50,27 @@ export interface SearchableDropdownOptions {
      * Optional text color for the option
      */
     color?: keyof typeof tokens;
+    favoriteResourceType?: FavoriteResourceType;
+    favoriteId?: string;
+    isFavorite?: boolean;
+    favoriteOrder?: number;
 }
+
+const sortOptionsByFavoriteOrder = (
+    options: readonly SearchableDropdownOptions[],
+): SearchableDropdownOptions[] =>
+    options
+        .map((option, index) => ({ option, index }))
+        .sort((a, b) => {
+            const aFavoriteOrder = a.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
+            const bFavoriteOrder = b.option.favoriteOrder ?? Number.MAX_SAFE_INTEGER;
+            return (
+                aFavoriteOrder - bFavoriteOrder ||
+                getOptionDisplayText(a.option).localeCompare(getOptionDisplayText(b.option)) ||
+                a.index - b.index
+            );
+        })
+        .map(({ option }) => option);
 
 export interface SearchableDropdownProps {
     /**
@@ -120,6 +142,9 @@ export interface SearchableDropdownProps {
      * Optional function to render a decoration element for each option.
      */
     renderDecoration?: (option: SearchableDropdownOptions) => React.JSX.Element | undefined;
+
+    /** Toggles a favorite without selecting or closing the dropdown. */
+    onToggleFavorite?: (resourceType: FavoriteResourceType, favoriteId: string) => void;
 }
 
 /**
@@ -193,6 +218,9 @@ const sizeToFontSize: Record<string, string> = {
 
 export const SearchableDropdown = (props: SearchableDropdownProps) => {
     const [searchText, setSearchText] = useState("");
+    const [displayedOptions, setDisplayedOptions] = useState(() =>
+        sortOptionsByFavoriteOrder(props.options),
+    );
     const [selectedOption, setSelectedOption] = useState(
         props.selectedOption ?? {
             value: "",
@@ -208,8 +236,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
     const listboxId = `${id}-listbox`;
 
     const filteredOptions = useMemo(
-        () => searchOptions(searchText, props.options),
-        [searchText, props.options],
+        () => searchOptions(searchText, displayedOptions),
+        [searchText, displayedOptions],
     );
 
     const [popoverWidth, setPopoverWidth] = useState(0);
@@ -233,8 +261,8 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
             : "var(--vscode-settings-dropdownBorder, var(--vscode-input-border, transparent))";
 
     const selectedOptionIndex = useMemo(
-        () => props.options.findIndex((opt) => opt.value === selectedOption.value),
-        [props.options, selectedOption.value],
+        () => displayedOptions.findIndex((opt) => opt.value === selectedOption.value),
+        [displayedOptions, selectedOption.value],
     );
 
     const activeDescendantId = activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined;
@@ -248,13 +276,13 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
     const initActiveIndex = useCallback(
         (direction: "down" | "up" = "down") => {
-            const optionCount = props.options.length;
+            const optionCount = displayedOptions.length;
             if (optionCount === 0) {
                 setActiveIndex(-1);
                 return;
             }
 
-            const currentIndex = props.options.findIndex(
+            const currentIndex = displayedOptions.findIndex(
                 (opt) => opt.value === selectedOption.value,
             );
             const nextIndex =
@@ -262,7 +290,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
             setActiveIndex(nextIndex);
         },
-        [props.options, selectedOption.value],
+        [displayedOptions, selectedOption.value],
     );
 
     const closePopup = useCallback((focusTrigger: boolean) => {
@@ -276,12 +304,12 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
 
     const updateOption = useCallback(
         (option: SearchableDropdownOptions) => {
-            const index = props.options.findIndex((opt) => opt.value === option.value);
+            const index = displayedOptions.findIndex((opt) => opt.value === option.value);
             setSelectedOption(option);
             props.onSelect(option, index);
             closePopup(true);
         },
-        [closePopup, props],
+        [closePopup, displayedOptions, props],
     );
 
     const openPopup = useCallback(
@@ -417,6 +445,16 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
         }
 
         if (e.key === "Tab") {
+            const activeOption = filteredOptions[activeIndex];
+            if (
+                activeOption?.favoriteResourceType &&
+                activeOption.favoriteId &&
+                props.onToggleFavorite
+            ) {
+                e.preventDefault();
+                document.getElementById(`${id}-favorite-${activeIndex}`)?.focus();
+                return;
+            }
             // Allow normal focus traversal; just close the popup.
             closePopup(false);
         }
@@ -437,8 +475,10 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
         }
 
         // If search is cleared, restore active index to the current selection when possible.
-        const currentIndex = props.options.findIndex((opt) => opt.value === selectedOption.value);
-        const nextIndex = currentIndex >= 0 ? currentIndex : props.options.length > 0 ? 0 : -1;
+        const currentIndex = displayedOptions.findIndex(
+            (opt) => opt.value === selectedOption.value,
+        );
+        const nextIndex = currentIndex >= 0 ? currentIndex : displayedOptions.length > 0 ? 0 : -1;
         setActiveIndex(nextIndex);
         if (nextIndex >= 0) {
             virtualizer.scrollToIndex(nextIndex, { align: "auto" });
@@ -484,12 +524,26 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
     }, []);
 
     useEffect(() => {
+        if (isOpen) {
+            setDisplayedOptions((currentOptions) =>
+                currentOptions.map(
+                    (currentOption) =>
+                        props.options.find((option) => option.value === currentOption.value) ??
+                        currentOption,
+                ),
+            );
+        } else {
+            setDisplayedOptions(sortOptionsByFavoriteOrder(props.options));
+        }
+    }, [isOpen, props.options]);
+
+    useEffect(() => {
         // If showPlaceholder is true, use empty value to show placeholder; otherwise fall back to first option
         const fallbackOption = props.showPlaceholder
             ? { value: "" }
-            : (props.options[0] ?? { value: "" });
+            : (displayedOptions[0] ?? { value: "" });
         setSelectedOption(props.selectedOption ?? fallbackOption);
-    }, [props.selectedOption, props.options, props.showPlaceholder]);
+    }, [displayedOptions, props.selectedOption, props.showPlaceholder]);
 
     useEffect(() => {
         if (!isOpen) {
@@ -534,6 +588,7 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
             positioning={{ position: "below", align: "start" }}
             open={isOpen}
             onOpenChange={(_e, data) => {
+                setDisplayedOptions(sortOptionsByFavoriteOrder(props.options));
                 setIsOpen(data.open);
                 if (data.open) {
                     setSearchText("");
@@ -738,6 +793,72 @@ export const SearchableDropdown = (props: SearchableDropdownProps) => {
                                                     <Text>{option.description}</Text>
                                                 )}
                                                 {option.icon && FluentOptionIcons[option.icon]}
+                                                {option.favoriteResourceType &&
+                                                    option.favoriteId &&
+                                                    props.onToggleFavorite &&
+                                                    (option.isFavorite || isActive) && (
+                                                        <Tooltip
+                                                            content={
+                                                                option.isFavorite
+                                                                    ? locConstants.connectionDialog
+                                                                          .removeFromFavorites
+                                                                    : locConstants.connectionDialog
+                                                                          .addToFavorites
+                                                            }
+                                                            relationship="label">
+                                                            <button
+                                                                id={`${id}-favorite-${virtualRow.index}`}
+                                                                type="button"
+                                                                tabIndex={-1}
+                                                                aria-label={
+                                                                    option.isFavorite
+                                                                        ? locConstants
+                                                                              .connectionDialog
+                                                                              .removeFromFavorites
+                                                                        : locConstants
+                                                                              .connectionDialog
+                                                                              .addToFavorites
+                                                                }
+                                                                aria-pressed={option.isFavorite}
+                                                                onMouseDown={(event) => {
+                                                                    event.preventDefault();
+                                                                    event.stopPropagation();
+                                                                }}
+                                                                onClick={(event) => {
+                                                                    event.preventDefault();
+                                                                    event.stopPropagation();
+                                                                    props.onToggleFavorite!(
+                                                                        option.favoriteResourceType!,
+                                                                        option.favoriteId!,
+                                                                    );
+                                                                }}
+                                                                onKeyDown={(event) => {
+                                                                    if (event.key === "Escape") {
+                                                                        event.preventDefault();
+                                                                        searchBoxRef.current?.focus();
+                                                                    } else if (
+                                                                        event.key === "Tab"
+                                                                    ) {
+                                                                        closePopup(false);
+                                                                    }
+                                                                }}
+                                                                style={{
+                                                                    display: "flex",
+                                                                    alignItems: "center",
+                                                                    padding: 0,
+                                                                    border: "none",
+                                                                    background: "transparent",
+                                                                    color: "inherit",
+                                                                    cursor: "pointer",
+                                                                }}>
+                                                                {option.isFavorite ? (
+                                                                    <FluentIcons.Star16Filled />
+                                                                ) : (
+                                                                    <FluentIcons.Star16Regular />
+                                                                )}
+                                                            </button>
+                                                        </Tooltip>
+                                                    )}
                                                 {isSelected && <FluentIcons.Checkmark16Regular />}
                                             </span>
                                         </div>

--- a/extensions/mssql/src/webviews/pages/Deployment/deploymentStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/deploymentStateProvider.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../../sharedInterfaces/deployment";
 import { getCoreRPCs } from "../../common/utils";
 import { ConnectionGroupSpec } from "../../../sharedInterfaces/connectionGroup";
-import { FormEvent } from "../../../sharedInterfaces/form";
+import { FavoriteResourceType, FormEvent } from "../../../sharedInterfaces/form";
 
 const DeploymentContext = createContext<DeploymentContextProps | undefined>(undefined);
 
@@ -46,6 +46,12 @@ const DeploymentStateProvider: React.FC<DeploymentProviderProps> = ({ children }
                 extensionRpc.action("setConnectionGroupDialogState", {
                     shouldOpen: shouldOpen,
                 });
+            },
+            toggleFavoriteOption: function (
+                resourceType: FavoriteResourceType,
+                favoriteId: string,
+            ): void {
+                extensionRpc.action("toggleFavoriteOption", { resourceType, favoriteId });
             },
             createConnectionGroup: function (connectionGroupSpec: ConnectionGroupSpec): void {
                 extensionRpc.action("createConnectionGroup", {

--- a/extensions/mssql/test/unit/deploymentFavorites.test.ts
+++ b/extensions/mssql/test/unit/deploymentFavorites.test.ts
@@ -14,7 +14,11 @@ import {
     toggleFavorite,
 } from "../../src/deployment/deploymentFavorites";
 import { configSelectedAzureSubscriptions } from "../../src/constants/constants";
-import { FavoriteResourceType, FormItemOptions } from "../../src/sharedInterfaces/form";
+import {
+    FavoriteResourceType,
+    FormItemOptions,
+    sortOptionsByFavoriteOrder,
+} from "../../src/sharedInterfaces/form";
 
 chai.use(sinonChai);
 
@@ -70,6 +74,15 @@ suite("Deployment Favorites", () => {
 
         expect(result[0].favoriteId).to.equal("subscription/resource-group");
         expect(result[0].isFavorite).to.equal(true);
+    });
+
+    test("preserves the original order when options do not use favorites", () => {
+        const options: FormItemOptions[] = [
+            { displayName: "Zulu", value: "zulu" },
+            { displayName: "Alpha", value: "alpha" },
+        ];
+
+        expect(sortOptionsByFavoriteOrder(options)).to.deep.equal(options);
     });
 
     test("reads legacy Azure subscription favorite IDs", () => {

--- a/extensions/mssql/test/unit/deploymentFavorites.test.ts
+++ b/extensions/mssql/test/unit/deploymentFavorites.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as chai from "chai";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import sinonChai from "sinon-chai";
+import * as vscode from "vscode";
+import {
+    applyFavorites,
+    getFavoriteIds,
+    toggleFavorite,
+} from "../../src/deployment/deploymentFavorites";
+import { configSelectedAzureSubscriptions } from "../../src/constants/constants";
+import { FavoriteResourceType, FormItemOptions } from "../../src/sharedInterfaces/form";
+
+chai.use(sinonChai);
+
+suite("Deployment Favorites", () => {
+    let sandbox: sinon.SinonSandbox;
+    let get: sinon.SinonStub;
+    let update: sinon.SinonStub;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        get = sandbox.stub();
+        update = sandbox.stub().resolves();
+        sandbox.stub(vscode.workspace, "getConfiguration").returns({
+            get,
+            update,
+        } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test("sorts favorites by insertion order and decorates options", () => {
+        get.returns(["two", "one"]);
+        const options: FormItemOptions[] = [
+            { displayName: "One", value: "one" },
+            { displayName: "Two", value: "two" },
+            { displayName: "Three", value: "three" },
+        ];
+
+        const result = applyFavorites(options, FavoriteResourceType.AzureSubscription);
+
+        expect(result.map((option) => option.value)).to.deep.equal(["two", "one", "three"]);
+        expect(result[0]).to.include({
+            favoriteResourceType: FavoriteResourceType.AzureSubscription,
+            favoriteId: "two",
+            isFavorite: true,
+            favoriteOrder: 0,
+        });
+        expect(result[1].favoriteOrder).to.equal(1);
+        expect(result[2].isFavorite).to.equal(false);
+        expect(result[2].favoriteOrder).to.equal(undefined);
+    });
+
+    test("uses scoped favorite IDs", () => {
+        get.returns(["subscription/resource-group"]);
+
+        const result = applyFavorites(
+            [{ displayName: "resource-group", value: "resource-group" }],
+            FavoriteResourceType.AzureResourceGroup,
+            (option) => `subscription/${option.value}`,
+        );
+
+        expect(result[0].favoriteId).to.equal("subscription/resource-group");
+        expect(result[0].isFavorite).to.equal(true);
+    });
+
+    test("reads legacy Azure subscription favorite IDs", () => {
+        get.returns(["tenant/subscription"]);
+
+        const result = getFavoriteIds(FavoriteResourceType.AzureSubscription);
+
+        expect(result).to.deep.equal(["subscription"]);
+    });
+
+    test("persists a new favorite globally", async () => {
+        get.returns(["existing"]);
+
+        const result = await toggleFavorite(FavoriteResourceType.AzureSubscription, "subscription");
+
+        expect(result).to.deep.equal(["existing", "subscription"]);
+        expect(update).to.have.been.calledWith(
+            configSelectedAzureSubscriptions,
+            ["existing", "subscription"],
+            vscode.ConfigurationTarget.Global,
+        );
+    });
+
+    test("removes an existing favorite", async () => {
+        get.returns(["subscription", "other"]);
+
+        const result = await toggleFavorite(FavoriteResourceType.AzureSubscription, "subscription");
+
+        expect(result).to.deep.equal(["other"]);
+    });
+});

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9087,6 +9087,12 @@
     <trans-unit id="mssql.walkthroughs.nextSteps.description">
       <source xml:lang="en">Familiarize yourself with more features of the MSSQL extension that can help you be more productive.</source>
     </trans-unit>
+    <trans-unit id="mssql.favoriteAzureServers">
+      <source xml:lang="en">Favorite Azure SQL servers used during database provisioning</source>
+    </trans-unit>
+    <trans-unit id="mssql.favoriteAzureResourceGroups">
+      <source xml:lang="en">Favorite Azure resource groups used during database provisioning</source>
+    </trans-unit>
     <trans-unit id="mssql.filterNode">
       <source xml:lang="en">Filter</source>
     </trans-unit>


### PR DESCRIPTION
## Description

<img width="1468" height="990" alt="favoriteResources" src="https://github.com/user-attachments/assets/044ae325-b203-46b5-9cd3-057007f846c9" />

Fixes https://github.com/microsoft/vscode-mssql/issues/22562

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
