### PR TITLE
Defer optional query result webview bundles

### DIFF
--- a/extensions/mssql/scripts/bundle-webviews.js
+++ b/extensions/mssql/scripts/bundle-webviews.js
@@ -24,6 +24,7 @@ void run(
                 tableDesigner: "src/webviews/pages/TableDesigner/index.tsx",
                 objectExplorerFilter: "src/webviews/pages/ObjectExplorerFilter/index.tsx",
                 queryResult: "src/webviews/pages/QueryResult/index.tsx",
+                queryResultPreview: "src/webviews/pages/QueryResult/queryResultPreviewIndex.tsx",
                 userSurvey: "src/webviews/pages/UserSurvey/index.tsx",
                 schemaDesigner: "src/webviews/pages/SchemaDesigner/index.tsx",
                 schemaCompare: "src/webviews/pages/SchemaCompare/index.tsx",

--- a/extensions/mssql/src/controllers/webviewBaseController.ts
+++ b/extensions/mssql/src/controllers/webviewBaseController.ts
@@ -181,6 +181,27 @@ export abstract class WebviewBaseController<State, Reducers> implements vscode.D
         }
     }
 
+    /**
+     * Reloads the current webview with a different bundle entry point while preserving the
+     * controller and its state. If the webview has not been resolved yet, the selected entry point
+     * is used when it is first created.
+     */
+    protected reloadWebview(sourceFile: string): void {
+        if (sourceFile === this._sourceFile) {
+            return;
+        }
+
+        this._sourceFile = sourceFile;
+        const webview = this._getWebview();
+        if (!webview) {
+            return;
+        }
+
+        this._loadStartTime = Date.now();
+        this.updateConnectionWebview(webview);
+        webview.html = this._getHtmlTemplate();
+    }
+
     protected initializeBase() {
         if (!this.state) {
             this.state = this._initialData;

--- a/extensions/mssql/src/queryResult/queryResultWebViewController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebViewController.ts
@@ -31,6 +31,7 @@ import {
     PreviewFeature,
     previewService,
 } from "../previews/previewService";
+import { getQueryResultWebviewSource } from "./queryResultWebviewSource";
 
 const QUERY_RESULT_VIEW_ID = "queryResult";
 
@@ -61,23 +62,29 @@ export class QueryResultWebviewController extends WebviewViewController<
         private _executionPlanService: ExecutionPlanService,
         private _sqlOutputContentProvider: SqlOutputContentProvider,
     ) {
-        super(context, QUERY_RESULT_VIEW_ID, QUERY_RESULT_VIEW_ID, {
-            resultSetSummaries: {},
-            messages: [],
-            tabStates: {
-                resultPaneTab: qr.QueryResultPaneTabs.Messages,
+        const isBetaResultsGridEnabled = previewService.isFeatureEnabled(
+            PreviewFeature.BetaResultsGrid,
+        );
+        super(
+            context,
+            getQueryResultWebviewSource(isBetaResultsGridEnabled),
+            QUERY_RESULT_VIEW_ID,
+            {
+                resultSetSummaries: {},
+                messages: [],
+                tabStates: {
+                    resultPaneTab: qr.QueryResultPaneTabs.Messages,
+                },
+                executionPlanState: {},
+                fontSettings: {},
+                gridSettings: {},
+                autoSizeColumnsMode: qr.ResultsGridAutoSizeStyle.HeadersAndData,
+                isExecuting: false,
+                executionElapsedMilliseconds: undefined,
+                rowsAffected: undefined,
+                isBetaResultsGridEnabled,
             },
-            executionPlanState: {},
-            fontSettings: {},
-            gridSettings: {},
-            autoSizeColumnsMode: qr.ResultsGridAutoSizeStyle.HeadersAndData,
-            isExecuting: false,
-            executionElapsedMilliseconds: undefined,
-            rowsAffected: undefined,
-            isBetaResultsGridEnabled: previewService.isFeatureEnabled(
-                PreviewFeature.BetaResultsGrid,
-            ),
-        });
+        );
 
         void this.initialize();
 
@@ -131,11 +138,18 @@ export class QueryResultWebviewController extends WebviewViewController<
                     }
                     stateChanged = true;
                 }
-                if (e.affectsConfiguration(getPreviewConfigKey(PreviewFeature.BetaResultsGrid))) {
+                if (
+                    e.affectsConfiguration(getPreviewConfigKey(PreviewFeature.BetaResultsGrid)) ||
+                    e.affectsConfiguration(Constants.configEnableExperimentalFeatures)
+                ) {
                     const newValue = this.isBetaResultsGridEnabled;
                     for (const [uri, state] of this._queryResultStateMap) {
                         state.isBetaResultsGridEnabled = newValue;
                         this._queryResultStateMap.set(uri, state);
+                    }
+                    this.reloadWebview(getQueryResultWebviewSource(newValue));
+                    for (const controller of this._queryResultWebviewPanelControllerMap.values()) {
+                        controller.reloadForResultsGridChange(newValue);
                     }
                     this.updateSelectionSummary();
                     stateChanged = true;

--- a/extensions/mssql/src/queryResult/queryResultWebviewPanelController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebviewPanelController.ts
@@ -9,6 +9,8 @@ import { randomUUID } from "crypto";
 import { WebviewPanelController } from "../controllers/webviewPanelController";
 import { QueryResultWebviewController } from "./queryResultWebViewController";
 import { registerCommonRequestHandlers } from "./utils";
+import { getQueryResultWebviewSource } from "./queryResultWebviewSource";
+import { PreviewFeature, previewService } from "../previews/previewService";
 
 export class QueryResultWebviewPanelController extends WebviewPanelController<
     qr.QueryResultWebviewState,
@@ -25,7 +27,9 @@ export class QueryResultWebviewPanelController extends WebviewPanelController<
     ) {
         super(
             context,
-            "queryResult",
+            getQueryResultWebviewSource(
+                previewService.isFeatureEnabled(PreviewFeature.BetaResultsGrid),
+            ),
             "queryResult",
             {
                 resultSetSummaries: {},
@@ -92,6 +96,10 @@ export class QueryResultWebviewPanelController extends WebviewPanelController<
 
     public updateUri(uri: string): void {
         this._uri = uri;
+    }
+
+    public reloadForResultsGridChange(isBetaResultsGridEnabled: boolean): void {
+        this.reloadWebview(getQueryResultWebviewSource(isBetaResultsGridEnabled));
     }
 
     public getQueryResultWebviewViewController(): QueryResultWebviewController {

--- a/extensions/mssql/src/queryResult/queryResultWebviewSource.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebviewSource.ts
@@ -3,11 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import "./queryResultEagerStyles";
-import { renderQueryResult } from "./queryResultEntrypoint";
-import { QueryResultsGridView } from "./queryResultsGridView";
-import ResultGrid from "./resultGrid";
+export const LEGACY_QUERY_RESULT_SOURCE = "queryResult";
+export const PREVIEW_QUERY_RESULT_SOURCE = "queryResultPreview";
 
-const QueryResultLegacyGridView = () => <QueryResultsGridView GridComponent={ResultGrid} />;
-
-renderQueryResult(QueryResultLegacyGridView, false);
+export function getQueryResultWebviewSource(isBetaResultsGridEnabled: boolean): string {
+    return isBetaResultsGridEnabled ? PREVIEW_QUERY_RESULT_SOURCE : LEGACY_QUERY_RESULT_SOURCE;
+}

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
@@ -231,7 +231,14 @@
 .fluent-result-grid .slick-header-column .slick-header-sortbutton,
 .fluent-result-grid .slick-header-column .slick-header-filterbutton {
     align-items: center;
+    appearance: none;
+    background-color: transparent;
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: 14px;
+    border: 0;
     box-sizing: border-box;
+    cursor: pointer;
     display: inline-flex;
     flex: 0 0 16px;
     float: none;
@@ -240,6 +247,7 @@
     line-height: 16px;
     margin-bottom: 0;
     min-width: 16px;
+    padding: 0;
     position: static;
     transform: none;
     vertical-align: middle;
@@ -248,11 +256,81 @@
 }
 
 .fluent-result-grid .slick-header-column .slick-header-sortbutton {
+    background-image: url("../../media/sort.svg");
     margin: 0 1px 0 0;
 }
 
 .fluent-result-grid .slick-header-column .slick-header-filterbutton {
+    background-image: url("../../media/filter.svg");
     margin: 0;
+}
+
+.vscode-dark .fluent-result-grid .slick-header-column .slick-header-sortbutton,
+.vscode-high-contrast .fluent-result-grid .slick-header-column .slick-header-sortbutton {
+    background-image: url("../../media/sort_inverse.svg");
+}
+
+.vscode-light .fluent-result-grid .slick-header-column .slick-header-sortbutton,
+.vscode-high-contrast.vscode-high-contrast-light
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-sortbutton {
+    background-image: url("../../media/sort.svg");
+}
+
+.vscode-dark .fluent-result-grid .slick-header-column .slick-header-sortbutton.sorted-asc,
+.vscode-high-contrast .fluent-result-grid .slick-header-column .slick-header-sortbutton.sorted-asc {
+    background-image: url("../../media/sort_asc_inverse.svg");
+}
+
+.vscode-light .fluent-result-grid .slick-header-column .slick-header-sortbutton.sorted-asc,
+.vscode-high-contrast.vscode-high-contrast-light
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-sortbutton.sorted-asc {
+    background-image: url("../../media/sort_asc.svg");
+}
+
+.vscode-dark .fluent-result-grid .slick-header-column .slick-header-sortbutton.sorted-desc,
+.vscode-high-contrast
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-sortbutton.sorted-desc {
+    background-image: url("../../media/sort_desc_inverse.svg");
+}
+
+.vscode-light .fluent-result-grid .slick-header-column .slick-header-sortbutton.sorted-desc,
+.vscode-high-contrast.vscode-high-contrast-light
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-sortbutton.sorted-desc {
+    background-image: url("../../media/sort_desc.svg");
+}
+
+.vscode-dark .fluent-result-grid .slick-header-column .slick-header-filterbutton,
+.vscode-high-contrast .fluent-result-grid .slick-header-column .slick-header-filterbutton {
+    background-image: url("../../media/filter_inverse.svg");
+}
+
+.vscode-light .fluent-result-grid .slick-header-column .slick-header-filterbutton,
+.vscode-high-contrast.vscode-high-contrast-light
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-filterbutton {
+    background-image: url("../../media/filter.svg");
+}
+
+.vscode-dark .fluent-result-grid .slick-header-column .slick-header-filterbutton.filtered,
+.vscode-high-contrast .fluent-result-grid .slick-header-column .slick-header-filterbutton.filtered {
+    background-image: url("../../media/filterFilled_inverse.svg");
+}
+
+.vscode-light .fluent-result-grid .slick-header-column .slick-header-filterbutton.filtered,
+.vscode-high-contrast.vscode-high-contrast-light
+    .fluent-result-grid
+    .slick-header-column
+    .slick-header-filterbutton.filtered {
+    background-image: url("../../media/filterFilled.svg");
 }
 
 .fluent-result-grid .slick-header-column .slick-sort-indicator,

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanEagerStyles.ts
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanEagerStyles.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Both renderers remain JavaScript-lazy, but their small stylesheets are part of each host page's
+// main bundle so switching renderers never depends on a second stylesheet request.
+import "../../index.css";
+import "azdataGraph/src/css/common.css";
+import "azdataGraph/src/css/explorer.css";
+import "@xyflow/react/dist/style.css";
+import "./reactFlowExecutionPlan.css";

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -253,6 +253,10 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
             setFindNodeOptions(controller.getUniqueElementProperties());
             setCost(controller.getTotalRelativeCost());
             setZoomNumber(controller.getZoomLevel());
+        } else {
+            setFindNodeOptions([]);
+            setCost(0);
+            setZoomNumber(100);
         }
     }, []);
 

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -3,14 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import "azdataGraph/src/css/common.css";
-import "azdataGraph/src/css/explorer.css";
 import "./executionPlan.css";
 
-import * as azdataGraph from "azdataGraph";
-import * as utils from "./queryPlanSetup";
-
-import { Button, Input, makeStyles, mergeClasses, tokens } from "@fluentui/react-components";
+import {
+    Button,
+    Input,
+    makeStyles,
+    mergeClasses,
+    Spinner,
+    tokens,
+} from "@fluentui/react-components";
 import {
     Checkmark16Regular,
     Checkmark20Regular,
@@ -19,20 +21,20 @@ import {
 } from "@fluentui/react-icons";
 import {
     KeyboardEvent as ReactKeyboardEvent,
+    lazy,
+    Suspense,
     useCallback,
     useEffect,
     useRef,
     useState,
 } from "react";
 
-import { ExecutionPlanView } from "./executionPlanView";
 import { ExecutionPlanGraphController } from "./executionPlanGraphController";
 import { normalizeExecutionPlanQuery } from "./executionPlanQuery";
 import { FindNode } from "./findNodes";
 import { HighlightExpensiveOperations } from "./highlightExpensiveOperations";
 import { LegacyIconStack } from "./legacyIconMenu";
 import { PropertiesPane } from "./properties";
-import { ReactFlowExecutionPlan } from "./reactFlowExecutionPlan";
 import { ReactFlowIconStack } from "./reactFlowIconMenu";
 import { locConstants } from "../../common/locConstants";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
@@ -44,6 +46,16 @@ import {
     VscodeFloatingWidget,
     VscodeFloatingWidgetAction,
 } from "../../common/vscodeFloatingWidget";
+
+const ReactFlowExecutionPlan = lazy(async () => {
+    const module = await import("./reactFlowExecutionPlan");
+    return { default: module.ReactFlowExecutionPlan };
+});
+
+const LegacyExecutionPlanRenderer = lazy(async () => {
+    const module = await import("./legacyExecutionPlanRenderer");
+    return { default: module.LegacyExecutionPlanRenderer };
+});
 
 const useStyles = makeStyles({
     panelContainer: {
@@ -202,7 +214,6 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
     const [propertiesWidth, setPropertiesWidth] = useState(400);
     const [containerHeight, setContainerHeight] = useState("100%");
     const resizableRef = useRef<HTMLDivElement>(null);
-    const legacyGraphContainerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<any | null>(null);
     const useReactFlow = executionPlanState?.isBetaExecutionPlanEnabled === true;
     const graph = executionPlanState?.executionPlanGraphs?.[graphIndex];
@@ -236,51 +247,7 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
         setPropertiesClicked(false);
     }, [isReactFlowActive]);
 
-    useEffect(() => {
-        if (isReactFlowActive || !graph || !legacyGraphContainerRef.current) {
-            return;
-        }
-
-        // @ts-ignore
-        window["mxLoadResources"] = false;
-        // @ts-ignore
-        window["mxForceIncludes"] = false;
-        // @ts-ignore
-        window["mxResourceExtension"] = ".txt";
-        // @ts-ignore
-        window["mxLoadStylesheets"] = false;
-        // @ts-ignore
-        window["mxBasePath"] = "./src/webviews/pages/ExecutionPlan/mxgraph";
-
-        const mxClient = azdataGraph.mx();
-
-        const executionPlanView = new ExecutionPlanView(graph.root);
-        const executionPlanGraph = executionPlanView.populate();
-        const queryPlanConfiguration = {
-            container: legacyGraphContainerRef.current,
-            queryPlanGraph: executionPlanGraph,
-            iconPaths: utils.getIconPaths(),
-            badgeIconPaths: utils.getBadgePaths(),
-            expandCollapsePaths: utils.getCollapseExpandPaths(themeKind),
-            // Keep the fallback's original azdataGraph tooltip implementation.
-            showTooltipOnClick: true,
-        };
-        const pen = new mxClient.azdataQueryPlan(queryPlanConfiguration);
-        pen.setTextFontColor("var(--vscode-editor-foreground)");
-        pen.setEdgeColor("var(--vscode-editor-foreground)");
-        executionPlanView.setDiagram(pen);
-
-        setExecutionPlanView(executionPlanView);
-        setFindNodeOptions(executionPlanView.getUniqueElementProperties());
-        setCost(executionPlanView.getTotalRelativeCost());
-
-        return () => {
-            const disposablePen = pen as unknown as { destroy?: () => void };
-            disposablePen.destroy?.();
-        };
-    }, [graph, isReactFlowActive, themeKind]);
-
-    const handleReactFlowReady = useCallback((controller: ExecutionPlanGraphController | null) => {
+    const handleRendererReady = useCallback((controller: ExecutionPlanGraphController | null) => {
         setExecutionPlanView(controller);
         if (controller) {
             setFindNodeOptions(controller.getUniqueElementProperties());
@@ -413,11 +380,18 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
                             ? `calc(100% - ${propertiesWidth}px - 35px)`
                             : "calc(100% - 35px)",
                     }}>
-                    {!isReactFlowActive && (
-                        <div
-                            ref={legacyGraphContainerRef}
-                            className={classes.legacyGraphContainer}
-                        />
+                    {!isReactFlowActive && graph && (
+                        <Suspense
+                            fallback={
+                                <Spinner label={locConstants.executionPlan.loadingExecutionPlan} />
+                            }>
+                            <LegacyExecutionPlanRenderer
+                                root={graph.root}
+                                themeKind={themeKind}
+                                className={classes.legacyGraphContainer}
+                                onReady={handleRendererReady}
+                            />
+                        </Suspense>
                     )}
                     {isReactFlowActive && graph && (
                         <WebviewErrorBoundary
@@ -440,11 +414,18 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
                                     errorInfo.componentStack,
                                 );
                             }}>
-                            <ReactFlowExecutionPlan
-                                root={graph.root}
-                                themeKind={themeKind}
-                                onReady={handleReactFlowReady}
-                            />
+                            <Suspense
+                                fallback={
+                                    <Spinner
+                                        label={locConstants.executionPlan.loadingExecutionPlan}
+                                    />
+                                }>
+                                <ReactFlowExecutionPlan
+                                    root={graph.root}
+                                    themeKind={themeKind}
+                                    onReady={handleRendererReady}
+                                />
+                            </Suspense>
                         </WebviewErrorBoundary>
                     )}
                 </div>

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/index.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/index.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import ReactDOM from "react-dom/client";
-import "../../index.css";
+import "./executionPlanEagerStyles";
 import { ExecutionPlanStateProvider } from "./executionPlanStateProvider";
 import { ExecutionPlanPage } from "./executionPlanPage";
 import { VscodeWebviewProvider } from "../../common/vscodeWebviewProvider";

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/legacyExecutionPlanRenderer.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/legacyExecutionPlanRenderer.tsx
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdataGraph from "azdataGraph";
+import { useEffect, useRef } from "react";
+import { ExecutionPlanNode } from "../../../sharedInterfaces/executionPlan";
+import { ColorThemeKind } from "../../../sharedInterfaces/webview";
+import { ExecutionPlanGraphController } from "./executionPlanGraphController";
+import { ExecutionPlanView } from "./executionPlanView";
+import * as utils from "./queryPlanSetup";
+
+interface LegacyExecutionPlanRendererProps {
+    root: ExecutionPlanNode;
+    themeKind: ColorThemeKind;
+    className?: string;
+    onReady: (controller: ExecutionPlanGraphController | null) => void;
+}
+
+export function LegacyExecutionPlanRenderer({
+    root,
+    themeKind,
+    className,
+    onReady,
+}: LegacyExecutionPlanRendererProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!containerRef.current) {
+            return;
+        }
+
+        const mxWindow = window as typeof window & {
+            mxLoadResources?: boolean;
+            mxForceIncludes?: boolean;
+            mxResourceExtension?: string;
+            mxLoadStylesheets?: boolean;
+            mxBasePath?: string;
+        };
+        mxWindow.mxLoadResources = false;
+        mxWindow.mxForceIncludes = false;
+        mxWindow.mxResourceExtension = ".txt";
+        mxWindow.mxLoadStylesheets = false;
+        mxWindow.mxBasePath = "./src/webviews/pages/ExecutionPlan/mxgraph";
+
+        const mxClient = azdataGraph.mx();
+        const executionPlanView = new ExecutionPlanView(root);
+        const executionPlanGraph = executionPlanView.populate();
+        const pen = new mxClient.azdataQueryPlan({
+            container: containerRef.current,
+            queryPlanGraph: executionPlanGraph,
+            iconPaths: utils.getIconPaths(),
+            badgeIconPaths: utils.getBadgePaths(),
+            expandCollapsePaths: utils.getCollapseExpandPaths(themeKind),
+            // Keep the fallback's original azdataGraph tooltip implementation.
+            showTooltipOnClick: true,
+        });
+        pen.setTextFontColor("var(--vscode-editor-foreground)");
+        pen.setEdgeColor("var(--vscode-editor-foreground)");
+        executionPlanView.setDiagram(pen);
+        onReady(executionPlanView);
+
+        return () => {
+            onReady(null);
+            const disposablePen = pen as unknown as { destroy?: () => void };
+            disposablePen.destroy?.();
+        };
+    }, [onReady, root, themeKind]);
+
+    return <div ref={containerRef} className={className} />;
+}

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
@@ -3,9 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import "@xyflow/react/dist/style.css";
-import "./reactFlowExecutionPlan.css";
-
 import {
     Edge,
     EdgeProps,

--- a/extensions/mssql/src/webviews/pages/QueryResult/index.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/index.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import ReactDOM from "react-dom/client";
-import "../../index.css";
+import "./queryResultEagerStyles";
 import { QueryResultStateProvider } from "./queryResultStateProvider";
 import { QueryResult } from "./queryResultPage";
 import { VscodeWebviewProvider } from "../../common/vscodeWebviewProvider";

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultEagerStyles.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultEagerStyles.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Keep styles for lazy experiences eager so switching views never waits on a stylesheet request.
+import "../../index.css";
+import "../ExecutionPlan/executionPlanEagerStyles";
+
+// Monaco editor styles used by the results text view.
+import "monaco-editor/esm/vs/editor/standalone/browser/standalone-tokens.css";
+import "monaco-editor/esm/vs/base/browser/ui/aria/aria.css";
+import "monaco-editor/esm/vs/editor/browser/widget/codeEditor/editor.css";
+import "monaco-editor/esm/vs/base/browser/ui/scrollbar/media/scrollbars.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/blockDecorations/blockDecorations.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/decorations/decorations.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/glyphMargin/glyphMargin.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/indentGuides/indentGuides.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/lineNumbers/lineNumbers.css";
+import "monaco-editor/esm/vs/base/browser/ui/mouseCursor/mouseCursor.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/viewLines/viewLines.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/linesDecorations/linesDecorations.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/margin/margin.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/marginDecorations/marginDecorations.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/minimap/minimap.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/overlayWidgets/overlayWidgets.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/rulers/rulers.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/scrollDecoration/scrollDecoration.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/selections/selections.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/viewCursors/viewCursors.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/whitespace/whitespace.css";
+import "monaco-editor/esm/vs/editor/browser/gpu/css/media/decorationCssRuleExtractor.css";
+import "monaco-editor/esm/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.css";
+import "monaco-editor/esm/vs/editor/browser/controller/editContext/native/nativeEditContext.css";
+import "monaco-editor/esm/vs/editor/browser/viewParts/gpuMark/gpuMark.css";
+import "monaco-editor/esm/vs/editor/browser/services/hoverService/hover.css";
+import "monaco-editor/esm/vs/base/browser/ui/hover/hoverWidget.css";
+import "monaco-editor/esm/vs/editor/browser/widget/markdownRenderer/browser/renderedMarkdown.css";
+import "monaco-editor/esm/vs/base/browser/ui/contextview/contextview.css";
+import "monaco-editor/esm/vs/base/browser/ui/selectBox/selectBox.css";
+import "monaco-editor/esm/vs/base/browser/ui/list/list.css";
+import "monaco-editor/esm/vs/base/browser/ui/dnd/dnd.css";
+import "monaco-editor/esm/vs/base/browser/ui/selectBox/selectBoxCustom.css";
+import "monaco-editor/esm/vs/base/browser/ui/actionbar/actionbar.css";
+import "monaco-editor/esm/vs/base/browser/ui/dropdown/dropdown.css";
+import "monaco-editor/esm/vs/platform/actions/browser/menuEntryActionViewItem.css";
+import "monaco-editor/esm/vs/editor/standalone/browser/quickInput/standaloneQuickInput.css";
+import "monaco-editor/esm/vs/base/browser/ui/toggle/toggle.css";
+import "monaco-editor/esm/vs/platform/quickinput/browser/media/quickInput.css";
+import "monaco-editor/esm/vs/base/browser/ui/button/button.css";
+import "monaco-editor/esm/vs/base/browser/ui/countBadge/countBadge.css";
+import "monaco-editor/esm/vs/base/browser/ui/progressbar/progressbar.css";
+import "monaco-editor/esm/vs/base/browser/ui/inputbox/inputBox.css";
+import "monaco-editor/esm/vs/base/browser/ui/findinput/findInput.css";
+import "monaco-editor/esm/vs/base/browser/ui/iconLabel/iconlabel.css";
+import "monaco-editor/esm/vs/base/browser/ui/keybindingLabel/keybindingLabel.css";
+import "monaco-editor/esm/vs/base/browser/ui/tree/media/tree.css";
+import "monaco-editor/esm/vs/base/browser/ui/sash/sash.css";
+import "monaco-editor/esm/vs/base/browser/ui/splitview/splitview.css";
+import "monaco-editor/esm/vs/base/browser/ui/table/table.css";
+import "monaco-editor/esm/vs/editor/browser/widget/diffEditor/components/accessibleDiffViewer.css";
+import "monaco-editor/esm/vs/base/browser/ui/toolbar/toolbar.css";
+import "monaco-editor/esm/vs/editor/browser/widget/diffEditor/style.css";
+import "monaco-editor/esm/vs/editor/browser/widget/multiDiffEditor/style.css";

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultEntrypoint.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultEntrypoint.tsx
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ComponentType } from "react";
+import ReactDOM from "react-dom/client";
+import { VscodeWebviewProvider } from "../../common/vscodeWebviewProvider";
+import { QueryResult } from "./queryResultPage";
+import { QueryResultStateProvider } from "./queryResultStateProvider";
+
+export function renderQueryResult(
+    GridView: ComponentType,
+    isBetaResultsGridEnabled: boolean,
+): void {
+    ReactDOM.createRoot(document.getElementById("root")!).render(
+        <VscodeWebviewProvider>
+            <QueryResultStateProvider>
+                <QueryResult
+                    GridView={GridView}
+                    isBetaResultsGridEnabled={isBetaResultsGridEnabled}
+                />
+            </QueryResultStateProvider>
+        </VscodeWebviewProvider>,
+    );
+}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultPage.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultPage.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { makeStyles, shorthands } from "@fluentui/react-components";
-import { useEffect } from "react";
+import { type ComponentType, useEffect } from "react";
 import { QueryResultPane } from "./queryResultPane";
 import { KeyCode } from "../../common/keys";
 import { isMetaOrCtrlKeyPressed } from "../../common/utils";
@@ -89,7 +89,12 @@ const useStyles = makeStyles({
     },
 });
 
-export const QueryResult = () => {
+interface QueryResultProps {
+    GridView: ComponentType;
+    isBetaResultsGridEnabled: boolean;
+}
+
+export const QueryResult = ({ GridView, isBetaResultsGridEnabled }: QueryResultProps) => {
     const classes = useStyles();
 
     // This is needed to stop the browser from selecting all the raw text in the webview when ctrl+a is pressed
@@ -110,7 +115,10 @@ export const QueryResult = () => {
         <div className={classes.root}>
             {
                 <div className={classes.mainContent}>
-                    <QueryResultPane />
+                    <QueryResultPane
+                        GridView={GridView}
+                        isBetaResultsGridEnabled={isBetaResultsGridEnabled}
+                    />
                 </div>
             }
         </div>

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultPane.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultPane.tsx
@@ -14,7 +14,7 @@ import {
     Spinner,
     Toolbar,
 } from "@fluentui/react-components";
-import { useContext, useEffect, useState } from "react";
+import { type ComponentType, useContext, useEffect, useState } from "react";
 import { DatabaseSearch24Regular, ErrorCircle24Regular, OpenRegular } from "@fluentui/react-icons";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { locConstants } from "../../common/locConstants";
@@ -116,7 +116,12 @@ const useStyles = makeStyles({
     },
 });
 
-export const QueryResultPane = () => {
+interface QueryResultPaneProps {
+    GridView: ComponentType;
+    isBetaResultsGridEnabled: boolean;
+}
+
+export const QueryResultPane = ({ GridView, isBetaResultsGridEnabled }: QueryResultPaneProps) => {
     const classes = useStyles();
     const context = useContext(QueryResultCommandsContext);
 
@@ -141,8 +146,6 @@ export const QueryResultPane = () => {
     const executionPlanGraphs = useQueryResultSelector<ExecutionPlanGraph[] | undefined>(
         (s) => s.executionPlanState?.executionPlanGraphs,
     );
-    const isBetaResultsGridEnabled = useQueryResultSelector((s) => s.isBetaResultsGridEnabled);
-
     const { keyBindings } = useVscodeWebview();
 
     useEffect(() => {
@@ -346,7 +349,7 @@ export const QueryResultPane = () => {
                                 : "hidden",
                     }}
                     aria-hidden={tabStates!.resultPaneTab !== qr.QueryResultPaneTabs.Results}>
-                    <QueryResultsTab />
+                    <QueryResultsTab GridView={GridView} />
                 </div>
 
                 <div

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultPreviewIndex.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultPreviewIndex.tsx
@@ -5,9 +5,6 @@
 
 import "./queryResultEagerStyles";
 import { renderQueryResult } from "./queryResultEntrypoint";
-import { QueryResultsGridView } from "./queryResultsGridView";
-import ResultGrid from "./resultGrid";
+import { QueryResultFluentResultGridView } from "./queryResultFluentResultGrid";
 
-const QueryResultLegacyGridView = () => <QueryResultsGridView GridComponent={ResultGrid} />;
-
-renderQueryResult(QueryResultLegacyGridView, false);
+renderQueryResult(QueryResultFluentResultGridView, true);

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
@@ -6,8 +6,8 @@
 import { makeStyles } from "@fluentui/react-components";
 import {
     createRef,
-    ForwardRefExoticComponent,
-    RefAttributes,
+    type ForwardRefExoticComponent,
+    type RefAttributes,
     useCallback,
     useContext,
     useEffect,
@@ -19,7 +19,7 @@ import { QueryResultCommandsContext } from "./queryResultStateProvider";
 import { useQueryResultSelector } from "./queryResultSelector";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import CommandBar from "./commandBar";
-import ResultGrid, { ResultGridHandle, ResultGridProps } from "./resultGrid";
+import type { ResultGridHandle, ResultGridProps } from "./resultGrid";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import { eventMatchesShortcut } from "../../common/keyboardUtils";
 import { WebviewAction } from "../../../sharedInterfaces/webview";
@@ -56,7 +56,7 @@ type ResultGridComponent = ForwardRefExoticComponent<
 >;
 
 export interface QueryResultsGridViewProps {
-    GridComponent?: ResultGridComponent;
+    GridComponent: ResultGridComponent;
     showExternalCommandBar?: boolean;
 }
 
@@ -69,7 +69,7 @@ const DEFAULT_FONT_SIZE = 12;
 const BASE_ROW_PADDING = 12;
 
 export const QueryResultsGridView = ({
-    GridComponent = ResultGrid,
+    GridComponent,
     showExternalCommandBar = true,
 }: QueryResultsGridViewProps) => {
     const classes = useStyles();

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsTab.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsTab.tsx
@@ -4,15 +4,49 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as qr from "../../../sharedInterfaces/queryResult";
-import { useContext, useEffect } from "react";
+import { makeStyles, Spinner } from "@fluentui/react-components";
+import { lazy, Suspense, useContext, useEffect } from "react";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
-import { QueryResultsTextView } from "./queryResultsTextView";
-import { QueryResultFluentResultGridView } from "./queryResultFluentResultGrid";
-import { QueryResultsGridView } from "./queryResultsGridView";
 import { useQueryResultSelector } from "./queryResultSelector";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import { eventMatchesShortcut } from "../../common/keyboardUtils";
 import { WebviewAction } from "../../../sharedInterfaces/webview";
+import { locConstants } from "../../common/locConstants";
+import { QueryResultFluentResultGridView } from "./queryResultFluentResultGrid";
+import { QueryResultsGridView } from "./queryResultsGridView";
+
+const useStyles = makeStyles({
+    loadingContainer: {
+        alignItems: "center",
+        backgroundColor: "var(--vscode-editor-background)",
+        boxSizing: "border-box",
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        minHeight: "120px",
+        padding: "20px",
+        width: "100%",
+    },
+});
+
+const QueryResultsLoading = () => {
+    const classes = useStyles();
+
+    return (
+        <div className={classes.loadingContainer} role="status">
+            <Spinner
+                label={locConstants.queryResult.loadingResultsMessage}
+                labelPosition="below"
+                size="large"
+            />
+        </div>
+    );
+};
+
+const QueryResultsTextView = lazy(async () => {
+    const module = await import("./queryResultsTextView");
+    return { default: module.QueryResultsTextView };
+});
 
 export const QueryResultsTab = () => {
     const context = useContext(QueryResultCommandsContext);
@@ -59,7 +93,11 @@ export const QueryResultsTab = () => {
     }, [tabStates?.resultPaneTab, context, keyBindings, viewMode]);
 
     if (viewMode === qr.QueryResultViewMode.Text) {
-        return <QueryResultsTextView />;
+        return (
+            <Suspense fallback={<QueryResultsLoading />}>
+                <QueryResultsTextView />
+            </Suspense>
+        );
     }
     if (isBetaResultsGridEnabled) {
         return <QueryResultFluentResultGridView />;

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsTab.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsTab.tsx
@@ -5,15 +5,13 @@
 
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { makeStyles, Spinner } from "@fluentui/react-components";
-import { lazy, Suspense, useContext, useEffect } from "react";
+import { type ComponentType, lazy, Suspense, useContext, useEffect } from "react";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
 import { useQueryResultSelector } from "./queryResultSelector";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import { eventMatchesShortcut } from "../../common/keyboardUtils";
 import { WebviewAction } from "../../../sharedInterfaces/webview";
 import { locConstants } from "../../common/locConstants";
-import { QueryResultFluentResultGridView } from "./queryResultFluentResultGrid";
-import { QueryResultsGridView } from "./queryResultsGridView";
 
 const useStyles = makeStyles({
     loadingContainer: {
@@ -35,7 +33,7 @@ const QueryResultsLoading = () => {
     return (
         <div className={classes.loadingContainer} role="status">
             <Spinner
-                label={locConstants.queryResult.loadingResultsMessage}
+                label={locConstants.queryResult.loadingTextView}
                 labelPosition="below"
                 size="large"
             />
@@ -48,7 +46,11 @@ const QueryResultsTextView = lazy(async () => {
     return { default: module.QueryResultsTextView };
 });
 
-export const QueryResultsTab = () => {
+interface QueryResultsTabProps {
+    GridView: ComponentType;
+}
+
+export const QueryResultsTab = ({ GridView }: QueryResultsTabProps) => {
     const context = useContext(QueryResultCommandsContext);
     if (!context) {
         return;
@@ -59,9 +61,6 @@ export const QueryResultsTab = () => {
         qr.QueryResultViewMode.Grid;
 
     const tabStates = useQueryResultSelector((state) => state.tabStates);
-    const isBetaResultsGridEnabled = useQueryResultSelector(
-        (state) => state.isBetaResultsGridEnabled,
-    );
     useEffect(() => {
         const handler = (event: KeyboardEvent) => {
             const isResultsTab = tabStates?.resultPaneTab === qr.QueryResultPaneTabs.Results;
@@ -99,8 +98,5 @@ export const QueryResultsTab = () => {
             </Suspense>
         );
     }
-    if (isBetaResultsGridEnabled) {
-        return <QueryResultFluentResultGridView />;
-    }
-    return <QueryResultsGridView />;
+    return <GridView />;
 };


### PR DESCRIPTION
## Summary

- Add separate legacy and preview query-result webview entry points.
- Select the entry before webview creation so legacy users eagerly load only the legacy grid runtime and preview users eagerly load only the new grid runtime.
- Keep the selected grid eager so first results render does not add a grid loading screen.
- Keep Monaco/text view and the React Flow or azdataGraph/mxGraph execution-plan renderer libraries lazy.
- Keep applicable styles eager and assets local so styling and offline behavior are unchanged.
- Address review feedback by using the text-view-specific loading label and resetting derived execution-plan state while a renderer is unavailable.

## Eager query-result payload

Production builds; MB values are decimal. Static JavaScript includes the selected query-result entry and all recursively imported static chunks. CSS is the generated eager stylesheet.

| Build | Static JavaScript | CSS | Total eager payload |
| --- | ---: | ---: | ---: |
| 1.43 | 2.706 MB | 0.015 MB | **2.721 MB** |
| 1.44 | 3.665 MB | 0.282 MB | **3.948 MB** |
| `main` (`a157f9ca1`) | 6.600 MB | 0.376 MB | **6.976 MB** |
| This PR — legacy entry (`9a9a4c9db`) | 1.786 MB | 0.108 MB | **1.894 MB** |
| This PR — preview entry (`9a9a4c9db`) | 2.441 MB | 0.375 MB | **2.816 MB** |

The legacy entry is **72.8% smaller** than main and **52.0% smaller** than 1.44. The preview entry is **59.6% smaller** than main and **28.7% smaller** than 1.44. Static graph inspection confirms that the preview entry contains no legacy SlickGrid runtime.

## Validation

- `npm run build` in `extensions/mssql`
- Changed-file ESLint and Prettier checks
- Production webview build
- Recursive production bundle graph measurement for both entries
- Static graph inspection confirming grid separation and lazy Monaco/execution-plan renderer libraries

Online packaging was previously attempted, but the running Extension Development Host had a SQL Tools Service DLL locked, preventing the installer from replacing it.