### PR TITLE
Improve Fluent Result Grid performance during result streaming

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridHeaderController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridHeaderController.ts
@@ -27,6 +27,32 @@ import {
 import type { FluentResultGridActiveDataColumn } from "./fluentResultGridControllerTypes";
 import type { FluentResultGridDataRow } from "./fluentResultGridDataView";
 
+function updateFluentResultGridHeaderButtonState({
+    headerNode,
+    columnId,
+    filters,
+    sort,
+}: {
+    headerNode: HTMLElement | null | undefined;
+    columnId: string;
+    filters: ColumnFilterMap;
+    sort: { columnId: string; direction: SortProperties } | undefined;
+}): void {
+    const filterButton = headerNode?.querySelector<HTMLButtonElement>(".slick-header-filterbutton");
+    const sortButton = headerNode?.querySelector<HTMLButtonElement>(".slick-header-sortbutton");
+    const filterValues = filters[columnId]?.filterValues ?? [];
+    filterButton?.classList.toggle("filtered", filterValues.length > 0);
+
+    sortButton?.classList.remove("sorted-asc", "sorted-desc");
+    if (sort?.columnId === columnId) {
+        if (sort.direction === "ASC") {
+            sortButton?.classList.add("sorted-asc");
+        } else if (sort.direction === "DESC") {
+            sortButton?.classList.add("sorted-desc");
+        }
+    }
+}
+
 export function updateFluentResultGridHeaderButtonStates({
     grid,
     filters,
@@ -42,22 +68,12 @@ export function updateFluentResultGridHeaderButtonStates({
             continue;
         }
 
-        const headerNode = grid.getHeaderColumn(grid.getColumnIndex(column.id));
-        const filterButton = headerNode?.querySelector<HTMLButtonElement>(
-            ".slick-header-filterbutton",
-        );
-        const sortButton = headerNode?.querySelector<HTMLButtonElement>(".slick-header-sortbutton");
-        const filterValues = filters[columnId]?.filterValues ?? [];
-        filterButton?.classList.toggle("filtered", filterValues.length > 0);
-
-        sortButton?.classList.remove("sorted-asc", "sorted-desc");
-        if (sort?.columnId === columnId) {
-            if (sort.direction === "ASC") {
-                sortButton?.classList.add("sorted-asc");
-            } else if (sort.direction === "DESC") {
-                sortButton?.classList.add("sorted-desc");
-            }
-        }
+        updateFluentResultGridHeaderButtonState({
+            headerNode: grid.getHeaderColumn(grid.getColumnIndex(column.id)),
+            columnId,
+            filters,
+            sort,
+        });
     }
 }
 
@@ -114,17 +130,6 @@ export function useFluentResultGridHeaderController({
         column: Column<FluentResultGridDataRow>,
     ) => Promise<void>;
 }): FluentResultGridHeaderController {
-    const updateHeaderButtonStates = useCallback(
-        (grid: SlickGrid) => {
-            updateFluentResultGridHeaderButtonStates({
-                grid,
-                filters: filterStateRef.current,
-                sort: sortStateRef.current,
-            });
-        },
-        [filterStateRef, sortStateRef],
-    );
-
     const openHeaderContextMenuForColumn = useCallback(
         (grid: SlickGrid, column: Column<FluentResultGridDataRow>, x: number, y: number) => {
             const columnId = column.id?.toString();
@@ -222,11 +227,20 @@ export function useFluentResultGridHeaderController({
             }
 
             node.tabIndex = -1;
+            const columnId = column.id?.toString();
+            if (!columnId) {
+                return;
+            }
             if (node.classList.contains("slick-header-with-filter")) {
                 node.classList.remove("slick-header-sortable", "slick-header-column-sorted");
                 node.querySelector(".slick-sort-indicator")?.remove();
                 node.querySelector(".slick-sort-indicator-numbered")?.remove();
-                updateHeaderButtonStates(grid);
+                updateFluentResultGridHeaderButtonState({
+                    headerNode: node,
+                    columnId,
+                    filters: filterStateRef.current,
+                    sort: sortStateRef.current,
+                });
                 return;
             }
 
@@ -277,9 +291,20 @@ export function useFluentResultGridHeaderController({
                 await openFilterMenuForColumn(grid, column);
             });
             node.insertBefore(filterButton, resizableHandle);
-            updateHeaderButtonStates(grid);
+            updateFluentResultGridHeaderButtonState({
+                headerNode: node,
+                columnId,
+                filters: filterStateRef.current,
+                sort: sortStateRef.current,
+            });
         },
-        [openFilterMenuForColumn, strings.commands, toggleSortForColumn, updateHeaderButtonStates],
+        [
+            filterStateRef,
+            openFilterMenuForColumn,
+            sortStateRef,
+            strings.commands,
+            toggleSortForColumn,
+        ],
     );
 
     const handleBeforeHeaderCellDestroy = useCallback((event: CustomEvent) => {

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
@@ -61,6 +61,19 @@ export function createFluentResultGridColumnSignature(columnInfo: readonly IDbCo
         .join("|");
 }
 
+export interface FluentResultGridColumnInfoSnapshot {
+    signature: string;
+    value: IDbColumn[];
+}
+
+export function stabilizeFluentResultGridColumnInfo(
+    current: FluentResultGridColumnInfoSnapshot | undefined,
+    columnInfo: IDbColumn[],
+): FluentResultGridColumnInfoSnapshot {
+    const signature = createFluentResultGridColumnSignature(columnInfo);
+    return current?.signature === signature ? current : { signature, value: columnInfo };
+}
+
 export function createFluentResultGridIdentitySignature({
     gridId,
     resultSetSummary,

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
@@ -42,12 +42,13 @@ import {
 } from "./fluentResultGridHeaderController";
 import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
-    createFluentResultGridColumnSignature,
     createFluentResultGridIdentitySignature,
     getFluentResultGridRowHeight,
     getFluentResultGridStateForEmit,
     normalizeFluentResultGridFrozenColumnIndex,
     normalizeFluentResultGridRowPadding,
+    stabilizeFluentResultGridColumnInfo,
+    type FluentResultGridColumnInfoSnapshot,
 } from "./fluentResultGridState";
 import {
     restoreFluentResultGridHorizontalScrollPosition,
@@ -102,10 +103,13 @@ export function useFluentResultGridController({
 
     const rowPadding = normalizeFluentResultGridRowPadding(gridSettings?.rowPadding);
     const rowHeight = getFluentResultGridRowHeight(rowHeightOverride, rowPadding);
-    const columnSignature = useMemo(
-        () => createFluentResultGridColumnSignature(resultSetSummary.columnInfo),
-        [resultSetSummary.columnInfo],
+    const stableColumnInfoRef = useRef<FluentResultGridColumnInfoSnapshot | undefined>(undefined);
+    stableColumnInfoRef.current = stabilizeFluentResultGridColumnInfo(
+        stableColumnInfoRef.current,
+        resultSetSummary.columnInfo,
     );
+    const columnSignature = stableColumnInfoRef.current.signature;
+    const stableColumnInfo = stableColumnInfoRef.current.value;
     const resultIdentitySignature = useMemo(
         () =>
             createFluentResultGridIdentitySignature({
@@ -148,10 +152,10 @@ export function useFluentResultGridController({
     const columns = useMemo<Column<FluentResultGridDataRow>[]>(
         () =>
             createFluentResultGridColumns({
-                columnInfo: resultSetSummary.columnInfo,
+                columnInfo: stableColumnInfo,
                 showRowNumberColumn,
             }),
-        [columnSignature, resultSetSummary.columnInfo, showRowNumberColumn],
+        [showRowNumberColumn, stableColumnInfo],
     );
 
     const emitStateChange = useCallback(

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -8,6 +8,7 @@ import {
     SortProperties,
     type ColumnFilterMap,
     type DbCellValue,
+    type IDbColumn,
 } from "../../src/sharedInterfaces/queryResult";
 import { FluentResultGridCommand } from "../../src/webviews/common/FluentResultGrid/types/fluentResultGridCommandIds";
 import type { FluentResultGridKeyBindingMap } from "../../src/webviews/common/FluentResultGrid/types/fluentResultGridCommands";
@@ -18,6 +19,7 @@ import {
 import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
     normalizeFluentResultGridFrozenColumnIndex,
+    stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
 import { isFluentResultGridHostCommand } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCommandUtils";
 import {
@@ -30,6 +32,20 @@ function cell(value: string | null): DbCellValue {
     return {
         displayValue: value ?? "",
         isNull: value === null,
+    };
+}
+
+function column(columnName: string): IDbColumn {
+    return {
+        baseCatalogName: "database",
+        baseColumnName: columnName,
+        baseSchemaName: "dbo",
+        baseServerName: "server",
+        baseTableName: "table",
+        columnName,
+        dataType: "varchar",
+        dataTypeName: "varchar",
+        udtAssemblyQualifiedName: "",
     };
 }
 
@@ -48,6 +64,19 @@ function keyboardEvent(
 }
 
 suite("Fluent Result Grid", () => {
+    suite("columns", () => {
+        test("retains column definitions when a result update contains the same schema", () => {
+            const first = stabilizeFluentResultGridColumnInfo(undefined, [column("name")]);
+            const repeatedSchema = stabilizeFluentResultGridColumnInfo(first, [column("name")]);
+            const changedSchema = stabilizeFluentResultGridColumnInfo(first, [column("new_name")]);
+
+            expect(repeatedSchema).to.equal(first);
+            expect(repeatedSchema.value).to.equal(first.value);
+            expect(changedSchema).to.not.equal(first);
+            expect(changedSchema.value).to.not.equal(first.value);
+        });
+    });
+
     suite("transforms", () => {
         test("preserves row IDs while filtering and sorting source rows", () => {
             const rows: SourceRow[] = [


### PR DESCRIPTION
## Description

Improves Fluent Result Grid responsiveness while streamed result state updates arrive.

- Reuses existing SlickGrid column definitions when the result update contains the same column schema, avoiding full column and header rebuilds on each update.
- Updates filter and sort styling for the header currently being rendered instead of rescanning every grid column for every header callback.
- Adds regression coverage for preserving column definitions across equivalent schema updates.

This branch is based on the latest `main` after #22652 was merged and contains only the focused grid regression fix.

## Validation

- `npm run build:extension`
- `npm run build:webviews`
- Targeted ESLint for the changed files
- Fluent Result Grid unit tests: 9 passing

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`) — targeted Fluent Result Grid tests pass
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant — not applicable
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)