### PR TITLE
Add IntelliSense timeout setting and update SQL Tools Service

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2709,6 +2709,14 @@
                     "description": "%mssql.intelliSense.enableIntelliSense%",
                     "scope": "window"
                 },
+                "mssql.intelliSense.completionTimeoutMilliseconds": {
+                    "type": "integer",
+                    "default": 2000,
+                    "minimum": 100,
+                    "maximum": 30000,
+                    "description": "%mssql.intelliSense.completionTimeoutMilliseconds%",
+                    "scope": "window"
+                },
                 "mssql.intelliSense.enableErrorChecking": {
                     "type": "boolean",
                     "default": true,

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2712,7 +2712,7 @@
                 "mssql.intelliSense.completionTimeoutMilliseconds": {
                     "type": "integer",
                     "default": 2000,
-                    "minimum": 100,
+                    "minimum": 500,
                     "maximum": 30000,
                     "description": "%mssql.intelliSense.completionTimeoutMilliseconds%",
                     "scope": "window"

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -198,6 +198,7 @@
     "mssql.resultsGrid.rowPadding": "Extra vertical padding in pixels added to each row in the results grid, controlling row density. Valid range: 0-10.",
     "mssql.query.displayBitAsNumber": "Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'",
     "mssql.intelliSense.enableIntelliSense": "Should IntelliSense be enabled",
+    "mssql.intelliSense.completionTimeoutMilliseconds": "Maximum time in milliseconds to wait for one IntelliSense completion operation before it times out. This does not change the SQL command timeout.",
     "mssql.intelliSense.enableErrorChecking": "Should IntelliSense error checking be enabled",
     "mssql.intelliSense.enableSuggestions": "Should IntelliSense suggestions be enabled",
     "mssql.intelliSense.enableQuickInfo": "Should IntelliSense quick info be enabled",

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260804.2",
+        version: "6.0.20260807.3",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9336,6 +9336,9 @@
     <trans-unit id="mssql.query.textSize">
       <source xml:lang="en">Maximum size of text and ntext data returned from a SELECT statement</source>
     </trans-unit>
+    <trans-unit id="mssql.intelliSense.completionTimeoutMilliseconds">
+      <source xml:lang="en">Maximum time in milliseconds to wait for one IntelliSense completion operation before it times out. This does not change the SQL command timeout.</source>
+    </trans-unit>
     <trans-unit id="mssql.openAzureDataStudioMigration">
       <source xml:lang="en">Migrate from Azure Data Studio</source>
     </trans-unit>


### PR DESCRIPTION
## Description

- Add `mssql.intelliSense.completionTimeoutMilliseconds` so users can configure the SQL Tools Service completion hard deadline.
- Default the setting to 2,000 ms and allow values from 500 through 30,000 ms at window scope, matching the server-side bounds.
- Update the bundled SQL Tools Service from `6.0.20260804.2` to `6.0.20260807.3`.
- Clarify that the setting applies to one IntelliSense completion operation and does not change the SQL command timeout.

Related to [#21930](https://github.com/microsoft/vscode-mssql/issues/21930) and [microsoft/sqltoolsservice#2779](https://github.com/microsoft/sqltoolsservice/pull/2779).

## SQL Tools Service changes

Updating to [`6.0.20260807.3`](https://github.com/microsoft/sqltoolsservice/releases/tag/6.0.20260807.3) brings these changes since `6.0.20260804.2`:

- Additional language-service logging ([microsoft/sqltoolsservice#2776](https://github.com/microsoft/sqltoolsservice/pull/2776)).
- Generated localized RESX resources ([microsoft/sqltoolsservice#2774](https://github.com/microsoft/sqltoolsservice/pull/2774)).
- Plaintext hover content ([microsoft/sqltoolsservice#2777](https://github.com/microsoft/sqltoolsservice/pull/2777)).
- Release the IntelliSense refresh lock before the asynchronous metadata rebuild, preventing the reproduced refresh lock exception and hang ([microsoft/sqltoolsservice#2778](https://github.com/microsoft/sqltoolsservice/pull/2778)).
- Preserve valid completion results across slow binding operations, stop timed-out queue items, keep document locks short, and support the configurable completion deadline ([microsoft/sqltoolsservice#2779](https://github.com/microsoft/sqltoolsservice/pull/2779)).

## Validation

- `npm run build -- --target mssql`
- `npm run lint -- --target mssql`
- `npm run package -- --target mssql --online`
- Verified online packaging downloads and installs SQL Tools Service `6.0.20260807.3`.
- Extension manifest schema and formatting validation.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
