### PR TITLE
Use mergeClasses for Griffel class composition

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGridToolbar.tsx
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGridToolbar.tsx
@@ -5,6 +5,7 @@
 
 import {
     makeStyles,
+    mergeClasses,
     Menu,
     MenuItem,
     MenuList,
@@ -220,7 +221,7 @@ const ToolbarOverflowButton = ({
     ...props
 }: ToolbarOverflowButtonProps & { className?: string }) => {
     const classes = useStyles();
-    const mergedClassName = [classes.toolbarButton, className].filter(Boolean).join(" ");
+    const mergedClassName = mergeClasses(classes.toolbarButton, className);
     return (
         <OverflowItem id={overflowId} groupId={overflowGroupId}>
             <ToolbarButton appearance="subtle" {...props} className={mergedClassName} />

--- a/extensions/mssql/src/webviews/common/dialogPageShell.tsx
+++ b/extensions/mssql/src/webviews/common/dialogPageShell.tsx
@@ -5,6 +5,7 @@
 
 import {
     makeStyles,
+    mergeClasses,
     MessageBar,
     MessageBarBody,
     Spinner,
@@ -220,7 +221,10 @@ export const DialogPageShell = ({
                                       }
                             }>
                             <div
-                                className={`${styles.header} ${compactHeader ? styles.compactHeader : ""}`}
+                                className={mergeClasses(
+                                    styles.header,
+                                    compactHeader && styles.compactHeader,
+                                )}
                                 style={{
                                     ...contentWidthStyle,
                                     gridTemplateColumns:
@@ -234,7 +238,10 @@ export const DialogPageShell = ({
                                 }}>
                                 {hasHeaderIcon && (
                                     <div
-                                        className={`${styles.iconContainer} ${compactHeader ? styles.compactIconContainer : ""}`}
+                                        className={mergeClasses(
+                                            styles.iconContainer,
+                                            compactHeader && styles.compactIconContainer,
+                                        )}
                                         style={{
                                             width: `${iconSize}px`,
                                             height: `${iconSize}px`,
@@ -245,7 +252,10 @@ export const DialogPageShell = ({
                                 <div className={styles.headerText}>
                                     {title && (
                                         <div
-                                            className={`${styles.title} ${compactHeader ? styles.compactTitle : ""}`}>
+                                            className={mergeClasses(
+                                                styles.title,
+                                                compactHeader && styles.compactTitle,
+                                            )}>
                                             {title}
                                         </div>
                                     )}

--- a/extensions/mssql/src/webviews/common/loadingLog.tsx
+++ b/extensions/mssql/src/webviews/common/loadingLog.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { makeStyles, Spinner, Text } from "@fluentui/react-components";
+import { makeStyles, mergeClasses, Spinner, Text } from "@fluentui/react-components";
 import {
     Checkmark12Regular,
     ChevronRight12Regular,
@@ -102,13 +102,14 @@ export function LoadingLog({ messages, minHeight }: LoadingLogProps) {
                     return (
                         <div className={classes.logRow} key={`${entry.message}-${index}`}>
                             <span
-                                className={`${classes.icon} ${
+                                className={mergeClasses(
+                                    classes.icon,
                                     isError
                                         ? classes.errorRow
                                         : isActive
                                           ? classes.activeIcon
-                                          : classes.doneIcon
-                                }`}>
+                                          : classes.doneIcon,
+                                )}>
                                 {isError ? (
                                     <ErrorCircle12Regular />
                                 ) : isActive ? (
@@ -118,9 +119,14 @@ export function LoadingLog({ messages, minHeight }: LoadingLogProps) {
                                 )}
                             </span>
                             <Text
-                                className={`${classes.text} ${
-                                    isError ? classes.errorRow : isActive ? classes.activeText : ""
-                                }`}>
+                                className={mergeClasses(
+                                    classes.text,
+                                    isError
+                                        ? classes.errorRow
+                                        : isActive
+                                          ? classes.activeText
+                                          : undefined,
+                                )}>
                                 {entry.message}
                             </Text>
                         </div>

--- a/extensions/mssql/src/webviews/common/publishDialog.tsx
+++ b/extensions/mssql/src/webviews/common/publishDialog.tsx
@@ -12,6 +12,7 @@ import {
     DialogSurface,
     DialogTitle,
     makeStyles,
+    mergeClasses,
 } from "@fluentui/react-components";
 import { useSetKeyboardNavigation } from "@fluentui/react-tabster";
 import { ReactElement, ReactNode, useEffect, useRef } from "react";
@@ -173,7 +174,7 @@ export function PublishDialogReport({
         <div className={classes.reportLayout}>
             {header}
             <div className={classes.reportScroll}>
-                <div className={`${markdownClasses.markdownPage} ${classes.markdownFill}`}>
+                <div className={mergeClasses(markdownClasses.markdownPage, classes.markdownFill)}>
                     <Markdown>{markdown}</Markdown>
                 </div>
             </div>

--- a/extensions/mssql/src/webviews/pages/AddFirewallRule/addFirewallRule.component.tsx
+++ b/extensions/mssql/src/webviews/pages/AddFirewallRule/addFirewallRule.component.tsx
@@ -19,6 +19,7 @@ import {
     LabelProps,
     Link,
     makeStyles,
+    mergeClasses,
     MessageBar,
     Option,
     OptionOnSelectData,
@@ -248,7 +249,10 @@ export const AddFirewallRuleDialog = ({
                                         </span>
                                     ),
                                 }}
-                                className={`${formStyles.formComponentDiv} ${styles.horizontalField}`}
+                                className={mergeClasses(
+                                    formStyles.formComponentDiv,
+                                    styles.horizontalField,
+                                )}
                                 orientation="horizontal">
                                 <Dropdown
                                     value={
@@ -288,7 +292,10 @@ export const AddFirewallRuleDialog = ({
                                         </span>
                                     ),
                                 }}
-                                className={`${formStyles.formComponentDiv} ${styles.horizontalField}`}
+                                className={mergeClasses(
+                                    formStyles.formComponentDiv,
+                                    styles.horizontalField,
+                                )}
                                 orientation="horizontal">
                                 <Dropdown
                                     value={
@@ -316,7 +323,10 @@ export const AddFirewallRuleDialog = ({
 
                     <Field
                         label={Loc.firewallRules.ruleName}
-                        className={`${formStyles.formComponentDiv} ${styles.horizontalField}`}
+                        className={mergeClasses(
+                            formStyles.formComponentDiv,
+                            styles.horizontalField,
+                        )}
                         orientation="horizontal">
                         <Input
                             value={ruleName}
@@ -328,7 +338,10 @@ export const AddFirewallRuleDialog = ({
                     </Field>
                     <Field
                         label={Loc.firewallRules.ipAddressRange}
-                        className={`${formStyles.formComponentDiv} ${styles.horizontalField}`}
+                        className={mergeClasses(
+                            formStyles.formComponentDiv,
+                            styles.horizontalField,
+                        )}
                         orientation="horizontal">
                         <RadioGroup
                             value={ipSelectionMode}

--- a/extensions/mssql/src/webviews/pages/AzureDataStudioMigration/azureDataStudioMigrationPage.tsx
+++ b/extensions/mssql/src/webviews/pages/AzureDataStudioMigration/azureDataStudioMigrationPage.tsx
@@ -23,6 +23,7 @@ import {
     Title3,
     Tooltip,
     makeStyles,
+    mergeClasses,
     shorthands,
 } from "@fluentui/react-components";
 import {
@@ -422,7 +423,10 @@ export const AzureDataStudioMigrationPage = () => {
                             </Title3>
                             <Body1
                                 as="p"
-                                className={`${classes.summaryText} ${classes.headerSubtitle}`}>
+                                className={mergeClasses(
+                                    classes.summaryText,
+                                    classes.headerSubtitle,
+                                )}>
                                 {LocMigration.subtitle}
                             </Body1>
                         </div>
@@ -588,7 +592,10 @@ export const AzureDataStudioMigrationPage = () => {
                                                         />
                                                     </TableHeaderCell>
                                                     <TableHeaderCell
-                                                        className={`${classes.narrowColumn} ${classes.statusColumnHeader}`}>
+                                                        className={mergeClasses(
+                                                            classes.narrowColumn,
+                                                            classes.statusColumnHeader,
+                                                        )}>
                                                         {LocMigration.connectionStatusColumn}
                                                     </TableHeaderCell>
                                                     <TableHeaderCell
@@ -631,7 +638,10 @@ export const AzureDataStudioMigrationPage = () => {
                                                                 )}
                                                             </TableCell>
                                                             <TableCell
-                                                                className={`${classes.narrowColumn} ${classes.statusColumnHeader}`}>
+                                                                className={mergeClasses(
+                                                                    classes.narrowColumn,
+                                                                    classes.statusColumnHeader,
+                                                                )}>
                                                                 {renderStatusIcon(
                                                                     group.status,
                                                                     group.statusMessage,
@@ -732,7 +742,10 @@ export const AzureDataStudioMigrationPage = () => {
                                                         />
                                                     </TableHeaderCell>
                                                     <TableHeaderCell
-                                                        className={`${classes.narrowColumn} ${classes.statusColumnHeader}`}>
+                                                        className={mergeClasses(
+                                                            classes.narrowColumn,
+                                                            classes.statusColumnHeader,
+                                                        )}>
                                                         {LocMigration.connectionStatusColumn}
                                                     </TableHeaderCell>
                                                     <TableHeaderCell className={classes.nameColumn}>

--- a/extensions/mssql/src/webviews/pages/Changelog/changelogPage.tsx
+++ b/extensions/mssql/src/webviews/pages/Changelog/changelogPage.tsx
@@ -12,6 +12,7 @@ import {
     Link,
     Text,
     makeStyles,
+    mergeClasses,
     shorthands,
     tokens,
 } from "@fluentui/react-components";
@@ -628,7 +629,10 @@ export const ChangelogPage = () => {
                 </div>
                 {changeIcon && (
                     <div
-                        className={`${classes.featureIconWrap} ${classes.featureIconWrapRight}`}
+                        className={mergeClasses(
+                            classes.featureIconWrap,
+                            classes.featureIconWrapRight,
+                        )}
                         style={{ width: `${iconSize}px`, height: `${iconSize}px` }}>
                         <img
                             className={classes.featureImage}

--- a/extensions/mssql/src/webviews/pages/CodeAnalysis/codeAnalysis.tsx
+++ b/extensions/mssql/src/webviews/pages/CodeAnalysis/codeAnalysis.tsx
@@ -19,6 +19,7 @@ import {
     TableRow,
     Text,
     makeStyles,
+    mergeClasses,
     tokens,
 } from "@fluentui/react-components";
 import { CodeAnalysisContext } from "./codeAnalysisStateProvider";
@@ -436,7 +437,10 @@ export const CodeAnalysisDialog = () => {
                                     {loc.rules}
                                 </TableHeaderCell>
                                 <TableHeaderCell
-                                    className={`${styles.tableHeaderCell} ${styles.severityCell}`}>
+                                    className={mergeClasses(
+                                        styles.tableHeaderCell,
+                                        styles.severityCell,
+                                    )}>
                                     {loc.severity}
                                 </TableHeaderCell>
                             </TableRow>
@@ -449,7 +453,10 @@ export const CodeAnalysisDialog = () => {
                                         {/* Category row */}
                                         <TableRow>
                                             <TableCell
-                                                className={`${styles.groupHeaderCell} ${styles.categoryHeaderCellClickable}`}
+                                                className={mergeClasses(
+                                                    styles.groupHeaderCell,
+                                                    styles.categoryHeaderCellClickable,
+                                                )}
                                                 onDoubleClick={() =>
                                                     toggleCategoryCollapsed(category)
                                                 }>

--- a/extensions/mssql/src/webviews/pages/ObjectExplorerFilter/ObjectExplorerFilterPresets.tsx
+++ b/extensions/mssql/src/webviews/pages/ObjectExplorerFilter/ObjectExplorerFilterPresets.tsx
@@ -13,6 +13,7 @@ import {
     DialogTitle,
     Input,
     makeStyles,
+    mergeClasses,
     Menu,
     MenuItem,
     MenuList,
@@ -418,7 +419,10 @@ export const ObjectExplorerFilterPresets = ({
                                 return (
                                     <div
                                         key={row.id}
-                                        className={`${classes.groupRow} ${row.separated ? classes.separatedGroupRow : ""}`}
+                                        className={mergeClasses(
+                                            classes.groupRow,
+                                            row.separated && classes.separatedGroupRow,
+                                        )}
                                         role="presentation"
                                         style={{
                                             transform: `translateY(${virtualRow.start}px)`,
@@ -459,7 +463,10 @@ export const ObjectExplorerFilterPresets = ({
                             return (
                                 <div
                                     key={row.id}
-                                    className={`${classes.row} ${isSelected ? classes.selectedRow : ""}`}
+                                    className={mergeClasses(
+                                        classes.row,
+                                        isSelected && classes.selectedRow,
+                                    )}
                                     role="listitem"
                                     aria-posinset={row.position + 1}
                                     aria-setsize={presets.length}
@@ -559,7 +566,10 @@ export const ObjectExplorerFilterPresets = ({
                                                     onClick={() => onSelect(row.preset)}>
                                                     <span className={classes.presetText}>
                                                         <Text
-                                                            className={`${classes.truncate} ${classes.presetTitle}`}
+                                                            className={mergeClasses(
+                                                                classes.truncate,
+                                                                classes.presetTitle,
+                                                            )}
                                                             weight={
                                                                 row.preset.isPinned &&
                                                                 row.preset.name
@@ -570,7 +580,10 @@ export const ObjectExplorerFilterPresets = ({
                                                         </Text>
                                                         {showSummary && (
                                                             <Text
-                                                                className={`${classes.truncate} ${classes.presetMetadata}`}
+                                                                className={mergeClasses(
+                                                                    classes.truncate,
+                                                                    classes.presetMetadata,
+                                                                )}
                                                                 size={200}>
                                                                 {summary}
                                                             </Text>

--- a/extensions/mssql/src/webviews/pages/QueryResult/commandBar.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/commandBar.tsx
@@ -5,6 +5,7 @@
 
 import {
     makeStyles,
+    mergeClasses,
     Menu,
     MenuItem,
     MenuList,
@@ -104,7 +105,7 @@ const ToolbarOverflowButton = ({
     ...props
 }: ToolbarOverflowButtonProps & { className?: string }) => {
     const classes = useStyles();
-    const mergedClassName = [classes.toolbarButton, className].filter(Boolean).join(" ");
+    const mergedClassName = mergeClasses(classes.toolbarButton, className);
     return (
         <OverflowItem id={overflowId} groupId={overflowGroupId}>
             <ToolbarButton appearance="subtle" {...props} className={mergedClassName} />

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Tooltip, makeStyles } from "@fluentui/react-components";
+import { Tooltip, makeStyles, mergeClasses } from "@fluentui/react-components";
 import { Fragment, useContext, useEffect, useMemo, useState } from "react";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { locConstants } from "../../common/locConstants";
@@ -329,7 +329,10 @@ function renderSelectionMetricsTooltip(
                 <div className={classes.selectionTooltipMetricRow} key={`${metric.label}-tooltip`}>
                     <span className={classes.selectionMetricLabel}>{metric.label}:</span>
                     <span
-                        className={`${classes.selectionMetricValue} ${classes.selectionTooltipMetricValue}`}>
+                        className={mergeClasses(
+                            classes.selectionMetricValue,
+                            classes.selectionTooltipMetricValue,
+                        )}>
                         {metric.value}
                     </span>
                 </div>
@@ -435,7 +438,7 @@ export const QueryResultSummaryFooter = ({
                             {locConstants.queryResult.rowsAffectedLabel}
                         </span>
                         <Tooltip withArrow relationship="description" content={rowsText}>
-                            <span className={`${classes.value} ${classes.rowsAccent}`}>
+                            <span className={mergeClasses(classes.value, classes.rowsAccent)}>
                                 {compactRowsText}
                             </span>
                         </Tooltip>
@@ -449,7 +452,7 @@ export const QueryResultSummaryFooter = ({
                             withArrow
                             relationship="description"
                             content={executionTooltipText}>
-                            <span className={`${classes.value} ${classes.timeAccent}`}>
+                            <span className={mergeClasses(classes.value, classes.timeAccent)}>
                                 {compactExecutionText}
                             </span>
                         </Tooltip>

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/editor/schemaDesignerEditorTablePanel.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/editor/schemaDesignerEditorTablePanel.tsx
@@ -12,6 +12,7 @@ import {
     Input,
     Label,
     makeStyles,
+    mergeClasses,
     Popover,
     PopoverSurface,
     PopoverTrigger,
@@ -308,9 +309,10 @@ const ColumnsTable = ({
                     <Button
                         size="small"
                         appearance="subtle"
-                        className={`${classes.dragHandleButton} ${
-                            draggedRowId === index ? classes.draggingHandleButton : ""
-                        }`}
+                        className={mergeClasses(
+                            classes.dragHandleButton,
+                            draggedRowId === index && classes.draggingHandleButton,
+                        )}
                         icon={<FluentIcons.ReOrderRegular />}
                         draggable={true}
                         onDragEnter={() => {

--- a/extensions/mssql/src/webviews/pages/SchemaDesigner/index.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaDesigner/index.tsx
@@ -11,7 +11,14 @@ import { useSchemaDesignerSelector } from "./schemaDesignerSelector";
 import { SchemaDesignerPage } from "./schemaDesignerPage";
 import { ReactFlowProvider } from "@xyflow/react";
 import { useEffect, useState } from "react";
-import { makeStyles, Toolbar, ToolbarButton, tokens, Tooltip } from "@fluentui/react-components";
+import {
+    makeStyles,
+    mergeClasses,
+    Toolbar,
+    ToolbarButton,
+    tokens,
+    Tooltip,
+} from "@fluentui/react-components";
 import { TableSettingsRegular } from "@fluentui/react-icons";
 import { DabPage } from "./dab/dabPage";
 import { SchemaDesigner } from "../../../sharedInterfaces/schemaDesigner";
@@ -109,11 +116,11 @@ const MainLayout = () => {
             </div>
             <div className={classes.content}>
                 <div
-                    className={`${classes.viewPane} ${
-                        activeView === SchemaDesigner.SchemaDesignerActiveView.SchemaDesigner
-                            ? ""
-                            : classes.inactiveViewPane
-                    }`}
+                    className={mergeClasses(
+                        classes.viewPane,
+                        activeView !== SchemaDesigner.SchemaDesignerActiveView.SchemaDesigner &&
+                            classes.inactiveViewPane,
+                    )}
                     aria-hidden={
                         activeView !== SchemaDesigner.SchemaDesignerActiveView.SchemaDesigner
                     }
@@ -130,11 +137,11 @@ const MainLayout = () => {
                     />
                 </div>
                 <div
-                    className={`${classes.viewPane} ${
-                        activeView === SchemaDesigner.SchemaDesignerActiveView.Dab
-                            ? ""
-                            : classes.inactiveViewPane
-                    }`}
+                    className={mergeClasses(
+                        classes.viewPane,
+                        activeView !== SchemaDesigner.SchemaDesignerActiveView.Dab &&
+                            classes.inactiveViewPane,
+                    )}
                     aria-hidden={activeView !== SchemaDesigner.SchemaDesignerActiveView.Dab}
                     inert={
                         activeView !== SchemaDesigner.SchemaDesignerActiveView.Dab


### PR DESCRIPTION
## Description

Fixes #22655.

- Compose Griffel-generated classes with `mergeClasses` instead of template literals and string joins.
- Preserve conditional styles while allowing Fluent UI to resolve atomic class precedence.
- Prevent runtime warnings when Fluent components receive multiple atomic identifiers in one class string.

Validation:

- `npm run lint -- --target mssql`
- `npm run build -- --target mssql`
- `npm run package -- --target mssql --online` was attempted but blocked by the active SQL Tools Service process locking `Microsoft.Azure.KeyVault.dll`.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
