### PR TITLE
Show message when query text is empty

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -468,6 +468,7 @@
     "The recent connections list has been cleared but there were errors while deleting some associated credentials. View the errors in the MSSQL output channel.": "The recent connections list has been cleared but there were errors while deleting some associated credentials. View the errors in the MSSQL output channel.",
     "Testing connection profile...": "Testing connection profile...",
     "Running query is not supported when the editor is in multiple selection mode.": "Running query is not supported when the editor is in multiple selection mode.",
+    "There is no query text to execute. Enter a query or select non-empty query text.": "There is no query text to execute. Enter a query or select non-empty query text.",
     "Please select a node from Object Explorer to script.": "Please select a node from Object Explorer to script.",
     "Please select only one node to script. Multiple node scripting is not supported.": "Please select only one node to script. Multiple node scripting is not supported.",
     "Could not find scripting metadata for {0} '{1}'./{0} is the node type{1} is the node label": {

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -767,6 +767,9 @@ export let connectProgressNoticationTitle = l10n.t("Testing connection profile..
 export let msgMultipleSelectionModeNotSupported = l10n.t(
     "Running query is not supported when the editor is in multiple selection mode.",
 );
+export let msgNoQueryTextToExecute = l10n.t(
+    "There is no query text to execute. Enter a query or select non-empty query text.",
+);
 export let msgSelectNodeToScript = l10n.t("Please select a node from Object Explorer to script.");
 export let msgSelectSingleNodeToScript = l10n.t(
     "Please select only one node to script. Multiple node scripting is not supported.",

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -2799,8 +2799,11 @@ export default class MainController implements vscode.Disposable {
             let uri = Utils.getActiveTextEditorUri();
             let title = path.basename(editor.document.fileName);
 
-            // return early if the document does contain any text
+            // Return early if the document does not contain any query text.
             if (editor.document.getText(undefined).trim().length === 0) {
+                void vscode.window.showInformationMessage(
+                    LocalizedConstants.msgNoQueryTextToExecute,
+                );
                 return;
             }
 
@@ -2817,6 +2820,9 @@ export default class MainController implements vscode.Disposable {
             let shouldRunSelection = false;
             if (!editor.selection.isEmpty) {
                 if (editor.document.getText(editor.selection).trim().length === 0) {
+                    void vscode.window.showInformationMessage(
+                        LocalizedConstants.msgNoQueryTextToExecute,
+                    );
                     return;
                 }
 
@@ -2890,6 +2896,9 @@ export default class MainController implements vscode.Disposable {
             // Trim down the selection. If it is empty after selecting, then we don't execute
             let selectionToTrim = editor.selection.isEmpty ? undefined : editor.selection;
             if (editor.document.getText(selectionToTrim).trim().length === 0) {
+                void vscode.window.showInformationMessage(
+                    LocalizedConstants.msgNoQueryTextToExecute,
+                );
                 return;
             }
 

--- a/extensions/mssql/test/unit/mainController.test.ts
+++ b/extensions/mssql/test/unit/mainController.test.ts
@@ -288,7 +288,7 @@ suite("MainController Tests", function () {
             expect(runQueryStub).to.not.have.been.called;
         });
 
-        test("does not execute when the selection contains only whitespace", async () => {
+        test("shows information and does not execute when the selection contains only whitespace", async () => {
             const selection = new vscode.Selection(0, 0, 0, 4);
             sandbox
                 .stub(vscode.window, "activeTextEditor")
@@ -296,6 +296,9 @@ suite("MainController Tests", function () {
 
             await mainController.onRunCurrentStatement();
 
+            expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+                LocalizedConstants.msgNoQueryTextToExecute,
+            );
             expect(runQueryStub).to.not.have.been.called;
             expect(runCurrentStatementStub).to.not.have.been.called;
         });
@@ -321,7 +324,7 @@ suite("MainController Tests", function () {
             expect(runCurrentStatementStub).to.not.have.been.called;
         });
 
-        test("does not execute when the document is empty", async () => {
+        test("shows information and does not execute when the document is empty", async () => {
             const selection = new vscode.Selection(0, 0, 0, 0);
             sandbox
                 .stub(vscode.window, "activeTextEditor")
@@ -329,6 +332,9 @@ suite("MainController Tests", function () {
 
             await mainController.onRunCurrentStatement();
 
+            expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+                LocalizedConstants.msgNoQueryTextToExecute,
+            );
             expect(runQueryStub).to.not.have.been.called;
             expect(runCurrentStatementStub).to.not.have.been.called;
         });
@@ -392,6 +398,34 @@ suite("MainController Tests", function () {
                 "query.sql",
                 undefined,
             );
+        });
+
+        test("shows information and does not execute when the document is empty", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 0);
+            sandbox
+                .stub(vscode.window, "activeTextEditor")
+                .get(() => createQueryTextEditor(selection, ""));
+
+            await mainController.onRunQuery();
+
+            expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+                LocalizedConstants.msgNoQueryTextToExecute,
+            );
+            expect(runQueryStub).to.not.have.been.called;
+        });
+
+        test("shows information and does not execute when the selection contains only whitespace", async () => {
+            const selection = new vscode.Selection(0, 0, 0, 4);
+            sandbox
+                .stub(vscode.window, "activeTextEditor")
+                .get(() => createQueryTextEditor(selection, "    select 'a';", "    "));
+
+            await mainController.onRunQuery();
+
+            expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+                LocalizedConstants.msgNoQueryTextToExecute,
+            );
+            expect(runQueryStub).to.not.have.been.called;
         });
     });
 

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -7758,6 +7758,9 @@
       <source xml:lang="en">The “{0}” extension uses a connection-sharing capability that the MSSQL extension is retiring. File a feature request for the capability you use so we can consider adding it natively.</source>
       <note>{0} is the extension name</note>
     </trans-unit>
+    <trans-unit id="++CODE++1a7dce1f7d58b78f71a31ac2a4451b08304b7426c9609ec2b348c9002e866c68">
+      <source xml:lang="en">There is no query text to execute. Enter a query or select non-empty query text.</source>
+    </trans-unit>
     <trans-unit id="++CODE++fe68202651f2e6c4af304386d80e491e5c52755db829443bb2cefbf2b25df757">
       <source xml:lang="en">There was an error updating the project</source>
     </trans-unit>


### PR DESCRIPTION
## Summary
- show a localized information message when Run Query has no non-whitespace text to execute
- apply the same behavior to Run Current Statement
- cover empty documents and whitespace-only selections with focused unit tests

<img width="471" height="125" alt="image" src="https://github.com/user-attachments/assets/624179ba-5178-4fed-8380-86365caddc78" />


## Validation
- MSSQL extension type-check passed
- targeted ESLint passed for all changed TypeScript files
- pre-commit localization extraction and lint-staged passed
- focused `onRun` test execution was blocked during global test loading by the pre-existing missing `vscode-mssql` module in `connectionSharingSession.test.ts`

Related to #22681