### PR TITLE
Restore Monaco find widget in designer webviews

### DIFF
--- a/extensions/mssql/src/webviews/common/vscodeMonaco.tsx
+++ b/extensions/mssql/src/webviews/common/vscodeMonaco.tsx
@@ -16,6 +16,8 @@ import {
 } from "@monaco-editor/react";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import "monaco-editor/esm/vs/basic-languages/sql/sql.contribution";
+import "monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles";
+import "monaco-editor/esm/vs/editor/contrib/find/browser/findController";
 import { useCallback, useEffect, useRef } from "react";
 import { ColorThemeKind } from "../../sharedInterfaces/webview";
 


### PR DESCRIPTION
## Summary
- restore Monaco's Ctrl+F find controller in Table Designer and Schema Designer definition panels
- bundle Monaco's Codicon styles and font so find-widget buttons render correctly
- keep Monaco fully local for firewalled and offline environments

<img width="529" height="58" alt="image" src="https://github.com/user-attachments/assets/92b2f799-1944-4ca4-95b8-6ceabdc97b49" />


## Bundle size impact
Production-equivalent measurement of each webview's complete loaded graph:

| Webview | Before | After | Raw increase | Gzip increase |
|---|---:|---:|---:|---:|
| Table Designer | 4,019,518 bytes | 4,195,325 bytes | 175,807 bytes (4.37%) | 68,330 bytes (6.43%) |
| Schema Designer | 4,638,670 bytes | 4,814,477 bytes | 175,807 bytes (3.79%) | 68,319 bytes (5.48%) |

Shared added assets:
- JavaScript: 78,876 bytes
- CSS: 6,747 bytes
- local Codicon font: 90,184 bytes

The assets are shared rather than duplicated between the two webviews. No CDN resources are loaded.

## Validation
- `npm run build:webviews` passed
- production `npm run build:webviews-bundle -- --prod` passed
- targeted ESLint passed for `vscodeMonaco.tsx`
- verified Table Designer and Schema Designer CSS contain the Codicon font face and reference the emitted local font
- pre-commit localization extraction and lint-staged passed

Related to #22683