### PR TITLE
Update SQL Tools Service to 6.0.20260810.1

### DIFF
--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260807.3",
+        version: "6.0.20260810.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",


### PR DESCRIPTION
## Summary
- update SQL Tools Service from `6.0.20260807.3` to `6.0.20260810.1`
- consume the database drop and rename fixes from microsoft/sqltoolsservice#2788

## Validation
- verified STS tag `6.0.20260810.1` is exactly sqltoolsservice commit `c5feb61f185959f4254765a7e3b89f31b104b2ee`
- verified all expected platform artifacts are published
- `npm run build -- --target mssql`
- focused config tests: 3 passed, 0 failed
- pre-commit localization extraction and lint-staged passed

Related to #22685