### PR TITLE
Improve execution plan graph accessibility

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2841,7 +2841,10 @@
     "Estimated Subtree Cost": "Estimated Subtree Cost",
     "Estimated Operator Cost": "Estimated Operator Cost",
     "The React Flow execution plan preview could not render this plan.": "The React Flow execution plan preview could not render this plan.",
-    "Execution plan": "Execution plan",
+    "Execution plan {0}, use arrow keys to navigate between nodes/{0} is the one-based execution plan number": {
+        "message": "Execution plan {0}, use arrow keys to navigate between nodes",
+        "comment": ["{0} is the one-based execution plan number"]
+    },
     "Execution plan details": "Execution plan details",
     "Expand {0}/{0} is the name of an execution plan operation": {
         "message": "Expand {0}",

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -986,7 +986,12 @@ export class LocConstants {
             reactFlowRendererError: l10n.t(
                 "The React Flow execution plan preview could not render this plan.",
             ),
-            executionPlanGraph: l10n.t("Execution plan"),
+            executionPlanGraph: (planNumber: number) =>
+                l10n.t({
+                    message: "Execution plan {0}, use arrow keys to navigate between nodes",
+                    args: [planNumber],
+                    comment: ["{0} is the one-based execution plan number"],
+                }),
             executionPlanDetails: l10n.t("Execution plan details"),
             expandNode: (name: string) =>
                 l10n.t({

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -427,6 +427,7 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
                                 <ReactFlowExecutionPlan
                                     root={graph.root}
                                     themeKind={themeKind}
+                                    planNumber={graphIndex + 1}
                                     onReady={handleRendererReady}
                                 />
                             </Suspense>

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanTooltipPosition.ts
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanTooltipPosition.ts
@@ -7,7 +7,6 @@ const TOOLTIP_WIDTH = 520;
 const TOOLTIP_MAXIMUM_HEIGHT = 420;
 const TOOLTIP_MINIMUM_HEIGHT = 80;
 const TOOLTIP_VIEWPORT_MARGIN = 8;
-const TOOLTIP_SOURCE_GAP = 8;
 const TOOLTIP_VERTICAL_CLAMP_HEIGHT = 200;
 
 export interface ExecutionPlanTooltipSourceBounds {
@@ -82,8 +81,8 @@ export function fitExecutionPlanTooltipPlacement(
 }
 
 /**
- * Positions node tooltips beside their source. If neither horizontal side has
- * enough room, the tooltip is placed above or below the node instead.
+ * Prefers the supplied anchor and lets the post-render fitting pass move the
+ * tooltip only when its measured dimensions would overflow the viewport.
  */
 export function getExecutionPlanTooltipPlacement(
     anchor: ExecutionPlanTooltipAnchor,
@@ -109,50 +108,9 @@ export function getExecutionPlanTooltipPlacement(
         };
     }
 
-    const source = anchor.sourceBounds;
-    const rightmostLeft = viewport.width - TOOLTIP_VIEWPORT_MARGIN - tooltipWidth;
-    if (rightmostLeft >= source.right) {
-        const left = Math.min(source.right + TOOLTIP_SOURCE_GAP, rightmostLeft);
-        return {
-            left,
-            top: defaultTop,
-            maxHeight: getMaximumHeight(defaultTop, viewport.height),
-        };
-    }
-
-    if (source.left - tooltipWidth >= TOOLTIP_VIEWPORT_MARGIN) {
-        const left = Math.max(
-            TOOLTIP_VIEWPORT_MARGIN,
-            source.left - tooltipWidth - TOOLTIP_SOURCE_GAP,
-        );
-        return {
-            left,
-            top: defaultTop,
-            maxHeight: getMaximumHeight(defaultTop, viewport.height),
-        };
-    }
-
-    const left = clamp(
-        (source.left + source.right - tooltipWidth) / 2,
-        TOOLTIP_VIEWPORT_MARGIN,
-        maximumLeft,
-    );
-    const belowTop = source.bottom + TOOLTIP_SOURCE_GAP;
-    const availableBelow = viewport.height - TOOLTIP_VIEWPORT_MARGIN - belowTop;
-    const availableAbove = source.top - TOOLTIP_SOURCE_GAP - TOOLTIP_VIEWPORT_MARGIN;
-
-    if (availableBelow >= TOOLTIP_MINIMUM_HEIGHT || availableBelow >= availableAbove) {
-        return {
-            left,
-            top: belowTop,
-            maxHeight: Math.min(TOOLTIP_MAXIMUM_HEIGHT, Math.max(0, availableBelow)),
-        };
-    }
-
-    const maxHeight = Math.min(TOOLTIP_MAXIMUM_HEIGHT, Math.max(0, availableAbove));
     return {
-        left,
-        top: source.top - TOOLTIP_SOURCE_GAP - maxHeight,
-        maxHeight,
+        left: anchor.x,
+        top: anchor.y,
+        maxHeight: getMaximumHeight(anchor.y, viewport.height),
     };
 }

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.css
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.css
@@ -8,6 +8,18 @@
     color: var(--vscode-editor-foreground);
 }
 
+.execution-plan-flow-announcement {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .execution-plan-flow-node {
     position: relative;
     box-sizing: border-box;

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
@@ -703,15 +703,9 @@ export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
 
             switch (event.key) {
                 case "ArrowRight":
-                    if (collapsedNodeIds.has(id)) {
-                        setCollapsedNodeIds((current) => {
-                            const next = new Set(current);
-                            next.delete(id);
-                            return next;
-                        });
-                        break;
+                    if (!collapsedNodeIds.has(id)) {
+                        targetId = model.getChildIds(id)[0];
                     }
-                    targetId = model.getChildIds(id)[0];
                     break;
                 case "ArrowLeft":
                     targetId = parentId;

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
@@ -714,14 +714,6 @@ export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
                     targetId = model.getChildIds(id)[0];
                     break;
                 case "ArrowLeft":
-                    if (model.getChildIds(id).length > 0 && !collapsedNodeIds.has(id)) {
-                        setCollapsedNodeIds((current) => {
-                            const next = new Set(current);
-                            next.add(id);
-                            return next;
-                        });
-                        break;
-                    }
                     targetId = parentId;
                     break;
                 case "ArrowUp":

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/reactFlowExecutionPlan.tsx
@@ -536,12 +536,14 @@ export class ReactFlowExecutionPlanController implements ExecutionPlanGraphContr
 interface ReactFlowExecutionPlanProps {
     root: ExecutionPlanNode;
     themeKind: ColorThemeKind;
+    planNumber: number;
     onReady: (controller: ExecutionPlanGraphController | null) => void;
 }
 
 export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
     root,
     themeKind,
+    planNumber,
     onReady,
 }) => {
     const model = useMemo(() => new ExecutionPlanModel(root), [root]);
@@ -553,6 +555,7 @@ export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
     const [highlightedId, setHighlightedId] = useState<string>();
     const [tooltipsEnabled, setTooltipsEnabled] = useState(true);
     const [tooltip, setTooltip] = useState<TooltipState>();
+    const [focusAnnouncement, setFocusAnnouncement] = useState("");
     const selectedIdRef = useRef(selectedId);
     const tooltipsEnabledRef = useRef(tooltipsEnabled);
     const nodeElementsRef = useRef(new Map<string, HTMLDivElement>());
@@ -664,7 +667,7 @@ export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
                         targetId,
                         content: formatExecutionPlanNodeTooltip(node),
                         x: bounds.right + 8,
-                        y: bounds.top,
+                        y: bounds.bottom + 8,
                         sourceBounds: {
                             left: bounds.left,
                             right: bounds.right,
@@ -860,65 +863,86 @@ export const ReactFlowExecutionPlan: React.FC<ReactFlowExecutionPlanProps> = ({
     }, [expandAncestors, focusNode, instance, model, onReady, positions]);
 
     return (
-        <div
-            ref={canvasRef}
-            className="execution-plan-flow-canvas"
-            role="tree"
-            aria-label={locConstants.executionPlan.executionPlanGraph}>
-            <ReactFlow<ExecutionPlanFlowNode, ExecutionPlanFlowEdge>
-                nodes={nodes}
-                edges={edges}
-                nodeTypes={NODE_TYPES}
-                edgeTypes={EDGE_TYPES}
-                onInit={setInstance}
-                defaultViewport={{ x: 0, y: 0, zoom: 1 }}
-                minZoom={0.01}
-                maxZoom={2}
-                panOnDrag
-                zoomOnScroll={false}
-                zoomOnPinch
-                zoomOnDoubleClick={false}
-                preventScrolling={false}
-                nodesDraggable={false}
-                nodesConnectable={false}
-                nodesFocusable={false}
-                autoPanOnNodeFocus={false}
-                edgesFocusable={false}
-                disableKeyboardA11y
-                onlyRenderVisibleElements
-                selectionOnDrag={false}
-                multiSelectionKeyCode={null}
-                deleteKeyCode={null}
-                proOptions={{ hideAttribution: true }}
-                onPaneClick={() => setTooltip(undefined)}
-                onEdgeClick={(event: MouseEvent, edge: ExecutionPlanFlowEdge) => {
-                    const edgeData = edge.data;
-                    if (tooltipsEnabledRef.current && edgeData) {
-                        const targetId = `edge:${edge.id}`;
-                        setTooltip((current) => {
-                            if (current?.targetId === targetId) {
-                                return undefined;
-                            }
-                            return {
-                                targetId,
-                                content: formatExecutionPlanEdgeTooltip(edgeData),
-                                x: event.clientX + 8,
-                                y: event.clientY + 8,
-                            };
-                        });
-                        focusNode(selectedIdRef.current);
+        <>
+            <div
+                className="execution-plan-flow-announcement"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true">
+                {focusAnnouncement}
+            </div>
+            <div
+                ref={canvasRef}
+                className="execution-plan-flow-canvas"
+                role="tree"
+                aria-label={locConstants.executionPlan.executionPlanGraph(planNumber)}
+                onFocusCapture={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) {
+                        setFocusAnnouncement(
+                            locConstants.executionPlan.executionPlanGraph(planNumber),
+                        );
                     }
-                }}></ReactFlow>
-            {tooltip && (
-                <ExecutionPlanTooltip
-                    tooltip={tooltip}
-                    onClose={() => {
-                        setTooltip(undefined);
-                        focusNode(selectedIdRef.current);
-                    }}
-                />
-            )}
-        </div>
+                }}
+                onBlurCapture={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) {
+                        setFocusAnnouncement("");
+                    }
+                }}>
+                <ReactFlow<ExecutionPlanFlowNode, ExecutionPlanFlowEdge>
+                    nodes={nodes}
+                    edges={edges}
+                    nodeTypes={NODE_TYPES}
+                    edgeTypes={EDGE_TYPES}
+                    onInit={setInstance}
+                    defaultViewport={{ x: 0, y: 0, zoom: 1 }}
+                    minZoom={0.01}
+                    maxZoom={2}
+                    panOnDrag
+                    zoomOnScroll={false}
+                    zoomOnPinch
+                    zoomOnDoubleClick={false}
+                    preventScrolling={false}
+                    nodesDraggable={false}
+                    nodesConnectable={false}
+                    nodesFocusable={false}
+                    autoPanOnNodeFocus={false}
+                    edgesFocusable={false}
+                    disableKeyboardA11y
+                    onlyRenderVisibleElements
+                    selectionOnDrag={false}
+                    multiSelectionKeyCode={null}
+                    deleteKeyCode={null}
+                    proOptions={{ hideAttribution: true }}
+                    onPaneClick={() => setTooltip(undefined)}
+                    onEdgeClick={(event: MouseEvent, edge: ExecutionPlanFlowEdge) => {
+                        const edgeData = edge.data;
+                        if (tooltipsEnabledRef.current && edgeData) {
+                            const targetId = `edge:${edge.id}`;
+                            setTooltip((current) => {
+                                if (current?.targetId === targetId) {
+                                    return undefined;
+                                }
+                                return {
+                                    targetId,
+                                    content: formatExecutionPlanEdgeTooltip(edgeData),
+                                    x: event.clientX + 8,
+                                    y: event.clientY + 8,
+                                };
+                            });
+                            focusNode(selectedIdRef.current);
+                        }
+                    }}></ReactFlow>
+                {tooltip && (
+                    <ExecutionPlanTooltip
+                        tooltip={tooltip}
+                        onClose={() => {
+                            setTooltip(undefined);
+                            focusNode(selectedIdRef.current);
+                        }}
+                    />
+                )}
+            </div>
+        </>
     );
 };
 

--- a/extensions/mssql/test/e2e/executionPlan.spec.ts
+++ b/extensions/mssql/test/e2e/executionPlan.spec.ts
@@ -105,10 +105,6 @@ test.describe("MSSQL Extension - Query Plan", async () => {
 
         await rootNode.focus();
         await rootNode.press("ArrowLeft");
-        await expect(rootNode).toHaveAttribute("aria-expanded", "false");
-        await expect(rootNode).toBeFocused();
-
-        await rootNode.press("ArrowRight");
         await expect(rootNode).toHaveAttribute("aria-expanded", "true");
         await expect(rootNode).toBeFocused();
 

--- a/extensions/mssql/test/e2e/executionPlan.spec.ts
+++ b/extensions/mssql/test/e2e/executionPlan.spec.ts
@@ -99,6 +99,13 @@ test.describe("MSSQL Extension - Query Plan", async () => {
         await collapseButton.press("Space");
         await expect(rootNode).toHaveAttribute("aria-expanded", "false");
         await expect(collapseButton).toBeFocused();
+
+        await rootNode.focus();
+        await rootNode.press("ArrowRight");
+        await expect(rootNode).toHaveAttribute("aria-expanded", "false");
+        await expect(rootNode).toBeFocused();
+
+        await collapseButton.focus();
         await collapseButton.press("Enter");
         await expect(rootNode).toHaveAttribute("aria-expanded", "true");
         await expect(collapseButton).toBeFocused();

--- a/extensions/mssql/test/e2e/executionPlan.spec.ts
+++ b/extensions/mssql/test/e2e/executionPlan.spec.ts
@@ -77,7 +77,13 @@ test.describe("MSSQL Extension - Query Plan", async () => {
 
         const rootNode = iframe.locator('[role="treeitem"][tabindex="0"]').first();
         await expect(rootNode).toBeVisible();
+        await expect(
+            iframe.getByRole("tree", { name: /Execution plan 1, use arrow keys/ }),
+        ).toBeVisible();
         await rootNode.focus();
+        await expect(iframe.getByRole("status")).toHaveText(
+            "Execution plan 1, use arrow keys to navigate between nodes",
+        );
         const viewport = iframe.locator(".react-flow__viewport").first();
         const viewportStyle = await viewport.getAttribute("style");
         await rootNode.press("ArrowRight");

--- a/extensions/mssql/test/unit/executionPlanTooltipPosition.test.ts
+++ b/extensions/mssql/test/unit/executionPlanTooltipPosition.test.ts
@@ -11,48 +11,57 @@ import {
 } from "../../src/webviews/pages/ExecutionPlan/executionPlanTooltipPosition";
 
 suite("ExecutionPlanTooltipPosition", () => {
-    test("places a node tooltip to the right when space is available", () => {
-        const placement = getExecutionPlanTooltipPlacement(
+    test("places a node tooltip at the bottom right when space is available", () => {
+        const preferredPlacement = getExecutionPlanTooltipPlacement(
             {
                 x: 188,
-                y: 100,
+                y: 188,
                 sourceBounds: { left: 100, right: 180, top: 100, bottom: 180 },
             },
             { width: 1000, height: 700 },
         );
+        const placement = fitExecutionPlanTooltipPlacement(
+            preferredPlacement,
+            { width: 520, height: 200 },
+            { width: 1000, height: 700 },
+        );
 
         expect(placement.left).to.equal(188);
-        expect(placement.top).to.equal(100);
+        expect(placement.top).to.equal(188);
     });
 
-    test("places a node tooltip to the left without covering its source", () => {
+    test("moves a node tooltip left only when it would overflow the viewport", () => {
         const sourceBounds = { left: 574, right: 654, top: 168, bottom: 248 };
-        const placement = getExecutionPlanTooltipPlacement(
-            {
-                x: sourceBounds.right + 8,
-                y: sourceBounds.top,
-                sourceBounds,
-            },
+        const preferredPlacement = getExecutionPlanTooltipPlacement(
+            { x: sourceBounds.right + 8, y: sourceBounds.bottom + 8, sourceBounds },
+            { width: 1063, height: 505 },
+        );
+        const placement = fitExecutionPlanTooltipPlacement(
+            preferredPlacement,
+            { width: 520, height: 200 },
             { width: 1063, height: 505 },
         );
 
-        expect(placement.left).to.equal(46);
-        expect(placement.left + 520).to.be.at.most(sourceBounds.left);
+        expect(preferredPlacement.left).to.equal(sourceBounds.right + 8);
+        expect(placement.left).to.equal(535);
+        expect(placement.top).to.equal(sourceBounds.bottom + 8);
     });
 
-    test("places a node tooltip vertically when neither side is wide enough", () => {
+    test("moves a node tooltip up only when it would overflow the viewport", () => {
         const sourceBounds = { left: 200, right: 280, top: 100, bottom: 180 };
-        const placement = getExecutionPlanTooltipPlacement(
-            {
-                x: sourceBounds.right + 8,
-                y: sourceBounds.top,
-                sourceBounds,
-            },
-            { width: 480, height: 700 },
+        const preferredPlacement = getExecutionPlanTooltipPlacement(
+            { x: sourceBounds.right + 8, y: sourceBounds.bottom + 8, sourceBounds },
+            { width: 1000, height: 300 },
+        );
+        const placement = fitExecutionPlanTooltipPlacement(
+            preferredPlacement,
+            { width: 520, height: 200 },
+            { width: 1000, height: 300 },
         );
 
-        expect(placement.top).to.equal(sourceBounds.bottom + 8);
-        expect(placement.maxHeight).to.equal(420);
+        expect(preferredPlacement.top).to.equal(sourceBounds.bottom + 8);
+        expect(placement.top).to.equal(92);
+        expect(placement.left).to.equal(sourceBounds.right + 8);
     });
 
     test("keeps edge tooltips inside the viewport", () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -2979,14 +2979,15 @@
     <trans-unit id="++CODE++f93991ad07957c41dfc5212f2709590b0a723ccb5f5c397fb7c681b218de236d">
       <source xml:lang="en">Execution cancelled</source>
     </trans-unit>
-    <trans-unit id="++CODE++5b273fdcb747a01d31053e82b95e940110b6fe3d05d9bffc057856d6f21d127b">
-      <source xml:lang="en">Execution plan</source>
-    </trans-unit>
     <trans-unit id="++CODE++a49223aa30fb671e98c03012a63a1c68e98b7cf3c612f59d98ba0057c54da0c9">
       <source xml:lang="en">Execution plan details</source>
     </trans-unit>
     <trans-unit id="++CODE++88a9a5f2694fe0574b7aedb637b626756bd9b763fe1f9853852480a5952e6c1d">
       <source xml:lang="en">Execution plan toolbar</source>
+    </trans-unit>
+    <trans-unit id="++CODE++2755320f7f041c845a3a28a6143d1595e153faab71dbe4b039f618d209b12c7c">
+      <source xml:lang="en">Execution plan {0}, use arrow keys to navigate between nodes</source>
+      <note>{0} is the one-based execution plan number</note>
     </trans-unit>
     <trans-unit id="++CODE++9c1c3546bc3e94eb9cf8d7e8bef7d64b5f0213e752e4be0185a9ffc4d87f671c">
       <source xml:lang="en">Execution time unavailable</source>


### PR DESCRIPTION
## Summary

- keep ArrowLeft and ArrowRight as navigation-only keys without changing node expansion
- leave collapse and expand behavior on the explicit accessible node button
- announce the plan number and arrow-key instructions when focus enters the React Flow graph
- avoid repeating graph-entry instructions during navigation within the graph
- prefer node tooltips at the node's bottom-right corner and reposition them only when measured viewport overflow requires it
- keep edge tooltip placement unchanged
- add focused E2E and unit coverage for the updated accessibility and tooltip behavior

Related to #22693. This PR intentionally does not close the issue; the issue should remain open for a separate release-branch PR.

## Validation

- `npm --prefix extensions/mssql run build:webviews`
- focused `ExecutionPlanTooltipPosition` unit tests: 6 passed
- focused ESLint for the changed implementation and tests
- Prettier check
- `git diff --check`

The full E2E scenario requires the VS Code and SQL integration test harness and was not run locally.