### PR TITLE
Fix error launching Create Project from Database from the projects view

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -158,7 +158,7 @@ export default class MainController implements vscode.Disposable {
         this.context.subscriptions.push(
             vscode.commands.registerCommand(
                 "sqlDatabaseProjects.createProjectFromDatabase",
-                async (context: vscodeMssql.ITreeNodeInfo | undefined) => {
+                async (context: vscodeMssql.ITreeNodeInfo | WorkspaceTreeItem | undefined) => {
                     return this.projectsController.createProjectFromDatabase(context);
                 },
             ),

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -1849,10 +1849,14 @@ export class ProjectsController {
             : "";
     }
 
+    /**
+     * This command can be launched from the Object Explorer, the projects view title menu, or the
+     * command palette, so only an Object Explorer node carries a connection profile.
+     */
     private getConnectionProfileFromContext(
-        context: mssqlVscode.ITreeNodeInfo | undefined,
+        context: mssqlVscode.ITreeNodeInfo | dataworkspace.WorkspaceTreeItem | undefined,
     ): mssqlVscode.IConnectionInfo | undefined {
-        return context?.connectionProfile;
+        return context && "connectionProfile" in context ? context.connectionProfile : undefined;
     }
 
     private refreshProjectsTree(workspaceTreeItem: dataworkspace.WorkspaceTreeItem): void {
@@ -1870,21 +1874,20 @@ export class ProjectsController {
      * prompting the user for a name, file path location and extract target
      */
     public async createProjectFromDatabase(
-        context: mssqlVscode.ITreeNodeInfo | undefined,
+        context: mssqlVscode.ITreeNodeInfo | dataworkspace.WorkspaceTreeItem | undefined,
     ): Promise<void> {
         const profile = this.getConnectionProfileFromContext(context);
-        if (context) {
+        if (profile) {
             // The profile we get from VS Code is for the overall server connection and isn't updated based
             // on the database node the command was launched from. Get the actual database name from the
             // MSSQL extension and update the connection info here.
             const treeNodeContext = context as mssqlVscode.ITreeNodeInfo;
-            const databaseName = (await utils.getVscodeMssqlApi()).getDatabaseNameFromTreeNode(
+            profile.database = (await utils.getVscodeMssqlApi()).getDatabaseNameFromTreeNode(
                 treeNodeContext,
             );
-            (profile as mssqlVscode.IConnectionInfo).database = databaseName;
         }
         await createNewProjectFromDatabaseWithQuickpick(
-            profile as mssqlVscode.IConnectionInfo,
+            profile,
             (
                 model: ImportDataModel,
                 connectionInfo?: string | mssqlVscode.IConnectionInfo,

--- a/extensions/sql-database-projects/test/projectController.test.ts
+++ b/extensions/sql-database-projects/test/projectController.test.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import * as sinon from "sinon";
 import * as dataworkspace from "dataworkspace";
+import * as vscodeMssql from "vscode-mssql";
 import * as baselines from "./baselines/baselines";
 import * as templates from "../src/templates/templates";
 import * as testUtils from "./testUtils";
@@ -15,9 +16,11 @@ import * as constants from "../src/common/constants";
 import { ExtractTarget } from "../src/common/enums";
 import * as utils from "../src/common/utils";
 
+import * as createProjectFromDatabaseQuickpick from "../src/dialogs/createProjectFromDatabaseQuickpick";
 import { SqlDatabaseProjectTreeViewProvider } from "../src/controllers/databaseProjectTreeViewProvider";
 import { ProjectsController } from "../src/controllers/projectController";
 import { NetCoreTool } from "../src/tools/netcoreTool";
+import { mockConnectionInfo } from "./dialogTestUtils";
 import { promises as fs } from "fs";
 import { createContext, TestContext } from "./testContext";
 import { Project } from "../src/models/project";
@@ -1416,6 +1419,59 @@ suite("ProjectsController", function (): void {
 
     suite("Create project from database operations and dialog", function (): void {
         teardown(() => {});
+
+        suite("launch context handling", function (): void {
+            let quickpickStub: sinon.SinonStub;
+            let getDatabaseNameFromTreeNodeStub: sinon.SinonStub;
+
+            setup(function (): void {
+                quickpickStub = sandbox
+                    .stub(
+                        createProjectFromDatabaseQuickpick,
+                        "createNewProjectFromDatabaseWithQuickpick",
+                    )
+                    .resolves();
+                getDatabaseNameFromTreeNodeStub = sandbox.stub().returns("NodeDatabase");
+                sandbox.stub(utils, "getVscodeMssqlApi").resolves({
+                    getDatabaseNameFromTreeNode: getDatabaseNameFromTreeNodeStub,
+                } as unknown as vscodeMssql.IExtension);
+            });
+
+            test("Should preselect the database when launched from an Object Explorer node", async function (): Promise<void> {
+                const projController = new ProjectsController(testContext.outputChannel);
+                const objectExplorerNode = {
+                    connectionProfile: { ...mockConnectionInfo },
+                } as unknown as vscodeMssql.ITreeNodeInfo;
+
+                await projController.createProjectFromDatabase(objectExplorerNode);
+
+                expect(quickpickStub.calledOnce, "quickpick should have been launched").to.be.true;
+                expect(
+                    quickpickStub.firstCall.args[0].database,
+                    "database should be taken from the selected Object Explorer node",
+                ).to.equal("NodeDatabase");
+            });
+
+            test("Should prompt for a connection when launched from the projects view", async function (): Promise<void> {
+                const projController = new ProjectsController(testContext.outputChannel);
+                const projectsViewItem: dataworkspace.WorkspaceTreeItem = {
+                    treeDataProvider: new SqlDatabaseProjectTreeViewProvider(),
+                    element: undefined,
+                };
+
+                await projController.createProjectFromDatabase(projectsViewItem);
+
+                expect(quickpickStub.calledOnce, "quickpick should have been launched").to.be.true;
+                expect(
+                    quickpickStub.firstCall.args[0],
+                    "a projects view item carries no connection profile",
+                ).to.be.undefined;
+                expect(
+                    getDatabaseNameFromTreeNodeStub.notCalled,
+                    "database name should not be looked up for a projects view item",
+                ).to.be.true;
+            });
+        });
 
         test("Should create list of all files and folders correctly", async function (): Promise<void> {
             // dummy structure is 2 files (one .sql, one .txt) under parent folder + 2 directories with 5 .sql scripts each


### PR DESCRIPTION
Fixes #22696

**Problem**
sqlDatabaseProjects.createProjectFromDatabase is contributed to three places: the SQL Projects view title menu, the command palette, and the Object Explorer submenu. The handler assumed the argument was always an Object Explorer node:

VS Code passes the selected resource to menu commands. Once a project is selected in the SQL Projects view, the title menu passes a WorkspaceTreeItem ({ treeDataProvider, element }), which has no connectionProfile. So profile was undefined and the assignment threw Cannot set properties of undefined (setting 'database').

This is why the failure looks intermittent: with nothing selected in the view, no argument is passed and the command works. After opening or clicking a project, the selection persists and every later invocation fails.

**Fix**
Discriminate on connectionProfile rather than on the truthiness of context, and declare the real argument union. The unsound as IConnectionInfo cast is removed; the quick-pick already accepts an optional profile and prompts when one is missing.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

Before: 
<img width="679" height="67" alt="image" src="https://github.com/user-attachments/assets/fc0ccb7f-6e04-4a9f-9a0a-818b332db6a3" />

After:
<img width="1604" height="812" alt="CreateFromDbLaunchIssue" src="https://github.com/user-attachments/assets/81c06bd9-01ff-49b6-a8cd-61573cba677c" />

