### PR TITLE
Fixing issue where port appears in Azure and Fabric browse modes

### DIFF
--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -779,8 +779,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                 newlyAddedAccountId &&
                 previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)
             ) {
-                this.clearEntraAccountCache();
-
                 const accountComponent = this.getFormComponent(state, "accountId");
 
                 if (accountComponent) {
@@ -2135,8 +2133,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                         return;
                     }
 
-                    // Invalidate account and tenant caches, then reload accounts
-                    this.clearEntraAccountCache();
                     accountsComponent.loadStatus = { status: ApiStatus.Loading };
                     this.updateState();
 

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -750,6 +750,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             const newlyAddedAccountId = state.azureAccounts.find(
                 (a) => !existingAccountIds.includes(a.id),
             )?.id;
+
             if (newlyAddedAccountId && newlyAddedAccountId !== state.selectedAccountId) {
                 state.selectedAccountId = newlyAddedAccountId;
                 state.azureTenants = [];
@@ -770,6 +771,29 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
                     state.selectedTenantId,
                 );
                 await provider.autoLoadContents(state);
+            }
+
+            // If they signed in with a new account and they're using VS Code accounts for EntraMFA auth,
+            // then add it to the MFA auth account list and select it.
+            if (
+                newlyAddedAccountId &&
+                previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)
+            ) {
+                this.clearEntraAccountCache();
+
+                const accountComponent = this.getFormComponent(state, "accountId");
+
+                if (accountComponent) {
+                    accountComponent.loadStatus = { status: ApiStatus.Loading };
+                }
+
+                this.updateState(state);
+
+                await this.loadVscodeEntraDataAsync();
+
+                state.connectionProfile.accountId = newlyAddedAccountId;
+                this.updateState(state);
+                await this.handleAzureMFAEdits("accountId");
             }
 
             return state;

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/azureBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/azureBrowsePage.tsx
@@ -138,7 +138,7 @@ export const AzureBrowsePage = () => {
                                 {mainOptions
                                     .filter(
                                         // filter out inputs that are manually handled
-                                        (opt) => !["server", "database"].includes(opt),
+                                        (opt) => !["server", "port", "database"].includes(opt),
                                     )
                                     .map((inputName, idx) => {
                                         const component =

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionFormPage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionFormPage.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useContext } from "react";
-import { makeStyles } from "@fluentui/react-components";
+import { fieldClassNames, makeStyles } from "@fluentui/react-components";
 import { ConnectionDialogContext } from "./connectionDialogStateProvider";
 import { useConnectionDialogSelector } from "./connectionDialogSelector";
 import { FormField } from "../../common/forms/form.component";
@@ -14,6 +14,9 @@ import {
     ConnectionDialogWebviewState,
     IConnectionDialogProfile,
 } from "../../../sharedInterfaces/connectionDialog";
+
+const PORT_INPUT_WIDTH = "72px"; // Width of the port input box. Narrow since it only holds a port number
+const DEFAULT_PORT_PLACEHOLDER = "1433";
 
 const useStyles = makeStyles({
     serverPortRow: {
@@ -33,10 +36,13 @@ const useStyles = makeStyles({
     portField: {
         flexShrink: 0,
     },
+    portFieldLayout: {
+        [`& .${fieldClassNames.validationMessage}`]: {
+            gridColumnStart: 2,
+            width: PORT_INPUT_WIDTH,
+        },
+    },
 });
-
-const PORT_INPUT_WIDTH = "72px"; // Width of the port input box. Narrow since it only holds a port number
-const DEFAULT_PORT_PLACEHOLDER = "1433";
 
 export const ConnectionFormPage = () => {
     const styles = useStyles();
@@ -99,6 +105,7 @@ export const ConnectionFormPage = () => {
                                 </div>
                                 <div className={styles.portField}>
                                     {renderFormField(portComponent, mainOptions.length, {
+                                        fieldClassName: styles.portFieldLayout,
                                         componentProps: {
                                             placeholder: DEFAULT_PORT_PLACEHOLDER,
                                             style: {

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -810,6 +810,167 @@ suite("ConnectionDialogWebviewController Tests", () => {
             });
         });
 
+        suite("signIntoAzureForBrowse", () => {
+            setup(() => {
+                sandbox.stub(controller["_azureBrowseProvider"], "loadCollections").resolves();
+                sandbox.stub(controller["_azureBrowseProvider"], "autoLoadContents").resolves();
+                sandbox.stub(controller["_fabricBrowseProvider"], "loadCollections").resolves();
+                sandbox.stub(controller["_fabricBrowseProvider"], "autoLoadContents").resolves();
+            });
+
+            test("refreshes auth account options and selects the newly added account when the VS Code Entra MFA preview is enabled", async () => {
+                stubPreviewService(sandbox, {
+                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
+                });
+                stubVscodeAzureSignIn(sandbox);
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
+                    .resolves([mockAccounts.signedInAccount]);
+                stubVscodeAzureTenantsForAccount(sandbox);
+
+                // Restore the constructor-time stub so the reducer's call to the real
+                // implementation refreshes the auth form's account/tenant options.
+                loadVscodeEntraDataAsyncStub.restore();
+
+                controller.state.azureAccounts = [];
+                controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+
+                await controller["_reducerHandlers"].get("signIntoAzureForBrowse")(
+                    controller.state,
+                    { browseTarget: ConnectionInputMode.AzureBrowse },
+                );
+
+                const accountComponent = controller.state.formComponents["accountId"];
+                expect(
+                    accountComponent.options.some(
+                        (o) => o.value === mockAccounts.signedInAccount.id,
+                    ),
+                    "auth account options should include the newly added account",
+                ).to.be.true;
+                expect(controller.state.connectionProfile.accountId).to.equal(
+                    mockAccounts.signedInAccount.id,
+                );
+
+                const tenantComponent = controller.state.formComponents["tenantId"];
+                expect(
+                    tenantComponent.options.length,
+                    "tenant options should be populated for the newly selected account",
+                ).to.be.greaterThan(0);
+                expect(controller.state.connectionProfile.tenantId).to.equal(
+                    mockTenants[0].tenantId,
+                );
+            });
+
+            test("does not alter auth form account options or connectionProfile.accountId when the VS Code Entra MFA preview is disabled", async () => {
+                stubPreviewService(sandbox, {
+                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
+                });
+                stubVscodeAzureSignIn(sandbox);
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
+                    .resolves([mockAccounts.signedInAccount]);
+                stubVscodeAzureTenantsForAccount(sandbox);
+
+                const accountComponent = controller.state.formComponents["accountId"];
+                const originalOptions = [{ displayName: "existing", value: "existing-account-id" }];
+                accountComponent.options = originalOptions;
+                controller.state.connectionProfile.accountId = "existing-account-id";
+
+                // Reset any calls made during controller construction so we only observe
+                // calls triggered by this reducer invocation.
+                loadVscodeEntraDataAsyncStub.resetHistory();
+
+                await controller["_reducerHandlers"].get("signIntoAzureForBrowse")(
+                    controller.state,
+                    { browseTarget: ConnectionInputMode.AzureBrowse },
+                );
+
+                // Browse sign-in still succeeds and selects the browsed account...
+                expect(controller.state.selectedAccountId).to.equal(
+                    mockAccounts.signedInAccount.id,
+                );
+                // ...but the auth form's account selection/options are untouched.
+                expect(controller.state.connectionProfile.accountId).to.equal(
+                    "existing-account-id",
+                );
+                expect(accountComponent.options).to.deep.equal(originalOptions);
+                expect(loadVscodeEntraDataAsyncStub.called).to.be.false;
+            });
+
+            test("leaves the existing auth selection unchanged when no new account was added", async () => {
+                stubPreviewService(sandbox, {
+                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
+                });
+                stubVscodeAzureSignIn(sandbox);
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
+                    .resolves([mockAccounts.signedInAccount]);
+                stubVscodeAzureTenantsForAccount(sandbox);
+
+                // The account is already known before sign-in, so re-authenticating it should
+                // not be treated as a newly added account.
+                controller.state.azureAccounts = [
+                    {
+                        id: mockAccounts.signedInAccount.id,
+                        name: mockAccounts.signedInAccount.label,
+                    },
+                ];
+
+                const accountComponent = controller.state.formComponents["accountId"];
+                const originalOptions = [{ displayName: "existing", value: "existing-account-id" }];
+                accountComponent.options = originalOptions;
+                controller.state.connectionProfile.accountId = "existing-account-id";
+
+                loadVscodeEntraDataAsyncStub.resetHistory();
+
+                await controller["_reducerHandlers"].get("signIntoAzureForBrowse")(
+                    controller.state,
+                    { browseTarget: ConnectionInputMode.AzureBrowse },
+                );
+
+                expect(loadVscodeEntraDataAsyncStub.called).to.be.false;
+                expect(controller.state.connectionProfile.accountId).to.equal(
+                    "existing-account-id",
+                );
+                expect(accountComponent.options).to.deep.equal(originalOptions);
+            });
+
+            test("applies the same event-scoped auth synchronization for FabricBrowse", async () => {
+                stubPreviewService(sandbox, {
+                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
+                });
+                stubVscodeAzureSignIn(sandbox);
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
+                    .resolves([mockAccounts.signedInAccount]);
+                stubVscodeAzureTenantsForAccount(sandbox);
+
+                loadVscodeEntraDataAsyncStub.restore();
+
+                controller.state.azureAccounts = [];
+                controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
+
+                await controller["_reducerHandlers"].get("signIntoAzureForBrowse")(
+                    controller.state,
+                    { browseTarget: ConnectionInputMode.FabricBrowse },
+                );
+
+                // The event-scoped auth synchronization added by this reducer applies
+                // regardless of browseTarget, so FabricBrowse sign-in refreshes the same
+                // auth form account options as AzureBrowse sign-in.
+                const accountComponent = controller.state.formComponents["accountId"];
+                expect(
+                    accountComponent.options.some(
+                        (o) => o.value === mockAccounts.signedInAccount.id,
+                    ),
+                    "auth account options should refresh for FabricBrowse sign-in too",
+                ).to.be.true;
+                expect(controller.state.connectionProfile.accountId).to.equal(
+                    mockAccounts.signedInAccount.id,
+                );
+            });
+        });
+
         suite("toggleFavoriteCollection", () => {
             test("delegates to the Azure provider for AzureBrowse", async () => {
                 const azureToggle = sandbox


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/vscode-mssql/issues/22720

Also fixes issues where:
* after a user signs into the Browse UX with a new account, that account isn't added to the dropdown list for MFA auth
* when a validation error message for the port input is displayed, the server and port inputs are misaligned

Before:
<img width="735" height="213" alt="image" src="https://github.com/user-attachments/assets/46709460-cb52-4b34-b1e8-dfa80c91bb26" />

After:
<img width="746" height="224" alt="image" src="https://github.com/user-attachments/assets/6af7398e-38aa-4772-b5b6-8fdfc3bac0b4" />

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
