### PR TITLE
Enable beta query experiences by default

### DIFF
--- a/extensions/mssql/README.md
+++ b/extensions/mssql/README.md
@@ -216,7 +216,8 @@ Configure the MSSQL extension in user preferences (`Cmd+,`) or workspace setting
 // Query Results & Grid
 {
   "mssql.openQueryResultsInTabByDefault": false,           // Open query results in a tab instead of side panel
-  "mssql.preview.betaResultsGrid": false,                  // (Preview) Enable the new query results grid with improved state management and column show/hide/freeze options
+  "mssql.preview.betaResultsGrid": true,                   // (Preview) New results grid; set to false to use the legacy grid
+  "mssql.preview.betaExecutionPlan": true,                 // (Preview) New execution plan experience; set to false to use the legacy experience
   "mssql.resultsFontFamily": null,                         // Font family for results grid (null = VS Code default)
   "mssql.resultsFontSize": null,                           // Font size for results grid in pixels (null = VS Code default)
   "mssql.defaultQueryResultsViewMode": "Grid",             // Default results view: "Grid" or "Text"

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1809,19 +1809,13 @@
                 },
                 "mssql.preview.betaResultsGrid": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "%mssql.preview.betaResultsGrid.description%",
-                    "scope": "application"
-                },
-                "mssql.preview.betaObjectExplorerFilter": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%mssql.preview.betaObjectExplorerFilter.description%",
                     "scope": "application"
                 },
                 "mssql.preview.betaExecutionPlan": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "%mssql.preview.betaExecutionPlan.description%",
                     "scope": "application"
                 },

--- a/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
@@ -16,7 +16,7 @@ import { TreeNodeInfo } from "./nodes/treeNodeInfo";
 import { randomUUID } from "crypto";
 import { sendActionEvent } from "extension-toolkit/vscode";
 import { ObjectExplorerFilterStore } from "./objectExplorerFilterStore";
-import { PreviewFeature, previewService } from "../previews/previewService";
+import { getPreviewConfigKey, PreviewFeature } from "../previews/previewService";
 
 export class ObjectExplorerFilterWebviewController extends WebviewPanelController<
     ObjectExplorerFilterState,
@@ -149,9 +149,13 @@ export class ObjectExplorerFilter {
             treeNode.nodeType,
             treeNode.filterableProperties,
         );
-        const isPreviewEnabled = previewService.isFeatureEnabled(
-            PreviewFeature.BetaObjectExplorerFilter,
-        );
+        const isPreviewEnabled =
+            vscode.workspace
+                .getConfiguration()
+                .get<boolean>(
+                    getPreviewConfigKey(PreviewFeature.BetaObjectExplorerFilter),
+                    false,
+                ) ?? false;
         const data: ObjectExplorerFilterState = {
             filterProperties: treeNode.filterableProperties,
             existingFilters: treeNode.filters,

--- a/extensions/mssql/test/unit/executionPlanWebviewController.test.ts
+++ b/extensions/mssql/test/unit/executionPlanWebviewController.test.ts
@@ -47,7 +47,7 @@ suite("ExecutionPlanWebviewController", () => {
                 loadState: ApiStatus.Loading,
                 executionPlanGraphs: [],
                 totalCost: 0,
-                isBetaExecutionPlanEnabled: false,
+                isBetaExecutionPlanEnabled: true,
             },
         };
 
@@ -56,7 +56,7 @@ suite("ExecutionPlanWebviewController", () => {
                 executionPlanGraphs: [],
                 loadState: ApiStatus.Loaded,
                 totalCost: 100,
-                isBetaExecutionPlanEnabled: false,
+                isBetaExecutionPlanEnabled: true,
             },
         };
 
@@ -181,7 +181,7 @@ suite("ExecutionPlanWebviewController", () => {
                 executionPlanGraphs: [],
                 loadState: ApiStatus.Loaded,
                 totalCost: 100,
-                isBetaExecutionPlanEnabled: false,
+                isBetaExecutionPlanEnabled: true,
             },
         });
 

--- a/extensions/mssql/test/unit/objectExplorerFilter.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerFilter.test.ts
@@ -16,7 +16,8 @@ import {
 import { ObjectExplorerFilterStore } from "../../src/objectExplorer/objectExplorerFilterStore";
 import { TreeNodeInfo } from "../../src/objectExplorer/nodes/treeNodeInfo";
 import { stubTelemetry } from "./utils";
-import { previewService } from "../../src/previews/previewService";
+import { getPreviewConfigKey, PreviewFeature } from "../../src/previews/previewService";
+import { createWorkspaceConfiguration } from "./stubs";
 
 chai.use(sinonChai);
 
@@ -28,7 +29,9 @@ suite("ObjectExplorerFilter tests", () => {
     setup(() => {
         sandbox = sinon.createSandbox();
         stubTelemetry(sandbox);
-        sandbox.stub(previewService, "isFeatureEnabled").returns(false);
+        sandbox
+            .stub(vscode.workspace, "getConfiguration")
+            .returns(createWorkspaceConfiguration({}));
         getPresetsStub = sandbox
             .stub(ObjectExplorerFilterStore.prototype, "getPresets")
             .resolves([]);
@@ -139,7 +142,11 @@ suite("ObjectExplorerFilter tests", () => {
     });
 
     test("loads reusable filters only when the preview is enabled", async () => {
-        (previewService.isFeatureEnabled as sinon.SinonStub).returns(true);
+        (vscode.workspace.getConfiguration as sinon.SinonStub).returns(
+            createWorkspaceConfiguration({
+                [getPreviewConfigKey(PreviewFeature.BetaObjectExplorerFilter)]: true,
+            }),
+        );
         getPresetsStub.resolves([
             {
                 id: "saved-filter",
@@ -164,6 +171,28 @@ suite("ObjectExplorerFilter tests", () => {
                     presets[0]?.id === "saved-filter" &&
                     presets[0]?.isPinned === true,
             ),
+        });
+
+        submitEmitter.fire([]);
+        await filtersPromise;
+    });
+
+    test("does not enable the preview from the global experimental setting", async () => {
+        (vscode.workspace.getConfiguration as sinon.SinonStub).returns(
+            createWorkspaceConfiguration({
+                enableExperimentalFeatures: true,
+            }),
+        );
+        const { stub, submitEmitter } = createControllerStub();
+        injectController(stub);
+
+        const filtersPromise = ObjectExplorerFilter.getFilters(extensionContext, createTreeNode());
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getPresetsStub).not.to.have.been.called;
+        expect(stub.loadData).to.have.been.calledWithMatch({
+            isPreviewEnabled: false,
+            filterPresets: [],
         });
 
         submitEmitter.fire([]);


### PR DESCRIPTION
## Description

Related to #22723

- Enables the beta query results grid and beta execution plan by default while preserving their preview flags as opt-outs.
- Hides the Object Explorer beta filter setting from the VS Code Settings UI while retaining support for the dedicated flag, defaulting it to off, and keeping it independent of `mssql.enableExperimentalFeatures`.
- Updates the README defaults and unit-test expectations for the promoted query experiences.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| MSSQL preview settings | <!-- Add before screenshot --> | <!-- Add after screenshot --> |

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
