### PR TITLE
Allow user to manually add firewall on firewall connection error in Azure Db Provisioning

### DIFF
--- a/extensions/mssql/src/deployment/azureSqlDatabaseHelpers.ts
+++ b/extensions/mssql/src/deployment/azureSqlDatabaseHelpers.ts
@@ -15,7 +15,11 @@ import { getGroupIdFormItem } from "../connectionconfig/formComponentHelpers";
 import { AzureSqlDatabase, ConnectionDialog } from "../constants/locConstants";
 import { ILogger } from "../sharedInterfaces/logger";
 import * as asd from "../sharedInterfaces/azureSqlDatabase";
-import { AuthenticationType, IConnectionDialogProfile } from "../sharedInterfaces/connectionDialog";
+import {
+    AddFirewallRuleDialogProps,
+    AuthenticationType,
+    IConnectionDialogProfile,
+} from "../sharedInterfaces/connectionDialog";
 import {
     findFirstFavoriteOption,
     FormItemActionButton,
@@ -36,12 +40,16 @@ import {
     getCloudResourceEndpoint,
 } from "../azure/vscodeEntraMfaUtils";
 import { getErrorMessage } from "../utils/utils";
+import { AddFirewallRuleState } from "../sharedInterfaces/addFirewallRule";
+import { populateAzureAccountInfo } from "../controllers/addFirewallRuleWebviewController";
+import { Deferred } from "../protocol";
 
 // Cached logger reference for use in helper functions that don't have
 // direct access to the controller's protected logger.
 let cachedLogger: ILogger | undefined;
 
 const FIREWALL_ERROR_CODE = 40615;
+const pendingFirewallRulePrompts = new WeakMap<DeploymentWebviewController, Deferred<boolean>>();
 
 function clearCacheDownstream(state: asd.AzureSqlDatabaseState, fromComponent: string): void {
     const order = asd.AZURE_SQL_DB_COMPONENT_ORDER as readonly string[];
@@ -402,6 +410,98 @@ export function registerAzureSqlDatabaseReducers(
         },
     );
 
+    deploymentController.registerReducer("openFirewallRuleDialog", async (state) => {
+        const azureSqlState = state.deploymentTypeState as asd.AzureSqlDatabaseState;
+        const errorMessage = azureSqlState.firewallErrorMessage || azureSqlState.errorMessage || "";
+
+        void promptForFirewallRule(deploymentController, azureSqlState, errorMessage)
+            .then((ruleCreated) => {
+                if (ruleCreated) {
+                    void connectToAzureSqlDatabase(deploymentController, true);
+                }
+            })
+            .catch((error) => {
+                cachedLogger?.error(
+                    `Failed to open the firewall rule dialog: ${getErrorMessage(error)}`,
+                );
+                surfaceConnectionError(deploymentController, azureSqlState, errorMessage, true);
+            });
+
+        return state;
+    });
+
+    deploymentController.registerReducer("closeFirewallRuleDialog", async (state) => {
+        const azureSqlState = state.deploymentTypeState as asd.AzureSqlDatabaseState;
+        closeFirewallRuleDialog(deploymentController, azureSqlState, false);
+        state.dialog = undefined;
+        state.deploymentTypeState = azureSqlState;
+        return state;
+    });
+
+    deploymentController.registerReducer("addAzureSqlFirewallRule", async (state, payload) => {
+        const azureSqlState = state.deploymentTypeState as asd.AzureSqlDatabaseState;
+        const dialog = azureSqlState.dialog as AddFirewallRuleDialogProps;
+        dialog.props.addFirewallRuleStatus = ApiStatus.Loading;
+        updateAzureSqlDatabaseState(deploymentController, azureSqlState);
+
+        try {
+            const subscription = getCachedSubscription(
+                azureSqlState,
+                azureSqlState.formState.subscriptionId,
+            );
+            if (!subscription) {
+                throw new Error(AzureSqlDatabase.noSubscriptionsFound);
+            }
+
+            const [startIp, endIp] =
+                typeof payload.firewallRuleSpec.ip === "string"
+                    ? [payload.firewallRuleSpec.ip, payload.firewallRuleSpec.ip]
+                    : [payload.firewallRuleSpec.ip.startIp, payload.firewallRuleSpec.ip.endIp];
+
+            await VsCodeAzureHelper.createFirewallRule(
+                subscription,
+                azureSqlState.formState.resourceGroup,
+                azureSqlState.formState.serverName,
+                payload.firewallRuleSpec.name,
+                startIp,
+                endIp,
+            );
+            azureSqlState.canAddFirewallRule = false;
+            closeFirewallRuleDialog(deploymentController, azureSqlState, true);
+            state.dialog = undefined;
+            sendActionEvent(TelemetryViews.AzureSqlDatabase, TelemetryActions.AddFirewallRule);
+        } catch (error) {
+            dialog.props.message = getErrorMessage(error);
+            dialog.props.addFirewallRuleStatus = ApiStatus.Error;
+            sendErrorEvent(
+                TelemetryViews.AzureSqlDatabase,
+                TelemetryActions.AddFirewallRule,
+                error as Error,
+                false,
+            );
+        }
+
+        state.deploymentTypeState = azureSqlState;
+        return state;
+    });
+
+    deploymentController.registerReducer("signIntoAzureForFirewallRule", async (state) => {
+        const azureSqlState = state.deploymentTypeState as asd.AzureSqlDatabaseState;
+        if (azureSqlState.dialog?.type !== "addFirewallRule") {
+            return state;
+        }
+
+        const dialogState = (azureSqlState.dialog as AddFirewallRuleDialogProps).props;
+        dialogState.loadingAccounts = true;
+        updateAzureSqlDatabaseState(deploymentController, azureSqlState);
+        try {
+            await populateAzureAccountInfo(dialogState, true);
+        } finally {
+            dialogState.loadingAccounts = false;
+        }
+        return state;
+    });
+
     deploymentController.registerReducer(
         "setCreateResourceGroupDrawerState",
         async (state, payload) => {
@@ -701,12 +801,115 @@ export function sendAzureSqlDatabaseCloseEventTelemetry(state: asd.AzureSqlDatab
     );
 }
 
+async function promptForFirewallRule(
+    deploymentController: DeploymentWebviewController,
+    state: asd.AzureSqlDatabaseState,
+    errorMessage: string,
+): Promise<boolean> {
+    const pendingPrompt = pendingFirewallRulePrompts.get(deploymentController);
+    if (pendingPrompt) {
+        return pendingPrompt.promise;
+    }
+
+    const prompt = new Deferred<boolean>();
+    pendingFirewallRulePrompts.set(deploymentController, prompt);
+
+    try {
+        const handleResult =
+            await deploymentController.mainController.connectionManager.firewallService.handleFirewallRule(
+                FIREWALL_ERROR_CODE,
+                errorMessage,
+            );
+        if (!handleResult.result || !handleResult.ipAddress) {
+            sendErrorEvent(
+                TelemetryViews.AzureSqlDatabase,
+                TelemetryActions.AddFirewallRule,
+                new Error(errorMessage),
+                true,
+                undefined,
+                "parseIP",
+            );
+        }
+
+        const dialogState: AddFirewallRuleState = {
+            message: errorMessage,
+            clientIp:
+                handleResult.result && handleResult.ipAddress ? handleResult.ipAddress : "0.0.0.0",
+            accounts: [],
+            tenants: {},
+            isSignedIn: await VsCodeAzureHelper.isSignedIn(),
+            loadingAccounts: false,
+            serverName: state.formState.serverName,
+            addFirewallRuleStatus: ApiStatus.NotStarted,
+        };
+
+        if (dialogState.isSignedIn) {
+            await populateAzureAccountInfo(dialogState, false);
+        }
+
+        state.dialog = {
+            type: "addFirewallRule",
+            props: dialogState,
+        } as AddFirewallRuleDialogProps;
+        state.firewallErrorMessage = errorMessage;
+        deploymentController.state.dialog = state.dialog;
+        updateAzureSqlDatabaseState(deploymentController, state);
+    } catch (error) {
+        pendingFirewallRulePrompts.delete(deploymentController);
+        prompt.reject(error);
+    }
+
+    return prompt.promise;
+}
+
+function closeFirewallRuleDialog(
+    deploymentController: DeploymentWebviewController,
+    state: asd.AzureSqlDatabaseState,
+    ruleCreated: boolean,
+): void {
+    if (!ruleCreated && state.firewallErrorMessage) {
+        state.connectionLoadState = ApiStatus.Error;
+        state.errorMessage = state.firewallErrorMessage;
+        state.canAddFirewallRule = true;
+    }
+    state.dialog = undefined;
+    deploymentController.state.dialog = undefined;
+    const prompt = pendingFirewallRulePrompts.get(deploymentController);
+    if (prompt) {
+        pendingFirewallRulePrompts.delete(deploymentController);
+        prompt.resolve(ruleCreated);
+    }
+}
+
+function surfaceConnectionError(
+    deploymentController: DeploymentWebviewController,
+    state: asd.AzureSqlDatabaseState,
+    errorMessage: string,
+    canAddFirewallRule: boolean,
+): void {
+    state.connectionLoadState = ApiStatus.Error;
+    state.errorMessage = errorMessage;
+    state.canAddFirewallRule = canAddFirewallRule;
+    state.firewallErrorMessage = canAddFirewallRule ? errorMessage : "";
+    sendErrorEvent(
+        TelemetryViews.AzureSqlDatabase,
+        TelemetryActions.ConnectToAzureSqlDatabase,
+        new Error(AzureSqlDatabase.connectionFailed),
+        false,
+    );
+    updateAzureSqlDatabaseState(deploymentController, state);
+}
+
 export async function connectToAzureSqlDatabase(
     deploymentController: DeploymentWebviewController,
+    firewallRuleAlreadyCreated = false,
 ): Promise<void> {
     const state = deploymentController.state.deploymentTypeState as asd.AzureSqlDatabaseState;
     const startTime = Date.now();
     state.connectionLoadState = ApiStatus.Loading;
+    state.canAddFirewallRule = false;
+    state.firewallErrorMessage = "";
+    state.errorMessage = undefined;
     updateAzureSqlDatabaseState(deploymentController, state);
 
     try {
@@ -757,7 +960,7 @@ export async function connectToAzureSqlDatabase(
         const retryDelayMs = 30_000;
         const connManager = deploymentController.mainController.connectionManager;
         const tempUri = `${state.formState.serverName}/${state.formState.databaseName}`;
-        let firewallRuleCreated = false;
+        let firewallRuleCreated = firewallRuleAlreadyCreated;
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             const success = await connManager.connect(
@@ -776,17 +979,35 @@ export async function connectToAzureSqlDatabase(
             const connInfo = connManager.getConnectionInfo(tempUri);
             const isFirewallError = connInfo?.errorNumber === FIREWALL_ERROR_CODE;
 
-            if (!isFirewallError || attempt === maxRetries) {
+            if (attempt === maxRetries && isFirewallError) {
+                const firewallErrorMessage =
+                    connInfo?.errorMessage || AzureSqlDatabase.connectionFailed;
+                surfaceConnectionError(deploymentController, state, firewallErrorMessage, true);
+                const ruleCreated = await promptForFirewallRule(
+                    deploymentController,
+                    state,
+                    firewallErrorMessage,
+                );
+
+                if (!ruleCreated) {
+                    return;
+                }
+
+                state.connectionLoadState = ApiStatus.Loading;
+                state.errorMessage = undefined;
+                state.canAddFirewallRule = false;
+                state.firewallErrorMessage = "";
+                updateAzureSqlDatabaseState(deploymentController, state);
+                attempt = 0;
+                firewallRuleCreated = true;
+            } else if (!isFirewallError) {
                 // Non-firewall error or exhausted retries — report failure
-                state.connectionLoadState = ApiStatus.Error;
-                state.errorMessage = connInfo?.errorMessage || AzureSqlDatabase.connectionFailed;
-                sendErrorEvent(
-                    TelemetryViews.AzureSqlDatabase,
-                    TelemetryActions.ConnectToAzureSqlDatabase,
-                    new Error(AzureSqlDatabase.connectionFailed),
+                surfaceConnectionError(
+                    deploymentController,
+                    state,
+                    connInfo?.errorMessage || AzureSqlDatabase.connectionFailed,
                     false,
                 );
-                updateAzureSqlDatabaseState(deploymentController, state);
                 return;
             }
 

--- a/extensions/mssql/src/sharedInterfaces/azureSqlDatabase.ts
+++ b/extensions/mssql/src/sharedInterfaces/azureSqlDatabase.ts
@@ -6,6 +6,7 @@
 import { ApiStatus } from "./webview";
 import { FormContextProps, FormItemSpec, FormReducers, FormState } from "./form";
 import { IDialogProps } from "./connectionDialog";
+import { FirewallRuleSpec } from "./firewallRule";
 import { KnownFreeLimitExhaustionBehavior, KnownSampleName, Server } from "@azure/arm-sql";
 import { AzureSubscription, AzureTenant } from "@microsoft/vscode-azext-azureauth";
 
@@ -51,6 +52,8 @@ export class AzureSqlDatabaseState
     provisionLoadState: ApiStatus = ApiStatus.NotStarted;
     deploymentStartTime: string = "";
     connectionLoadState: ApiStatus = ApiStatus.NotStarted;
+    canAddFirewallRule: boolean = false;
+    firewallErrorMessage: string = "";
     /** True when the server was just created via the drawer with SQL auth credentials already provided */
     serverCreatedWithAuth: boolean = false;
     azureComponentStatuses: Record<string, ApiStatus> = {
@@ -151,6 +154,10 @@ export interface AzureSqlDatabaseContextProps extends FormContextProps<AzureSqlD
     submitCreateResourceGroup(spec: CreateResourceGroupSpec): void;
     setCreateServerDrawerState(shouldOpen: boolean): void;
     submitCreateServer(spec: CreateServerSpec): void;
+    openFirewallRuleDialog(): void;
+    closeFirewallRuleDialog(): void;
+    addFirewallRule(firewallRuleSpec: FirewallRuleSpec): void;
+    signIntoAzureForFirewallRule(): void;
 }
 
 export interface AzureSqlDatabaseReducers extends FormReducers<AzureSqlDatabaseFormState> {
@@ -160,4 +167,8 @@ export interface AzureSqlDatabaseReducers extends FormReducers<AzureSqlDatabaseF
     submitCreateResourceGroup: { spec: CreateResourceGroupSpec };
     setCreateServerDrawerState: { shouldOpen: boolean };
     submitCreateServer: { spec: CreateServerSpec };
+    openFirewallRuleDialog: {};
+    closeFirewallRuleDialog: {};
+    addAzureSqlFirewallRule: { firewallRuleSpec: FirewallRuleSpec };
+    signIntoAzureForFirewallRule: {};
 }

--- a/extensions/mssql/src/webviews/pages/Deployment/AzureSqlDatabase/azureSqlDatabaseDeploymentWizard.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/AzureSqlDatabase/azureSqlDatabaseDeploymentWizard.tsx
@@ -92,6 +92,9 @@ export const AzureSqlDatabaseDeploymentWizard: React.FC<AzureSqlDatabaseDeployme
     );
     const provisionLoadState = useAzureSqlDatabaseDeploymentSelector((s) => s.provisionLoadState);
     const connectionLoadState = useAzureSqlDatabaseDeploymentSelector((s) => s.connectionLoadState);
+    const firewallErrorMessage = useAzureSqlDatabaseDeploymentSelector(
+        (s) => s.firewallErrorMessage,
+    );
     const serverCreatedWithAuth = useAzureSqlDatabaseDeploymentSelector(
         (s) => s.serverCreatedWithAuth,
     );
@@ -113,7 +116,9 @@ export const AzureSqlDatabaseDeploymentWizard: React.FC<AzureSqlDatabaseDeployme
     );
 
     const hasProvisioningError =
-        provisionLoadState === ApiStatus.Error || connectionLoadState === ApiStatus.Error;
+        provisionLoadState === ApiStatus.Error ||
+        connectionLoadState === ApiStatus.Error ||
+        !!firewallErrorMessage;
     const isStateReady = !!formState && !!formComponents && "accountId" in formComponents;
     const isFormValid = isAzureSqlFormValid(
         loadState,
@@ -168,7 +173,7 @@ export const AzureSqlDatabaseDeploymentWizard: React.FC<AzureSqlDatabaseDeployme
             title: locConstants.azureSqlDatabase.provisioning,
             render: () => <AzureSqlDatabaseProvisioningPage />,
             canGoBack: () => hasProvisioningError,
-            canGoNext: () => connectionLoadState === ApiStatus.Loaded,
+            canGoNext: () => connectionLoadState === ApiStatus.Loaded && !firewallErrorMessage,
             showCancel: () => hasProvisioningError,
             onPrevious: () => {
                 // Reset validation so the user can re-submit

--- a/extensions/mssql/src/webviews/pages/Deployment/AzureSqlDatabase/azureSqlDatabaseProvisioningPage.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/AzureSqlDatabase/azureSqlDatabaseProvisioningPage.tsx
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useContext, useMemo } from "react";
-import { makeStyles, tokens } from "@fluentui/react-components";
+import { Button, makeStyles, tokens } from "@fluentui/react-components";
+import { AddRegular } from "@fluentui/react-icons";
 import { ApiStatus } from "../../../../sharedInterfaces/webview";
 import { locConstants } from "../../../common/locConstants";
 import { useAzureSqlDatabaseDeploymentSelector } from "../deploymentSelector";
@@ -19,6 +20,8 @@ import {
     generateAzureSqlDatabaseBicep,
     generateAzureSqlDatabaseTerraform,
 } from "../deploymentScripts";
+import { AddFirewallRuleDialogProps } from "../../../../sharedInterfaces/connectionDialog";
+import { AddFirewallRuleDialog } from "../../AddFirewallRule/addFirewallRule.component";
 
 const useStyles = makeStyles({
     outerDiv: {
@@ -58,6 +61,7 @@ const useStyles = makeStyles({
         padding: "20px",
         width: "100%",
         minWidth: 0,
+        boxSizing: "border-box",
     },
     cardDiv: {
         width: "100%",
@@ -70,10 +74,14 @@ const useStyles = makeStyles({
         whiteSpace: "nowrap",
     },
     cardItemError: {
+        display: "block",
+        width: "100%",
+        minWidth: 0,
+        maxWidth: "100%",
         fontSize: "14px",
         padding: "10px 0",
         whiteSpace: "normal",
-        overflowWrap: "break-word",
+        overflowWrap: "anywhere",
         wordBreak: "break-word",
     },
     cardItemLabel: {
@@ -83,6 +91,9 @@ const useStyles = makeStyles({
     cardBody: {
         padding: "0",
     },
+    addFirewallRuleButton: {
+        alignSelf: "flex-start",
+    },
 });
 
 export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
@@ -91,6 +102,9 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
     const provisionLoadState = useAzureSqlDatabaseDeploymentSelector((s) => s.provisionLoadState);
     const connectionLoadState = useAzureSqlDatabaseDeploymentSelector((s) => s.connectionLoadState);
     const errorMessage = useAzureSqlDatabaseDeploymentSelector((s) => s.errorMessage);
+    const firewallErrorMessage = useAzureSqlDatabaseDeploymentSelector(
+        (s) => s.firewallErrorMessage,
+    );
     const databaseName = useAzureSqlDatabaseDeploymentSelector((s) => s.formState?.databaseName);
     const deploymentStartTime = useAzureSqlDatabaseDeploymentSelector((s) => s.deploymentStartTime);
     const subscriptionName = useAzureSqlDatabaseDeploymentSelector((s) => s.subscriptionName);
@@ -103,6 +117,8 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
     const maxVcores = useAzureSqlDatabaseDeploymentSelector((s) => s.formState?.maxVcores);
     const serverRegion = useAzureSqlDatabaseDeploymentSelector((s) => s.serverRegion);
     const connectionString = useAzureSqlDatabaseDeploymentSelector((s) => s.connectionString);
+    const dialog = useAzureSqlDatabaseDeploymentSelector((s) => s.dialog);
+    const canAddFirewallRule = useAzureSqlDatabaseDeploymentSelector((s) => s.canAddFirewallRule);
 
     const scriptBaseName = (databaseName || "database").replace(/[^a-zA-Z0-9-_]/g, "_");
     const scripts = useMemo<PostDeploymentScript[]>(() => {
@@ -148,6 +164,12 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
 
     if (!provisionLoadState) return undefined;
 
+    const connectionErrorMessage =
+        connectionLoadState === ApiStatus.Error || firewallErrorMessage
+            ? errorMessage || firewallErrorMessage
+            : undefined;
+    const hasConnectionError = !!connectionErrorMessage;
+
     const deploymentSucceeded = provisionLoadState === ApiStatus.Loaded;
 
     const stepStatus =
@@ -160,7 +182,7 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
         if (provisionLoadState !== ApiStatus.Loaded) {
             return `${locConstants.azureSqlDatabase.deploymentInProgress}...`;
         }
-        if (connectionLoadState === ApiStatus.Error) {
+        if (hasConnectionError) {
             return locConstants.azureSqlDatabase.connectionFailed;
         }
         if (connectionLoadState !== ApiStatus.Loaded) {
@@ -171,6 +193,15 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
 
     return (
         <div className={classes.outerDiv}>
+            {context && dialog?.type === "addFirewallRule" && (
+                <AddFirewallRuleDialog
+                    mode="modal"
+                    state={(dialog as AddFirewallRuleDialogProps).props}
+                    addFirewallRule={context.addFirewallRule}
+                    closeDialog={context.closeFirewallRuleDialog}
+                    signIntoAzure={context.signIntoAzureForFirewallRule}
+                />
+            )}
             <div className={classes.innerDiv}>
                 <div className={classes.contentHeader}>
                     {locConstants.azureSqlDatabase.provisioning} {databaseName}
@@ -181,14 +212,23 @@ export const AzureSqlDatabaseProvisioningPage: React.FC = () => {
                     className={classes.cardDiv}
                     bodyClassName={classes.cardBody}>
                     <div className={classes.cardContentDiv}>
-                        {errorMessage ? (
+                        {errorMessage || connectionErrorMessage ? (
                             <div className={classes.cardColumn} style={{ paddingRight: "20px" }}>
                                 <span className={classes.cardItemError}>
                                     <span className={classes.cardItemLabel}>
                                         {locConstants.common.error}:
                                     </span>
-                                    {errorMessage}
+                                    {errorMessage || connectionErrorMessage}
                                 </span>
+                                {canAddFirewallRule && (
+                                    <Button
+                                        appearance="secondary"
+                                        className={classes.addFirewallRuleButton}
+                                        icon={<AddRegular />}
+                                        onClick={() => context?.openFirewallRuleDialog()}>
+                                        {locConstants.firewallRules.addFirewallRule}
+                                    </Button>
+                                )}
                             </div>
                         ) : (
                             <>

--- a/extensions/mssql/src/webviews/pages/Deployment/deploymentStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/Deployment/deploymentStateProvider.tsx
@@ -140,6 +140,18 @@ const DeploymentStateProvider: React.FC<DeploymentProviderProps> = ({ children }
                     spec: spec,
                 });
             },
+            openFirewallRuleDialog: function (): void {
+                extensionRpc.action("openFirewallRuleDialog", {});
+            },
+            closeFirewallRuleDialog: function (): void {
+                extensionRpc.action("closeFirewallRuleDialog", {});
+            },
+            addFirewallRule: function (firewallRuleSpec): void {
+                extensionRpc.action("addAzureSqlFirewallRule", { firewallRuleSpec });
+            },
+            signIntoAzureForFirewallRule: function (): void {
+                extensionRpc.action("signIntoAzureForFirewallRule", {});
+            },
             //#endregion
         }),
         [extensionRpc, formAction],

--- a/extensions/mssql/test/unit/azureSqlDatabaseHelpers.test.ts
+++ b/extensions/mssql/test/unit/azureSqlDatabaseHelpers.test.ts
@@ -1,0 +1,407 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureSubscription } from "@microsoft/vscode-azext-azureauth";
+import { KnownFreeLimitExhaustionBehavior } from "@azure/arm-sql";
+import { expect } from "chai";
+import * as chai from "chai";
+import * as sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { VsCodeAzureHelper } from "../../src/connectionconfig/azureHelpers";
+import {
+    AddFirewallRuleDialogProps,
+    AuthenticationType,
+} from "../../src/sharedInterfaces/connectionDialog";
+import {
+    AzureSqlDatabaseFormItemSpec,
+    AzureSqlDatabaseReducers,
+    AzureSqlDatabaseState,
+} from "../../src/sharedInterfaces/azureSqlDatabase";
+import { DeploymentWebviewState } from "../../src/sharedInterfaces/deployment";
+import { ApiStatus } from "../../src/sharedInterfaces/webview";
+import { DeploymentWebviewController } from "../../src/deployment/deploymentWebviewController";
+import { registerAzureSqlDatabaseReducers } from "../../src/deployment/azureSqlDatabaseHelpers";
+import { stubTelemetry } from "./utils";
+
+chai.use(sinonChai);
+
+suite("Azure SQL Database reducers", () => {
+    let sandbox: sinon.SinonSandbox;
+    let controller: sinon.SinonStubbedInstance<DeploymentWebviewController>;
+    let controllerState: DeploymentWebviewState;
+    let azureSqlState: AzureSqlDatabaseState;
+    let reducers: Map<
+        keyof AzureSqlDatabaseReducers,
+        (state: DeploymentWebviewState, payload: any) => Promise<DeploymentWebviewState>
+    >;
+    let subscription: AzureSubscription;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        stubTelemetry(sandbox);
+        subscription = {
+            name: "Test Subscription",
+            subscriptionId: "subscription-id",
+        } as AzureSubscription;
+        azureSqlState = new AzureSqlDatabaseState({
+            formState: {
+                accountId: "account-id",
+                tenantId: "tenant-id",
+                subscriptionId: subscription.subscriptionId,
+                resourceGroup: "resource-group",
+                serverName: "server-name",
+                databaseName: "database-name",
+                authenticationType: AuthenticationType.SqlLogin,
+                userName: "admin",
+                password: "password",
+                savePassword: true,
+                freeLimitBehavior: KnownFreeLimitExhaustionBehavior.AutoPause,
+                profileName: "",
+                groupId: "",
+                dataSource: "",
+                collation: "SQL_Latin1_General_CP1_CI_AS",
+                maintenanceConfig: "",
+                enableAlwaysEncrypted: false,
+                maxVcores: "2",
+            },
+            subscriptions: [subscription],
+        });
+        controllerState = new DeploymentWebviewState();
+        controllerState.deploymentTypeState = azureSqlState;
+
+        reducers = new Map();
+        controller = sandbox.createStubInstance(DeploymentWebviewController);
+        sandbox.stub(controller, "state").value(controllerState);
+        controller.registerReducer.callsFake((name, reducer) => {
+            reducers.set(
+                name as keyof AzureSqlDatabaseReducers,
+                reducer as (
+                    state: DeploymentWebviewState,
+                    payload: any,
+                ) => Promise<DeploymentWebviewState>,
+            );
+        });
+        registerAzureSqlDatabaseReducers(controller);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function getReducer(name: keyof AzureSqlDatabaseReducers) {
+        const reducer = reducers.get(name);
+        expect(reducer, `${name} reducer should be registered`).to.exist;
+        return reducer!;
+    }
+
+    test("loadAzureComponent ignores components that have already started loading", async () => {
+        azureSqlState.azureComponentStatuses.tenantId = ApiStatus.Loading;
+
+        const result = await getReducer("loadAzureComponent")(controllerState, {
+            componentName: "tenantId",
+        });
+
+        expect(result).to.equal(controllerState);
+        expect(azureSqlState.azureComponentStatuses.tenantId).to.equal(ApiStatus.Loading);
+    });
+
+    test("loadAzureComponent propagates component errors downstream", async () => {
+        azureSqlState.formState.accountId = "";
+        azureSqlState.formComponents.tenantId = {} as AzureSqlDatabaseFormItemSpec;
+
+        await getReducer("loadAzureComponent")(controllerState, {
+            componentName: "tenantId",
+        });
+
+        expect(azureSqlState.azureComponentStatuses.tenantId).to.equal(ApiStatus.Error);
+        expect(azureSqlState.azureComponentStatuses.subscriptionId).to.equal(ApiStatus.Error);
+        expect(azureSqlState.azureComponentStatuses.resourceGroup).to.equal(ApiStatus.Error);
+        expect(azureSqlState.azureComponentStatuses.serverName).to.equal(ApiStatus.Error);
+    });
+
+    test("startAzureSqlDatabaseDeployment stops when validation fails", async () => {
+        controller.validateDeploymentForm.resolves(["databaseName"]);
+
+        await getReducer("startAzureSqlDatabaseDeployment")(controllerState, { tags: {} });
+
+        expect(azureSqlState.formErrors).to.deep.equal(["databaseName"]);
+        expect(azureSqlState.formValidationLoadState).to.equal(ApiStatus.NotStarted);
+        expect(azureSqlState.provisionLoadState).to.equal(ApiStatus.NotStarted);
+    });
+
+    test("openFirewallRuleDialog surfaces the firewall dialog", async () => {
+        const handleFirewallRule = sandbox.stub().resolves({ result: true, ipAddress: "10.0.0.1" });
+        sandbox.stub(VsCodeAzureHelper, "isSignedIn").resolves(false);
+        controller.mainController = {
+            connectionManager: {
+                firewallService: { handleFirewallRule },
+            },
+        } as any;
+        azureSqlState.errorMessage = "Firewall access required";
+
+        await getReducer("openFirewallRuleDialog")(controllerState, {});
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(handleFirewallRule).to.have.been.calledWith(40615, "Firewall access required");
+        expect(azureSqlState.dialog?.type).to.equal("addFirewallRule");
+        expect(controllerState.dialog).to.equal(azureSqlState.dialog);
+
+        await getReducer("closeFirewallRuleDialog")(controllerState, {});
+    });
+
+    test("closeFirewallRuleDialog restores the connection error", async () => {
+        azureSqlState.dialog = {
+            type: "addFirewallRule",
+            props: {},
+        } as any;
+        controllerState.dialog = azureSqlState.dialog;
+        azureSqlState.firewallErrorMessage = "Firewall access required";
+
+        await getReducer("closeFirewallRuleDialog")(controllerState, {});
+
+        expect(azureSqlState.dialog).to.be.undefined;
+        expect(controllerState.dialog).to.be.undefined;
+        expect(azureSqlState.connectionLoadState).to.equal(ApiStatus.Error);
+        expect(azureSqlState.errorMessage).to.equal("Firewall access required");
+        expect(azureSqlState.canAddFirewallRule).to.be.true;
+    });
+
+    test("addAzureSqlFirewallRule creates a rule and closes the dialog", async () => {
+        const createFirewallRule = sandbox.stub(VsCodeAzureHelper, "createFirewallRule").resolves();
+        azureSqlState.dialog = {
+            type: "addFirewallRule",
+            props: { addFirewallRuleStatus: ApiStatus.NotStarted },
+        } as any;
+
+        await getReducer("addAzureSqlFirewallRule")(controllerState, {
+            firewallRuleSpec: {
+                name: "AllowClient",
+                ip: { startIp: "10.0.0.1", endIp: "10.0.0.2" },
+            },
+        });
+
+        expect(createFirewallRule).to.have.been.calledWith(
+            subscription,
+            "resource-group",
+            "server-name",
+            "AllowClient",
+            "10.0.0.1",
+            "10.0.0.2",
+        );
+        expect(azureSqlState.dialog).to.be.undefined;
+        expect(azureSqlState.canAddFirewallRule).to.be.false;
+    });
+
+    test("addAzureSqlFirewallRule retains the dialog when creation fails", async () => {
+        sandbox.stub(VsCodeAzureHelper, "createFirewallRule").rejects(new Error("Creation failed"));
+        azureSqlState.dialog = {
+            type: "addFirewallRule",
+            props: { addFirewallRuleStatus: ApiStatus.NotStarted },
+        } as any;
+
+        await getReducer("addAzureSqlFirewallRule")(controllerState, {
+            firewallRuleSpec: { name: "AllowClient", ip: "10.0.0.1" },
+        });
+
+        const dialog = azureSqlState.dialog as AddFirewallRuleDialogProps;
+        expect(dialog.props.addFirewallRuleStatus).to.equal(ApiStatus.Error);
+        expect(dialog.props.message).to.equal("Creation failed");
+    });
+
+    test("signIntoAzureForFirewallRule ignores unrelated dialogs", async () => {
+        azureSqlState.dialog = undefined;
+
+        const result = await getReducer("signIntoAzureForFirewallRule")(controllerState, {});
+
+        expect(result).to.equal(controllerState);
+        expect(controller.updateState).not.to.have.been.called;
+    });
+
+    test("setCreateResourceGroupDrawerState loads locations when opening", async () => {
+        const locations = [{ name: "eastus", displayName: "East US" }];
+        sandbox.stub(VsCodeAzureHelper, "getLocationsForSubscription").resolves(locations);
+        azureSqlState.createServerDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("setCreateResourceGroupDrawerState")(controllerState, {
+            shouldOpen: true,
+        });
+
+        expect(azureSqlState.createServerDrawerState).to.be.undefined;
+        expect(azureSqlState.createResourceGroupDrawerState).to.deep.equal({
+            locationOptions: locations,
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        });
+    });
+
+    test("setCreateResourceGroupDrawerState closes the drawer", async () => {
+        azureSqlState.createResourceGroupDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("setCreateResourceGroupDrawerState")(controllerState, {
+            shouldOpen: false,
+        });
+
+        expect(azureSqlState.createResourceGroupDrawerState).to.be.undefined;
+    });
+
+    test("submitCreateResourceGroup selects the created resource group", async () => {
+        const createResourceGroup = sandbox
+            .stub(VsCodeAzureHelper, "createResourceGroup")
+            .resolves();
+        azureSqlState.formState.serverName = "old-server";
+        azureSqlState.createResourceGroupDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("submitCreateResourceGroup")(controllerState, {
+            spec: {
+                resourceGroupName: "new-resource-group",
+                location: "eastus",
+                tags: { environment: "test" },
+            },
+        });
+
+        expect(createResourceGroup).to.have.been.calledWith(
+            subscription,
+            "new-resource-group",
+            "eastus",
+            { environment: "test" },
+        );
+        expect(azureSqlState.formState.resourceGroup).to.equal("new-resource-group");
+        expect(azureSqlState.formState.serverName).to.equal("");
+        expect(azureSqlState.azureComponentStatuses.resourceGroup).to.equal(ApiStatus.NotStarted);
+        expect(azureSqlState.azureComponentStatuses.serverName).to.equal(ApiStatus.NotStarted);
+        expect(azureSqlState.createResourceGroupDrawerState).to.be.undefined;
+    });
+
+    test("submitCreateResourceGroup leaves the drawer open after an error", async () => {
+        sandbox
+            .stub(VsCodeAzureHelper, "createResourceGroup")
+            .rejects(new Error("Creation failed"));
+        azureSqlState.createResourceGroupDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("submitCreateResourceGroup")(controllerState, {
+            spec: { resourceGroupName: "new-resource-group", location: "eastus" },
+        });
+
+        expect(azureSqlState.createResourceGroupDrawerState.createLoadState).to.equal(
+            ApiStatus.Error,
+        );
+        expect(azureSqlState.createResourceGroupDrawerState.message).to.equal("Creation failed");
+    });
+
+    test("setCreateServerDrawerState loads locations and the resource group default", async () => {
+        const locations = [{ name: "eastus", displayName: "East US" }];
+        sandbox.stub(VsCodeAzureHelper, "getLocationsForSubscription").resolves(locations);
+        sandbox.stub(VsCodeAzureHelper, "getDefaultLocationForResourceGroup").resolves("eastus");
+        azureSqlState.createResourceGroupDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("setCreateServerDrawerState")(controllerState, { shouldOpen: true });
+
+        expect(azureSqlState.createResourceGroupDrawerState).to.be.undefined;
+        expect(azureSqlState.createServerDrawerState).to.deep.equal({
+            locationOptions: locations,
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+            defaultLocation: "eastus",
+        });
+    });
+
+    test("setCreateServerDrawerState closes the drawer", async () => {
+        azureSqlState.createServerDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("setCreateServerDrawerState")(controllerState, { shouldOpen: false });
+
+        expect(azureSqlState.createServerDrawerState).to.be.undefined;
+    });
+
+    test("submitCreateServer selects the server and preserves SQL credentials", async () => {
+        sandbox.stub(VsCodeAzureHelper, "getAccountObjectId").resolves("account-object-id");
+        const createSqlServer = sandbox.stub(VsCodeAzureHelper, "createSqlServer").resolves();
+        azureSqlState.accounts = [{ id: "account-id", label: "Test User" }];
+        azureSqlState.createServerDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("submitCreateServer")(controllerState, {
+            spec: {
+                serverName: "new-server",
+                location: "eastus",
+                authenticationType: AuthenticationType.AzureMFAAndUser,
+                adminLogin: "sql-admin",
+                adminPassword: "secret",
+                savePassword: true,
+            },
+        });
+
+        expect(createSqlServer).to.have.been.calledWith(
+            subscription,
+            "resource-group",
+            "new-server",
+            "eastus",
+            sinon.match({
+                authenticationType: AuthenticationType.AzureMFAAndUser,
+                adminLogin: "sql-admin",
+                adminPassword: "secret",
+                entraAdmin: sinon.match({
+                    login: "Test User",
+                    sid: "account-object-id",
+                    tenantId: "tenant-id",
+                }),
+            }),
+        );
+        expect(azureSqlState.formState.serverName).to.equal("new-server");
+        expect(azureSqlState.formState.userName).to.equal("sql-admin");
+        expect(azureSqlState.formState.password).to.equal("secret");
+        expect(azureSqlState.formState.savePassword).to.be.true;
+        expect(azureSqlState.serverCreatedWithAuth).to.be.true;
+        expect(azureSqlState.createServerDrawerState).to.be.undefined;
+    });
+
+    test("submitCreateServer leaves the drawer open after an error", async () => {
+        sandbox.stub(VsCodeAzureHelper, "getAccountObjectId").resolves(undefined);
+        sandbox.stub(VsCodeAzureHelper, "createSqlServer").rejects(new Error("Creation failed"));
+        azureSqlState.createServerDrawerState = {
+            locationOptions: [],
+            locationsLoadState: ApiStatus.Loaded,
+            createLoadState: ApiStatus.NotStarted,
+        };
+
+        await getReducer("submitCreateServer")(controllerState, {
+            spec: {
+                serverName: "new-server",
+                location: "eastus",
+                authenticationType: AuthenticationType.AzureMFA,
+            },
+        });
+
+        expect(azureSqlState.createServerDrawerState.createLoadState).to.equal(ApiStatus.Error);
+        expect(azureSqlState.createServerDrawerState.message).to.equal("Creation failed");
+    });
+});


### PR DESCRIPTION
## Description

Allow user to manually add firewall on firewall connection error in Azure Db Provisioning. This codepath is pretty self-contained; it only happens when the automatically added firewall rule does not work for connection.

Fixes https://github.com/microsoft/vscode-mssql/issues/22719

<img width="1467" height="990" alt="manualAddFirewallRule" src="https://github.com/user-attachments/assets/a14b3506-1bdc-4eff-8837-8428e130d21b" />

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
