### PR TITLE
Fix horizontal scrollbar reset in Beta Results Grid

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController.ts
@@ -5,8 +5,6 @@
 
 import {
     useCallback,
-    useEffect,
-    useRef,
     useState,
     type FocusEvent as ReactFocusEvent,
     type KeyboardEvent as ReactKeyboardEvent,
@@ -36,18 +34,16 @@ export interface FluentResultGridKeyboardController {
     isGridFocused: boolean;
 }
 
-const KEYBOARD_FOCUS_WINDOW_MS = 250;
-
 /**
- * Only focus that immediately follows a Tab keydown should reveal the active grid cell. Native
- * scrollbar interactions can focus the grid container without dispatching a pointer event.
+ * Only keyboard-visible focus should reveal the active grid cell. The browser preserves this
+ * signal when focus enters the webview from its host, while native scrollbar interactions do not
+ * make the container focus-visible.
  */
-export function isFluentResultGridKeyboardInitiatedFocus(
-    tabKeyDownAt: number | undefined,
-    now: number,
+export function shouldRevealFluentResultGridActiveCell(
+    isDirectContainerFocus: boolean,
+    isFocusVisible: boolean,
 ): boolean {
-    const elapsed = tabKeyDownAt === undefined ? Number.POSITIVE_INFINITY : now - tabKeyDownAt;
-    return elapsed >= 0 && elapsed < KEYBOARD_FOCUS_WINDOW_MS;
+    return isDirectContainerFocus && isFocusVisible;
 }
 
 export function useFluentResultGridKeyboardController({
@@ -189,31 +185,14 @@ export function useFluentResultGridKeyboardController({
         grid.gotoCell(row, cell, false);
     }, [containerRef, reactGridRef]);
 
-    const tabKeyDownAtRef = useRef<number | undefined>(undefined);
-    useEffect(() => {
-        const handleWindowKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Tab") {
-                tabKeyDownAtRef.current = performance.now();
-            }
-        };
-
-        window.addEventListener("keydown", handleWindowKeyDown, true);
-        return () => window.removeEventListener("keydown", handleWindowKeyDown, true);
-    }, []);
-
     const handleGridContainerFocus = useCallback(
         (event: ReactFocusEvent<HTMLDivElement>) => {
             setIsGridFocused(true);
 
-            if (event.target !== event.currentTarget) {
-                return;
-            }
-
-            const shouldRevealActiveCell = isFluentResultGridKeyboardInitiatedFocus(
-                tabKeyDownAtRef.current,
-                performance.now(),
+            const shouldRevealActiveCell = shouldRevealFluentResultGridActiveCell(
+                event.target === event.currentTarget,
+                event.currentTarget.matches(":focus-visible"),
             );
-            tabKeyDownAtRef.current = undefined;
             if (shouldRevealActiveCell) {
                 focusGrid();
             }

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController.ts
@@ -5,6 +5,8 @@
 
 import {
     useCallback,
+    useEffect,
+    useRef,
     useState,
     type FocusEvent as ReactFocusEvent,
     type KeyboardEvent as ReactKeyboardEvent,
@@ -32,6 +34,20 @@ export interface FluentResultGridKeyboardController {
     handleGridKeyDownCapture: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
     handleKeyDown: (eventData: SlickEventData, args: { grid: SlickGrid }) => void;
     isGridFocused: boolean;
+}
+
+const KEYBOARD_FOCUS_WINDOW_MS = 250;
+
+/**
+ * Only focus that immediately follows a Tab keydown should reveal the active grid cell. Native
+ * scrollbar interactions can focus the grid container without dispatching a pointer event.
+ */
+export function isFluentResultGridKeyboardInitiatedFocus(
+    tabKeyDownAt: number | undefined,
+    now: number,
+): boolean {
+    const elapsed = tabKeyDownAt === undefined ? Number.POSITIVE_INFINITY : now - tabKeyDownAt;
+    return elapsed >= 0 && elapsed < KEYBOARD_FOCUS_WINDOW_MS;
 }
 
 export function useFluentResultGridKeyboardController({
@@ -173,11 +189,32 @@ export function useFluentResultGridKeyboardController({
         grid.gotoCell(row, cell, false);
     }, [containerRef, reactGridRef]);
 
+    const tabKeyDownAtRef = useRef<number | undefined>(undefined);
+    useEffect(() => {
+        const handleWindowKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Tab") {
+                tabKeyDownAtRef.current = performance.now();
+            }
+        };
+
+        window.addEventListener("keydown", handleWindowKeyDown, true);
+        return () => window.removeEventListener("keydown", handleWindowKeyDown, true);
+    }, []);
+
     const handleGridContainerFocus = useCallback(
         (event: ReactFocusEvent<HTMLDivElement>) => {
             setIsGridFocused(true);
 
-            if (event.target === event.currentTarget) {
+            if (event.target !== event.currentTarget) {
+                return;
+            }
+
+            const shouldRevealActiveCell = isFluentResultGridKeyboardInitiatedFocus(
+                tabKeyDownAtRef.current,
+                performance.now(),
+            );
+            tabKeyDownAtRef.current = undefined;
+            if (shouldRevealActiveCell) {
                 focusGrid();
             }
         },

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -22,6 +22,7 @@ import {
     stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
 import { isFluentResultGridHostCommand } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCommandUtils";
+import { isFluentResultGridKeyboardInitiatedFocus } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController";
 import {
     getFluentResultGridKeyboardAction,
     type FluentResultGridKeyboardShortcutEvent,
@@ -218,6 +219,14 @@ suite("Fluent Result Grid", () => {
                     {},
                 ),
             ).to.deep.equal({ kind: "moveFocus", forward: false });
+        });
+
+        test("only keyboard-initiated container focus reveals the active cell", () => {
+            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1005)).to.equal(true);
+            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1249)).to.equal(true);
+            expect(isFluentResultGridKeyboardInitiatedFocus(undefined, 1005)).to.equal(false);
+            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1250)).to.equal(false);
+            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 999)).to.equal(false);
         });
     });
 });

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -22,7 +22,7 @@ import {
     stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
 import { isFluentResultGridHostCommand } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCommandUtils";
-import { isFluentResultGridKeyboardInitiatedFocus } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController";
+import { shouldRevealFluentResultGridActiveCell } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboardController";
 import {
     getFluentResultGridKeyboardAction,
     type FluentResultGridKeyboardShortcutEvent,
@@ -221,12 +221,10 @@ suite("Fluent Result Grid", () => {
             ).to.deep.equal({ kind: "moveFocus", forward: false });
         });
 
-        test("only keyboard-initiated container focus reveals the active cell", () => {
-            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1005)).to.equal(true);
-            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1249)).to.equal(true);
-            expect(isFluentResultGridKeyboardInitiatedFocus(undefined, 1005)).to.equal(false);
-            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 1250)).to.equal(false);
-            expect(isFluentResultGridKeyboardInitiatedFocus(1000, 999)).to.equal(false);
+        test("only keyboard-visible container focus reveals the active cell", () => {
+            expect(shouldRevealFluentResultGridActiveCell(true, true)).to.equal(true);
+            expect(shouldRevealFluentResultGridActiveCell(true, false)).to.equal(false);
+            expect(shouldRevealFluentResultGridActiveCell(false, true)).to.equal(false);
         });
     });
 });


### PR DESCRIPTION
## Description

Prevents the Beta Results Grid from revealing the active cell when native scrollbar interaction focuses the outer grid container. The active cell is now revealed only when container focus immediately follows Tab keyboard navigation, preserving the horizontal scrollbar position while the vertical scrollbar is dragged.

Issue #22738

## Validation

- Fluent Result Grid unit tests: 10 passed
- Extension build: passed
- Webview bundle build: passed
- Changed-file formatting and lint: passed (3 pre-existing warnings)
- Full mssql unit-test target: 3,528 passed, 23 unrelated failures, 12 skipped; the failures are outside the files changed by this PR

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (npm run test)
- [x] Code follows the contributing guidelines
- [x] Telemetry/logging updated if relevant (not applicable)
- [x] No regressions or UX breakage

## Reviewers Checklist

- [ ] Code changes are understandable and maintainable
- [ ] Automated tests cover the changes
- [ ] Manual testing covers impacted scenarios
- [ ] Documentation is updated or not required