### PR TITLE
Edit Data: clear restored cell changes

### DIFF
--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -214,7 +214,12 @@ export interface TableExplorerContextProps extends CoreRPCs {
     loadSubset: (rowCount: number) => void;
     createRow: () => void;
     deleteRow: (rowId: number) => void;
-    updateCell: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
+    updateCell: (
+        rowId: number,
+        columnId: number,
+        newValue: string,
+        requestId: number,
+    ) => Promise<void>;
     revertCell: (rowId: number, columnId: number) => Promise<void>;
     revertRow: (rowId: number) => Promise<void>;
     generateScript: () => void;

--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -50,6 +50,11 @@ export interface EditCellResult {
     isRowDirty: boolean;
 }
 
+export interface CellUpdateAcknowledgement {
+    requestId: number;
+    isDirty: boolean;
+}
+
 export interface EditReferencedTableInfo {
     schemaName: string;
     tableName: string;
@@ -201,6 +206,7 @@ export interface TableExplorerWebViewState {
     currentPage?: number; // Track the current page number in the data grid
     failedCells?: string[]; // Track cells that failed to update (format: "rowId-columnId")
     originalCellValues?: Map<string, DbCellValue>; // Cache original cell values for reliable revert (key: "rowId-columnId")
+    cellUpdateAcknowledgements?: Record<string, CellUpdateAcknowledgement>; // Latest service response per cell
 }
 
 export interface TableExplorerContextProps extends CoreRPCs {
@@ -208,7 +214,7 @@ export interface TableExplorerContextProps extends CoreRPCs {
     loadSubset: (rowCount: number) => void;
     createRow: () => void;
     deleteRow: (rowId: number) => void;
-    updateCell: (rowId: number, columnId: number, newValue: string) => void;
+    updateCell: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
     revertCell: (rowId: number, columnId: number) => void;
     revertRow: (rowId: number) => void;
     generateScript: () => void;
@@ -229,7 +235,7 @@ export interface TableExplorerReducers {
     loadSubset: { rowCount: number };
     createRow: {};
     deleteRow: { rowId: number };
-    updateCell: { rowId: number; columnId: number; newValue: string };
+    updateCell: { rowId: number; columnId: number; newValue: string; requestId: number };
     revertCell: { rowId: number; columnId: number };
     revertRow: { rowId: number };
     generateScript: {};

--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -210,7 +210,7 @@ export interface TableExplorerWebViewState {
 }
 
 export interface TableExplorerContextProps extends CoreRPCs {
-    commitChanges: () => void;
+    commitChanges: () => Promise<void>;
     loadSubset: (rowCount: number) => void;
     createRow: () => void;
     deleteRow: (rowId: number) => void;

--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -215,7 +215,7 @@ export interface TableExplorerContextProps extends CoreRPCs {
     createRow: () => void;
     deleteRow: (rowId: number) => void;
     updateCell: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
-    revertCell: (rowId: number, columnId: number) => void;
+    revertCell: (rowId: number, columnId: number) => Promise<void>;
     revertRow: (rowId: number) => Promise<void>;
     generateScript: () => void;
     openScriptInEditor: () => void;

--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -216,7 +216,7 @@ export interface TableExplorerContextProps extends CoreRPCs {
     deleteRow: (rowId: number) => void;
     updateCell: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
     revertCell: (rowId: number, columnId: number) => void;
-    revertRow: (rowId: number) => void;
+    revertRow: (rowId: number) => Promise<void>;
     generateScript: () => void;
     openScriptInEditor: () => void;
     copyScriptToClipboard: () => void;

--- a/extensions/mssql/src/tableExplorer/editDataUtils.ts
+++ b/extensions/mssql/src/tableExplorer/editDataUtils.ts
@@ -39,6 +39,19 @@ export async function commitChangesAndClearTracking(
     }
 }
 
+export async function updateCellAndTrackFailure(
+    updateCell: () => Promise<void>,
+    trackFailure: () => void,
+): Promise<boolean> {
+    try {
+        await updateCell();
+        return true;
+    } catch {
+        trackFailure();
+        return false;
+    }
+}
+
 export async function revertCellAndClearTracking(
     revertCell: () => Promise<void>,
     clearTracking: () => void,

--- a/extensions/mssql/src/tableExplorer/editDataUtils.ts
+++ b/extensions/mssql/src/tableExplorer/editDataUtils.ts
@@ -25,3 +25,16 @@ export function removeAcknowledgedCleanCellChanges<T extends { requestId: number
 
     return changed;
 }
+
+export async function commitChangesAndClearTracking(
+    commitChanges: () => Promise<void>,
+    clearTracking?: () => void,
+): Promise<boolean> {
+    try {
+        await commitChanges();
+        clearTracking?.();
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/extensions/mssql/src/tableExplorer/editDataUtils.ts
+++ b/extensions/mssql/src/tableExplorer/editDataUtils.ts
@@ -38,3 +38,16 @@ export async function commitChangesAndClearTracking(
         return false;
     }
 }
+
+export async function revertCellAndClearTracking(
+    revertCell: () => Promise<void>,
+    clearTracking: () => void,
+): Promise<boolean> {
+    try {
+        await revertCell();
+        clearTracking();
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/extensions/mssql/src/tableExplorer/editDataUtils.ts
+++ b/extensions/mssql/src/tableExplorer/editDataUtils.ts
@@ -3,25 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EditCell, EditRow } from "../sharedInterfaces/tableExplorer";
+import { CellUpdateAcknowledgement } from "../sharedInterfaces/tableExplorer";
 
 /**
- * Removes locally tracked edits that the edit service reports as clean.
+ * Removes locally tracked edits whose matching request the edit service reports as clean.
  * The service performs the SQL-type-aware conversion and comparison, so its dirty state is
  * authoritative for values such as NULL, dates, and culture-specific numeric representations.
  */
-export function removeCleanCellChanges(
-    rows: EditRow[],
-    cellChanges: Map<string, unknown>,
+export function removeAcknowledgedCleanCellChanges<T extends { requestId: number }>(
+    acknowledgements: Record<string, CellUpdateAcknowledgement> | undefined,
+    cellChanges: Map<string, T>,
 ): boolean {
     let changed = false;
 
-    for (const row of rows) {
-        row.cells.forEach((cell, columnIndex) => {
-            if ((cell as EditCell).isDirty === false) {
-                changed = cellChanges.delete(`${row.id}-${columnIndex}`) || changed;
-            }
-        });
+    for (const [cellKey, acknowledgement] of Object.entries(acknowledgements ?? {})) {
+        const trackedChange = cellChanges.get(cellKey);
+        if (!acknowledgement.isDirty && trackedChange?.requestId === acknowledgement.requestId) {
+            changed = cellChanges.delete(cellKey) || changed;
+        }
     }
 
     return changed;

--- a/extensions/mssql/src/tableExplorer/editDataUtils.ts
+++ b/extensions/mssql/src/tableExplorer/editDataUtils.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { EditCell, EditRow } from "../sharedInterfaces/tableExplorer";
+
+/**
+ * Removes locally tracked edits that the edit service reports as clean.
+ * The service performs the SQL-type-aware conversion and comparison, so its dirty state is
+ * authoritative for values such as NULL, dates, and culture-specific numeric representations.
+ */
+export function removeCleanCellChanges(
+    rows: EditRow[],
+    cellChanges: Map<string, unknown>,
+): boolean {
+    let changed = false;
+
+    for (const row of rows) {
+        row.cells.forEach((cell, columnIndex) => {
+            if ((cell as EditCell).isDirty === false) {
+                changed = cellChanges.delete(`${row.id}-${columnIndex}`) || changed;
+            }
+        });
+    }
+
+    return changed;
+}

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -1878,6 +1878,17 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 return state;
             }
 
+            if (this._sessionReplacementPending) {
+                this.logger.debug("Rejecting custom query while session replacement is pending");
+                endActivity.end(ActivityStatus.Succeeded, {
+                    elapsedTime: (Date.now() - startTime).toString(),
+                    operationId: this.operationId,
+                    cancelled: "true",
+                    ...filterTelemetry,
+                });
+                return state;
+            }
+
             if (!(await this.tearDownEditSession(state, true))) {
                 this.logger.debug("User cancelled custom query due to pending changes");
                 endActivity.end(ActivityStatus.Succeeded, {

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -36,6 +36,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private operationId: string;
     private _preserveTableQuery = false;
     private _latestCellUpdateRequestIds = new Map<string, number>();
+    private _cellUpdateQueues = new Map<string, Promise<void>>();
 
     constructor(
         context: vscode.ExtensionContext,
@@ -404,6 +405,25 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             isDirty: isRowDirty,
             state: isRowDirty ? EditRowState.dirtyUpdate : EditRowState.clean,
         };
+    }
+
+    private async enqueueCellUpdate<T>(cellKey: string, update: () => Promise<T>): Promise<T> {
+        const previousUpdate = this._cellUpdateQueues.get(cellKey) ?? Promise.resolve();
+        let completeUpdate!: () => void;
+        const currentUpdate = new Promise<void>((resolve) => {
+            completeUpdate = resolve;
+        });
+        this._cellUpdateQueues.set(cellKey, currentUpdate);
+
+        await previousUpdate;
+        try {
+            return await update();
+        } finally {
+            completeUpdate();
+            if (this._cellUpdateQueues.get(cellKey) === currentUpdate) {
+                this._cellUpdateQueues.delete(cellKey);
+            }
+        }
     }
 
     /**
@@ -843,11 +863,14 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             }
 
             try {
-                const updateCellResult = await this._tableExplorerService.updateCell(
-                    state.ownerUri,
-                    payload.rowId,
-                    payload.columnId,
-                    payload.newValue,
+                const ownerUri = state.ownerUri;
+                const updateCellResult = await this.enqueueCellUpdate(cacheKey, () =>
+                    this._tableExplorerService.updateCell(
+                        ownerUri,
+                        payload.rowId,
+                        payload.columnId,
+                        payload.newValue,
+                    ),
                 );
 
                 if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -36,7 +36,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private operationId: string;
     private _preserveTableQuery = false;
     private _latestCellUpdateRequestIds = new Map<string, number>();
-    private _cellUpdateQueues = new Map<string, Promise<void>>();
+    private _cellOperationQueues = new Map<string, Promise<void>>();
+    private _pendingCellOperations = new Set<Promise<void>>();
+    private _lifecycleOperationQueue = Promise.resolve();
+    private _lifecycleOperationCount = 0;
+    private _cellOperationsEnabled = true;
 
     constructor(
         context: vscode.ExtensionContext,
@@ -110,6 +114,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
     private onEditSessionReady(result: EditSessionReadyParams): void {
         if (result.success) {
+            this._cellOperationsEnabled = true;
             this.state.ownerUri = result.ownerUri;
             this.state.loadStatus = ApiStatus.Loading;
             this.updateState();
@@ -407,21 +412,53 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         };
     }
 
-    private async enqueueCellUpdate<T>(cellKey: string, update: () => Promise<T>): Promise<T> {
-        const previousUpdate = this._cellUpdateQueues.get(cellKey) ?? Promise.resolve();
-        let completeUpdate!: () => void;
-        const currentUpdate = new Promise<void>((resolve) => {
-            completeUpdate = resolve;
+    private async enqueueCellOperation<T>(
+        cellKey: string,
+        operation: () => Promise<T>,
+    ): Promise<T> {
+        const lifecycleOperations = this._lifecycleOperationQueue;
+        const previousOperation = this._cellOperationQueues.get(cellKey) ?? Promise.resolve();
+        let completeOperation!: () => void;
+        const currentOperation = new Promise<void>((resolve) => {
+            completeOperation = resolve;
         });
-        this._cellUpdateQueues.set(cellKey, currentUpdate);
+        this._cellOperationQueues.set(cellKey, currentOperation);
+        this._pendingCellOperations.add(currentOperation);
 
-        await previousUpdate;
+        await Promise.all([lifecycleOperations, previousOperation]);
         try {
-            return await update();
+            return await operation();
         } finally {
-            completeUpdate();
-            if (this._cellUpdateQueues.get(cellKey) === currentUpdate) {
-                this._cellUpdateQueues.delete(cellKey);
+            completeOperation();
+            this._pendingCellOperations.delete(currentOperation);
+            if (this._cellOperationQueues.get(cellKey) === currentOperation) {
+                this._cellOperationQueues.delete(cellKey);
+            }
+        }
+    }
+
+    private async enqueueLifecycleOperation<T>(operation: () => Promise<T>): Promise<T> {
+        this._lifecycleOperationCount++;
+        const previousLifecycleOperations = this._lifecycleOperationQueue;
+        const pendingCellOperations = [...this._pendingCellOperations];
+        let completeLifecycleOperation!: () => void;
+        const currentLifecycleOperation = new Promise<void>((resolve) => {
+            completeLifecycleOperation = resolve;
+        });
+        const lifecycleOperations = previousLifecycleOperations.then(
+            () => currentLifecycleOperation,
+        );
+        this._lifecycleOperationQueue = lifecycleOperations;
+
+        await previousLifecycleOperations;
+        await Promise.all(pendingCellOperations);
+        try {
+            return await operation();
+        } finally {
+            this._lifecycleOperationCount--;
+            completeLifecycleOperation();
+            if (this._lifecycleOperationQueue === lifecycleOperations) {
+                this._lifecycleOperationQueue = Promise.resolve();
             }
         }
     }
@@ -432,18 +469,21 @@ export class TableExplorerWebViewController extends WebviewPanelController<
      * disposes the backend session (best-effort), and clears any pending-edit bookkeeping.
      */
     private async tearDownEditSession(state: TableExplorerWebViewState): Promise<void> {
-        state.loadStatus = ApiStatus.Loading;
+        this._cellOperationsEnabled = false;
+        await this.enqueueLifecycleOperation(async () => {
+            state.loadStatus = ApiStatus.Loading;
 
-        state.resultSet = undefined;
-        this.updateState();
+            state.resultSet = undefined;
+            this.updateState();
 
-        try {
-            await this._tableExplorerService.dispose(state.ownerUri);
-        } catch {}
+            try {
+                await this._tableExplorerService.dispose(state.ownerUri);
+            } catch {}
 
-        this.resetPendingChangesState(state);
-        this.showRestorePromptAfterClose = false;
-        this.updateState();
+            this.resetPendingChangesState(state);
+            this.showRestorePromptAfterClose = false;
+            this.updateState();
+        });
     }
 
     /**
@@ -494,51 +534,53 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
-            try {
-                await this._tableExplorerService.commit(state.ownerUri);
-                vscode.window.showInformationMessage(
-                    LocConstants.TableExplorer.changesSavedSuccessfully,
-                );
+            return await this.enqueueLifecycleOperation(async () => {
+                try {
+                    await this._tableExplorerService.commit(state.ownerUri);
+                    vscode.window.showInformationMessage(
+                        LocConstants.TableExplorer.changesSavedSuccessfully,
+                    );
 
-                // Clear tracking state after successful commit
-                state.newRows = [];
-                state.deletedRows = [];
-                state.failedCells = [];
-                state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
-                state.cellUpdateAcknowledgements = {};
-                this._latestCellUpdateRequestIds.clear();
-                this.showRestorePromptAfterClose = false;
+                    // Clear tracking state after successful commit
+                    state.newRows = [];
+                    state.deletedRows = [];
+                    state.failedCells = [];
+                    state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
+                    state.cellUpdateAcknowledgements = {};
+                    this._latestCellUpdateRequestIds.clear();
+                    this.showRestorePromptAfterClose = false;
 
-                this.logger.debug(
-                    `Cleared new rows, deleted rows, failed cells, and original cell values cache after successful commit - OperationId: ${this.operationId}`,
-                );
+                    this.logger.debug(
+                        `Cleared new rows, deleted rows, failed cells, and original cell values cache after successful commit - OperationId: ${this.operationId}`,
+                    );
 
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                this.logger.error(
-                    `Error committing changes: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
-
-                endActivity.endFailed(
-                    new Error("Failed to commit changes"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
+                    endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
-                    },
-                );
+                    });
+                } catch (error) {
+                    this.logger.error(
+                        `Error committing changes: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
 
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
-                );
-            }
+                    endActivity.endFailed(
+                        new Error("Failed to commit changes"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
+                    );
 
-            return state;
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
+                    );
+                }
+
+                return state;
+            });
         });
 
         this.registerReducer("loadSubset", async (state, payload) => {
@@ -722,105 +764,107 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             // so they cannot be reverted and should be removed from the UI immediately
             const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
 
-            try {
-                await this._tableExplorerService.deleteRow(state.ownerUri, payload.rowId);
+            return await this.enqueueLifecycleOperation(async () => {
+                try {
+                    await this._tableExplorerService.deleteRow(state.ownerUri, payload.rowId);
 
-                // Remove all failed cells for this row
-                if (state.failedCells) {
-                    state.failedCells = state.failedCells.filter(
-                        (key) => !key.startsWith(`${payload.rowId}-`),
-                    );
-                }
+                    // Remove all failed cells for this row
+                    if (state.failedCells) {
+                        state.failedCells = state.failedCells.filter(
+                            (key) => !key.startsWith(`${payload.rowId}-`),
+                        );
+                    }
 
-                // Clear all cached original values for this row
-                if (state.originalCellValues) {
-                    const keysToDelete: string[] = [];
-                    state.originalCellValues.forEach((_, key) => {
-                        if (key.startsWith(`${payload.rowId}-`)) {
-                            keysToDelete.push(key);
+                    // Clear all cached original values for this row
+                    if (state.originalCellValues) {
+                        const keysToDelete: string[] = [];
+                        state.originalCellValues.forEach((_, key) => {
+                            if (key.startsWith(`${payload.rowId}-`)) {
+                                keysToDelete.push(key);
+                            }
+                        });
+                        keysToDelete.forEach((key) => state.originalCellValues?.delete(key));
+                        this.logger.debug(
+                            `Cleared ${keysToDelete.length} cached values for deleted row ${payload.rowId}`,
+                        );
+                    }
+
+                    if (isNewRow) {
+                        // For newly created rows, the backend completely removes them
+                        // Remove from newRows tracking and from resultSet immediately
+                        state.newRows = state.newRows.filter((row) => row.id !== payload.rowId);
+
+                        if (state.resultSet) {
+                            state.resultSet = {
+                                ...state.resultSet,
+                                subset: state.resultSet.subset.filter(
+                                    (row) => row.id !== payload.rowId,
+                                ),
+                                rowCount: state.resultSet.rowCount - 1,
+                            };
                         }
-                    });
-                    keysToDelete.forEach((key) => state.originalCellValues?.delete(key));
-                    this.logger.debug(
-                        `Cleared ${keysToDelete.length} cached values for deleted row ${payload.rowId}`,
-                    );
-                }
 
-                if (isNewRow) {
-                    // For newly created rows, the backend completely removes them
-                    // Remove from newRows tracking and from resultSet immediately
-                    state.newRows = state.newRows.filter((row) => row.id !== payload.rowId);
+                        vscode.window.showInformationMessage(
+                            LocConstants.TableExplorer.rowDeletedSuccessfully,
+                        );
 
-                    if (state.resultSet) {
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: state.resultSet.subset.filter(
-                                (row) => row.id !== payload.rowId,
-                            ),
-                            rowCount: state.resultSet.rowCount - 1,
-                        };
+                        this.logger.debug(
+                            `Removed newly created row ${payload.rowId} from UI (${state.newRows.length} new rows remaining)`,
+                        );
+
+                        // Check if we still have unsaved changes
+                        if (state.newRows.length === 0 && state.deletedRows.length === 0) {
+                            this.showRestorePromptAfterClose = false;
+                        }
+                    } else {
+                        // For existing rows, mark for deletion (keep visible but styled as deleted)
+                        if (!state.deletedRows.includes(payload.rowId)) {
+                            state.deletedRows = [...state.deletedRows, payload.rowId];
+                        }
+
+                        vscode.window.showInformationMessage(
+                            LocConstants.TableExplorer.rowMarkedForRemoval,
+                        );
+
+                        this.showRestorePromptAfterClose = true;
+
+                        this.logger.debug(
+                            `Marked row ${payload.rowId} for deletion (${state.deletedRows.length} total deleted)`,
+                        );
                     }
 
-                    vscode.window.showInformationMessage(
-                        LocConstants.TableExplorer.rowDeletedSuccessfully,
-                    );
+                    // Update state to trigger re-render
+                    this.updateState();
 
-                    this.logger.debug(
-                        `Removed newly created row ${payload.rowId} from UI (${state.newRows.length} new rows remaining)`,
-                    );
+                    await this.regenerateScriptIfVisible(state);
 
-                    // Check if we still have unsaved changes
-                    if (state.newRows.length === 0 && state.deletedRows.length === 0) {
-                        this.showRestorePromptAfterClose = false;
-                    }
-                } else {
-                    // For existing rows, mark for deletion (keep visible but styled as deleted)
-                    if (!state.deletedRows.includes(payload.rowId)) {
-                        state.deletedRows = [...state.deletedRows, payload.rowId];
-                    }
-
-                    vscode.window.showInformationMessage(
-                        LocConstants.TableExplorer.rowMarkedForRemoval,
-                    );
-
-                    this.showRestorePromptAfterClose = true;
-
-                    this.logger.debug(
-                        `Marked row ${payload.rowId} for deletion (${state.deletedRows.length} total deleted)`,
-                    );
-                }
-
-                // Update state to trigger re-render
-                this.updateState();
-
-                await this.regenerateScriptIfVisible(state);
-
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                this.logger.error(
-                    `Error deleting row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
-
-                endActivity.endFailed(
-                    new Error("Failed to delete row"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
+                    endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
-                    },
-                );
+                    });
+                } catch (error) {
+                    this.logger.error(
+                        `Error deleting row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
 
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToRemoveRow(getErrorMessage(error)),
-                );
-            }
+                    endActivity.endFailed(
+                        new Error("Failed to delete row"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
+                    );
 
-            return state;
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToRemoveRow(getErrorMessage(error)),
+                    );
+                }
+
+                return state;
+            });
         });
 
         this.registerReducer("updateCell", async (state, payload) => {
@@ -842,178 +886,211 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             // Cache the original cell value BEFORE attempting the update
             // This ensures we can revert even if the update fails
             const cacheKey = `${payload.rowId}-${payload.columnId}`;
-            this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
-            if (state.resultSet && !state.originalCellValues?.has(cacheKey)) {
-                const rowIndex = state.resultSet.subset.findIndex(
-                    (row) => row.id === payload.rowId,
-                );
-                if (rowIndex !== -1) {
-                    const originalCell = state.resultSet.subset[rowIndex].cells[payload.columnId];
-                    if (!state.originalCellValues) {
-                        state.originalCellValues = new Map<string, DbCellValue>();
-                    }
-                    // Deep copy to ensure we have all properties
-                    state.originalCellValues.set(cacheKey, {
-                        displayValue: originalCell.displayValue,
-                        isNull: originalCell.isNull,
-                        invariantCultureDisplayValue: originalCell.invariantCultureDisplayValue,
-                    });
-                    this.logger.trace(`Cached original value for cell ${cacheKey}`);
-                }
+            const registeredBeforeQueue = this._lifecycleOperationCount === 0;
+            if (registeredBeforeQueue) {
+                this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
             }
 
-            try {
-                const ownerUri = state.ownerUri;
-                const updateCellResult = await this.enqueueCellUpdate(cacheKey, () =>
-                    this._tableExplorerService.updateCell(
+            const ownerUri = state.ownerUri;
+            return await this.enqueueCellOperation(cacheKey, async () => {
+                if (!this._cellOperationsEnabled) {
+                    if (this._latestCellUpdateRequestIds.get(cacheKey) === payload.requestId) {
+                        this._latestCellUpdateRequestIds.delete(cacheKey);
+                    }
+                    return state;
+                }
+
+                if (!registeredBeforeQueue) {
+                    this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
+                }
+                if (state.resultSet && !state.originalCellValues?.has(cacheKey)) {
+                    const rowIndex = state.resultSet.subset.findIndex(
+                        (row) => row.id === payload.rowId,
+                    );
+                    if (rowIndex !== -1) {
+                        const originalCell =
+                            state.resultSet.subset[rowIndex].cells[payload.columnId];
+                        if (!state.originalCellValues) {
+                            state.originalCellValues = new Map<string, DbCellValue>();
+                        }
+                        // Deep copy to ensure we have all properties
+                        state.originalCellValues.set(cacheKey, {
+                            displayValue: originalCell.displayValue,
+                            isNull: originalCell.isNull,
+                            invariantCultureDisplayValue: originalCell.invariantCultureDisplayValue,
+                        });
+                        this.logger.trace(`Cached original value for cell ${cacheKey}`);
+                    }
+                }
+
+                try {
+                    const updateCellResult = await this._tableExplorerService.updateCell(
                         ownerUri,
                         payload.rowId,
                         payload.columnId,
                         payload.newValue,
-                    ),
-                );
-
-                if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
-                    this.logger.trace(
-                        `Ignoring stale update response for cell ${cacheKey}, request ${payload.requestId}`,
                     );
+
+                    if (!this._cellOperationsEnabled) {
+                        endActivity.end(ActivityStatus.Succeeded, {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        });
+                        return state;
+                    }
+
+                    if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
+                        this.logger.trace(
+                            `Ignoring stale update response for cell ${cacheKey}, request ${payload.requestId}`,
+                        );
+                        endActivity.end(ActivityStatus.Succeeded, {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        });
+                        return state;
+                    }
+
+                    // Remove from failed cells tracking if it was previously failed
+                    if (state.failedCells) {
+                        const failedKey = `${payload.rowId}-${payload.columnId}`;
+                        state.failedCells = state.failedCells.filter((key) => key !== failedKey);
+                    }
+
+                    if (!updateCellResult.cell.isDirty) {
+                        state.originalCellValues?.delete(cacheKey);
+                    }
+                    state.cellUpdateAcknowledgements = {
+                        ...state.cellUpdateAcknowledgements,
+                        [cacheKey]: {
+                            requestId: payload.requestId,
+                            isDirty: updateCellResult.cell.isDirty,
+                        },
+                    };
+
+                    // Update the cell value in the result set if the row is still loaded
+                    if (state.resultSet) {
+                        const rowIndex = state.resultSet.subset.findIndex(
+                            (row) => row.id === payload.rowId,
+                        );
+
+                        if (rowIndex !== -1) {
+                            const updatedRow = this.updateResultCell(
+                                state,
+                                state.resultSet.subset[rowIndex],
+                                payload.columnId,
+                                updateCellResult.cell,
+                            );
+                            state.resultSet = {
+                                ...state.resultSet,
+                                subset: state.resultSet.subset.map((row, index) =>
+                                    index === rowIndex ? updatedRow : row,
+                                ),
+                            };
+
+                            this.logger.debug(
+                                `Updated cell in result set at row ${rowIndex}, column ${payload.columnId}`,
+                            );
+                        }
+                    }
+                    this.showRestorePromptAfterClose = this.hasPendingChanges(state);
+                    this.updateState();
+
+                    this.logger.debug(
+                        `Cell updated successfully - OperationId: ${this.operationId}`,
+                    );
+
+                    await this.regenerateScriptIfVisible(state);
+
                     endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
                     });
-                    return state;
-                }
+                } catch (error) {
+                    if (!this._cellOperationsEnabled) {
+                        endActivity.endFailed(
+                            new Error("Cell update stopped during session disposal"),
+                            false /* includeErrorMessage */,
+                        );
+                        return state;
+                    }
 
-                // Remove from failed cells tracking if it was previously failed
-                if (state.failedCells) {
+                    if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
+                        this.logger.trace(
+                            `Ignoring stale update failure for cell ${cacheKey}, request ${payload.requestId}`,
+                        );
+                        endActivity.endFailed(
+                            new Error("Stale cell update failed"),
+                            false /* includeErrorMessage */,
+                        );
+                        return state;
+                    }
+
+                    this.logger.error(
+                        `Error updating cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
+
+                    // Track failed cell for UI highlighting
                     const failedKey = `${payload.rowId}-${payload.columnId}`;
-                    state.failedCells = state.failedCells.filter((key) => key !== failedKey);
-                }
-
-                if (!updateCellResult.cell.isDirty) {
-                    state.originalCellValues?.delete(cacheKey);
-                }
-                state.cellUpdateAcknowledgements = {
-                    ...state.cellUpdateAcknowledgements,
-                    [cacheKey]: {
-                        requestId: payload.requestId,
-                        isDirty: updateCellResult.cell.isDirty,
-                    },
-                };
-
-                // Update the cell value in the result set if the row is still loaded
-                if (state.resultSet) {
-                    const rowIndex = state.resultSet.subset.findIndex(
-                        (row) => row.id === payload.rowId,
-                    );
-
-                    if (rowIndex !== -1) {
-                        const updatedRow = this.updateResultCell(
-                            state,
-                            state.resultSet.subset[rowIndex],
-                            payload.columnId,
-                            updateCellResult.cell,
-                        );
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: state.resultSet.subset.map((row, index) =>
-                                index === rowIndex ? updatedRow : row,
-                            ),
-                        };
-
-                        this.logger.debug(
-                            `Updated cell in result set at row ${rowIndex}, column ${payload.columnId}`,
-                        );
+                    if (!state.failedCells) {
+                        state.failedCells = [failedKey];
+                    } else if (!state.failedCells.includes(failedKey)) {
+                        state.failedCells = [...state.failedCells, failedKey];
                     }
-                }
-                this.showRestorePromptAfterClose = this.hasPendingChanges(state);
-                this.updateState();
 
-                this.logger.debug(`Cell updated successfully - OperationId: ${this.operationId}`);
+                    // Update the cell in the result set to show the attempted value with isDirty flag
+                    // This ensures the UI shows what the user typed even though the update failed
+                    if (state.resultSet) {
+                        const rowIndex = state.resultSet.subset.findIndex(
+                            (row) => row.id === payload.rowId,
+                        );
 
-                await this.regenerateScriptIfVisible(state);
+                        if (rowIndex !== -1) {
+                            const currentRow = state.resultSet.subset[rowIndex];
+                            const currentCell = currentRow.cells[payload.columnId];
+                            const failedCell = {
+                                ...currentCell,
+                                displayValue: payload.newValue,
+                                isDirty: true,
+                            };
+                            const updatedRow = this.updateResultCell(
+                                state,
+                                currentRow,
+                                payload.columnId,
+                                failedCell,
+                            );
+                            state.resultSet = {
+                                ...state.resultSet,
+                                subset: state.resultSet.subset.map((row, index) =>
+                                    index === rowIndex ? updatedRow : row,
+                                ),
+                            };
 
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
-                    this.logger.trace(
-                        `Ignoring stale update failure for cell ${cacheKey}, request ${payload.requestId}`,
-                    );
+                            this.logger.debug(
+                                `Updated cell in result set to show failed edit at row ${rowIndex}, column ${payload.columnId}`,
+                            );
+                        }
+                    }
+
+                    this.updateState();
+
                     endActivity.endFailed(
-                        new Error("Stale cell update failed"),
-                        false /* includeErrorMessage */,
-                    );
-                    return state;
-                }
-
-                this.logger.error(
-                    `Error updating cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
-
-                // Track failed cell for UI highlighting
-                const failedKey = `${payload.rowId}-${payload.columnId}`;
-                if (!state.failedCells) {
-                    state.failedCells = [failedKey];
-                } else if (!state.failedCells.includes(failedKey)) {
-                    state.failedCells = [...state.failedCells, failedKey];
-                }
-
-                // Update the cell in the result set to show the attempted value with isDirty flag
-                // This ensures the UI shows what the user typed even though the update failed
-                if (state.resultSet) {
-                    const rowIndex = state.resultSet.subset.findIndex(
-                        (row) => row.id === payload.rowId,
+                        new Error("Failed to update cell"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
                     );
 
-                    if (rowIndex !== -1) {
-                        const currentRow = state.resultSet.subset[rowIndex];
-                        const currentCell = currentRow.cells[payload.columnId];
-                        const failedCell = {
-                            ...currentCell,
-                            displayValue: payload.newValue,
-                            isDirty: true,
-                        };
-                        const updatedRow = this.updateResultCell(
-                            state,
-                            currentRow,
-                            payload.columnId,
-                            failedCell,
-                        );
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: state.resultSet.subset.map((row, index) =>
-                                index === rowIndex ? updatedRow : row,
-                            ),
-                        };
-
-                        this.logger.debug(
-                            `Updated cell in result set to show failed edit at row ${rowIndex}, column ${payload.columnId}`,
-                        );
-                    }
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToUpdateCell(getErrorMessage(error)),
+                    );
                 }
 
-                this.updateState();
-
-                endActivity.endFailed(
-                    new Error("Failed to update cell"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
-                        elapsedTime: (Date.now() - startTime).toString(),
-                        operationId: this.operationId,
-                    },
-                );
-
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToUpdateCell(getErrorMessage(error)),
-                );
-            }
-
-            return state;
+                return state;
+            });
         });
 
         this.registerReducer("revertCell", async (state, payload) => {
@@ -1034,109 +1111,138 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
             const cacheKey = `${payload.rowId}-${payload.columnId}`;
 
-            try {
-                // Always call the service to revert to ensure backend state is properly cleaned up
-                this.logger.trace(`Calling service to revert cell ${cacheKey}`);
-                const revertCellResult = await this._tableExplorerService.revertCell(
-                    state.ownerUri,
-                    payload.rowId,
-                    payload.columnId,
-                );
-
-                // Check if we have a cached original value
-                const cachedOriginalValue = state.originalCellValues?.get(cacheKey);
-
-                // Use cached value if available to ensure correct display, otherwise use service result
-                // Creating a new object ensures React detects the change
-                const revertedCell = cachedOriginalValue
-                    ? {
-                          ...cachedOriginalValue,
-                          isDirty: false,
-                      }
-                    : {
-                          ...revertCellResult.cell,
-                          isDirty: false,
-                      };
-
-                if (cachedOriginalValue) {
-                    this.logger.trace(`Using cached original value for cell ${cacheKey}`);
+            return await this.enqueueCellOperation(cacheKey, async () => {
+                if (!this._cellOperationsEnabled) {
+                    return state;
                 }
 
-                // Remove from cache after successful revert
-                if (state.originalCellValues?.has(cacheKey)) {
-                    state.originalCellValues.delete(cacheKey);
-                    this.logger.trace(
-                        `Removed cached value for cell ${cacheKey} after successful revert`,
-                    );
-                }
-                if (state.cellUpdateAcknowledgements) {
-                    delete state.cellUpdateAcknowledgements[cacheKey];
-                }
-                this._latestCellUpdateRequestIds.delete(cacheKey);
-
-                // Remove from failed cells tracking
-                if (state.failedCells) {
-                    const failedKey = `${payload.rowId}-${payload.columnId}`;
-                    state.failedCells = state.failedCells.filter((key) => key !== failedKey);
-                }
-
-                // Update the cell value in the result set
-                if (state.resultSet && revertedCell) {
-                    const rowIndex = state.resultSet.subset.findIndex(
-                        (row) => row.id === payload.rowId,
+                try {
+                    // Always call the service to revert to ensure backend state is properly cleaned up
+                    this.logger.trace(`Calling service to revert cell ${cacheKey}`);
+                    const revertCellResult = await this._tableExplorerService.revertCell(
+                        state.ownerUri,
+                        payload.rowId,
+                        payload.columnId,
                     );
 
-                    if (rowIndex !== -1) {
-                        const newSubset = state.resultSet.subset.map((row, idx) =>
-                            idx === rowIndex
-                                ? this.updateResultCell(state, row, payload.columnId, revertedCell)
-                                : row,
-                        );
-
-                        // Create completely new resultSet object
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: newSubset,
-                        };
-                        this.showRestorePromptAfterClose = this.hasPendingChanges(state);
-
-                        this.logger.debug(
-                            `Reverted cell in result set at row ${rowIndex}, column ${payload.columnId}`,
-                        );
-
-                        this.updateState();
+                    if (!this._cellOperationsEnabled) {
+                        endActivity.end(ActivityStatus.Succeeded, {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        });
+                        return state;
                     }
-                }
-                this.logger.debug(`Cell reverted successfully - OperationId: ${this.operationId}`);
 
-                await this.regenerateScriptIfVisible(state);
+                    // Check if we have a cached original value
+                    const cachedOriginalValue = state.originalCellValues?.get(cacheKey);
 
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                this.logger.error(
-                    `Error reverting cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
+                    // Use cached value if available to ensure correct display, otherwise use service result
+                    // Creating a new object ensures React detects the change
+                    const revertedCell = cachedOriginalValue
+                        ? {
+                              ...cachedOriginalValue,
+                              isDirty: false,
+                          }
+                        : {
+                              ...revertCellResult.cell,
+                              isDirty: false,
+                          };
 
-                endActivity.endFailed(
-                    new Error("Failed to revert cell"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
+                    if (cachedOriginalValue) {
+                        this.logger.trace(`Using cached original value for cell ${cacheKey}`);
+                    }
+
+                    // Remove from cache after successful revert
+                    if (state.originalCellValues?.has(cacheKey)) {
+                        state.originalCellValues.delete(cacheKey);
+                        this.logger.trace(
+                            `Removed cached value for cell ${cacheKey} after successful revert`,
+                        );
+                    }
+                    if (state.cellUpdateAcknowledgements) {
+                        delete state.cellUpdateAcknowledgements[cacheKey];
+                    }
+                    this._latestCellUpdateRequestIds.delete(cacheKey);
+
+                    // Remove from failed cells tracking
+                    if (state.failedCells) {
+                        const failedKey = `${payload.rowId}-${payload.columnId}`;
+                        state.failedCells = state.failedCells.filter((key) => key !== failedKey);
+                    }
+
+                    // Update the cell value in the result set
+                    if (state.resultSet && revertedCell) {
+                        const rowIndex = state.resultSet.subset.findIndex(
+                            (row) => row.id === payload.rowId,
+                        );
+
+                        if (rowIndex !== -1) {
+                            const newSubset = state.resultSet.subset.map((row, idx) =>
+                                idx === rowIndex
+                                    ? this.updateResultCell(
+                                          state,
+                                          row,
+                                          payload.columnId,
+                                          revertedCell,
+                                      )
+                                    : row,
+                            );
+
+                            // Create completely new resultSet object
+                            state.resultSet = {
+                                ...state.resultSet,
+                                subset: newSubset,
+                            };
+                            this.showRestorePromptAfterClose = this.hasPendingChanges(state);
+
+                            this.logger.debug(
+                                `Reverted cell in result set at row ${rowIndex}, column ${payload.columnId}`,
+                            );
+
+                            this.updateState();
+                        }
+                    }
+                    this.logger.debug(
+                        `Cell reverted successfully - OperationId: ${this.operationId}`,
+                    );
+
+                    await this.regenerateScriptIfVisible(state);
+
+                    endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
-                    },
-                );
+                    });
+                } catch (error) {
+                    if (!this._cellOperationsEnabled) {
+                        endActivity.endFailed(
+                            new Error("Cell revert stopped during session disposal"),
+                            false /* includeErrorMessage */,
+                        );
+                        return state;
+                    }
 
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToRevertCell(getErrorMessage(error)),
-                );
-            }
+                    this.logger.error(
+                        `Error reverting cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
 
-            return state;
+                    endActivity.endFailed(
+                        new Error("Failed to revert cell"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
+                    );
+
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToRevertCell(getErrorMessage(error)),
+                    );
+                }
+
+                return state;
+            });
         });
 
         this.registerReducer("revertRow", async (state, payload) => {
@@ -1153,133 +1259,137 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
-            try {
-                const revertRowResult = await this._tableExplorerService.revertRow(
-                    state.ownerUri,
-                    payload.rowId,
-                );
-
-                // Remove from deletedRows if it was marked for deletion
-                state.deletedRows = state.deletedRows.filter((id) => id !== payload.rowId);
-
-                // Remove all failed cells for this row
-                if (state.failedCells) {
-                    state.failedCells = state.failedCells.filter(
-                        (key) => !key.startsWith(`${payload.rowId}-`),
+            return await this.enqueueLifecycleOperation(async () => {
+                try {
+                    const revertRowResult = await this._tableExplorerService.revertRow(
+                        state.ownerUri,
+                        payload.rowId,
                     );
-                }
 
-                // Clear all cached original values for this row
-                if (state.originalCellValues) {
-                    const keysToDelete: string[] = [];
-                    state.originalCellValues.forEach((_, key) => {
-                        if (key.startsWith(`${payload.rowId}-`)) {
-                            keysToDelete.push(key);
-                        }
-                    });
-                    keysToDelete.forEach((key) => state.originalCellValues?.delete(key));
-                    this.logger.debug(
-                        `Cleared ${keysToDelete.length} cached values for row ${payload.rowId}`,
-                    );
-                }
-                if (state.cellUpdateAcknowledgements) {
-                    state.cellUpdateAcknowledgements = Object.fromEntries(
-                        Object.entries(state.cellUpdateAcknowledgements).filter(
-                            ([key]) => !key.startsWith(`${payload.rowId}-`),
-                        ),
-                    );
-                }
-                for (const key of this._latestCellUpdateRequestIds.keys()) {
-                    if (key.startsWith(`${payload.rowId}-`)) {
-                        this._latestCellUpdateRequestIds.delete(key);
-                    }
-                }
+                    // Remove from deletedRows if it was marked for deletion
+                    state.deletedRows = state.deletedRows.filter((id) => id !== payload.rowId);
 
-                // Check if this was a newly created row (row will be null after revert)
-                const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
-
-                if (revertRowResult.row) {
-                    // Update the row in the result set (for existing rows that were modified)
-                    if (state.resultSet) {
-                        const rowIndex = state.resultSet.subset.findIndex(
-                            (row) => row.id === payload.rowId,
+                    // Remove all failed cells for this row
+                    if (state.failedCells) {
+                        state.failedCells = state.failedCells.filter(
+                            (key) => !key.startsWith(`${payload.rowId}-`),
                         );
+                    }
 
-                        if (rowIndex !== -1) {
+                    // Clear all cached original values for this row
+                    if (state.originalCellValues) {
+                        const keysToDelete: string[] = [];
+                        state.originalCellValues.forEach((_, key) => {
+                            if (key.startsWith(`${payload.rowId}-`)) {
+                                keysToDelete.push(key);
+                            }
+                        });
+                        keysToDelete.forEach((key) => state.originalCellValues?.delete(key));
+                        this.logger.debug(
+                            `Cleared ${keysToDelete.length} cached values for row ${payload.rowId}`,
+                        );
+                    }
+                    if (state.cellUpdateAcknowledgements) {
+                        state.cellUpdateAcknowledgements = Object.fromEntries(
+                            Object.entries(state.cellUpdateAcknowledgements).filter(
+                                ([key]) => !key.startsWith(`${payload.rowId}-`),
+                            ),
+                        );
+                    }
+                    for (const key of this._latestCellUpdateRequestIds.keys()) {
+                        if (key.startsWith(`${payload.rowId}-`)) {
+                            this._latestCellUpdateRequestIds.delete(key);
+                        }
+                    }
+
+                    // Check if this was a newly created row (row will be null after revert)
+                    const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
+
+                    if (revertRowResult.row) {
+                        // Update the row in the result set (for existing rows that were modified)
+                        if (state.resultSet) {
+                            const rowIndex = state.resultSet.subset.findIndex(
+                                (row) => row.id === payload.rowId,
+                            );
+
+                            if (rowIndex !== -1) {
+                                state.resultSet = {
+                                    ...state.resultSet,
+                                    subset: state.resultSet.subset.map((row, idx) => {
+                                        if (idx === rowIndex) {
+                                            return revertRowResult.row;
+                                        }
+
+                                        return row;
+                                    }),
+                                };
+
+                                this.updateState();
+
+                                this.logger.debug(
+                                    `Reverted row at index ${rowIndex} with ${revertRowResult.row.cells.length} cells`,
+                                );
+                            }
+                        }
+                    } else if (isNewRow) {
+                        // Row was a newly created row that was reverted - remove it from the UI
+                        state.newRows = state.newRows.filter((row) => row.id !== payload.rowId);
+
+                        if (state.resultSet) {
                             state.resultSet = {
                                 ...state.resultSet,
-                                subset: state.resultSet.subset.map((row, idx) => {
-                                    if (idx === rowIndex) {
-                                        return revertRowResult.row;
-                                    }
-
-                                    return row;
-                                }),
+                                subset: state.resultSet.subset.filter(
+                                    (row) => row.id !== payload.rowId,
+                                ),
+                                rowCount: state.resultSet.rowCount - 1,
                             };
+                        }
 
-                            this.updateState();
+                        this.updateState();
 
-                            this.logger.debug(
-                                `Reverted row at index ${rowIndex} with ${revertRowResult.row.cells.length} cells`,
-                            );
+                        this.logger.debug(
+                            `Removed newly created row ${payload.rowId} from UI after revert`,
+                        );
+
+                        // Check if we still have unsaved changes
+                        if (state.newRows.length === 0 && state.deletedRows.length === 0) {
+                            this.showRestorePromptAfterClose = false;
                         }
                     }
-                } else if (isNewRow) {
-                    // Row was a newly created row that was reverted - remove it from the UI
-                    state.newRows = state.newRows.filter((row) => row.id !== payload.rowId);
-
-                    if (state.resultSet) {
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: state.resultSet.subset.filter(
-                                (row) => row.id !== payload.rowId,
-                            ),
-                            rowCount: state.resultSet.rowCount - 1,
-                        };
-                    }
-
-                    this.updateState();
 
                     this.logger.debug(
-                        `Removed newly created row ${payload.rowId} from UI after revert`,
+                        `Row reverted successfully - OperationId: ${this.operationId}`,
                     );
 
-                    // Check if we still have unsaved changes
-                    if (state.newRows.length === 0 && state.deletedRows.length === 0) {
-                        this.showRestorePromptAfterClose = false;
-                    }
-                }
+                    await this.regenerateScriptIfVisible(state);
 
-                this.logger.debug(`Row reverted successfully - OperationId: ${this.operationId}`);
-
-                await this.regenerateScriptIfVisible(state);
-
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                this.logger.error(
-                    `Error reverting row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
-
-                endActivity.endFailed(
-                    new Error("Failed to revert row"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
+                    endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
-                    },
-                );
+                    });
+                } catch (error) {
+                    this.logger.error(
+                        `Error reverting row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
 
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToRevertRow(getErrorMessage(error)),
-                );
-            }
+                    endActivity.endFailed(
+                        new Error("Failed to revert row"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
+                    );
 
-            return state;
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToRevertRow(getErrorMessage(error)),
+                    );
+                }
+
+                return state;
+            });
         });
 
         this.registerReducer("generateScript", async (state) => {
@@ -1853,7 +1963,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             this.logger.info("User chose to save changes before closing");
 
             try {
-                await this._tableExplorerService.commit(this.state.ownerUri);
+                await this.enqueueLifecycleOperation(() =>
+                    this._tableExplorerService.commit(this.state.ownerUri),
+                );
                 vscode.window.showInformationMessage(
                     LocConstants.TableExplorer.changesSavedSuccessfully,
                 );
@@ -1880,12 +1992,14 @@ export class TableExplorerWebViewController extends WebviewPanelController<
      * This is called when the webview tab is closed (after any prompts are handled).
      */
     public override dispose(): void {
+        this._cellOperationsEnabled = false;
         if (this.state.ownerUri) {
-            this.logger.info(
-                `Disposing Table Explorer resources for ownerUri: ${this.state.ownerUri}`,
-            );
+            const ownerUri = this.state.ownerUri;
+            this.logger.info(`Disposing Table Explorer resources for ownerUri: ${ownerUri}`);
 
-            void this._tableExplorerService.dispose(this.state.ownerUri).catch((error) => {
+            void this.enqueueLifecycleOperation(() =>
+                this._tableExplorerService.dispose(ownerUri),
+            ).catch((error) => {
                 this.logger.error(
                     `Error disposing table explorer service: ${getErrorMessage(error)}`,
                 );

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -518,6 +518,15 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         }
     }
 
+    private trackUnappliedCellUpdate(state: TableExplorerWebViewState, cacheKey: string): void {
+        this._failedEditOperations.add(cacheKey);
+        if (!state.failedCells?.includes(cacheKey)) {
+            state.failedCells = [...(state.failedCells ?? []), cacheKey];
+        }
+        this.showRestorePromptAfterClose = true;
+        this.updateState();
+    }
+
     /**
      * Tears down the active edit session in preparation for re-initializing with a new query:
      * marks state as loading, clears the stale result set so the webview re-initializes the grid,
@@ -992,8 +1001,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("updateCell", async (state, payload) => {
+            const cacheKey = `${payload.rowId}-${payload.columnId}`;
             if (this.areEditMutationsBlocked()) {
-                return state;
+                this.trackUnappliedCellUpdate(state, cacheKey);
+                throw new Error("Cell update was not applied because the session is unavailable");
             }
 
             this.logger.debug(
@@ -1013,7 +1024,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
             // Cache the original cell value BEFORE attempting the update
             // This ensures we can revert even if the update fails
-            const cacheKey = `${payload.rowId}-${payload.columnId}`;
             const registeredBeforeQueue = this._lifecycleOperationCount === 0;
             if (registeredBeforeQueue) {
                 this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
@@ -1026,7 +1036,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     if (this._latestCellUpdateRequestIds.get(cacheKey) === payload.requestId) {
                         this._latestCellUpdateRequestIds.delete(cacheKey);
                     }
-                    return state;
+                    this.trackUnappliedCellUpdate(state, cacheKey);
+                    throw new Error(
+                        "Cell update was not applied because the session is unavailable",
+                    );
                 }
 
                 if (!registeredBeforeQueue) {
@@ -1062,11 +1075,14 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (!this._cellOperationsEnabled) {
-                        endActivity.end(ActivityStatus.Succeeded, {
-                            elapsedTime: (Date.now() - startTime).toString(),
-                            operationId: this.operationId,
-                        });
-                        return state;
+                        if (this.isDisposed) {
+                            endActivity.end(ActivityStatus.Succeeded, {
+                                elapsedTime: (Date.now() - startTime).toString(),
+                                operationId: this.operationId,
+                            });
+                            return state;
+                        }
+                        throw new Error("Cell update stopped during session disposal");
                     }
 
                     if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
@@ -1142,7 +1158,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             new Error("Cell update stopped during session disposal"),
                             false /* includeErrorMessage */,
                         );
-                        return state;
+                        if (this.isDisposed) {
+                            return state;
+                        }
+                        this.trackUnappliedCellUpdate(state, cacheKey);
+                        throw error;
                     }
 
                     if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -589,6 +589,21 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             LocConstants.TableExplorer.changesSavedSuccessfully,
                         );
 
+                        if (state.resultSet) {
+                            state.resultSet = {
+                                ...state.resultSet,
+                                subset: state.resultSet.subset.map((row) => ({
+                                    ...row,
+                                    isDirty: false,
+                                    state: EditRowState.clean,
+                                    cells: row.cells.map((cell) => ({
+                                        ...cell,
+                                        isDirty: false,
+                                    })),
+                                })),
+                            };
+                        }
+
                         // Clear tracking state after successful commit
                         state.newRows = [];
                         state.deletedRows = [];

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -43,6 +43,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private _lifecycleOperationCount = 0;
     private _cellOperationsEnabled = true;
     private _commitInProgress = false;
+    private _sessionReplacementPending = false;
 
     constructor(
         context: vscode.ExtensionContext,
@@ -118,6 +119,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         if (result.success) {
             this._cellOperationsEnabled = true;
             this._commitInProgress = false;
+            this._sessionReplacementPending = false;
             this.state.ownerUri = result.ownerUri;
             this.state.loadStatus = ApiStatus.Loading;
             this.updateState();
@@ -501,7 +503,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     }
 
     private areEditMutationsBlocked(): boolean {
-        return !this._cellOperationsEnabled || this._commitInProgress;
+        return (
+            !this._cellOperationsEnabled ||
+            this._commitInProgress ||
+            this._sessionReplacementPending
+        );
     }
 
     /**
@@ -513,30 +519,37 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state: TableExplorerWebViewState,
         confirmDiscardPendingChanges = false,
     ): Promise<boolean> {
-        return await this.enqueueLifecycleOperation(async () => {
-            if (
-                confirmDiscardPendingChanges &&
-                this.hasPendingChanges(state) &&
-                !(await this.promptDiscardPendingChanges())
-            ) {
-                return false;
-            }
+        this._sessionReplacementPending = true;
+        try {
+            return await this.enqueueLifecycleOperation(async () => {
+                if (
+                    confirmDiscardPendingChanges &&
+                    this.hasPendingChanges(state) &&
+                    !(await this.promptDiscardPendingChanges())
+                ) {
+                    this._sessionReplacementPending = false;
+                    return false;
+                }
 
-            this._cellOperationsEnabled = false;
-            state.loadStatus = ApiStatus.Loading;
+                this._cellOperationsEnabled = false;
+                state.loadStatus = ApiStatus.Loading;
 
-            state.resultSet = undefined;
-            this.updateState();
+                state.resultSet = undefined;
+                this.updateState();
 
-            try {
-                await this._tableExplorerService.dispose(state.ownerUri);
-            } catch {}
+                try {
+                    await this._tableExplorerService.dispose(state.ownerUri);
+                } catch {}
 
-            this.resetPendingChangesState(state);
-            this.showRestorePromptAfterClose = false;
-            this.updateState();
-            return true;
-        });
+                this.resetPendingChangesState(state);
+                this.showRestorePromptAfterClose = false;
+                this.updateState();
+                return true;
+            });
+        } catch (error) {
+            this._sessionReplacementPending = false;
+            throw error;
+        }
     }
 
     /**
@@ -573,6 +586,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         this.registerReducer("commitChanges", async (state) => {
             if (this._commitInProgress) {
                 throw new Error("A commit is already in progress");
+            }
+            if (this.areEditMutationsBlocked()) {
+                return state;
             }
             this._commitInProgress = true;
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -510,6 +510,12 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         );
     }
 
+    private throwIfEditMutationBlocked(): void {
+        if (this.areEditMutationsBlocked()) {
+            throw new Error("Edit operation was not applied because the session is unavailable");
+        }
+    }
+
     /**
      * Tears down the active edit session in preparation for re-initializing with a new query:
      * marks state as loading, clears the stale result set so the webview re-initializes the grid,
@@ -587,9 +593,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             if (this._commitInProgress) {
                 throw new Error("A commit is already in progress");
             }
-            if (this.areEditMutationsBlocked()) {
-                return state;
-            }
+            this.throwIfEditMutationBlocked();
             this._commitInProgress = true;
 
             this.logger.info(
@@ -1379,9 +1383,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("revertRow", async (state, payload) => {
-            if (this.areEditMutationsBlocked()) {
-                return state;
-            }
+            this.throwIfEditMutationBlocked();
 
             this.logger.debug(`Reverting row: ${payload.rowId} - OperationId: ${this.operationId}`);
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -71,6 +71,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 currentPage: 1, // Start on page 1
                 failedCells: [], // Track cells that failed to update
                 originalCellValues: new Map<string, DbCellValue>(), // Cache original values for reliable revert
+                cellUpdateAcknowledgements: {},
             },
             {
                 title: qualifiedTableName,
@@ -365,6 +366,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.deletedRows = [];
         state.failedCells = [];
         state.originalCellValues?.clear();
+        state.cellUpdateAcknowledgements = {};
         state.updateScript = undefined;
     }
 
@@ -471,6 +473,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 state.deletedRows = [];
                 state.failedCells = [];
                 state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
+                state.cellUpdateAcknowledgements = {};
                 this.showRestorePromptAfterClose = false;
 
                 this.logger.debug(
@@ -862,6 +865,13 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         if (!updateCellResult.cell.isDirty) {
                             state.originalCellValues?.delete(cacheKey);
                         }
+                        state.cellUpdateAcknowledgements = {
+                            ...state.cellUpdateAcknowledgements,
+                            [cacheKey]: {
+                                requestId: payload.requestId,
+                                isDirty: updateCellResult.cell.isDirty,
+                            },
+                        };
 
                         this.showRestorePromptAfterClose = this.hasPendingChanges(state);
 
@@ -992,6 +1002,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         `Removed cached value for cell ${cacheKey} after successful revert`,
                     );
                 }
+                if (state.cellUpdateAcknowledgements) {
+                    delete state.cellUpdateAcknowledgements[cacheKey];
+                }
 
                 // Remove from failed cells tracking
                 if (state.failedCells) {
@@ -1104,6 +1117,13 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     keysToDelete.forEach((key) => state.originalCellValues?.delete(key));
                     this.logger.debug(
                         `Cleared ${keysToDelete.length} cached values for row ${payload.rowId}`,
+                    );
+                }
+                if (state.cellUpdateAcknowledgements) {
+                    state.cellUpdateAcknowledgements = Object.fromEntries(
+                        Object.entries(state.cellUpdateAcknowledgements).filter(
+                            ([key]) => !key.startsWith(`${payload.rowId}-`),
+                        ),
                     );
                 }
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -42,6 +42,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private _lifecycleOperationQueue = Promise.resolve();
     private _lifecycleOperationCount = 0;
     private _cellOperationsEnabled = true;
+    private _commitInProgress = false;
 
     constructor(
         context: vscode.ExtensionContext,
@@ -116,6 +117,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private onEditSessionReady(result: EditSessionReadyParams): void {
         if (result.success) {
             this._cellOperationsEnabled = true;
+            this._commitInProgress = false;
             this.state.ownerUri = result.ownerUri;
             this.state.loadStatus = ApiStatus.Loading;
             this.updateState();
@@ -471,6 +473,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         }
     }
 
+    private areEditMutationsBlocked(): boolean {
+        return !this._cellOperationsEnabled || this._commitInProgress;
+    }
+
     /**
      * Tears down the active edit session in preparation for re-initializing with a new query:
      * marks state as loading, clears the stale result set so the webview re-initializes the grid,
@@ -526,6 +532,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
     private registerRpcHandlers(): void {
         this.registerReducer("commitChanges", async (state) => {
+            if (this._commitInProgress) {
+                throw new Error("A commit is already in progress");
+            }
+            this._commitInProgress = true;
+
             this.logger.info(
                 `Committing changes for: ${state.tableName} - OperationId: ${this.operationId}`,
             );
@@ -542,56 +553,60 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
-            return await this.enqueueLifecycleOperation(async () => {
-                try {
-                    this.throwIfCellOperationsFailed();
-                    await this._tableExplorerService.commit(state.ownerUri);
-                    vscode.window.showInformationMessage(
-                        LocConstants.TableExplorer.changesSavedSuccessfully,
-                    );
+            try {
+                return await this.enqueueLifecycleOperation(async () => {
+                    try {
+                        this.throwIfCellOperationsFailed();
+                        await this._tableExplorerService.commit(state.ownerUri);
+                        vscode.window.showInformationMessage(
+                            LocConstants.TableExplorer.changesSavedSuccessfully,
+                        );
 
-                    // Clear tracking state after successful commit
-                    state.newRows = [];
-                    state.deletedRows = [];
-                    state.failedCells = [];
-                    state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
-                    state.cellUpdateAcknowledgements = {};
-                    this._latestCellUpdateRequestIds.clear();
-                    this._failedCellOperations.clear();
-                    this.showRestorePromptAfterClose = false;
+                        // Clear tracking state after successful commit
+                        state.newRows = [];
+                        state.deletedRows = [];
+                        state.failedCells = [];
+                        state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
+                        state.cellUpdateAcknowledgements = {};
+                        this._latestCellUpdateRequestIds.clear();
+                        this._failedCellOperations.clear();
+                        this.showRestorePromptAfterClose = false;
 
-                    this.logger.debug(
-                        `Cleared new rows, deleted rows, failed cells, and original cell values cache after successful commit - OperationId: ${this.operationId}`,
-                    );
+                        this.logger.debug(
+                            `Cleared new rows, deleted rows, failed cells, and original cell values cache after successful commit - OperationId: ${this.operationId}`,
+                        );
 
-                    endActivity.end(ActivityStatus.Succeeded, {
-                        elapsedTime: (Date.now() - startTime).toString(),
-                        operationId: this.operationId,
-                    });
-                } catch (error) {
-                    this.logger.error(
-                        `Error committing changes: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                    );
-
-                    endActivity.endFailed(
-                        new Error("Failed to commit changes"),
-                        true /* includeErrorMessage */,
-                        undefined /* errorCode */,
-                        undefined /* errorType */,
-                        {
+                        endActivity.end(ActivityStatus.Succeeded, {
                             elapsedTime: (Date.now() - startTime).toString(),
                             operationId: this.operationId,
-                        },
-                    );
+                        });
+                    } catch (error) {
+                        this.logger.error(
+                            `Error committing changes: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                        );
 
-                    vscode.window.showErrorMessage(
-                        LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
-                    );
-                    throw error;
-                }
+                        endActivity.endFailed(
+                            new Error("Failed to commit changes"),
+                            true /* includeErrorMessage */,
+                            undefined /* errorCode */,
+                            undefined /* errorType */,
+                            {
+                                elapsedTime: (Date.now() - startTime).toString(),
+                                operationId: this.operationId,
+                            },
+                        );
 
-                return state;
-            });
+                        vscode.window.showErrorMessage(
+                            LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
+                        );
+                        throw error;
+                    }
+
+                    return state;
+                });
+            } finally {
+                this._commitInProgress = false;
+            }
         });
 
         this.registerReducer("loadSubset", async (state, payload) => {
@@ -680,7 +695,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("createRow", async (state) => {
-            if (!this._cellOperationsEnabled) {
+            if (this.areEditMutationsBlocked()) {
                 return state;
             }
 
@@ -768,6 +783,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("deleteRow", async (state, payload) => {
+            if (this.areEditMutationsBlocked()) {
+                return state;
+            }
+
             this.logger.debug(`Deleting row: ${payload.rowId} - OperationId: ${this.operationId}`);
 
             const startTime = Date.now();
@@ -893,7 +912,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("updateCell", async (state, payload) => {
-            if (!this._cellOperationsEnabled) {
+            if (this.areEditMutationsBlocked()) {
                 return state;
             }
 
@@ -1127,6 +1146,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("revertCell", async (state, payload) => {
+            if (this.areEditMutationsBlocked()) {
+                return state;
+            }
+
             this.logger.debug(
                 `Reverting cell: row ${payload.rowId}, column ${payload.columnId} - OperationId: ${this.operationId}`,
             );
@@ -1281,6 +1304,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("revertRow", async (state, payload) => {
+            if (this.areEditMutationsBlocked()) {
+                return state;
+            }
+
             this.logger.debug(`Reverting row: ${payload.rowId} - OperationId: ${this.operationId}`);
 
             const startTime = Date.now();

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -477,6 +477,29 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         return `row:${rowId}`;
     }
 
+    private hasTrackedPendingChangesForRow(
+        state: TableExplorerWebViewState,
+        rowId: number,
+    ): boolean {
+        const rowKeyPrefix = `${rowId}-`;
+        const row = state.resultSet?.subset.find((resultRow) => resultRow.id === rowId);
+        return (
+            state.newRows.some((newRow) => newRow.id === rowId) ||
+            state.deletedRows.includes(rowId) ||
+            [...(state.originalCellValues?.keys() ?? [])].some((key) =>
+                key.startsWith(rowKeyPrefix),
+            ) ||
+            (state.failedCells?.some((key) => key.startsWith(rowKeyPrefix)) ?? false) ||
+            Object.entries(state.cellUpdateAcknowledgements ?? {}).some(
+                ([key, acknowledgement]) => key.startsWith(rowKeyPrefix) && acknowledgement.isDirty,
+            ) ||
+            row?.isDirty === true ||
+            row?.state === EditRowState.dirtyInsert ||
+            row?.state === EditRowState.dirtyDelete ||
+            row?.state === EditRowState.dirtyUpdate
+        );
+    }
+
     private areEditMutationsBlocked(): boolean {
         return !this._cellOperationsEnabled || this._commitInProgress;
     }
@@ -804,6 +827,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
+            this.showRestorePromptAfterClose = true;
             return await this.enqueueLifecycleOperation(async () => {
                 // A preceding commit can move the row from new to persisted while this operation waits.
                 const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
@@ -860,11 +884,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         this.logger.debug(
                             `Removed newly created row ${payload.rowId} from UI (${state.newRows.length} new rows remaining)`,
                         );
-
-                        // Check if we still have unsaved changes
-                        if (state.newRows.length === 0 && state.deletedRows.length === 0) {
-                            this.showRestorePromptAfterClose = false;
-                        }
                     } else {
                         // For existing rows, mark for deletion (keep visible but styled as deleted)
                         if (!state.deletedRows.includes(payload.rowId)) {
@@ -875,12 +894,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             LocConstants.TableExplorer.rowMarkedForRemoval,
                         );
 
-                        this.showRestorePromptAfterClose = true;
-
                         this.logger.debug(
                             `Marked row ${payload.rowId} for deletion (${state.deletedRows.length} total deleted)`,
                         );
                     }
+                    this.showRestorePromptAfterClose = this.hasPendingChanges(state);
 
                     // Update state to trigger re-render
                     this.updateState();
@@ -910,6 +928,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     vscode.window.showErrorMessage(
                         LocConstants.TableExplorer.failedToRemoveRow(getErrorMessage(error)),
                     );
+                    this.showRestorePromptAfterClose = this.hasPendingChanges(state);
                 }
 
                 return state;
@@ -1333,6 +1352,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             );
 
             return await this.enqueueLifecycleOperation(async () => {
+                const hadTrackedPendingChanges = this.hasTrackedPendingChangesForRow(
+                    state,
+                    payload.rowId,
+                );
                 try {
                     const revertRowResult = await this._tableExplorerService.revertRow(
                         state.ownerUri,
@@ -1465,7 +1488,12 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     vscode.window.showErrorMessage(
                         LocConstants.TableExplorer.failedToRevertRow(getErrorMessage(error)),
                     );
-                    this._failedEditOperations.add(this.getRowRevertFailureKey(payload.rowId));
+                    const failureKey = this.getRowRevertFailureKey(payload.rowId);
+                    if (hadTrackedPendingChanges) {
+                        this._failedEditOperations.add(failureKey);
+                    } else {
+                        this._failedEditOperations.delete(failureKey);
+                    }
                     throw error;
                 }
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -35,6 +35,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 > {
     private operationId: string;
     private _preserveTableQuery = false;
+    private _latestCellUpdateRequestIds = new Map<string, number>();
 
     constructor(
         context: vscode.ExtensionContext,
@@ -367,14 +368,15 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.failedCells = [];
         state.originalCellValues?.clear();
         state.cellUpdateAcknowledgements = {};
+        this._latestCellUpdateRequestIds.clear();
         state.updateScript = undefined;
     }
 
     private updateResultCell(
+        state: TableExplorerWebViewState,
         row: EditRow,
         columnId: number,
         cell: EditCell,
-        isRowDirty: boolean,
     ): EditRow {
         const cells = [...row.cells];
         cells[columnId] = cell;
@@ -385,6 +387,16 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 cells,
             };
         }
+
+        const rowKeyPrefix = `${row.id}-`;
+        const hasPendingCellUpdate = [...this._latestCellUpdateRequestIds].some(
+            ([key, requestId]) =>
+                key.startsWith(rowKeyPrefix) &&
+                state.cellUpdateAcknowledgements?.[key]?.requestId !== requestId,
+        );
+        const isRowDirty =
+            hasPendingCellUpdate ||
+            cells.some((resultCell) => (resultCell as EditCell).isDirty === true);
 
         return {
             ...row,
@@ -474,6 +486,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 state.failedCells = [];
                 state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
                 state.cellUpdateAcknowledgements = {};
+                this._latestCellUpdateRequestIds.clear();
                 this.showRestorePromptAfterClose = false;
 
                 this.logger.debug(
@@ -809,6 +822,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             // Cache the original cell value BEFORE attempting the update
             // This ensures we can revert even if the update fails
             const cacheKey = `${payload.rowId}-${payload.columnId}`;
+            this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
             if (state.resultSet && !state.originalCellValues?.has(cacheKey)) {
                 const rowIndex = state.resultSet.subset.findIndex(
                     (row) => row.id === payload.rowId,
@@ -836,6 +850,17 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     payload.newValue,
                 );
 
+                if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
+                    this.logger.trace(
+                        `Ignoring stale update response for cell ${cacheKey}, request ${payload.requestId}`,
+                    );
+                    endActivity.end(ActivityStatus.Succeeded, {
+                        elapsedTime: (Date.now() - startTime).toString(),
+                        operationId: this.operationId,
+                    });
+                    return state;
+                }
+
                 // Remove from failed cells tracking if it was previously failed
                 if (state.failedCells) {
                     const failedKey = `${payload.rowId}-${payload.columnId}`;
@@ -849,19 +874,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (rowIndex !== -1) {
-                        const updatedRow = this.updateResultCell(
-                            state.resultSet.subset[rowIndex],
-                            payload.columnId,
-                            updateCellResult.cell,
-                            updateCellResult.isRowDirty,
-                        );
-                        state.resultSet = {
-                            ...state.resultSet,
-                            subset: state.resultSet.subset.map((row, index) =>
-                                index === rowIndex ? updatedRow : row,
-                            ),
-                        };
-
                         if (!updateCellResult.cell.isDirty) {
                             state.originalCellValues?.delete(cacheKey);
                         }
@@ -871,6 +883,18 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                                 requestId: payload.requestId,
                                 isDirty: updateCellResult.cell.isDirty,
                             },
+                        };
+                        const updatedRow = this.updateResultCell(
+                            state,
+                            state.resultSet.subset[rowIndex],
+                            payload.columnId,
+                            updateCellResult.cell,
+                        );
+                        state.resultSet = {
+                            ...state.resultSet,
+                            subset: state.resultSet.subset.map((row, index) =>
+                                index === rowIndex ? updatedRow : row,
+                            ),
                         };
 
                         this.showRestorePromptAfterClose = this.hasPendingChanges(state);
@@ -892,6 +916,17 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     operationId: this.operationId,
                 });
             } catch (error) {
+                if (this._latestCellUpdateRequestIds.get(cacheKey) !== payload.requestId) {
+                    this.logger.trace(
+                        `Ignoring stale update failure for cell ${cacheKey}, request ${payload.requestId}`,
+                    );
+                    endActivity.endFailed(
+                        new Error("Stale cell update failed"),
+                        false /* includeErrorMessage */,
+                    );
+                    return state;
+                }
+
                 this.logger.error(
                     `Error updating cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
                 );
@@ -912,15 +947,25 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (rowIndex !== -1) {
-                        const currentCell =
-                            state.resultSet.subset[rowIndex].cells[payload.columnId];
+                        const currentRow = state.resultSet.subset[rowIndex];
+                        const currentCell = currentRow.cells[payload.columnId];
                         const failedCell = {
                             ...currentCell,
                             displayValue: payload.newValue,
                             isDirty: true,
                         };
-
-                        state.resultSet.subset[rowIndex].cells[payload.columnId] = failedCell;
+                        const updatedRow = this.updateResultCell(
+                            state,
+                            currentRow,
+                            payload.columnId,
+                            failedCell,
+                        );
+                        state.resultSet = {
+                            ...state.resultSet,
+                            subset: state.resultSet.subset.map((row, index) =>
+                                index === rowIndex ? updatedRow : row,
+                            ),
+                        };
 
                         this.logger.debug(
                             `Updated cell in result set to show failed edit at row ${rowIndex}, column ${payload.columnId}`,
@@ -1005,6 +1050,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 if (state.cellUpdateAcknowledgements) {
                     delete state.cellUpdateAcknowledgements[cacheKey];
                 }
+                this._latestCellUpdateRequestIds.delete(cacheKey);
 
                 // Remove from failed cells tracking
                 if (state.failedCells) {
@@ -1021,12 +1067,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     if (rowIndex !== -1) {
                         const newSubset = state.resultSet.subset.map((row, idx) =>
                             idx === rowIndex
-                                ? this.updateResultCell(
-                                      row,
-                                      payload.columnId,
-                                      revertedCell,
-                                      revertCellResult.isRowDirty,
-                                  )
+                                ? this.updateResultCell(state, row, payload.columnId, revertedCell)
                                 : row,
                         );
 
@@ -1125,6 +1166,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             ([key]) => !key.startsWith(`${payload.rowId}-`),
                         ),
                     );
+                }
+                for (const key of this._latestCellUpdateRequestIds.keys()) {
+                    if (key.startsWith(`${payload.rowId}-`)) {
+                        this._latestCellUpdateRequestIds.delete(key);
+                    }
                 }
 
                 // Check if this was a newly created row (row will be null after revert)

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -12,6 +12,9 @@ import {
     EditSessionReadyParams,
     DbCellValue,
     SqlPaneMode,
+    EditRow,
+    EditRowState,
+    EditCell,
 } from "../sharedInterfaces/tableExplorer";
 import { TreeNodeInfo } from "../objectExplorer/nodes/treeNodeInfo";
 import ConnectionManager from "../controllers/connectionManager";
@@ -363,6 +366,30 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.failedCells = [];
         state.originalCellValues?.clear();
         state.updateScript = undefined;
+    }
+
+    private updateResultCell(
+        row: EditRow,
+        columnId: number,
+        cell: EditCell,
+        isRowDirty: boolean,
+    ): EditRow {
+        const cells = [...row.cells];
+        cells[columnId] = cell;
+
+        if (row.state === EditRowState.dirtyInsert) {
+            return {
+                ...row,
+                cells,
+            };
+        }
+
+        return {
+            ...row,
+            cells,
+            isDirty: isRowDirty,
+            state: isRowDirty ? EditRowState.dirtyUpdate : EditRowState.clean,
+        };
     }
 
     /**
@@ -806,8 +833,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     payload.newValue,
                 );
 
-                this.showRestorePromptAfterClose = true;
-
                 // Remove from failed cells tracking if it was previously failed
                 if (state.failedCells) {
                     const failedKey = `${payload.rowId}-${payload.columnId}`;
@@ -821,12 +846,24 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (rowIndex !== -1) {
-                        const updatedCell = {
-                            ...updateCellResult.cell,
-                            displayValue: payload.newValue,
+                        const updatedRow = this.updateResultCell(
+                            state.resultSet.subset[rowIndex],
+                            payload.columnId,
+                            updateCellResult.cell,
+                            updateCellResult.isRowDirty,
+                        );
+                        state.resultSet = {
+                            ...state.resultSet,
+                            subset: state.resultSet.subset.map((row, index) =>
+                                index === rowIndex ? updatedRow : row,
+                            ),
                         };
 
-                        state.resultSet.subset[rowIndex].cells[payload.columnId] = updatedCell;
+                        if (!updateCellResult.cell.isDirty) {
+                            state.originalCellValues?.delete(cacheKey);
+                        }
+
+                        this.showRestorePromptAfterClose = this.hasPendingChanges(state);
 
                         this.updateState();
 
@@ -969,26 +1006,23 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (rowIndex !== -1) {
-                        // Create a completely new subset array with new row objects
-                        const newSubset = state.resultSet.subset.map((row, idx) => {
-                            if (idx === rowIndex) {
-                                // Create new cells array with the reverted cell
-                                const newCells = [...row.cells];
-                                newCells[payload.columnId] = revertedCell;
-
-                                return {
-                                    ...row,
-                                    cells: newCells,
-                                };
-                            }
-                            return { ...row }; // Create new row objects to ensure change detection
-                        });
+                        const newSubset = state.resultSet.subset.map((row, idx) =>
+                            idx === rowIndex
+                                ? this.updateResultCell(
+                                      row,
+                                      payload.columnId,
+                                      revertedCell,
+                                      revertCellResult.isRowDirty,
+                                  )
+                                : row,
+                        );
 
                         // Create completely new resultSet object
                         state.resultSet = {
                             ...state.resultSet,
                             subset: newSubset,
                         };
+                        this.showRestorePromptAfterClose = this.hasPendingChanges(state);
 
                         this.logger.debug(
                             `Reverted cell in result set at row ${rowIndex}, column ${payload.columnId}`,

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -38,6 +38,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private _latestCellUpdateRequestIds = new Map<string, number>();
     private _cellOperationQueues = new Map<string, Promise<void>>();
     private _pendingCellOperations = new Set<Promise<void>>();
+    private _failedCellOperations = new Set<string>();
     private _lifecycleOperationQueue = Promise.resolve();
     private _lifecycleOperationCount = 0;
     private _cellOperationsEnabled = true;
@@ -375,6 +376,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.originalCellValues?.clear();
         state.cellUpdateAcknowledgements = {};
         this._latestCellUpdateRequestIds.clear();
+        this._failedCellOperations.clear();
         state.updateScript = undefined;
     }
 
@@ -463,6 +465,12 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         }
     }
 
+    private throwIfCellOperationsFailed(): void {
+        if (this._failedCellOperations.size > 0) {
+            throw new Error("One or more cell operations failed");
+        }
+    }
+
     /**
      * Tears down the active edit session in preparation for re-initializing with a new query:
      * marks state as loading, clears the stale result set so the webview re-initializes the grid,
@@ -536,6 +544,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
             return await this.enqueueLifecycleOperation(async () => {
                 try {
+                    this.throwIfCellOperationsFailed();
                     await this._tableExplorerService.commit(state.ownerUri);
                     vscode.window.showInformationMessage(
                         LocConstants.TableExplorer.changesSavedSuccessfully,
@@ -548,6 +557,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
                     state.cellUpdateAcknowledgements = {};
                     this._latestCellUpdateRequestIds.clear();
+                    this._failedCellOperations.clear();
                     this.showRestorePromptAfterClose = false;
 
                     this.logger.debug(
@@ -759,12 +769,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
-            // Check if this is a newly created row BEFORE calling the service
-            // The backend completely removes new rows (including decrementing NextRowId),
-            // so they cannot be reverted and should be removed from the UI immediately
-            const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
-
             return await this.enqueueLifecycleOperation(async () => {
+                // A preceding commit can move the row from new to persisted while this operation waits.
+                const isNewRow = state.newRows.some((row) => row.id === payload.rowId);
+
                 try {
                     await this._tableExplorerService.deleteRow(state.ownerUri, payload.rowId);
 
@@ -773,6 +781,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         state.failedCells = state.failedCells.filter(
                             (key) => !key.startsWith(`${payload.rowId}-`),
                         );
+                    }
+                    for (const key of this._failedCellOperations) {
+                        if (key.startsWith(`${payload.rowId}-`)) {
+                            this._failedCellOperations.delete(key);
+                        }
                     }
 
                     // Clear all cached original values for this row
@@ -951,6 +964,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     }
 
                     // Remove from failed cells tracking if it was previously failed
+                    this._failedCellOperations.delete(cacheKey);
                     if (state.failedCells) {
                         const failedKey = `${payload.rowId}-${payload.columnId}`;
                         state.failedCells = state.failedCells.filter((key) => key !== failedKey);
@@ -1031,6 +1045,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
                     // Track failed cell for UI highlighting
                     const failedKey = `${payload.rowId}-${payload.columnId}`;
+                    this._failedCellOperations.add(cacheKey);
                     if (!state.failedCells) {
                         state.failedCells = [failedKey];
                     } else if (!state.failedCells.includes(failedKey)) {
@@ -1163,6 +1178,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         delete state.cellUpdateAcknowledgements[cacheKey];
                     }
                     this._latestCellUpdateRequestIds.delete(cacheKey);
+                    this._failedCellOperations.delete(cacheKey);
 
                     // Remove from failed cells tracking
                     if (state.failedCells) {
@@ -1224,6 +1240,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     this.logger.error(
                         `Error reverting cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
                     );
+                    this._failedCellOperations.add(cacheKey);
 
                     endActivity.endFailed(
                         new Error("Failed to revert cell"),
@@ -1299,6 +1316,11 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     for (const key of this._latestCellUpdateRequestIds.keys()) {
                         if (key.startsWith(`${payload.rowId}-`)) {
                             this._latestCellUpdateRequestIds.delete(key);
+                        }
+                    }
+                    for (const key of this._failedCellOperations) {
+                        if (key.startsWith(`${payload.rowId}-`)) {
+                            this._failedCellOperations.delete(key);
                         }
                     }
 
@@ -1963,9 +1985,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             this.logger.info("User chose to save changes before closing");
 
             try {
-                await this.enqueueLifecycleOperation(() =>
-                    this._tableExplorerService.commit(this.state.ownerUri),
-                );
+                await this.enqueueLifecycleOperation(() => {
+                    this.throwIfCellOperationsFailed();
+                    return this._tableExplorerService.commit(this.state.ownerUri);
+                });
                 vscode.window.showInformationMessage(
                     LocConstants.TableExplorer.changesSavedSuccessfully,
                 );

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -509,9 +509,20 @@ export class TableExplorerWebViewController extends WebviewPanelController<
      * marks state as loading, clears the stale result set so the webview re-initializes the grid,
      * disposes the backend session (best-effort), and clears any pending-edit bookkeeping.
      */
-    private async tearDownEditSession(state: TableExplorerWebViewState): Promise<void> {
-        this._cellOperationsEnabled = false;
-        await this.enqueueLifecycleOperation(async () => {
+    private async tearDownEditSession(
+        state: TableExplorerWebViewState,
+        confirmDiscardPendingChanges = false,
+    ): Promise<boolean> {
+        return await this.enqueueLifecycleOperation(async () => {
+            if (
+                confirmDiscardPendingChanges &&
+                this.hasPendingChanges(state) &&
+                !(await this.promptDiscardPendingChanges())
+            ) {
+                return false;
+            }
+
+            this._cellOperationsEnabled = false;
             state.loadStatus = ApiStatus.Loading;
 
             state.resultSet = undefined;
@@ -524,6 +535,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             this.resetPendingChangesState(state);
             this.showRestorePromptAfterClose = false;
             this.updateState();
+            return true;
         });
     }
 
@@ -1141,6 +1153,8 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             const failedCell = {
                                 ...currentCell,
                                 displayValue: payload.newValue,
+                                invariantCultureDisplayValue: payload.newValue,
+                                isNull: false,
                                 isDirty: true,
                             };
                             const updatedRow = this.updateResultCell(
@@ -1846,7 +1860,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 return state;
             }
 
-            if (this.hasPendingChanges(state) && !(await this.promptDiscardPendingChanges())) {
+            if (!(await this.tearDownEditSession(state, true))) {
                 this.logger.debug("User cancelled custom query due to pending changes");
                 endActivity.end(ActivityStatus.Succeeded, {
                     elapsedTime: (Date.now() - startTime).toString(),
@@ -1856,8 +1870,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 });
                 return state;
             }
-
-            await this.tearDownEditSession(state);
 
             const objectName = state.tableName;
             const schemaName = state.schemaName;

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -38,7 +38,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     private _latestCellUpdateRequestIds = new Map<string, number>();
     private _cellOperationQueues = new Map<string, Promise<void>>();
     private _pendingCellOperations = new Set<Promise<void>>();
-    private _failedCellOperations = new Set<string>();
+    private _failedEditOperations = new Set<string>();
     private _lifecycleOperationQueue = Promise.resolve();
     private _lifecycleOperationCount = 0;
     private _cellOperationsEnabled = true;
@@ -378,7 +378,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.originalCellValues?.clear();
         state.cellUpdateAcknowledgements = {};
         this._latestCellUpdateRequestIds.clear();
-        this._failedCellOperations.clear();
+        this._failedEditOperations.clear();
         state.updateScript = undefined;
     }
 
@@ -467,10 +467,14 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         }
     }
 
-    private throwIfCellOperationsFailed(): void {
-        if (this._failedCellOperations.size > 0) {
-            throw new Error("One or more cell operations failed");
+    private throwIfEditOperationsFailed(): void {
+        if (this._failedEditOperations.size > 0) {
+            throw new Error("One or more edit operations failed");
         }
+    }
+
+    private getRowRevertFailureKey(rowId: number): string {
+        return `row:${rowId}`;
     }
 
     private areEditMutationsBlocked(): boolean {
@@ -556,7 +560,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             try {
                 return await this.enqueueLifecycleOperation(async () => {
                     try {
-                        this.throwIfCellOperationsFailed();
+                        this.throwIfEditOperationsFailed();
                         await this._tableExplorerService.commit(state.ownerUri);
                         vscode.window.showInformationMessage(
                             LocConstants.TableExplorer.changesSavedSuccessfully,
@@ -569,7 +573,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
                         state.cellUpdateAcknowledgements = {};
                         this._latestCellUpdateRequestIds.clear();
-                        this._failedCellOperations.clear();
+                        this._failedEditOperations.clear();
                         this.showRestorePromptAfterClose = false;
 
                         this.logger.debug(
@@ -806,6 +810,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
                 try {
                     await this._tableExplorerService.deleteRow(state.ownerUri, payload.rowId);
+                    this._failedEditOperations.delete(this.getRowRevertFailureKey(payload.rowId));
 
                     // Remove all failed cells for this row
                     if (state.failedCells) {
@@ -813,9 +818,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             (key) => !key.startsWith(`${payload.rowId}-`),
                         );
                     }
-                    for (const key of this._failedCellOperations) {
+                    for (const key of this._failedEditOperations) {
                         if (key.startsWith(`${payload.rowId}-`)) {
-                            this._failedCellOperations.delete(key);
+                            this._failedEditOperations.delete(key);
                         }
                     }
 
@@ -1001,7 +1006,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     }
 
                     // Remove from failed cells tracking if it was previously failed
-                    this._failedCellOperations.delete(cacheKey);
+                    this._failedEditOperations.delete(cacheKey);
                     if (state.failedCells) {
                         const failedKey = `${payload.rowId}-${payload.columnId}`;
                         state.failedCells = state.failedCells.filter((key) => key !== failedKey);
@@ -1082,7 +1087,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
                     // Track failed cell for UI highlighting
                     const failedKey = `${payload.rowId}-${payload.columnId}`;
-                    this._failedCellOperations.add(cacheKey);
+                    this._failedEditOperations.add(cacheKey);
                     if (!state.failedCells) {
                         state.failedCells = [failedKey];
                     } else if (!state.failedCells.includes(failedKey)) {
@@ -1225,7 +1230,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     ) {
                         this._latestCellUpdateRequestIds.delete(cacheKey);
                     }
-                    this._failedCellOperations.delete(cacheKey);
+                    this._failedEditOperations.delete(cacheKey);
 
                     // Remove from failed cells tracking
                     if (state.failedCells) {
@@ -1287,7 +1292,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     this.logger.error(
                         `Error reverting cell: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
                     );
-                    this._failedCellOperations.add(cacheKey);
+                    this._failedEditOperations.add(cacheKey);
 
                     endActivity.endFailed(
                         new Error("Failed to revert cell"),
@@ -1333,6 +1338,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         state.ownerUri,
                         payload.rowId,
                     );
+                    this._failedEditOperations.delete(this.getRowRevertFailureKey(payload.rowId));
 
                     // Remove from deletedRows if it was marked for deletion
                     state.deletedRows = state.deletedRows.filter((id) => id !== payload.rowId);
@@ -1369,9 +1375,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             this._latestCellUpdateRequestIds.delete(key);
                         }
                     }
-                    for (const key of this._failedCellOperations) {
+                    for (const key of this._failedEditOperations) {
                         if (key.startsWith(`${payload.rowId}-`)) {
-                            this._failedCellOperations.delete(key);
+                            this._failedEditOperations.delete(key);
                         }
                     }
 
@@ -1459,6 +1465,8 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     vscode.window.showErrorMessage(
                         LocConstants.TableExplorer.failedToRevertRow(getErrorMessage(error)),
                     );
+                    this._failedEditOperations.add(this.getRowRevertFailureKey(payload.rowId));
+                    throw error;
                 }
 
                 return state;
@@ -2012,8 +2020,8 @@ export class TableExplorerWebViewController extends WebviewPanelController<
     /**
      * Override the base class's showRestorePrompt to handle unsaved changes.
      * This is called from the onDidDispose handler in the base class.
-     * Prompts the user to save or discard changes, then allows disposal to continue.
-     * Always returns undefined to allow the close to proceed after handling the user's choice.
+     * Prompts the user to save or discard changes. If saving fails, restores the webview
+     * without disposing the edit session so the user can retry.
      */
     protected override async showRestorePrompt(): Promise<
         | {
@@ -2037,7 +2045,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
             try {
                 await this.enqueueLifecycleOperation(() => {
-                    this.throwIfCellOperationsFailed();
+                    this.throwIfEditOperationsFailed();
                     return this._tableExplorerService.commit(this.state.ownerUri);
                 });
                 vscode.window.showInformationMessage(
@@ -2050,6 +2058,13 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 vscode.window.showErrorMessage(
                     LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
                 );
+                return {
+                    title: LocConstants.TableExplorer.Save,
+                    run: async () => {
+                        await this.createWebviewPanel();
+                        this.panel.reveal();
+                    },
+                };
             }
         } else if (result === LocConstants.TableExplorer.Discard) {
             this.logger.info("User chose to discard changes");
@@ -2057,7 +2072,6 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             this.logger.info("User dismissed the prompt - treating as discard");
         }
 
-        // Always return undefined to allow disposal to continue
         return undefined;
     }
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -141,6 +141,8 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             this.state.loadStatus = ApiStatus.Error;
             this.state.resultSet = undefined;
             this._preserveTableQuery = false;
+            this._cellOperationsEnabled = false;
+            this._sessionReplacementPending = false;
             this.updateState();
 
             sendErrorEvent(
@@ -584,6 +586,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 `Failed to restore original session: ${getErrorMessage(restoreError)}`,
             );
             state.loadStatus = ApiStatus.Error;
+            this._sessionReplacementPending = false;
             return false;
         }
     }

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -527,7 +527,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state: TableExplorerWebViewState,
         confirmDiscardPendingChanges = false,
     ): Promise<boolean> {
+        const previousLoadStatus = state.loadStatus;
         this._sessionReplacementPending = true;
+        state.loadStatus = ApiStatus.Loading;
+        this.updateState();
         try {
             return await this.enqueueLifecycleOperation(async () => {
                 if (
@@ -536,11 +539,12 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     !(await this.promptDiscardPendingChanges())
                 ) {
                     this._sessionReplacementPending = false;
+                    state.loadStatus = previousLoadStatus;
+                    this.updateState();
                     return false;
                 }
 
                 this._cellOperationsEnabled = false;
-                state.loadStatus = ApiStatus.Loading;
 
                 state.resultSet = undefined;
                 this.updateState();
@@ -556,6 +560,8 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             });
         } catch (error) {
             this._sessionReplacementPending = false;
+            state.loadStatus = previousLoadStatus;
+            this.updateState();
             throw error;
         }
     }
@@ -1222,9 +1228,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("revertCell", async (state, payload) => {
-            if (this.areEditMutationsBlocked()) {
-                return state;
-            }
+            this.throwIfEditMutationBlocked();
 
             this.logger.debug(
                 `Reverting cell: row ${payload.rowId}, column ${payload.columnId} - OperationId: ${this.operationId}`,
@@ -1246,7 +1250,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
             return await this.enqueueCellOperation(cacheKey, async () => {
                 if (!this._cellOperationsEnabled) {
-                    return state;
+                    throw new Error(
+                        "Cell revert was not applied because the session is unavailable",
+                    );
                 }
 
                 try {
@@ -1259,11 +1265,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     );
 
                     if (!this._cellOperationsEnabled) {
-                        endActivity.end(ActivityStatus.Succeeded, {
-                            elapsedTime: (Date.now() - startTime).toString(),
-                            operationId: this.operationId,
-                        });
-                        return state;
+                        throw new Error(
+                            "Cell revert was not applied because the session is unavailable",
+                        );
                     }
 
                     // Check if we have a cached original value
@@ -1357,7 +1361,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             new Error("Cell revert stopped during session disposal"),
                             false /* includeErrorMessage */,
                         );
-                        return state;
+                        throw error;
                     }
 
                     this.logger.error(
@@ -1379,6 +1383,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     vscode.window.showErrorMessage(
                         LocConstants.TableExplorer.failedToRevertCell(getErrorMessage(error)),
                     );
+                    throw error;
                 }
 
                 return state;

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -1166,6 +1166,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             );
 
             const cacheKey = `${payload.rowId}-${payload.columnId}`;
+            const latestUpdateRequestIdAtRevert = this._latestCellUpdateRequestIds.get(cacheKey);
 
             return await this.enqueueCellOperation(cacheKey, async () => {
                 if (!this._cellOperationsEnabled) {
@@ -1218,7 +1219,12 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     if (state.cellUpdateAcknowledgements) {
                         delete state.cellUpdateAcknowledgements[cacheKey];
                     }
-                    this._latestCellUpdateRequestIds.delete(cacheKey);
+                    if (
+                        this._latestCellUpdateRequestIds.get(cacheKey) ===
+                        latestUpdateRequestIdAtRevert
+                    ) {
+                        this._latestCellUpdateRequestIds.delete(cacheKey);
+                    }
                     this._failedCellOperations.delete(cacheKey);
 
                     // Remove from failed cells tracking

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -867,23 +867,24 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     state.failedCells = state.failedCells.filter((key) => key !== failedKey);
                 }
 
-                // Update the cell value in the result set
-                if (state.resultSet && updateCellResult.cell) {
+                if (!updateCellResult.cell.isDirty) {
+                    state.originalCellValues?.delete(cacheKey);
+                }
+                state.cellUpdateAcknowledgements = {
+                    ...state.cellUpdateAcknowledgements,
+                    [cacheKey]: {
+                        requestId: payload.requestId,
+                        isDirty: updateCellResult.cell.isDirty,
+                    },
+                };
+
+                // Update the cell value in the result set if the row is still loaded
+                if (state.resultSet) {
                     const rowIndex = state.resultSet.subset.findIndex(
                         (row) => row.id === payload.rowId,
                     );
 
                     if (rowIndex !== -1) {
-                        if (!updateCellResult.cell.isDirty) {
-                            state.originalCellValues?.delete(cacheKey);
-                        }
-                        state.cellUpdateAcknowledgements = {
-                            ...state.cellUpdateAcknowledgements,
-                            [cacheKey]: {
-                                requestId: payload.requestId,
-                                isDirty: updateCellResult.cell.isDirty,
-                            },
-                        };
                         const updatedRow = this.updateResultCell(
                             state,
                             state.resultSet.subset[rowIndex],
@@ -897,15 +898,13 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             ),
                         };
 
-                        this.showRestorePromptAfterClose = this.hasPendingChanges(state);
-
-                        this.updateState();
-
                         this.logger.debug(
                             `Updated cell in result set at row ${rowIndex}, column ${payload.columnId}`,
                         );
                     }
                 }
+                this.showRestorePromptAfterClose = this.hasPendingChanges(state);
+                this.updateState();
 
                 this.logger.debug(`Cell updated successfully - OperationId: ${this.operationId}`);
 

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -587,6 +587,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     vscode.window.showErrorMessage(
                         LocConstants.TableExplorer.failedToSaveChanges(getErrorMessage(error)),
                     );
+                    throw error;
                 }
 
                 return state;
@@ -679,9 +680,14 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("createRow", async (state) => {
+            if (!this._cellOperationsEnabled) {
+                return state;
+            }
+
             this.logger.info(
                 `Creating new row for: ${state.tableName} - OperationId: ${this.operationId}`,
             );
+            this.showRestorePromptAfterClose = true;
 
             const startTime = Date.now();
             const endActivity = startActivity(
@@ -694,65 +700,71 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 },
             );
 
-            try {
-                const result = await this._tableExplorerService.createRow(state.ownerUri);
-                vscode.window.showInformationMessage(
-                    LocConstants.TableExplorer.rowCreatedSuccessfully,
-                );
-                this.logger.debug(
-                    `Created row with ID: ${result.newRowId} - OperationId: ${this.operationId}`,
-                );
-
-                // Track new row and mark unsaved changes
-                state.newRows = [...state.newRows, result.row];
-                this.showRestorePromptAfterClose = true;
-
-                // Update result set with new row
-                if (state.resultSet) {
-                    // Create a completely new resultSet object to ensure React detects the change
-                    state.resultSet = {
-                        ...state.resultSet,
-                        subset: [...state.resultSet.subset, result.row],
-                        rowCount: state.resultSet.rowCount + 1,
-                    };
-
-                    this.logger.debug(
-                        `Added new row to result set, now has ${state.resultSet.rowCount} rows (${state.newRows.length} new)`,
-                    );
-
-                    this.updateState();
-                } else {
-                    this.logger.warn("Cannot add row: result set is undefined");
+            return await this.enqueueLifecycleOperation(async () => {
+                if (!this._cellOperationsEnabled) {
+                    return state;
                 }
 
-                await this.regenerateScriptIfVisible(state);
+                try {
+                    const result = await this._tableExplorerService.createRow(state.ownerUri);
+                    vscode.window.showInformationMessage(
+                        LocConstants.TableExplorer.rowCreatedSuccessfully,
+                    );
+                    this.logger.debug(
+                        `Created row with ID: ${result.newRowId} - OperationId: ${this.operationId}`,
+                    );
 
-                endActivity.end(ActivityStatus.Succeeded, {
-                    elapsedTime: (Date.now() - startTime).toString(),
-                    operationId: this.operationId,
-                });
-            } catch (error) {
-                this.logger.error(
-                    `Error creating row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
-                );
+                    // Track new row and mark unsaved changes
+                    state.newRows = [...state.newRows, result.row];
 
-                endActivity.endFailed(
-                    new Error("Failed to create row"),
-                    true /* includeErrorMessage */,
-                    undefined /* errorCode */,
-                    undefined /* errorType */,
-                    {
+                    // Update result set with new row
+                    if (state.resultSet) {
+                        // Create a completely new resultSet object to ensure React detects the change
+                        state.resultSet = {
+                            ...state.resultSet,
+                            subset: [...state.resultSet.subset, result.row],
+                            rowCount: state.resultSet.rowCount + 1,
+                        };
+
+                        this.logger.debug(
+                            `Added new row to result set, now has ${state.resultSet.rowCount} rows (${state.newRows.length} new)`,
+                        );
+
+                        this.updateState();
+                    } else {
+                        this.logger.warn("Cannot add row: result set is undefined");
+                    }
+
+                    await this.regenerateScriptIfVisible(state);
+
+                    endActivity.end(ActivityStatus.Succeeded, {
                         elapsedTime: (Date.now() - startTime).toString(),
                         operationId: this.operationId,
-                    },
-                );
+                    });
+                } catch (error) {
+                    this.showRestorePromptAfterClose = this.hasPendingChanges(state);
+                    this.logger.error(
+                        `Error creating row: ${getErrorMessage(error)} - OperationId: ${this.operationId}`,
+                    );
 
-                vscode.window.showErrorMessage(
-                    LocConstants.TableExplorer.failedToCreateNewRow(getErrorMessage(error)),
-                );
-            }
+                    endActivity.endFailed(
+                        new Error("Failed to create row"),
+                        true /* includeErrorMessage */,
+                        undefined /* errorCode */,
+                        undefined /* errorType */,
+                        {
+                            elapsedTime: (Date.now() - startTime).toString(),
+                            operationId: this.operationId,
+                        },
+                    );
 
-            return state;
+                    vscode.window.showErrorMessage(
+                        LocConstants.TableExplorer.failedToCreateNewRow(getErrorMessage(error)),
+                    );
+                }
+
+                return state;
+            });
         });
 
         this.registerReducer("deleteRow", async (state, payload) => {
@@ -881,6 +893,10 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("updateCell", async (state, payload) => {
+            if (!this._cellOperationsEnabled) {
+                return state;
+            }
+
             this.logger.debug(
                 `Updating cell: row ${payload.rowId}, column ${payload.columnId} - OperationId: ${this.operationId}`,
             );
@@ -903,6 +919,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             if (registeredBeforeQueue) {
                 this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
             }
+            this.showRestorePromptAfterClose = true;
 
             const ownerUri = state.ownerUri;
             return await this.enqueueCellOperation(cacheKey, async () => {
@@ -916,6 +933,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 if (!registeredBeforeQueue) {
                     this._latestCellUpdateRequestIds.set(cacheKey, payload.requestId);
                 }
+                this.showRestorePromptAfterClose = true;
                 if (state.resultSet && !state.originalCellValues?.has(cacheKey)) {
                     const rowIndex = state.resultSet.subset.findIndex(
                         (row) => row.id === payload.rowId,

--- a/extensions/mssql/src/webviews/common/rpc.ts
+++ b/extensions/mssql/src/webviews/common/rpc.ts
@@ -189,6 +189,16 @@ export class WebviewRpc<Reducers> {
         });
     }
 
+    public async actionAsync<MethodName extends keyof Reducers>(
+        method: MethodName,
+        payload?: Reducers[MethodName],
+    ): Promise<void> {
+        await this.sendRequest(ReducerRequest.type<Reducers>(), {
+            type: method,
+            payload: payload,
+        });
+    }
+
     public sendActionEvent(event: WebviewTelemetryActionEvent) {
         void this.sendNotification(SendActionEventNotification.type, event);
     }

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -27,8 +27,12 @@ import {
     AppliedSortColumn,
     stripTrailingOrderByAndSemicolon,
 } from "../../../tableExplorer/tableQueryComposer";
-import { removeCleanCellChanges } from "../../../tableExplorer/editDataUtils";
-import { EditSubsetResult, ExportData } from "../../../sharedInterfaces/tableExplorer";
+import { removeAcknowledgedCleanCellChanges } from "../../../tableExplorer/editDataUtils";
+import {
+    CellUpdateAcknowledgement,
+    EditSubsetResult,
+    ExportData,
+} from "../../../sharedInterfaces/tableExplorer";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
 import { locConstants as loc } from "../../common/locConstants";
 import TableExplorerCustomPager from "./TableExplorerCustomPager";
@@ -63,6 +67,7 @@ const isNumericSqlType = (dataTypeName?: string): boolean => {
 
 interface TableDataGridProps {
     resultSet: EditSubsetResult | undefined;
+    cellUpdateAcknowledgements?: Record<string, CellUpdateAcknowledgement>;
     themeKind?: ColorThemeKind;
     pageSize?: number;
     currentRowCount?: number;
@@ -71,7 +76,7 @@ interface TableDataGridProps {
     newRowIds?: number[];
     tableQuery?: string;
     onDeleteRow?: (rowId: number) => void;
-    onUpdateCell?: (rowId: number, columnId: number, newValue: string) => void;
+    onUpdateCell?: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
     onRevertCell?: (rowId: number, columnId: number) => void;
     onRevertRow?: (rowId: number) => void;
     onCellChangeCountChanged?: (count: number) => void;
@@ -106,6 +111,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
     (
         {
             resultSet,
+            cellUpdateAcknowledgements,
             themeKind,
             pageSize = 50,
             failedCells,
@@ -131,6 +137,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         const [currentTheme, setCurrentTheme] = useState<ColorThemeKind | undefined>(themeKind);
         const reactGridRef = useRef<SlickgridReactInstance | null>(null);
         const cellChangesRef = useRef<Map<string, any>>(new Map());
+        const nextCellUpdateRequestIdRef = useRef(0);
         const deletedRowsRef = useRef<Set<number>>(new Set());
         const newRowIdsRef = useRef<Set<number>>(new Set());
         const failedCellsRef = useRef<Set<string>>(new Set());
@@ -614,14 +621,6 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 return;
             }
 
-            const changeTrackingChanged = removeCleanCellChanges(
-                resultSet.subset,
-                cellChangesRef.current,
-            );
-            if (changeTrackingChanged && onCellChangeCountChanged) {
-                onCellChangeCountChanged(cellChangesRef.current.size);
-            }
-
             const previousResultSet = previousResultSetRef.current;
             const isInitialLoad = !isInitializedRef.current || !previousResultSet;
             const columnCountChanged =
@@ -849,6 +848,17 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             previousResultSetRef.current = resultSet;
         }, [resultSet, options, themeKind, pageSize]);
 
+        useEffect(() => {
+            const changeTrackingChanged = removeAcknowledgedCleanCellChanges(
+                cellUpdateAcknowledgements,
+                cellChangesRef.current,
+            );
+            if (changeTrackingChanged) {
+                onCellChangeCountChanged?.(cellChangesRef.current.size);
+                reactGridRef.current?.slickGrid?.invalidate();
+            }
+        }, [cellUpdateAcknowledgements]);
+
         // Restore pagination after dataset changes
         useEffect(() => {
             if (
@@ -926,12 +936,14 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
 
             // Track the change using original data column index (not visible cell index)
             const changeKey = `${rowId}-${dataColumnIndex}`;
+            const requestId = ++nextCellUpdateRequestIdRef.current;
             cellChangesRef.current.set(changeKey, {
                 rowId,
                 columnIndex: dataColumnIndex,
                 columnId: column?.id,
                 field: column?.field,
                 newValue: args.item[column?.field],
+                requestId,
             });
 
             // Notify parent of change count update
@@ -942,7 +954,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             // Notify parent
             if (onUpdateCell) {
                 const newValue = args.item[column?.field];
-                onUpdateCell(rowId, dataColumnIndex, newValue);
+                onUpdateCell(rowId, dataColumnIndex, newValue, requestId);
             }
 
             // Update the display without full re-render

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -30,6 +30,7 @@ import {
 import {
     removeAcknowledgedCleanCellChanges,
     revertCellAndClearTracking,
+    updateCellAndTrackFailure,
 } from "../../../tableExplorer/editDataUtils";
 import {
     CellUpdateAcknowledgement,
@@ -80,7 +81,12 @@ interface TableDataGridProps {
     tableQuery?: string;
     mutationsBlocked?: boolean;
     onDeleteRow?: (rowId: number) => void;
-    onUpdateCell?: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
+    onUpdateCell?: (
+        rowId: number,
+        columnId: number,
+        newValue: string,
+        requestId: number,
+    ) => Promise<void>;
     onRevertCell?: (rowId: number, columnId: number) => Promise<void>;
     onRevertRow?: (rowId: number) => Promise<void>;
     onCellChangeCountChanged?: (count: number) => void;
@@ -982,7 +988,13 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             // Notify parent
             if (onUpdateCell) {
                 const newValue = args.item[column?.field];
-                onUpdateCell(rowId, dataColumnIndex, newValue, requestId);
+                void updateCellAndTrackFailure(
+                    () => onUpdateCell(rowId, dataColumnIndex, newValue, requestId),
+                    () => {
+                        failedCellsRef.current.add(changeKey);
+                        reactGridRef.current?.slickGrid?.invalidate();
+                    },
+                );
             }
 
             // Update the display without full re-render

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -27,7 +27,10 @@ import {
     AppliedSortColumn,
     stripTrailingOrderByAndSemicolon,
 } from "../../../tableExplorer/tableQueryComposer";
-import { removeAcknowledgedCleanCellChanges } from "../../../tableExplorer/editDataUtils";
+import {
+    removeAcknowledgedCleanCellChanges,
+    revertCellAndClearTracking,
+} from "../../../tableExplorer/editDataUtils";
 import {
     CellUpdateAcknowledgement,
     EditSubsetResult,
@@ -78,7 +81,7 @@ interface TableDataGridProps {
     mutationsBlocked?: boolean;
     onDeleteRow?: (rowId: number) => void;
     onUpdateCell?: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
-    onRevertCell?: (rowId: number, columnId: number) => void;
+    onRevertCell?: (rowId: number, columnId: number) => Promise<void>;
     onRevertRow?: (rowId: number) => Promise<void>;
     onCellChangeCountChanged?: (count: number) => void;
     onDeletionCountChanged?: (count: number) => void;
@@ -1027,6 +1030,23 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             reactGridRef.current?.slickGrid?.invalidate();
         }
 
+        async function revertCell(rowId: number, columnId: number) {
+            if (mutationsBlockedRef.current || !onRevertCell) {
+                return;
+            }
+
+            const changeKey = `${rowId}-${columnId}`;
+            await revertCellAndClearTracking(
+                () => onRevertCell(rowId, columnId),
+                () => {
+                    cellChangesRef.current.delete(changeKey);
+                    failedCellsRef.current.delete(changeKey);
+                    onCellChangeCountChanged?.(cellChangesRef.current.size);
+                    reactGridRef.current?.slickGrid?.invalidate();
+                },
+            );
+        }
+
         function handleCellClick(_e: Event, args: any) {
             const metadata = reactGridRef.current?.gridService.getColumnFromEventArguments(args);
             if (metadata?.columnDef.id !== "undo") {
@@ -1139,19 +1159,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     const column = gridColumns[cellIndex];
                     // Use the original column index stored in column metadata (handles hidden columns)
                     const dataColumnIndex = (column as any)?.originalIndex ?? cellIndex;
-                    const changeKey = `${rowId}-${dataColumnIndex}`;
-
-                    if (onRevertCell) {
-                        onRevertCell(rowId, dataColumnIndex);
-                    }
-
-                    cellChangesRef.current.delete(changeKey);
-                    failedCellsRef.current.delete(changeKey);
-
-                    // Notify parent of change count update
-                    if (onCellChangeCountChanged) {
-                        onCellChangeCountChanged(cellChangesRef.current.size);
-                    }
+                    void revertCell(rowId, dataColumnIndex);
                     break;
 
                 case "revert-row":

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -79,7 +79,7 @@ interface TableDataGridProps {
     onDeleteRow?: (rowId: number) => void;
     onUpdateCell?: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
     onRevertCell?: (rowId: number, columnId: number) => void;
-    onRevertRow?: (rowId: number) => void;
+    onRevertRow?: (rowId: number) => Promise<void>;
     onCellChangeCountChanged?: (count: number) => void;
     onDeletionCountChanged?: (count: number) => void;
     onSelectedRowsChanged?: (selectedRowIds: number[]) => void;
@@ -857,15 +857,28 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         }, [resultSet, options, themeKind, pageSize]);
 
         useEffect(() => {
-            const changeTrackingChanged = removeAcknowledgedCleanCellChanges(
+            let changeTrackingChanged = removeAcknowledgedCleanCellChanges(
                 cellUpdateAcknowledgements,
                 cellChangesRef.current,
             );
+            const dirtyCellKeys = new Set(failedCells ?? []);
+            for (const [key, acknowledgement] of Object.entries(cellUpdateAcknowledgements ?? {})) {
+                if (acknowledgement.isDirty) {
+                    dirtyCellKeys.add(key);
+                }
+            }
+            for (const key of dirtyCellKeys) {
+                const rowId = Number(key.slice(0, key.lastIndexOf("-")));
+                if (!deletedRowsRef.current.has(rowId) && !cellChangesRef.current.has(key)) {
+                    cellChangesRef.current.set(key, {});
+                    changeTrackingChanged = true;
+                }
+            }
             if (changeTrackingChanged) {
                 onCellChangeCountChanged?.(cellChangesRef.current.size);
                 reactGridRef.current?.slickGrid?.invalidate();
             }
-        }, [cellUpdateAcknowledgements]);
+        }, [cellUpdateAcknowledgements, failedCells, deletedRows]);
 
         // Restore pagination after dataset changes
         useEffect(() => {
@@ -979,13 +992,15 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         // context menu's "Revert Row" command. Notifies the backend, clears
         // local deletion / cell-change tracking for the row, and updates parent
         // counters.
-        function revertRow(rowId: number) {
-            if (mutationsBlockedRef.current) {
+        async function revertRow(rowId: number) {
+            if (mutationsBlockedRef.current || !onRevertRow) {
                 return;
             }
 
-            if (onRevertRow) {
-                onRevertRow(rowId);
+            try {
+                await onRevertRow(rowId);
+            } catch {
+                return;
             }
 
             deletedRowsRef.current.delete(rowId);
@@ -1027,7 +1042,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 lastItemsPerPageRef.current = reactGridRef.current.paginationService.itemsPerPage;
             }
 
-            revertRow(rowId);
+            void revertRow(rowId);
         }
 
         function handleCellKeyDown(e: KeyboardEvent, _args: any) {
@@ -1067,7 +1082,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 lastItemsPerPageRef.current = reactGridRef.current.paginationService.itemsPerPage;
             }
 
-            revertRow(dataItem.id);
+            void revertRow(dataItem.id);
             e.preventDefault();
             e.stopPropagation();
         }
@@ -1140,7 +1155,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     break;
 
                 case "revert-row":
-                    revertRow(rowId);
+                    void revertRow(rowId);
                     break;
 
                 case "modify-table":

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -75,6 +75,7 @@ interface TableDataGridProps {
     deletedRows?: number[];
     newRowIds?: number[];
     tableQuery?: string;
+    mutationsBlocked?: boolean;
     onDeleteRow?: (rowId: number) => void;
     onUpdateCell?: (rowId: number, columnId: number, newValue: string, requestId: number) => void;
     onRevertCell?: (rowId: number, columnId: number) => void;
@@ -118,6 +119,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             deletedRows,
             newRowIds,
             tableQuery,
+            mutationsBlocked = false,
             onDeleteRow,
             onUpdateCell,
             onRevertCell,
@@ -141,6 +143,8 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         const deletedRowsRef = useRef<Set<number>>(new Set());
         const newRowIdsRef = useRef<Set<number>>(new Set());
         const failedCellsRef = useRef<Set<string>>(new Set());
+        const mutationsBlockedRef = useRef(mutationsBlocked);
+        mutationsBlockedRef.current = mutationsBlocked;
         const lastPageRef = useRef<number>(1);
         const lastItemsPerPageRef = useRef<number>(pageSize);
         const previousResultSetRef = useRef<EditSubsetResult | undefined>(undefined);
@@ -294,7 +298,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 grid.updateColumns();
             },
             deleteRows: (rowIds: number[]) => {
-                if (!onDeleteRow) {
+                if (!onDeleteRow || mutationsBlockedRef.current) {
                     return;
                 }
                 if (reactGridRef.current?.paginationService) {
@@ -605,6 +609,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             }
         }, [themeKind, currentTheme]);
 
+        useEffect(() => {
+            reactGridRef.current?.slickGrid?.setOptions({ editable: !mutationsBlocked });
+        }, [mutationsBlocked]);
+
         // When the table query changes (custom query run), reset the previous result set
         // reference so the next resultSet update triggers a full grid re-initialization
         // (Scenario 1) instead of an incremental update (Scenario 2). This is necessary
@@ -662,7 +670,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     setOptions({
                         autoEdit: false,
                         autoCommitEdit: true,
-                        editable: true,
+                        editable: !mutationsBlocked,
                         autoResize: createFluentAutoResizeOptions("#grid-container", {
                             autoHeight: false,
                             bottomPadding: 10,
@@ -920,6 +928,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         }
 
         function handleCellChange(_e: CustomEvent, args: any) {
+            if (mutationsBlockedRef.current) {
+                return;
+            }
+
             // Capture pagination state
             if (reactGridRef.current?.paginationService) {
                 lastPageRef.current = reactGridRef.current.paginationService.pageNumber;
@@ -968,6 +980,10 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         // local deletion / cell-change tracking for the row, and updates parent
         // counters.
         function revertRow(rowId: number) {
+            if (mutationsBlockedRef.current) {
+                return;
+            }
+
             if (onRevertRow) {
                 onRevertRow(rowId);
             }
@@ -1093,12 +1109,15 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                     break;
 
                 case "delete-row":
-                    if (onDeleteRow) {
+                    if (onDeleteRow && !mutationsBlockedRef.current) {
                         onDeleteRow(rowId);
                     }
                     break;
 
                 case "revert-cell":
+                    if (mutationsBlockedRef.current) {
+                        break;
+                    }
                     const cellIndex = args.cell;
                     // Get the actual column from the grid (accounts for hidden columns)
                     const gridColumns = reactGridRef.current?.slickGrid?.getVisibleColumns() || [];

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -27,6 +27,7 @@ import {
     AppliedSortColumn,
     stripTrailingOrderByAndSemicolon,
 } from "../../../tableExplorer/tableQueryComposer";
+import { removeCleanCellChanges } from "../../../tableExplorer/editDataUtils";
 import { EditSubsetResult, ExportData } from "../../../sharedInterfaces/tableExplorer";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
 import { locConstants as loc } from "../../common/locConstants";
@@ -611,6 +612,14 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         useEffect(() => {
             if (!resultSet?.columnInfo || !resultSet?.subset) {
                 return;
+            }
+
+            const changeTrackingChanged = removeCleanCellChanges(
+                resultSet.subset,
+                cellChangesRef.current,
+            );
+            if (changeTrackingChanged && onCellChangeCountChanged) {
+                onCellChangeCountChanged(cellChangesRef.current.size);
             }
 
             const previousResultSet = previousResultSetRef.current;

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
@@ -407,7 +407,7 @@ export const TableExplorerPage: React.FC = () => {
                                     deletedRows={deletedRows}
                                     newRowIds={newRows?.map((r) => r.id)}
                                     tableQuery={tableQuery}
-                                    mutationsBlocked={isSaving}
+                                    mutationsBlocked={isSaving || isLoading}
                                     onDeleteRow={context?.deleteRow}
                                     onUpdateCell={context?.updateCell}
                                     onRevertCell={context?.revertCell}

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
@@ -173,6 +173,7 @@ export const TableExplorerPage: React.FC = () => {
     const gridRef = useRef<TableDataGridRef>(null);
     const [cellChangeCount, setCellChangeCount] = React.useState(0);
     const [deletionCount, setDeletionCount] = React.useState(0);
+    const [isSaving, setIsSaving] = React.useState(false);
     const [selectedRowIds, setSelectedRowIds] = React.useState<number[]>([]);
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [activeFilters, setActiveFilters] = React.useState<AppliedFilter[]>([]);
@@ -354,6 +355,8 @@ export const TableExplorerPage: React.FC = () => {
                     <div className={classes.contentArea}>
                         <TableExplorerToolbar
                             onSaveComplete={handleSaveComplete}
+                            isSaving={isSaving}
+                            onSavingChange={setIsSaving}
                             cellChangeCount={cellChangeCount}
                             deletionCount={deletionCount}
                             currentRowCount={currentRowCount}
@@ -378,7 +381,7 @@ export const TableExplorerPage: React.FC = () => {
                                     columns={filterColumns}
                                     onApply={handleApplyFilters}
                                     onClear={handleClearFilters}
-                                    disabled={isLoading}
+                                    disabled={isLoading || isSaving}
                                     initialFilters={activeFilters}
                                     isOpen={filtersOpen}
                                 />
@@ -404,6 +407,7 @@ export const TableExplorerPage: React.FC = () => {
                                     deletedRows={deletedRows}
                                     newRowIds={newRows?.map((r) => r.id)}
                                     tableQuery={tableQuery}
+                                    mutationsBlocked={isSaving}
                                     onDeleteRow={context?.deleteRow}
                                     onUpdateCell={context?.updateCell}
                                     onRevertCell={context?.revertCell}

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
@@ -124,6 +124,9 @@ export const TableExplorerPage: React.FC = () => {
     const loadStatus = useTableExplorerSelector((s) => s.loadStatus);
     const currentRowCount = useTableExplorerSelector((s) => s.currentRowCount);
     const failedCells = useTableExplorerSelector((s) => s.failedCells);
+    const cellUpdateAcknowledgements = useTableExplorerSelector(
+        (s) => s.cellUpdateAcknowledgements,
+    );
     const deletedRows = useTableExplorerSelector((s) => s.deletedRows);
     const newRows = useTableExplorerSelector((s) => s.newRows);
     const showScriptPane = useTableExplorerSelector((s) => s.showScriptPane);
@@ -394,6 +397,7 @@ export const TableExplorerPage: React.FC = () => {
                                 <TableDataGrid
                                     ref={gridRef}
                                     resultSet={resultSet}
+                                    cellUpdateAcknowledgements={cellUpdateAcknowledgements}
                                     themeKind={themeKind}
                                     currentRowCount={currentRowCount}
                                     failedCells={failedCells}

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -54,8 +54,8 @@ export const TableExplorerStateProvider: React.FC<{
                 extensionRpc.action("revertCell", { rowId, columnId });
             },
 
-            revertRow: function (rowId: number): void {
-                extensionRpc.action("revertRow", { rowId });
+            revertRow: async function (rowId: number): Promise<void> {
+                await extensionRpc.actionAsync("revertRow", { rowId });
             },
 
             generateScript: function (): void {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -41,8 +41,13 @@ export const TableExplorerStateProvider: React.FC<{
                 extensionRpc.action("deleteRow", { rowId });
             },
 
-            updateCell: function (rowId: number, columnId: number, newValue: string): void {
-                extensionRpc.action("updateCell", { rowId, columnId, newValue });
+            updateCell: function (
+                rowId: number,
+                columnId: number,
+                newValue: string,
+                requestId: number,
+            ): void {
+                extensionRpc.action("updateCell", { rowId, columnId, newValue, requestId });
             },
 
             revertCell: function (rowId: number, columnId: number): void {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -50,8 +50,8 @@ export const TableExplorerStateProvider: React.FC<{
                 extensionRpc.action("updateCell", { rowId, columnId, newValue, requestId });
             },
 
-            revertCell: function (rowId: number, columnId: number): void {
-                extensionRpc.action("revertCell", { rowId, columnId });
+            revertCell: async function (rowId: number, columnId: number): Promise<void> {
+                await extensionRpc.actionAsync("revertCell", { rowId, columnId });
             },
 
             revertRow: async function (rowId: number): Promise<void> {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -41,13 +41,18 @@ export const TableExplorerStateProvider: React.FC<{
                 extensionRpc.action("deleteRow", { rowId });
             },
 
-            updateCell: function (
+            updateCell: async function (
                 rowId: number,
                 columnId: number,
                 newValue: string,
                 requestId: number,
-            ): void {
-                extensionRpc.action("updateCell", { rowId, columnId, newValue, requestId });
+            ): Promise<void> {
+                await extensionRpc.actionAsync("updateCell", {
+                    rowId,
+                    columnId,
+                    newValue,
+                    requestId,
+                });
             },
 
             revertCell: async function (rowId: number, columnId: number): Promise<void> {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -25,8 +25,8 @@ export const TableExplorerStateProvider: React.FC<{
     const commands = useMemo<TableExplorerContextProps>(
         () => ({
             ...getCoreRPCs(extensionRpc),
-            commitChanges: function (): void {
-                extensionRpc.action("commitChanges", {});
+            commitChanges: async function (): Promise<void> {
+                await extensionRpc.actionAsync("commitChanges", {});
             },
 
             loadSubset: function (rowCount: number): void {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerToolbar.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerToolbar.tsx
@@ -35,6 +35,7 @@ import { locConstants as loc } from "../../common/locConstants";
 import { useTableExplorerContext } from "./TableExplorerStateProvider";
 import { useTableExplorerSelector } from "./tableExplorerSelector";
 import { ApiStatus } from "../../../sharedInterfaces/webview";
+import { commitChangesAndClearTracking } from "../../../tableExplorer/editDataUtils";
 import type { DataColumnVisibility } from "./TableDataGrid";
 
 const useStyles = makeStyles({
@@ -152,12 +153,8 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
 
     const lastSubmittedRowCountRef = React.useRef<number>(DEFAULT_ROW_COUNT);
 
-    const handleSave = () => {
-        context.commitChanges();
-        // Call the callback to clear change tracking after save
-        if (onSaveComplete) {
-            onSaveComplete();
-        }
+    const handleSave = async () => {
+        await commitChangesAndClearTracking(context.commitChanges, onSaveComplete);
     };
 
     const handleAddRow = () => {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerToolbar.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerToolbar.tsx
@@ -53,6 +53,8 @@ const useStyles = makeStyles({
 
 interface TableExplorerToolbarProps {
     onSaveComplete?: () => void;
+    isSaving?: boolean;
+    onSavingChange?: (isSaving: boolean) => void;
     cellChangeCount: number;
     deletionCount: number;
     currentRowCount?: number;
@@ -126,6 +128,8 @@ const ColumnsMenu: React.FC<ColumnsMenuProps> = ({
 
 export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
     onSaveComplete,
+    isSaving = false,
+    onSavingChange,
     cellChangeCount,
     deletionCount,
     currentRowCount,
@@ -148,17 +152,28 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
     // Use selectors to access state
     const loadStatus = useTableExplorerSelector((s) => s.loadStatus);
     const isLoading = loadStatus === ApiStatus.Loading;
+    const isBusy = isLoading || isSaving;
 
     const [loadRowCount, setLoadRowCount] = React.useState<string>(String(DEFAULT_ROW_COUNT));
 
     const lastSubmittedRowCountRef = React.useRef<number>(DEFAULT_ROW_COUNT);
 
     const handleSave = async () => {
-        await commitChangesAndClearTracking(context.commitChanges, onSaveComplete);
+        if (isSaving) {
+            return;
+        }
+        onSavingChange?.(true);
+        try {
+            await commitChangesAndClearTracking(context.commitChanges, onSaveComplete);
+        } finally {
+            onSavingChange?.(false);
+        }
     };
 
     const handleAddRow = () => {
-        context.createRow();
+        if (!isSaving) {
+            context.createRow();
+        }
     };
 
     const fetchRowsForValue = (rawValue: string) => {
@@ -221,7 +236,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                 title={saveButtonText}
                 icon={<SaveRegular />}
                 onClick={handleSave}
-                disabled={changeCount === 0 || isLoading}>
+                disabled={changeCount === 0 || isBusy}>
                 {saveButtonText}
             </ToolbarButton>
             <ToolbarButton
@@ -229,14 +244,14 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                 title={loc.tableExplorer.addRow}
                 icon={<AddRegular />}
                 onClick={handleAddRow}
-                disabled={isLoading}>
+                disabled={isBusy}>
                 {loc.tableExplorer.addRow}
             </ToolbarButton>
             <Menu>
                 <MenuTrigger disableButtonEnhancement>
                     <SplitButton
                         icon={<CodeRegular />}
-                        disabled={isLoading}
+                        disabled={isBusy}
                         size="small"
                         primaryActionButton={{
                             onClick: showScriptPane
@@ -269,7 +284,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                 title={loc.tableExplorer.viewTableDiagram}
                 icon={<OrganizationRegular />}
                 onClick={() => context.viewTableDiagram()}
-                disabled={isLoading}>
+                disabled={isBusy}>
                 {loc.tableExplorer.viewTableDiagram}
             </ToolbarButton>
             {onShowSql && (
@@ -278,7 +293,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                     title={loc.tableExplorer.openSqlInEditor}
                     icon={<DocumentTextRegular />}
                     onClick={onShowSql}
-                    disabled={isLoading}>
+                    disabled={isBusy}>
                     {loc.tableExplorer.showSql}
                 </ToolbarButton>
             )}
@@ -290,7 +305,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                     title={loc.tableExplorer.filtersTooltip}
                     icon={<FilterRegular />}
                     onClick={onToggleFilters}
-                    disabled={isLoading}>
+                    disabled={isBusy}>
                     {loc.tableExplorer.filters}
                 </ToolbarButton>
             )}
@@ -301,7 +316,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                             aria-label={loc.tableExplorer.export}
                             title={loc.tableExplorer.export}
                             icon={<ArrowDownloadRegular />}
-                            disabled={isLoading}>
+                            disabled={isBusy}>
                             {loc.tableExplorer.export}
                         </ToolbarButton>
                     </MenuTrigger>
@@ -322,7 +337,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
             )}
             {getDataColumns && onSetColumnVisibility && (
                 <ColumnsMenu
-                    isLoading={isLoading}
+                    isLoading={isBusy}
                     getDataColumns={getDataColumns}
                     onSetColumnVisibility={onSetColumnVisibility}
                 />
@@ -333,7 +348,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                     title={loc.tableExplorer.deleteSelected(selectedRowCount)}
                     icon={<DeleteRegular />}
                     onClick={onDeleteSelected}
-                    disabled={isLoading}>
+                    disabled={isBusy}>
                     {loc.tableExplorer.deleteSelected(selectedRowCount)}
                 </ToolbarButton>
             )}
@@ -347,7 +362,7 @@ export const TableExplorerToolbar: React.FC<TableExplorerToolbarProps> = ({
                     onBlur={onRowCountBlur}
                     size="small"
                     freeform
-                    disabled={isLoading}>
+                    disabled={isBusy}>
                     <Option value="10">10</Option>
                     <Option value="50">50</Option>
                     <Option value="100">100</Option>

--- a/extensions/mssql/test/unit/editDataUtils.test.ts
+++ b/extensions/mssql/test/unit/editDataUtils.test.ts
@@ -4,51 +4,55 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { removeCleanCellChanges } from "../../src/tableExplorer/editDataUtils";
-import { EditCell, EditRow, EditRowState } from "../../src/sharedInterfaces/tableExplorer";
+import { removeAcknowledgedCleanCellChanges } from "../../src/tableExplorer/editDataUtils";
 
 suite("editDataUtils", () => {
-    const createRow = (cellDirtyStates: boolean[]): EditRow => ({
-        id: 7,
-        isDirty: cellDirtyStates.some(Boolean),
-        state: cellDirtyStates.some(Boolean) ? EditRowState.dirtyUpdate : EditRowState.clean,
-        cells: cellDirtyStates.map(
-            (isDirty, index): EditCell => ({
-                displayValue: String(index),
-                invariantCultureDisplayValue: String(index),
-                isNull: false,
-                isDirty,
-            }),
-        ),
-    });
-
     test("removes a locally tracked cell when the service reports it clean", () => {
-        const changes = new Map<string, unknown>([["7-0", { newValue: "original" }]]);
+        const changes = new Map([["7-0", { requestId: 1, newValue: "original" }]]);
 
-        const changed = removeCleanCellChanges([createRow([false])], changes);
+        const changed = removeAcknowledgedCleanCellChanges(
+            { "7-0": { requestId: 1, isDirty: false } },
+            changes,
+        );
 
         expect(changed).to.be.true;
         expect(changes).to.be.empty;
     });
 
-    test("preserves other dirty cells in the same row", () => {
-        const changes = new Map<string, unknown>([
-            ["7-0", { newValue: "original" }],
-            ["7-1", { newValue: "changed" }],
+    test("preserves a pending cell when another cell is acknowledged clean", () => {
+        const changes = new Map([
+            ["7-0", { requestId: 1, newValue: "original" }],
+            ["7-1", { requestId: 2, newValue: "pending" }],
         ]);
 
-        const changed = removeCleanCellChanges([createRow([false, true])], changes);
+        const changed = removeAcknowledgedCleanCellChanges(
+            { "7-0": { requestId: 1, isDirty: false } },
+            changes,
+        );
 
         expect(changed).to.be.true;
         expect([...changes.keys()]).to.deep.equal(["7-1"]);
     });
 
-    test("does not clear tracking when dirty state is absent", () => {
-        const row = createRow([true]);
-        delete (row.cells[0] as { isDirty?: boolean }).isDirty;
-        const changes = new Map<string, unknown>([["7-0", { newValue: "changed" }]]);
+    test("preserves a newer edit when an older request is acknowledged clean", () => {
+        const changes = new Map([["7-0", { requestId: 2, newValue: "newer edit" }]]);
 
-        const changed = removeCleanCellChanges([row], changes);
+        const changed = removeAcknowledgedCleanCellChanges(
+            { "7-0": { requestId: 1, isDirty: false } },
+            changes,
+        );
+
+        expect(changed).to.be.false;
+        expect([...changes.keys()]).to.deep.equal(["7-0"]);
+    });
+
+    test("preserves a matching edit when the service reports it dirty", () => {
+        const changes = new Map([["7-0", { requestId: 1, newValue: "changed" }]]);
+
+        const changed = removeAcknowledgedCleanCellChanges(
+            { "7-0": { requestId: 1, isDirty: true } },
+            changes,
+        );
 
         expect(changed).to.be.false;
         expect([...changes.keys()]).to.deep.equal(["7-0"]);

--- a/extensions/mssql/test/unit/editDataUtils.test.ts
+++ b/extensions/mssql/test/unit/editDataUtils.test.ts
@@ -8,6 +8,7 @@ import {
     commitChangesAndClearTracking,
     removeAcknowledgedCleanCellChanges,
     revertCellAndClearTracking,
+    updateCellAndTrackFailure,
 } from "../../src/tableExplorer/editDataUtils";
 
 suite("editDataUtils", () => {
@@ -90,6 +91,38 @@ suite("editDataUtils", () => {
 
         expect(committed).to.be.false;
         expect(trackingCleared).to.be.false;
+    });
+
+    test("does not mark a successful cell update as failed", async () => {
+        let failureTracked = false;
+
+        const updated = await updateCellAndTrackFailure(
+            async () => {},
+            () => {
+                failureTracked = true;
+            },
+        );
+
+        expect(updated).to.be.true;
+        expect(failureTracked).to.be.false;
+    });
+
+    test("preserves tracking and marks a rejected cell update as failed", async () => {
+        const trackedChanges = new Map([["7-0", "pending"]]);
+        let failureTracked = false;
+
+        const updated = await updateCellAndTrackFailure(
+            async () => {
+                throw new Error("Update was not applied");
+            },
+            () => {
+                failureTracked = true;
+            },
+        );
+
+        expect(updated).to.be.false;
+        expect(failureTracked).to.be.true;
+        expect(trackedChanges.has("7-0")).to.be.true;
     });
 
     test("clears cell tracking after a successful revert", async () => {

--- a/extensions/mssql/test/unit/editDataUtils.test.ts
+++ b/extensions/mssql/test/unit/editDataUtils.test.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { removeAcknowledgedCleanCellChanges } from "../../src/tableExplorer/editDataUtils";
+import {
+    commitChangesAndClearTracking,
+    removeAcknowledgedCleanCellChanges,
+} from "../../src/tableExplorer/editDataUtils";
 
 suite("editDataUtils", () => {
     test("removes a locally tracked cell when the service reports it clean", () => {
@@ -56,5 +59,35 @@ suite("editDataUtils", () => {
 
         expect(changed).to.be.false;
         expect([...changes.keys()]).to.deep.equal(["7-0"]);
+    });
+
+    test("clears local tracking after a successful commit", async () => {
+        let trackingCleared = false;
+
+        const committed = await commitChangesAndClearTracking(
+            async () => {},
+            () => {
+                trackingCleared = true;
+            },
+        );
+
+        expect(committed).to.be.true;
+        expect(trackingCleared).to.be.true;
+    });
+
+    test("preserves local tracking after a failed commit", async () => {
+        let trackingCleared = false;
+
+        const committed = await commitChangesAndClearTracking(
+            async () => {
+                throw new Error("Commit failed");
+            },
+            () => {
+                trackingCleared = true;
+            },
+        );
+
+        expect(committed).to.be.false;
+        expect(trackingCleared).to.be.false;
     });
 });

--- a/extensions/mssql/test/unit/editDataUtils.test.ts
+++ b/extensions/mssql/test/unit/editDataUtils.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { removeCleanCellChanges } from "../../src/tableExplorer/editDataUtils";
+import { EditCell, EditRow, EditRowState } from "../../src/sharedInterfaces/tableExplorer";
+
+suite("editDataUtils", () => {
+    const createRow = (cellDirtyStates: boolean[]): EditRow => ({
+        id: 7,
+        isDirty: cellDirtyStates.some(Boolean),
+        state: cellDirtyStates.some(Boolean) ? EditRowState.dirtyUpdate : EditRowState.clean,
+        cells: cellDirtyStates.map(
+            (isDirty, index): EditCell => ({
+                displayValue: String(index),
+                invariantCultureDisplayValue: String(index),
+                isNull: false,
+                isDirty,
+            }),
+        ),
+    });
+
+    test("removes a locally tracked cell when the service reports it clean", () => {
+        const changes = new Map<string, unknown>([["7-0", { newValue: "original" }]]);
+
+        const changed = removeCleanCellChanges([createRow([false])], changes);
+
+        expect(changed).to.be.true;
+        expect(changes).to.be.empty;
+    });
+
+    test("preserves other dirty cells in the same row", () => {
+        const changes = new Map<string, unknown>([
+            ["7-0", { newValue: "original" }],
+            ["7-1", { newValue: "changed" }],
+        ]);
+
+        const changed = removeCleanCellChanges([createRow([false, true])], changes);
+
+        expect(changed).to.be.true;
+        expect([...changes.keys()]).to.deep.equal(["7-1"]);
+    });
+
+    test("does not clear tracking when dirty state is absent", () => {
+        const row = createRow([true]);
+        delete (row.cells[0] as { isDirty?: boolean }).isDirty;
+        const changes = new Map<string, unknown>([["7-0", { newValue: "changed" }]]);
+
+        const changed = removeCleanCellChanges([row], changes);
+
+        expect(changed).to.be.false;
+        expect([...changes.keys()]).to.deep.equal(["7-0"]);
+    });
+});

--- a/extensions/mssql/test/unit/editDataUtils.test.ts
+++ b/extensions/mssql/test/unit/editDataUtils.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import {
     commitChangesAndClearTracking,
     removeAcknowledgedCleanCellChanges,
+    revertCellAndClearTracking,
 } from "../../src/tableExplorer/editDataUtils";
 
 suite("editDataUtils", () => {
@@ -88,6 +89,36 @@ suite("editDataUtils", () => {
         );
 
         expect(committed).to.be.false;
+        expect(trackingCleared).to.be.false;
+    });
+
+    test("clears cell tracking after a successful revert", async () => {
+        let trackingCleared = false;
+
+        const reverted = await revertCellAndClearTracking(
+            async () => {},
+            () => {
+                trackingCleared = true;
+            },
+        );
+
+        expect(reverted).to.be.true;
+        expect(trackingCleared).to.be.true;
+    });
+
+    test("preserves cell tracking after a failed revert", async () => {
+        let trackingCleared = false;
+
+        const reverted = await revertCellAndClearTracking(
+            async () => {
+                throw new Error("Revert failed");
+            },
+            () => {
+                trackingCleared = true;
+            },
+        );
+
+        expect(reverted).to.be.false;
         expect(trackingCleared).to.be.false;
     });
 });

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -1479,18 +1479,37 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(mockTableExplorerService.generateScripts.calledOnce).to.be.true;
         });
 
-        test("should show error message when revertRow fails", async () => {
+        test("should preserve tracking and block commit when revertRow fails", async () => {
             // Arrange
             controller.state.ownerUri = "test-owner-uri";
+            controller.state.deletedRows = [0];
             const error = new Error("Revert row failed");
             mockTableExplorerService.revertRow.rejects(error);
+            mockTableExplorerService.commit.resolves({});
 
             // Act
-            await controller["_reducerHandlers"].get("revertRow")(controller.state, { rowId: 0 });
+            let revertRejected = false;
+            try {
+                await controller["_reducerHandlers"].get("revertRow")(controller.state, {
+                    rowId: 0,
+                });
+            } catch {
+                revertRejected = true;
+            }
+            let commitRejected = false;
+            try {
+                await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+            } catch {
+                commitRejected = true;
+            }
 
             // Assert
-            expect(showErrorMessageStub.calledOnce).to.be.true;
-            expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to revert row");
+            expect(revertRejected).to.be.true;
+            expect(commitRejected).to.be.true;
+            expect(showErrorMessageStub.calledWithMatch(sinon.match("Failed to revert row"))).to.be
+                .true;
+            expect(controller.state.deletedRows).to.deep.equal([0]);
+            expect(mockTableExplorerService.commit.called).to.be.false;
         });
 
         test("should remove newly created row from UI when revert returns null", async () => {
@@ -2516,7 +2535,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             revert.reject(new Error("Revert failed"));
             await revertRequest;
-            await saveRequest;
+            const restoreAction = await saveRequest;
 
             expect(mockTableExplorerService.commit.called).to.be.false;
             expect(
@@ -2525,6 +2544,45 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 ),
             ).to.be.false;
             expect(showErrorMessageStub.called).to.be.true;
+            expect(restoreAction).not.to.be.undefined;
+        });
+
+        test("should restore the session when a queued save-on-close commit fails", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            const commit = createDeferred<EditCommitResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.commit.returns(commit.promise);
+            showWarningMessageStub.resolves(LocConstants.TableExplorer.Save);
+            const createWebviewPanelStub = vscode.window.createWebviewPanel as sinon.SinonStub;
+            createWebviewPanelStub.resetHistory();
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const saveRequest = controller["showRestorePrompt"]();
+            update.resolve(createEditCellResult("Updated", true));
+            await updateRequest;
+            await waitForPromises();
+
+            expect(mockTableExplorerService.commit.called).to.be.true;
+            commit.reject(new Error("Commit failed"));
+            const restoreAction = await saveRequest;
+
+            expect(restoreAction).not.to.be.undefined;
+            await restoreAction?.run();
+            expect(createWebviewPanelStub.calledOnce).to.be.true;
+            expect((mockPanel.reveal as sinon.SinonStub).called).to.be.true;
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+            expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -2103,6 +2103,40 @@ suite("TableExplorerWebViewController - Reducers", () => {
     });
 
     suite("runTableQuery reducer", () => {
+        const queueReplacementBehindCellUpdate = async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const queryRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.TestTable",
+                },
+            );
+            await waitForPromises();
+
+            return { queryRequest, update, updateRequest };
+        };
+
+        const finishPendingUpdate = async (
+            pending: Awaited<ReturnType<typeof queueReplacementBehindCellUpdate>>,
+        ) => {
+            pending.update.resolve(createEditCellResult("Updated", true));
+            await Promise.all([pending.updateRequest, pending.queryRequest]);
+        };
+
         setup(async () => {
             // Flush any microtasks from the constructor's void this.initialize() and
             // void loadResultSet() so their async operations complete and call counts
@@ -2257,6 +2291,51 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(mockTableExplorerService.initialize.called).to.be.false;
             // State should be unchanged
             expect(controller.state.newRows).to.have.lengthOf(1);
+        });
+
+        test("should cancel a delete queued after session replacement", async () => {
+            const pending = await queueReplacementBehindCellUpdate();
+
+            const deleteRequest = controller["_reducerHandlers"].get("deleteRow")(
+                controller.state,
+                { rowId: 0 },
+            );
+            await finishPendingUpdate(pending);
+            await deleteRequest;
+
+            expect(mockTableExplorerService.deleteRow.called).to.be.false;
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+            expect(mockTableExplorerService.initialize.called).to.be.false;
+        });
+
+        test("should cancel a row revert queued after session replacement", async () => {
+            const pending = await queueReplacementBehindCellUpdate();
+
+            const revertRequest = controller["_reducerHandlers"].get("revertRow")(
+                controller.state,
+                { rowId: 0 },
+            );
+            await finishPendingUpdate(pending);
+            await revertRequest;
+
+            expect(mockTableExplorerService.revertRow.called).to.be.false;
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+            expect(mockTableExplorerService.initialize.called).to.be.false;
+        });
+
+        test("should cancel a commit queued after session replacement", async () => {
+            const pending = await queueReplacementBehindCellUpdate();
+
+            const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
+                controller.state,
+                {},
+            );
+            await finishPendingUpdate(pending);
+            await commitRequest;
+
+            expect(mockTableExplorerService.commit.called).to.be.false;
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+            expect(mockTableExplorerService.initialize.called).to.be.false;
         });
 
         test("should proceed when user confirms pending changes warning", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -2219,6 +2219,48 @@ suite("TableExplorerWebViewController - Reducers", () => {
             ).to.be.true;
         });
 
+        test("should reject a second query while session replacement is pending", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.newRows = [];
+            controller.state.deletedRows = [];
+            controller.state.originalCellValues = new Map();
+            mockTableExplorerService.dispose.resolves();
+            const initialize = createDeferred<EditInitializeResult>();
+            mockTableExplorerService.initialize.returns(initialize.promise);
+
+            const firstRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.FirstQuery",
+                },
+            );
+            await waitForPromises();
+            const secondRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.SecondQuery",
+                },
+            );
+            await Promise.resolve(secondRequest);
+
+            expect(mockTableExplorerService.dispose.callCount).to.equal(1);
+            expect(mockTableExplorerService.initialize.callCount).to.equal(1);
+            expect(
+                mockTableExplorerService.initialize.calledWithMatch(
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    "SELECT * FROM dbo.FirstQuery",
+                ),
+            ).to.be.true;
+
+            initialize.resolve({} as EditInitializeResult);
+            await firstRequest;
+
+            expect(controller.state.tableQuery).to.equal("SELECT * FROM dbo.FirstQuery");
+        });
+
         test("should clear pending changes after successful re-initialization", async () => {
             // Arrange
             controller.state.ownerUri = "test-owner-uri";

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -1383,12 +1383,18 @@ suite("TableExplorerWebViewController - Reducers", () => {
             mockTableExplorerService.revertCell.rejects(error);
 
             // Act
-            await controller["_reducerHandlers"].get("revertCell")(controller.state, {
-                rowId: 0,
-                columnId: 1,
-            });
+            let revertRejected = false;
+            try {
+                await controller["_reducerHandlers"].get("revertCell")(controller.state, {
+                    rowId: 0,
+                    columnId: 1,
+                });
+            } catch {
+                revertRejected = true;
+            }
 
             // Assert
+            expect(revertRejected).to.be.true;
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to revert cell");
         });
@@ -2379,6 +2385,58 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(controller.state.newRows).to.have.lengthOf(1);
         });
 
+        test("should block grid mutations until replacement cancellation completes", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.loadStatus = ApiStatus.Loaded;
+            controller.state.resultSet = createMockSubsetResult(2);
+            controller.state.newRows = [createMockRow(100, ["3", "New", "Row"])];
+            const warning = createDeferred<string | undefined>();
+            showWarningMessageStub.returns(warning.promise);
+            mockTableExplorerService.updateCell.resolves(createEditCellResult("Updated", true));
+
+            const queryRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.TestTable",
+                },
+            );
+            await waitForPromises();
+
+            expect(controller.state.loadStatus).to.equal(ApiStatus.Loading);
+            expect(controller["_sessionReplacementPending"]).to.be.true;
+
+            warning.resolve(undefined);
+            await queryRequest;
+
+            expect(controller.state.loadStatus).to.equal(ApiStatus.Loaded);
+            expect(controller["_sessionReplacementPending"]).to.be.false;
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Updated",
+                requestId: 1,
+            });
+            expect(mockTableExplorerService.updateCell.calledOnce).to.be.true;
+        });
+
+        test("should reject a cell revert blocked by session replacement", async () => {
+            const pending = await queueReplacementBehindCellUpdate();
+
+            const revertRequest = controller["_reducerHandlers"].get("revertCell")(
+                controller.state,
+                { rowId: 0, columnId: 1 },
+            );
+            const revertRejected = Promise.resolve(revertRequest).then(
+                () => false,
+                () => true,
+            );
+            await finishPendingUpdate(pending);
+
+            expect(await revertRejected).to.be.true;
+            expect(mockTableExplorerService.revertCell.called).to.be.false;
+            expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
+        });
+
         test("should cancel a delete queued after session replacement", async () => {
             const pending = await queueReplacementBehindCellUpdate();
 
@@ -2800,11 +2858,15 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     columnId: 1,
                 },
             );
+            const revertRejected = Promise.resolve(revertRequest).then(
+                () => false,
+                () => true,
+            );
             await waitForPromises();
             const saveRequest = controller["showRestorePrompt"]();
 
             revert.reject(new Error("Revert failed"));
-            await revertRequest;
+            expect(await revertRejected).to.be.true;
             const restoreAction = await saveRequest;
 
             expect(mockTableExplorerService.commit.called).to.be.false;

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -82,6 +82,16 @@ suite("TableExplorerWebViewController - Reducers", () => {
         ],
     });
 
+    const createDeferred = <T>() => {
+        let resolve!: (value: T) => void;
+        let reject!: (reason?: unknown) => void;
+        const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+            resolve = resolvePromise;
+            reject = rejectPromise;
+        });
+        return { promise, resolve, reject };
+    };
+
     setup(() => {
         sandbox = sinon.createSandbox();
 
@@ -652,6 +662,150 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 "0-1": { requestId: 3, isDirty: false },
                 "0-2": { requestId: 2, isDirty: true },
             });
+        });
+
+        test("should ignore an older same-cell response that completes last", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const olderUpdate = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .returns(olderUpdate.promise)
+                .onSecondCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Newest",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Newest",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                });
+
+            const olderRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Older",
+                    requestId: 1,
+                },
+            );
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Newest",
+                requestId: 2,
+            });
+            olderUpdate.resolve({
+                cell: {
+                    displayValue: "Older",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Older",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await olderRequest;
+
+            expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
+            expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
+                requestId: 2,
+                isDirty: true,
+            });
+        });
+
+        test("should ignore an older same-cell failure that completes last", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const olderUpdate = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .returns(olderUpdate.promise)
+                .onSecondCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Newest",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Newest",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                });
+            showErrorMessageStub.resetHistory();
+
+            const olderRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Older",
+                    requestId: 1,
+                },
+            );
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Newest",
+                requestId: 2,
+            });
+            olderUpdate.reject(new Error("Older update failed"));
+            await olderRequest;
+
+            expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
+            expect(controller.state.failedCells).to.be.empty;
+            expect(showErrorMessageStub).not.to.have.been.called;
+        });
+
+        test("should derive row dirty state from current cells when responses complete out of order", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const cleanFirstName = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .returns(cleanFirstName.promise)
+                .onSecondCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Changed last name",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Changed last name",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                });
+
+            const cleanRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "John",
+                    requestId: 1,
+                },
+            );
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 2,
+                newValue: "Changed last name",
+                requestId: 2,
+            });
+            cleanFirstName.resolve({
+                cell: {
+                    displayValue: "John",
+                    isNull: false,
+                    invariantCultureDisplayValue: "John",
+                    isDirty: false,
+                },
+                isRowDirty: false,
+            });
+            await cleanRequest;
+
+            expect(controller.state.resultSet?.subset[0].isDirty).to.be.true;
+            expect(controller.state.resultSet?.subset[0].state).to.equal(EditRowState.dirtyUpdate);
+            expect(
+                (controller.state.resultSet?.subset[0].cells[2] as { isDirty?: boolean }).isDirty,
+            ).to.be.true;
         });
 
         test("should regenerate script if script pane is visible", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -760,6 +760,10 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 1,
                 },
             );
+            const updateRejected = Promise.resolve(updateRequest).then(
+                () => false,
+                () => true,
+            );
             await waitForPromises();
 
             expect(mockTableExplorerService.deleteRow.called).to.be.false;
@@ -767,13 +771,14 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             commit.resolve({});
             await commitRequest;
-            await Promise.all([deleteRequest, updateRequest]);
+            await deleteRequest;
 
             expect(controller.state.newRows).to.be.empty;
             expect(controller.state.deletedRows).to.be.empty;
             expect(controller.state.resultSet?.subset.some((row) => row.id === 100)).to.be.true;
             expect(mockTableExplorerService.deleteRow.called).to.be.false;
             expect(mockTableExplorerService.updateCell.called).to.be.false;
+            expect(await updateRejected).to.be.true;
         });
     });
 
@@ -2417,6 +2422,70 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 requestId: 1,
             });
             expect(mockTableExplorerService.updateCell.calledOnce).to.be.true;
+        });
+
+        test("should reject a replacement-race update and block save after cancellation", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.loadStatus = ApiStatus.Loaded;
+            controller.state.resultSet = createMockSubsetResult(2);
+            controller.state.newRows = [createMockRow(100, ["3", "New", "Row"])];
+            const warning = createDeferred<string | undefined>();
+            showWarningMessageStub.returns(warning.promise);
+            mockTableExplorerService.updateCell.resolves(
+                createEditCellResult("Replacement race edit", true),
+            );
+            mockTableExplorerService.commit.resolves({});
+
+            const queryRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.TestTable",
+                },
+            );
+            await waitForPromises();
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Replacement race edit",
+                    requestId: 1,
+                },
+            );
+            const updateRejected = Promise.resolve(updateRequest).then(
+                () => false,
+                () => true,
+            );
+
+            warning.resolve(undefined);
+            await queryRequest;
+
+            const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
+                controller.state,
+                {},
+            );
+            const commitRejected = Promise.resolve(commitRequest).then(
+                () => false,
+                () => true,
+            );
+
+            expect(await updateRejected).to.be.true;
+            expect(await commitRejected).to.be.true;
+            expect(controller.state.failedCells).to.deep.equal(["0-1"]);
+            expect(mockTableExplorerService.updateCell.called).to.be.false;
+            expect(mockTableExplorerService.commit.called).to.be.false;
+
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Replacement race edit",
+                requestId: 2,
+            });
+            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+
+            expect(mockTableExplorerService.updateCell.calledOnce).to.be.true;
+            expect(mockTableExplorerService.commit.calledOnce).to.be.true;
         });
 
         test("should reject a cell revert blocked by session replacement", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -83,6 +83,16 @@ suite("TableExplorerWebViewController - Reducers", () => {
         ],
     });
 
+    const createEditCellResult = (displayValue: string, isDirty: boolean): EditCellResult => ({
+        cell: {
+            displayValue,
+            isNull: false,
+            invariantCultureDisplayValue: displayValue,
+            isDirty,
+        },
+        isRowDirty: isDirty,
+    });
+
     const createDeferred = <T>() => {
         let resolve!: (value: T) => void;
         let reject!: (reason?: unknown) => void;
@@ -1360,6 +1370,75 @@ suite("TableExplorerWebViewController - Reducers", () => {
             ).to.be.true;
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("John");
             expect(controller.state.originalCellValues).to.be.empty;
+        });
+
+        test("should preserve an update queued after a cell revert", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const firstUpdate = createDeferred<EditCellResult>();
+            const revert = createDeferred<EditCellResult>();
+            const secondUpdate = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .returns(firstUpdate.promise)
+                .onSecondCall()
+                .returns(secondUpdate.promise);
+            mockTableExplorerService.revertCell.returns(revert.promise);
+
+            const firstUpdateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "First update",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const revertRequest = controller["_reducerHandlers"].get("revertCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                },
+            );
+            const secondUpdateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Second update",
+                    requestId: 2,
+                },
+            );
+
+            firstUpdate.resolve(createEditCellResult("First update", true));
+            await firstUpdateRequest;
+            await waitForPromises();
+
+            expect(mockTableExplorerService.revertCell.called).to.be.true;
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
+
+            revert.resolve(createEditCellResult("John", false));
+            await revertRequest;
+            await waitForPromises();
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(2);
+            expect(mockTableExplorerService.updateCell.secondCall.args[3]).to.equal(
+                "Second update",
+            );
+
+            secondUpdate.resolve(createEditCellResult("Second update", true));
+            await secondUpdateRequest;
+
+            expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal(
+                "Second update",
+            );
+            expect(controller.state.resultSet?.subset[0].isDirty).to.be.true;
+            expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
+                requestId: 2,
+                isDirty: true,
+            });
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -497,6 +497,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Updated",
+                requestId: 1,
             });
 
             // Assert
@@ -542,11 +543,13 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Changed",
+                requestId: 1,
             });
             await controller["_reducerHandlers"].get("updateCell")(controller.state, {
                 rowId: 0,
                 columnId: 1,
                 newValue: "John",
+                requestId: 2,
             });
 
             const row = controller.state.resultSet?.subset[0];
@@ -559,6 +562,10 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(row?.isDirty).to.be.false;
             expect(row?.state).to.equal(EditRowState.clean);
             expect(controller.state.originalCellValues).to.be.empty;
+            expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
+                requestId: 2,
+                isDirty: false,
+            });
         });
 
         test("should preserve normalized null values returned by the service", async () => {
@@ -578,6 +585,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "",
+                requestId: 1,
             });
 
             expect(controller.state.resultSet?.subset[0].cells[1]).to.deep.include({
@@ -624,9 +632,9 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 });
 
             for (const edit of [
-                { columnId: 1, newValue: "Changed first name" },
-                { columnId: 2, newValue: "Changed last name" },
-                { columnId: 1, newValue: "John" },
+                { columnId: 1, newValue: "Changed first name", requestId: 1 },
+                { columnId: 2, newValue: "Changed last name", requestId: 2 },
+                { columnId: 1, newValue: "John", requestId: 3 },
             ]) {
                 await controller["_reducerHandlers"].get("updateCell")(controller.state, {
                     rowId: 0,
@@ -640,6 +648,10 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(row?.isDirty).to.be.true;
             expect(row?.state).to.equal(EditRowState.dirtyUpdate);
             expect([...controller.state.originalCellValues!.keys()]).to.deep.equal(["0-2"]);
+            expect(controller.state.cellUpdateAcknowledgements).to.deep.equal({
+                "0-1": { requestId: 3, isDirty: false },
+                "0-2": { requestId: 2, isDirty: true },
+            });
         });
 
         test("should regenerate script if script pane is visible", async () => {
@@ -666,6 +678,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Updated",
+                requestId: 1,
             });
 
             // Assert
@@ -683,6 +696,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Updated",
+                requestId: 1,
             });
 
             // Assert

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -20,6 +20,7 @@ import {
     EditScriptResult,
     EditSessionReadyParams,
     EditInitializeResult,
+    EditCommitResult,
     DbCellValue,
     SqlPaneMode,
 } from "../../src/sharedInterfaces/tableExplorer";
@@ -278,6 +279,42 @@ suite("TableExplorerWebViewController - Reducers", () => {
             ).to.be.true;
             expect(controller.state.originalCellValues).to.be.empty;
             expect(controller.state.cellUpdateAcknowledgements).to.be.empty;
+        });
+
+        test("should not commit after a queued cell update fails", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.commit.resolves({});
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Invalid",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
+                controller.state,
+                {},
+            );
+
+            update.reject(new Error("Update failed"));
+            await updateRequest;
+            await commitRequest;
+
+            expect(mockTableExplorerService.commit.called).to.be.false;
+            expect(controller.state.failedCells).to.deep.equal(["0-1"]);
+            expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
+            expect(
+                showInformationMessageStub.calledWith(
+                    LocConstants.TableExplorer.changesSavedSuccessfully,
+                ),
+            ).to.be.false;
         });
     });
 
@@ -574,6 +611,46 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 ),
             ).to.be.true;
             expect(controller.state.deletedRows).to.deep.equal([0]);
+        });
+
+        test("should classify a new row after a preceding commit completes", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            const newRow = createMockRow(100, ["3", "New", "Row"]);
+            controller.state.newRows = [newRow];
+            controller.state.resultSet = {
+                ...createMockSubsetResult(2),
+                subset: [...createMockSubsetResult(2).subset, newRow],
+                rowCount: 3,
+            };
+            const commit = createDeferred<EditCommitResult>();
+            mockTableExplorerService.commit.returns(commit.promise);
+            mockTableExplorerService.deleteRow.resolves({});
+
+            const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
+                controller.state,
+                {},
+            );
+            await waitForPromises();
+            const deleteRequest = controller["_reducerHandlers"].get("deleteRow")(
+                controller.state,
+                { rowId: 100 },
+            );
+            await waitForPromises();
+
+            expect(mockTableExplorerService.deleteRow.called).to.be.false;
+
+            commit.resolve({});
+            await commitRequest;
+            await deleteRequest;
+
+            expect(controller.state.newRows).to.be.empty;
+            expect(controller.state.deletedRows).to.deep.equal([100]);
+            expect(controller.state.resultSet?.subset.some((row) => row.id === 100)).to.be.true;
+            expect(
+                showInformationMessageStub.calledWith(
+                    LocConstants.TableExplorer.rowMarkedForRemoval,
+                ),
+            ).to.be.true;
         });
     });
 
@@ -2248,6 +2325,40 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             // Assert
             expect(resultState.tableName).to.equal("TestTable");
+        });
+    });
+
+    suite("close lifecycle", () => {
+        test("should not save on close after a queued cell revert fails", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const revert = createDeferred<EditCellResult>();
+            mockTableExplorerService.revertCell.returns(revert.promise);
+            mockTableExplorerService.commit.resolves({});
+            showWarningMessageStub.resolves(LocConstants.TableExplorer.Save);
+            showInformationMessageStub.resetHistory();
+
+            const revertRequest = controller["_reducerHandlers"].get("revertCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                },
+            );
+            await waitForPromises();
+            const saveRequest = controller["showRestorePrompt"]();
+
+            revert.reject(new Error("Revert failed"));
+            await revertRequest;
+            await saveRequest;
+
+            expect(mockTableExplorerService.commit.called).to.be.false;
+            expect(
+                showInformationMessageStub.calledWith(
+                    LocConstants.TableExplorer.changesSavedSuccessfully,
+                ),
+            ).to.be.false;
+            expect(showErrorMessageStub.called).to.be.true;
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -338,6 +338,36 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 ),
             ).to.be.false;
         });
+
+        test("should normalize dirty metadata before a clean-row revert fails", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const dirtyRow = controller.state.resultSet.subset[0];
+            dirtyRow.isDirty = true;
+            dirtyRow.state = EditRowState.dirtyUpdate;
+            (dirtyRow.cells[1] as (typeof dirtyRow.cells)[number] & { isDirty: boolean }).isDirty =
+                true;
+            controller.state.originalCellValues?.set("0-1", createMockCell("John"));
+            controller.state.cellUpdateAcknowledgements = {
+                "0-1": { requestId: 1, isDirty: true },
+            };
+            mockTableExplorerService.commit.resolves({});
+            mockTableExplorerService.revertRow.rejects(new Error("Revert row failed"));
+
+            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+            try {
+                await controller["_reducerHandlers"].get("revertRow")(controller.state, {
+                    rowId: 0,
+                });
+            } catch {}
+            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+
+            const committedRow = controller.state.resultSet.subset[0];
+            expect(committedRow.isDirty).to.be.false;
+            expect(committedRow.state).to.equal(EditRowState.clean);
+            expect((committedRow.cells[1] as { isDirty?: boolean }).isDirty).to.be.false;
+            expect(mockTableExplorerService.commit.callCount).to.equal(2);
+        });
     });
 
     suite("loadSubset reducer", () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -2261,6 +2261,50 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(controller.state.tableQuery).to.equal("SELECT * FROM dbo.FirstQuery");
         });
 
+        test("should recover query and mutation handling after failed session readiness", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.newRows = [];
+            controller.state.deletedRows = [];
+            controller.state.originalCellValues = new Map();
+            mockTableExplorerService.dispose.resolves();
+            mockTableExplorerService.initialize.resolves();
+            mockTableExplorerService.commit.resolves({});
+
+            await controller["_reducerHandlers"].get("runTableQuery")(controller.state, {
+                queryString: "SELECT * FROM dbo.FailingQuery",
+            });
+            controller["onEditSessionReady"]({
+                ownerUri: "test-owner-uri",
+                success: false,
+                message: "Query failed",
+            });
+
+            expect(controller["_sessionReplacementPending"]).to.be.false;
+            expect(controller.state.loadStatus).to.equal(ApiStatus.Error);
+            const blockedCommit = Promise.resolve(
+                controller["_reducerHandlers"].get("commitChanges")(controller.state, {}),
+            ).then(
+                () => false,
+                () => true,
+            );
+            expect(await blockedCommit).to.be.true;
+            expect(mockTableExplorerService.commit.called).to.be.false;
+
+            await controller["_reducerHandlers"].get("runTableQuery")(controller.state, {
+                queryString: "SELECT * FROM dbo.RetryQuery",
+            });
+            controller["onEditSessionReady"]({
+                ownerUri: "test-owner-uri",
+                success: true,
+                message: "",
+            });
+            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+
+            expect(mockTableExplorerService.dispose.callCount).to.equal(2);
+            expect(mockTableExplorerService.initialize.callCount).to.equal(2);
+            expect(mockTableExplorerService.commit.calledOnce).to.be.true;
+        });
+
         test("should clear pending changes after successful re-initialization", async () => {
             // Arrange
             controller.state.ownerUri = "test-owner-uri";
@@ -2503,6 +2547,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             // Assert
             expect(controller.state.loadStatus).to.equal(ApiStatus.Error);
+            expect(controller["_sessionReplacementPending"]).to.be.false;
             expect(showErrorMessageStub.calledWithMatch(sinon.match.string)).to.be.true;
         });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -628,6 +628,27 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to remove row");
         });
 
+        test("should enable the close prompt while an existing-row delete is pending", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const deleteRow = createDeferred<Record<string, never>>();
+            mockTableExplorerService.deleteRow.returns(deleteRow.promise);
+
+            const deleteRequest = controller["_reducerHandlers"].get("deleteRow")(
+                controller.state,
+                { rowId: 0 },
+            );
+            await waitForPromises();
+
+            expect(controller["_options"].showRestorePromptAfterClose).to.be.true;
+            expect(controller.state.deletedRows).to.be.empty;
+
+            deleteRow.resolve({});
+            await deleteRequest;
+
+            expect(controller.state.deletedRows).to.deep.equal([0]);
+        });
+
         test("should wait for queued cell updates before deleting a row", async () => {
             controller.state.ownerUri = "test-owner-uri";
             controller.state.resultSet = createMockSubsetResult(2);
@@ -1510,6 +1531,22 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 .true;
             expect(controller.state.deletedRows).to.deep.equal([0]);
             expect(mockTableExplorerService.commit.called).to.be.false;
+        });
+
+        test("should not block commit when a clean-row revert fails", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            mockTableExplorerService.revertRow.rejects(new Error("Revert row failed"));
+            mockTableExplorerService.commit.resolves({});
+
+            try {
+                await controller["_reducerHandlers"].get("revertRow")(controller.state, {
+                    rowId: 0,
+                });
+            } catch {}
+            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+
+            expect(mockTableExplorerService.commit.calledOnceWith("test-owner-uri")).to.be.true;
         });
 
         test("should remove newly created row from UI when revert returns null", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -663,7 +663,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(controller.state.deletedRows).to.deep.equal([0]);
         });
 
-        test("should classify a new row after a preceding commit completes", async () => {
+        test("should block cell and row mutations while commit is pending", async () => {
             controller.state.ownerUri = "test-owner-uri";
             const newRow = createMockRow(100, ["3", "New", "Row"]);
             controller.state.newRows = [newRow];
@@ -674,7 +674,6 @@ suite("TableExplorerWebViewController - Reducers", () => {
             };
             const commit = createDeferred<EditCommitResult>();
             mockTableExplorerService.commit.returns(commit.promise);
-            mockTableExplorerService.deleteRow.resolves({});
 
             const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
                 controller.state,
@@ -685,22 +684,29 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 controller.state,
                 { rowId: 100 },
             );
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated during commit",
+                    requestId: 1,
+                },
+            );
             await waitForPromises();
 
             expect(mockTableExplorerService.deleteRow.called).to.be.false;
+            expect(mockTableExplorerService.updateCell.called).to.be.false;
 
             commit.resolve({});
             await commitRequest;
-            await deleteRequest;
+            await Promise.all([deleteRequest, updateRequest]);
 
             expect(controller.state.newRows).to.be.empty;
-            expect(controller.state.deletedRows).to.deep.equal([100]);
+            expect(controller.state.deletedRows).to.be.empty;
             expect(controller.state.resultSet?.subset.some((row) => row.id === 100)).to.be.true;
-            expect(
-                showInformationMessageStub.calledWith(
-                    LocConstants.TableExplorer.rowMarkedForRemoval,
-                ),
-            ).to.be.true;
+            expect(mockTableExplorerService.deleteRow.called).to.be.false;
+            expect(mockTableExplorerService.updateCell.called).to.be.false;
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -664,23 +664,16 @@ suite("TableExplorerWebViewController - Reducers", () => {
             });
         });
 
-        test("should ignore an older same-cell response that completes last", async () => {
+        test("should serialize same-cell updates in request order", async () => {
             controller.state.ownerUri = "test-owner-uri";
             controller.state.resultSet = createMockSubsetResult(2);
             const olderUpdate = createDeferred<EditCellResult>();
+            const newerUpdate = createDeferred<EditCellResult>();
             mockTableExplorerService.updateCell
                 .onFirstCall()
                 .returns(olderUpdate.promise)
                 .onSecondCall()
-                .resolves({
-                    cell: {
-                        displayValue: "Newest",
-                        isNull: false,
-                        invariantCultureDisplayValue: "Newest",
-                        isDirty: true,
-                    },
-                    isRowDirty: true,
-                });
+                .returns(newerUpdate.promise);
 
             const olderRequest = controller["_reducerHandlers"].get("updateCell")(
                 controller.state,
@@ -691,12 +684,20 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 1,
                 },
             );
-            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
-                rowId: 0,
-                columnId: 1,
-                newValue: "Newest",
-                requestId: 2,
-            });
+            const newerRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Newest",
+                    requestId: 2,
+                },
+            );
+            await Promise.resolve();
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
+            expect(mockTableExplorerService.updateCell.firstCall.args[3]).to.equal("Older");
+
             olderUpdate.resolve({
                 cell: {
                     displayValue: "Older",
@@ -707,6 +708,21 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 isRowDirty: true,
             });
             await olderRequest;
+            await Promise.resolve();
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(2);
+            expect(mockTableExplorerService.updateCell.secondCall.args[3]).to.equal("Newest");
+
+            newerUpdate.resolve({
+                cell: {
+                    displayValue: "Newest",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Newest",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await newerRequest;
 
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
             expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
@@ -715,7 +731,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
             });
         });
 
-        test("should ignore an older same-cell failure that completes last", async () => {
+        test("should continue serialized same-cell updates after an older failure", async () => {
             controller.state.ownerUri = "test-owner-uri";
             controller.state.resultSet = createMockSubsetResult(2);
             const olderUpdate = createDeferred<EditCellResult>();
@@ -743,18 +759,80 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 1,
                 },
             );
-            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
-                rowId: 0,
-                columnId: 1,
-                newValue: "Newest",
-                requestId: 2,
-            });
+            const newerRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Newest",
+                    requestId: 2,
+                },
+            );
+            await Promise.resolve();
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
+
             olderUpdate.reject(new Error("Older update failed"));
             await olderRequest;
+            await newerRequest;
 
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(2);
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
             expect(controller.state.failedCells).to.be.empty;
             expect(showErrorMessageStub.called).to.be.false;
+        });
+
+        test("should process a newer same-cell failure after an older success", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const olderUpdate = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .returns(olderUpdate.promise)
+                .onSecondCall()
+                .rejects(new Error("Newest update failed"));
+            showErrorMessageStub.resetHistory();
+
+            const olderRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Older",
+                    requestId: 1,
+                },
+            );
+            const newerRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Newest",
+                    requestId: 2,
+                },
+            );
+            await Promise.resolve();
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
+
+            olderUpdate.resolve({
+                cell: {
+                    displayValue: "Older",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Older",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await olderRequest;
+            await newerRequest;
+
+            expect(mockTableExplorerService.updateCell.callCount).to.equal(2);
+            expect(mockTableExplorerService.updateCell.firstCall.args[3]).to.equal("Older");
+            expect(mockTableExplorerService.updateCell.secondCall.args[3]).to.equal("Newest");
+            expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
+            expect(controller.state.failedCells).to.deep.equal(["0-1"]);
+            expect(showErrorMessageStub.calledOnce).to.be.true;
         });
 
         test("should derive row dirty state from current cells when responses complete out of order", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -754,7 +754,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Newest");
             expect(controller.state.failedCells).to.be.empty;
-            expect(showErrorMessageStub).not.to.have.been.called;
+            expect(showErrorMessageStub.called).to.be.false;
         });
 
         test("should derive row dirty state from current cells when responses complete out of order", async () => {
@@ -806,6 +806,47 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(
                 (controller.state.resultSet?.subset[0].cells[2] as { isDirty?: boolean }).isDirty,
             ).to.be.true;
+        });
+
+        test("should acknowledge a clean update after loadSubset removes its row", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const cleanUpdate = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(cleanUpdate.promise);
+            mockTableExplorerService.subset.resolves({
+                ...createMockSubsetResult(1),
+                subset: [createMockRow(1, ["2", "Jane", "Smith"])],
+            });
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "John",
+                    requestId: 1,
+                },
+            );
+            await controller["_reducerHandlers"].get("loadSubset")(controller.state, {
+                rowCount: 1,
+            });
+            cleanUpdate.resolve({
+                cell: {
+                    displayValue: "John",
+                    isNull: false,
+                    invariantCultureDisplayValue: "John",
+                    isDirty: false,
+                },
+                isRowDirty: false,
+            });
+            await updateRequest;
+
+            expect(controller.state.resultSet?.subset.some((row) => row.id === 0)).to.be.false;
+            expect(controller.state.originalCellValues).to.be.empty;
+            expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
+                requestId: 1,
+                isDirty: false,
+            });
         });
 
         test("should regenerate script if script pane is visible", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -92,6 +92,8 @@ suite("TableExplorerWebViewController - Reducers", () => {
         return { promise, resolve, reject };
     };
 
+    const waitForPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
     setup(() => {
         sandbox = sinon.createSandbox();
 
@@ -116,7 +118,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
         mockWebview = {
             postMessage: sandbox.stub(),
             asWebviewUri: sandbox.stub().returns(vscode.Uri.parse("file:///webview")),
-            onDidReceiveMessage: sandbox.stub(),
+            onDidReceiveMessage: sandbox.stub().returns({ dispose: sandbox.stub() }),
         } as any;
 
         mockPanel = {
@@ -126,8 +128,8 @@ suite("TableExplorerWebViewController - Reducers", () => {
             options: {},
             reveal: sandbox.stub(),
             dispose: sandbox.stub(),
-            onDidDispose: sandbox.stub(),
-            onDidChangeViewState: sandbox.stub(),
+            onDidDispose: sandbox.stub().returns({ dispose: sandbox.stub() }),
+            onDidChangeViewState: sandbox.stub().returns({ dispose: sandbox.stub() }),
             iconPath: undefined,
         } as any;
 
@@ -232,6 +234,50 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(mockTableExplorerService.commit.calledOnce).to.be.true;
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to save changes");
+        });
+
+        test("should wait for queued cell updates before committing", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.commit.resolves({});
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const commitRequest = controller["_reducerHandlers"].get("commitChanges")(
+                controller.state,
+                {},
+            );
+            await waitForPromises();
+
+            expect(mockTableExplorerService.commit.called).to.be.false;
+
+            update.resolve({
+                cell: {
+                    displayValue: "Updated",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Updated",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await updateRequest;
+            await commitRequest;
+
+            expect(
+                mockTableExplorerService.updateCell.calledBefore(mockTableExplorerService.commit),
+            ).to.be.true;
+            expect(controller.state.originalCellValues).to.be.empty;
+            expect(controller.state.cellUpdateAcknowledgements).to.be.empty;
         });
     });
 
@@ -484,6 +530,51 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to remove row");
         });
+
+        test("should wait for queued cell updates before deleting a row", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.deleteRow.resolves({});
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const deleteRequest = controller["_reducerHandlers"].get("deleteRow")(
+                controller.state,
+                { rowId: 0 },
+            );
+            await waitForPromises();
+
+            expect(mockTableExplorerService.deleteRow.called).to.be.false;
+
+            update.resolve({
+                cell: {
+                    displayValue: "Updated",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Updated",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await updateRequest;
+            await deleteRequest;
+
+            expect(
+                mockTableExplorerService.updateCell.calledBefore(
+                    mockTableExplorerService.deleteRow,
+                ),
+            ).to.be.true;
+            expect(controller.state.deletedRows).to.deep.equal([0]);
+        });
     });
 
     suite("updateCell reducer", () => {
@@ -693,7 +784,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 2,
                 },
             );
-            await Promise.resolve();
+            await waitForPromises();
 
             expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
             expect(mockTableExplorerService.updateCell.firstCall.args[3]).to.equal("Older");
@@ -708,7 +799,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 isRowDirty: true,
             });
             await olderRequest;
-            await Promise.resolve();
+            await waitForPromises();
 
             expect(mockTableExplorerService.updateCell.callCount).to.equal(2);
             expect(mockTableExplorerService.updateCell.secondCall.args[3]).to.equal("Newest");
@@ -768,7 +859,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 2,
                 },
             );
-            await Promise.resolve();
+            await waitForPromises();
 
             expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
 
@@ -811,7 +902,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     requestId: 2,
                 },
             );
-            await Promise.resolve();
+            await waitForPromises();
 
             expect(mockTableExplorerService.updateCell.callCount).to.equal(1);
 
@@ -1048,6 +1139,63 @@ suite("TableExplorerWebViewController - Reducers", () => {
             // Assert
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to revert cell");
+        });
+
+        test("should wait for a queued cell update before reverting the cell", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.revertCell.resolves({
+                cell: {
+                    displayValue: "John",
+                    isNull: false,
+                    invariantCultureDisplayValue: "John",
+                    isDirty: false,
+                },
+                isRowDirty: false,
+            });
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            const revertRequest = controller["_reducerHandlers"].get("revertCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                },
+            );
+            await waitForPromises();
+
+            expect(mockTableExplorerService.revertCell.called).to.be.false;
+
+            update.resolve({
+                cell: {
+                    displayValue: "Updated",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Updated",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await updateRequest;
+            await revertRequest;
+
+            expect(
+                mockTableExplorerService.updateCell.calledBefore(
+                    mockTableExplorerService.revertCell,
+                ),
+            ).to.be.true;
+            expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("John");
+            expect(controller.state.originalCellValues).to.be.empty;
         });
     });
 
@@ -2100,6 +2248,48 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             // Assert
             expect(resultState.tableName).to.equal("TestTable");
+        });
+    });
+
+    suite("dispose", () => {
+        test("should wait for queued cell updates before disposing the session", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+            mockTableExplorerService.dispose.resolves();
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+            controller.dispose();
+            await waitForPromises();
+
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+
+            update.resolve({
+                cell: {
+                    displayValue: "Updated",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Updated",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await updateRequest;
+            await controller["_lifecycleOperationQueue"];
+
+            expect(
+                mockTableExplorerService.updateCell.calledBefore(mockTableExplorerService.dispose),
+            ).to.be.true;
+            expect(mockTableExplorerService.dispose.calledOnceWith("test-owner-uri")).to.be.true;
         });
     });
 });

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -521,7 +521,9 @@ suite("TableExplorerWebViewController - Reducers", () => {
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to create a new row");
         });
 
-        test("should finish a pending row creation before replacing the session", async () => {
+        test("should prompt after a pending row creation before replacing the session", async () => {
+            await waitForPromises();
+            mockTableExplorerService.initialize.resetHistory();
             controller.state.ownerUri = "test-owner-uri";
             controller.state.resultSet = createMockSubsetResult(2);
             const create = createDeferred<EditCreateRowResult>();
@@ -553,10 +555,14 @@ suite("TableExplorerWebViewController - Reducers", () => {
             await queryRequest;
 
             expect(
-                mockTableExplorerService.createRow.calledBefore(mockTableExplorerService.dispose),
+                showWarningMessageStub.calledWithMatch(
+                    LocConstants.TableExplorer.pendingChangesWillBeLost,
+                ),
             ).to.be.true;
-            expect(controller.state.newRows).to.be.empty;
-            expect(controller.state.resultSet).to.be.undefined;
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+            expect(mockTableExplorerService.initialize.called).to.be.false;
+            expect(controller.state.newRows).to.have.lengthOf(1);
+            expect(controller.state.resultSet?.subset.some((row) => row.id === 100)).to.be.true;
         });
     });
 
@@ -1291,6 +1297,27 @@ suite("TableExplorerWebViewController - Reducers", () => {
             // Assert
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to update cell");
+        });
+
+        test("should show a failed attempted value when the original cell is null", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            controller.state.resultSet.subset[0].cells[1] = createMockCell("NULL", true);
+            mockTableExplorerService.updateCell.rejects(new Error("Update cell failed"));
+
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Attempted value",
+                requestId: 1,
+            });
+
+            expect(controller.state.resultSet.subset[0].cells[1]).to.deep.include({
+                displayValue: "Attempted value",
+                invariantCultureDisplayValue: "Attempted value",
+                isNull: false,
+                isDirty: true,
+            });
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -2315,10 +2315,15 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 controller.state,
                 { rowId: 0 },
             );
+            const revertRejected = Promise.resolve(revertRequest).then(
+                () => false,
+                () => true,
+            );
             await finishPendingUpdate(pending);
-            await revertRequest;
 
+            expect(await revertRejected).to.be.true;
             expect(mockTableExplorerService.revertRow.called).to.be.false;
+            expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
             expect(mockTableExplorerService.dispose.called).to.be.false;
             expect(mockTableExplorerService.initialize.called).to.be.false;
         });
@@ -2330,10 +2335,15 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 controller.state,
                 {},
             );
+            const commitRejected = Promise.resolve(commitRequest).then(
+                () => false,
+                () => true,
+            );
             await finishPendingUpdate(pending);
-            await commitRequest;
 
+            expect(await commitRejected).to.be.true;
             expect(mockTableExplorerService.commit.called).to.be.false;
+            expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
             expect(mockTableExplorerService.dispose.called).to.be.false;
             expect(mockTableExplorerService.initialize.called).to.be.false;
         });

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -509,6 +509,137 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 ),
             ).to.be.true;
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Updated");
+            expect(controller.state.resultSet?.subset[0].isDirty).to.be.true;
+            expect(controller.state.resultSet?.subset[0].state).to.equal(EditRowState.dirtyUpdate);
+        });
+
+        test("should clear cell and row dirty state when restored to the original value", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Changed",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Changed",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                })
+                .onSecondCall()
+                .resolves({
+                    cell: {
+                        displayValue: "John",
+                        isNull: false,
+                        invariantCultureDisplayValue: "John",
+                        isDirty: false,
+                    },
+                    isRowDirty: false,
+                });
+
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "Changed",
+            });
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "John",
+            });
+
+            const row = controller.state.resultSet?.subset[0];
+            expect(row?.cells[1]).to.deep.include({
+                displayValue: "John",
+                invariantCultureDisplayValue: "John",
+                isNull: false,
+                isDirty: false,
+            });
+            expect(row?.isDirty).to.be.false;
+            expect(row?.state).to.equal(EditRowState.clean);
+            expect(controller.state.originalCellValues).to.be.empty;
+        });
+
+        test("should preserve normalized null values returned by the service", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            mockTableExplorerService.updateCell.resolves({
+                cell: {
+                    displayValue: "NULL",
+                    isNull: true,
+                    invariantCultureDisplayValue: "NULL",
+                    isDirty: false,
+                },
+                isRowDirty: false,
+            });
+
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "",
+            });
+
+            expect(controller.state.resultSet?.subset[0].cells[1]).to.deep.include({
+                displayValue: "NULL",
+                invariantCultureDisplayValue: "NULL",
+                isNull: true,
+                isDirty: false,
+            });
+        });
+
+        test("should preserve other dirty cells when one cell is restored", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            mockTableExplorerService.updateCell
+                .onFirstCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Changed first name",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Changed first name",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                })
+                .onSecondCall()
+                .resolves({
+                    cell: {
+                        displayValue: "Changed last name",
+                        isNull: false,
+                        invariantCultureDisplayValue: "Changed last name",
+                        isDirty: true,
+                    },
+                    isRowDirty: true,
+                })
+                .onThirdCall()
+                .resolves({
+                    cell: {
+                        displayValue: "John",
+                        isNull: false,
+                        invariantCultureDisplayValue: "John",
+                        isDirty: false,
+                    },
+                    isRowDirty: true,
+                });
+
+            for (const edit of [
+                { columnId: 1, newValue: "Changed first name" },
+                { columnId: 2, newValue: "Changed last name" },
+                { columnId: 1, newValue: "John" },
+            ]) {
+                await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                    rowId: 0,
+                    ...edit,
+                });
+            }
+
+            const row = controller.state.resultSet?.subset[0];
+            expect((row?.cells[1] as { isDirty?: boolean }).isDirty).to.be.false;
+            expect((row?.cells[2] as { isDirty?: boolean }).isDirty).to.be.true;
+            expect(row?.isDirty).to.be.true;
+            expect(row?.state).to.equal(EditRowState.dirtyUpdate);
+            expect([...controller.state.originalCellValues!.keys()]).to.deep.equal(["0-2"]);
         });
 
         test("should regenerate script if script pane is visible", async () => {

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -229,9 +229,15 @@ suite("TableExplorerWebViewController - Reducers", () => {
             mockTableExplorerService.commit.rejects(error);
 
             // Act
-            await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+            let commitRejected = false;
+            try {
+                await controller["_reducerHandlers"].get("commitChanges")(controller.state, {});
+            } catch {
+                commitRejected = true;
+            }
 
             // Assert
+            expect(commitRejected).to.be.true;
             expect(mockTableExplorerService.commit.calledOnce).to.be.true;
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to save changes");
@@ -305,8 +311,14 @@ suite("TableExplorerWebViewController - Reducers", () => {
 
             update.reject(new Error("Update failed"));
             await updateRequest;
-            await commitRequest;
+            let commitRejected = false;
+            try {
+                await commitRequest;
+            } catch {
+                commitRejected = true;
+            }
 
+            expect(commitRejected).to.be.true;
             expect(mockTableExplorerService.commit.called).to.be.false;
             expect(controller.state.failedCells).to.deep.equal(["0-1"]);
             expect(controller.state.originalCellValues?.has("0-1")).to.be.true;
@@ -467,6 +479,44 @@ suite("TableExplorerWebViewController - Reducers", () => {
             // Assert
             expect(showErrorMessageStub.calledOnce).to.be.true;
             expect(showErrorMessageStub.firstCall.args[0]).to.include("Failed to create a new row");
+        });
+
+        test("should finish a pending row creation before replacing the session", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const create = createDeferred<EditCreateRowResult>();
+            mockTableExplorerService.createRow.returns(create.promise);
+            mockTableExplorerService.dispose.resolves();
+            mockTableExplorerService.initialize.resolves();
+
+            const createRequest = controller["_reducerHandlers"].get("createRow")(
+                controller.state,
+                {},
+            );
+            await waitForPromises();
+            const queryRequest = controller["_reducerHandlers"].get("runTableQuery")(
+                controller.state,
+                {
+                    queryString: "SELECT * FROM dbo.TestTable",
+                },
+            );
+            await waitForPromises();
+
+            expect(mockTableExplorerService.dispose.called).to.be.false;
+
+            create.resolve({
+                newRowId: 100,
+                row: createMockRow(100, ["", "", ""]),
+                defaultValues: ["", "", ""],
+            });
+            await createRequest;
+            await queryRequest;
+
+            expect(
+                mockTableExplorerService.createRow.calledBefore(mockTableExplorerService.dispose),
+            ).to.be.true;
+            expect(controller.state.newRows).to.be.empty;
+            expect(controller.state.resultSet).to.be.undefined;
         });
     });
 
@@ -655,6 +705,37 @@ suite("TableExplorerWebViewController - Reducers", () => {
     });
 
     suite("updateCell reducer", () => {
+        test("should enable the close prompt while a cell update is pending", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            const update = createDeferred<EditCellResult>();
+            mockTableExplorerService.updateCell.returns(update.promise);
+
+            const updateRequest = controller["_reducerHandlers"].get("updateCell")(
+                controller.state,
+                {
+                    rowId: 0,
+                    columnId: 1,
+                    newValue: "Updated",
+                    requestId: 1,
+                },
+            );
+            await waitForPromises();
+
+            expect(controller["_options"].showRestorePromptAfterClose).to.be.true;
+
+            update.resolve({
+                cell: {
+                    displayValue: "Updated",
+                    isNull: false,
+                    invariantCultureDisplayValue: "Updated",
+                    isDirty: true,
+                },
+                isRowDirty: true,
+            });
+            await updateRequest;
+        });
+
         test("should update cell value in resultSet", async () => {
             // Arrange
             controller.state.ownerUri = "test-owner-uri";


### PR DESCRIPTION
## Summary
Clears Edit Data dirty state when a cell is changed back to its original value while preserving other pending edits. Pending cell operations remain consistent across saves, reverts, and session changes.

Fixes #22736

## Screenshots
**Before:**

_Add a screenshot showing a restored cell still marked as modified here._

**After:**

_Add a screenshot showing the restored cell and row in a clean state here._