### PR TITLE
Adding ability to package with local SQL Tools Service

### DIFF
--- a/extensions/mssql/scripts/package-extension.js
+++ b/extensions/mssql/scripts/package-extension.js
@@ -310,6 +310,8 @@ Examples:
 Requirements:
     - Install workspace dependencies from the repository root: npm ci
     - Extension must be built first: npm run build -- --target mssql
+    - SQLTOOLS_SERVICE_PACKAGE_DIR may point to predownloaded SQL Tools Service packages.
+      Packages must use the configured Microsoft.SqlTools.ServiceLayer-<platform archive> names.
     - SQLTOOLS_MCP_NUPKG_DIR must point to downloaded SQL Tools MCP nupkgs when using --package-mcp
 `);
 }

--- a/extensions/mssql/scripts/print-sqltools-mcp-packages.js
+++ b/extensions/mssql/scripts/print-sqltools-mcp-packages.js
@@ -92,6 +92,7 @@ function main() {
 module.exports = {
     getPackageSpecs,
     getSqlToolsMcpConfig,
+    loadConfig,
 };
 
 if (require.main === module) {

--- a/extensions/mssql/scripts/print-sqltools-service-packages.js
+++ b/extensions/mssql/scripts/print-sqltools-service-packages.js
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const { loadConfig } = require("./print-sqltools-mcp-packages");
+
+const packagePrefix = "Microsoft.SqlTools.ServiceLayer-";
+
+function getSqlToolsServiceConfig() {
+    const config = loadConfig();
+    if (!config?.service) {
+        throw new Error("SQL Tools Service config was not found.");
+    }
+
+    return config.service;
+}
+
+function getPackageNames(config) {
+    return Object.values(config.downloadFileNames)
+        .map((fileName) => `${packagePrefix}${fileName}`)
+        .sort();
+}
+
+function showHelp() {
+    console.log(`
+Usage:
+  node scripts/print-sqltools-service-packages.js [--version]
+
+Options:
+  --version  Print the configured SQL Tools Service version instead of package names.
+`);
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    if (args.includes("--help") || args.includes("-h")) {
+        showHelp();
+        return;
+    }
+
+    const config = getSqlToolsServiceConfig();
+    if (args.includes("--version")) {
+        console.log(config.version);
+        return;
+    }
+
+    for (const packageName of getPackageNames(config)) {
+        console.log(packageName);
+    }
+}
+
+module.exports = {
+    getPackageNames,
+    getSqlToolsServiceConfig,
+};
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260810.1",
+        version: "6.0.20260819.2",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/mssql/src/configurations/config.ts
+++ b/extensions/mssql/src/configurations/config.ts
@@ -7,7 +7,7 @@ export const config = {
     service: {
         downloadUrl:
             "https://github.com/Microsoft/sqltoolsservice/releases/download/{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-        version: "6.0.20260819.2",
+        version: "6.0.20260810.1",
         downloadFileNames: {
             Windows_64: "win-x64-net10.0.zip",
             Windows_ARM64: "win-arm64-net10.0.zip",

--- a/extensions/mssql/src/languageservice/serviceDownloadProvider.ts
+++ b/extensions/mssql/src/languageservice/serviceDownloadProvider.ts
@@ -37,7 +37,7 @@ export default class ServiceDownloadProvider {
     /**
      * Returns the download url for given platform
      */
-    private getRuntimeDownloadPackageFileName(platform: Runtime): string {
+    public getRuntimeDownloadPackageFileName(platform: Runtime): string {
         let fileNamesJson = this._config.getSqlToolsConfigValue("downloadFileNames") as Record<
             string,
             string | undefined
@@ -163,6 +163,41 @@ export default class ServiceDownloadProvider {
             this._logger.info(`[ERROR] ${err}`);
             throw err;
         }
+        return true;
+    }
+
+    /**
+     * Installs SQL Tools Service from a package that has already been downloaded.
+     */
+    public async installServiceFromPackage(
+        platform: Runtime,
+        packagePath: string,
+    ): Promise<boolean> {
+        const packageStats = await fs.stat(packagePath).catch(() => undefined);
+        if (!packageStats?.isFile()) {
+            throw new Error(`SQL Tools Service package not found: ${packagePath}`);
+        }
+
+        const installDirectory = await this.getOrCreateInstallDirectory(platform);
+        this._logger.info(`${Constants.serviceInstallingTo} ${installDirectory}.`);
+
+        const pkg: IPackage = {
+            installPath: installDirectory,
+            url: packagePath,
+            tmpFile: undefined,
+            isZipFile: path.extname(packagePath) === ".zip",
+        };
+        pkg.tmpFile = await this.createTempPackageFile(pkg);
+
+        try {
+            await fs.copyFile(packagePath, pkg.tmpFile.name);
+            this._logger.debug(`Copied package to ${pkg.tmpFile.name}...`);
+            await this.decompressAndInstallPackage(pkg);
+        } catch (err) {
+            this._logger.info(`[ERROR] ${err}`);
+            throw err;
+        }
+
         return true;
     }
 

--- a/extensions/mssql/src/languageservice/serviceInstallerUtil.ts
+++ b/extensions/mssql/src/languageservice/serviceInstallerUtil.ts
@@ -12,6 +12,10 @@ import ServerProvider from "./server";
 import { IStatusView } from "./interfaces";
 import { ILogger } from "../sharedInterfaces/logger";
 import * as fs from "fs";
+import * as path from "path";
+
+const sqlToolsServicePackageDirectoryVariable = "SQLTOOLS_SERVICE_PACKAGE_DIR";
+const sqlToolsServicePackagePrefix = "Microsoft.SqlTools.ServiceLayer-";
 
 export class StubStatusView implements IStatusView {
     constructor(private _log: (msg: string) => void) {}
@@ -99,14 +103,27 @@ export async function cleanAndInstallService(runtime: Runtime): Promise<void> {
         logger.error(`Error deleting service install directory: ${error.message}`);
         throw error;
     }
-    let path: string;
+    let installPath: string;
     try {
-        path = await serverProvider.downloadAndGetServerInstallFolder(runtime);
+        const packageDirectory = process.env[sqlToolsServicePackageDirectoryVariable];
+        if (packageDirectory) {
+            const packageFileName = `${sqlToolsServicePackagePrefix}${downloadProvider.getRuntimeDownloadPackageFileName(runtime)}`;
+            const packagePath = path.join(packageDirectory, packageFileName);
+            await downloadProvider.installServiceFromPackage(runtime, packagePath);
+            installPath = await downloadProvider.tryGetInstallDirectory(runtime);
+            if (!installPath) {
+                throw new Error(
+                    `Installed SQL Tools Service package is incomplete: ${packagePath}`,
+                );
+            }
+        } else {
+            installPath = await serverProvider.downloadAndGetServerInstallFolder(runtime);
+        }
     } catch (error) {
         logger.error(`Error installing service for runtime ${runtime}: ${error.message}`);
         throw error;
     }
-    logger.debug(`Service installation complete for runtime: ${runtime}, path: ${path}`);
+    logger.debug(`Service installation complete for runtime: ${runtime}, path: ${installPath}`);
 }
 
 /*

--- a/extensions/mssql/test/unit/download.test.ts
+++ b/extensions/mssql/test/unit/download.test.ts
@@ -122,6 +122,80 @@ suite("ServiceDownloadProvider Tests", () => {
         expect(actual).to.equal(expected);
     });
 
+    test("getRuntimeDownloadPackageFileName returns the configured platform archive", () => {
+        config.getSqlToolsConfigValue
+            .withArgs("downloadFileNames")
+            .returns({ Windows_64: "win-x64.zip" });
+        const downloadProvider = new ServiceDownloadProvider(
+            config,
+            testLogger,
+            statusView,
+            testDownloadHelper,
+            testDecompressProvider,
+        );
+
+        expect(downloadProvider.getRuntimeDownloadPackageFileName(Runtime.Windows_64)).to.equal(
+            "win-x64.zip",
+        );
+    });
+
+    test("installServiceFromPackage copies and extracts a predownloaded package without HTTP", async () => {
+        const testRoot = path.join(__dirname, "testPredownloadedService");
+        const packagePath = path.join(testRoot, "Microsoft.SqlTools.ServiceLayer-win-x64.zip");
+        const installDirectory = path.join(testRoot, "install");
+
+        await fs.rm(testRoot, { recursive: true, force: true });
+        try {
+            await fs.mkdir(testRoot, { recursive: true });
+            await fs.writeFile(packagePath, "package contents");
+            config.getSqlToolsInstallDirectory.returns(installDirectory);
+            config.getSqlToolsPackageVersion.returns("1.0.0");
+            testDecompressProvider.decompress.resolves();
+
+            const downloadProvider = new ServiceDownloadProvider(
+                config,
+                testLogger,
+                statusView,
+                testDownloadHelper,
+                testDecompressProvider,
+            );
+
+            await downloadProvider.installServiceFromPackage(Runtime.Windows_64, packagePath);
+
+            expect(testDownloadHelper.downloadFile).to.not.have.been.called;
+            expect(testDecompressProvider.decompress).to.have.been.calledOnce;
+            expect(testDecompressProvider.decompress.firstCall.args[0].isZipFile).to.be.true;
+            expect(statusView.serviceInstalled).to.have.been.calledOnce;
+        } finally {
+            await fs.rm(testRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("installServiceFromPackage rejects a missing predownloaded package", async () => {
+        const packagePath = path.join(__dirname, "missing-service-package.zip");
+        const downloadProvider = new ServiceDownloadProvider(
+            config,
+            testLogger,
+            statusView,
+            testDownloadHelper,
+            testDecompressProvider,
+        );
+
+        let error: Error | undefined;
+        try {
+            await downloadProvider.installServiceFromPackage(Runtime.Windows_64, packagePath);
+        } catch (err) {
+            if (!(err instanceof Error)) {
+                throw err;
+            }
+            error = err;
+        }
+
+        expect(error?.message).to.equal(`SQL Tools Service package not found: ${packagePath}`);
+        expect(testDownloadHelper.downloadFile).to.not.have.been.called;
+        expect(testDecompressProvider.decompress).to.not.have.been.called;
+    });
+
     test("tryGetInstallDirectory returns undefined when portable install folder exists but required files are missing", async () => {
         const installRoot = path.join(__dirname, "testServicePortableMissing");
         const installDirectory = path.join(installRoot, "1.0.0", "Portable");


### PR DESCRIPTION
Adding some hooks that allow bundling the VSIXes to optionally specify a local copy of SQL Tools Service instead of pulling from the STS GitHub releases