### PR TITLE
query: Add setting to hide batch messages

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2392,6 +2392,12 @@
                     "default": false,
                     "scope": "resource"
                 },
+                "mssql.showBatchMessages": {
+                    "type": "boolean",
+                    "description": "%mssql.showBatchMessages%",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "mssql.splitPaneSelection": {
                     "type": "string",
                     "description": "%mssql.splitPaneSelection%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -140,6 +140,7 @@
     "mssql.copyIncludeHeaders": "[Optional] Configuration options for copying results from the Results View",
     "mssql.copyRemoveNewLine": "[Optional] Configuration options for copying multi-line results from the Results View",
     "mssql.showBatchTime": "[Optional] Should execution time be shown for individual batches",
+    "mssql.showBatchMessages": "[Optional] Show batch start and completion messages, including 'Started executing query at...' and 'Commands completed successfully'.",
     "mssql.splitPaneSelection": "[Optional] Configuration options for which column new result panes should open in",
     "mssql.preventAutoExecuteScript": "Prevent automatic execution of scripts (e.g., 'Select Top 1000'). When enabled, scripts will not be automatically executed upon generation.",
     "mssql.format.alignColumnDefinitionsInColumns": "**Used when Preview Formatter is disabled.** Should column definitions be aligned?",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -300,6 +300,7 @@ export const configMaxRecentConnections = "maxRecentConnections";
 export const configCopyRemoveNewLine = "copyRemoveNewLine";
 export const configSplitPaneSelection = "splitPaneSelection";
 export const configShowBatchTime = "showBatchTime";
+export const configShowBatchMessages = "showBatchMessages";
 export const configMessagesCopyIncludeTimestamps = "messages.copyIncludeTimestamps";
 export const configPreventAutoExecuteScript = "mssql.query.preventAutoExecuteScript";
 export enum extConfigResultKeys {

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -638,12 +638,14 @@ export default class QueryRunner {
         message.time = new Date(message.time).toLocaleTimeString();
         message.rowsAffected = getRowsAffectedFromMessage(message.message);
 
-        // save the message into the batch summary so it can be restored on view refresh
-        if (message.batchId >= 0 && this._batchSetMessages[message.batchId] !== undefined) {
-            this._batchSetMessages[message.batchId].push(message);
+        if (message.isError || Utils.shouldShowBatchMessages(this.uri)) {
+            // save the message into the batch summary so it can be restored on view refresh
+            if (message.batchId >= 0 && this._batchSetMessages[message.batchId] !== undefined) {
+                this._batchSetMessages[message.batchId].push(message);
+            }
         }
 
-        // Send the message to the results pane
+        // Send the message so non-display state, such as rows affected, remains current
         this._messageEmitter.fire(message);
 
         // Set row count on status bar if there are no errors

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -630,6 +630,10 @@ export class SqlOutputContentProvider {
             );
 
             const batchStartListener = queryRunner.onBatchStart(async (batch) => {
+                if (!Utils.shouldShowBatchMessages(queryRunner.uri)) {
+                    return;
+                }
+
                 let time = new Date().toLocaleTimeString();
                 if (batch.executionElapsed && batch.executionEnd) {
                     time = new Date(batch.executionStart).toLocaleTimeString();
@@ -665,7 +669,9 @@ export class SqlOutputContentProvider {
                     queryRunner.uri,
                 );
 
-                resultWebviewState.messages.push(message);
+                if (message.isError || Utils.shouldShowBatchMessages(queryRunner.uri)) {
+                    resultWebviewState.messages.push(message);
+                }
                 if (typeof message.rowsAffected === "number") {
                     resultWebviewState.rowsAffected = message.rowsAffected;
                 }
@@ -690,11 +696,13 @@ export class SqlOutputContentProvider {
                 resultWebviewState.isExecuting = false;
                 resultWebviewState.executionStartTime = undefined;
                 resultWebviewState.executionElapsedMilliseconds = totalElapsedMilliseconds;
-                resultWebviewState.messages.push({
-                    message: LocalizedConstants.elapsedTimeLabel(totalMilliseconds),
-                    isError: false, // Elapsed time messages are never displayed as errors
-                    time: new Date().toLocaleTimeString(),
-                });
+                if (Utils.shouldShowBatchMessages(queryRunner.uri)) {
+                    resultWebviewState.messages.push({
+                        message: LocalizedConstants.elapsedTimeLabel(totalMilliseconds),
+                        isError: false, // Elapsed time messages are never displayed as errors
+                        time: new Date().toLocaleTimeString(),
+                    });
+                }
                 // if there is an error, show the error message and set the tab to the messages tab
                 let tabState: QueryResultPaneTabs;
                 if (hasError) {

--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -707,6 +707,14 @@ function getExtensionConfiguration(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
 }
 
+export function shouldShowBatchMessages(uri: string): boolean {
+    return (
+        vscode.workspace
+            .getConfiguration(Constants.extensionConfigSectionName, vscode.Uri.parse(uri))
+            .get<boolean>(Constants.configShowBatchMessages) !== false
+    );
+}
+
 export function getConfigTracingLevel(): string {
     let config = getExtensionConfiguration();
     if (config) {

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -454,6 +454,67 @@ suite("Query Runner tests", () => {
         expect(queryRunner.batchSetMessages[message.message.batchId].length).to.equal(1);
     });
 
+    test("Notification - Message does not cache non-error messages when disabled", () => {
+        const config = stubs.createWorkspaceConfiguration({
+            [Constants.configShowBatchMessages]: false,
+        });
+        getConfigurationStub.returns(config);
+        const message: QueryExecuteContracts.QueryExecuteMessageParams = {
+            message: {
+                batchId: 0,
+                isError: false,
+                message: "Commands completed successfully.",
+                time: new Date().toISOString(),
+            },
+            ownerUri: standardUri,
+        };
+        const queryRunner = createQueryRunner();
+        const messageListener = sandbox.spy();
+        queryRunner.onMessage(messageListener);
+        queryRunner.batchSetMessages[message.message.batchId] = [];
+
+        queryRunner.handleMessage(message);
+
+        expect(queryRunner.batchSetMessages[message.message.batchId]).to.be.empty;
+        expect(messageListener).to.have.been.calledWith(message.message);
+        expect(testStatusView.showRowCount).to.have.been.calledWith(
+            standardUri,
+            message.message.message,
+        );
+        expect(getConfigurationStub).to.have.been.calledWith(
+            Constants.extensionConfigSectionName,
+            vscode.Uri.parse(standardUri),
+        );
+    });
+
+    test("Notification - Message preserves errors when batch messages are disabled", () => {
+        const config = stubs.createWorkspaceConfiguration({
+            [Constants.configShowBatchMessages]: false,
+        });
+        getConfigurationStub.returns(config);
+        const message: QueryExecuteContracts.QueryExecuteMessageParams = {
+            message: {
+                batchId: 0,
+                isError: true,
+                message: "Incorrect syntax near 'FROM'.",
+                time: new Date().toISOString(),
+            },
+            ownerUri: standardUri,
+        };
+        const queryRunner = createQueryRunner();
+        const messageListener = sandbox.spy();
+        queryRunner.onMessage(messageListener);
+        queryRunner.batchSetMessages[message.message.batchId] = [];
+
+        queryRunner.handleMessage(message);
+
+        expect(queryRunner.batchSetMessages[message.message.batchId]).to.deep.equal([
+            message.message,
+        ]);
+        expect(messageListener).to.have.been.calledWith(message.message);
+        expect(testStatusView.hideRowCount).to.have.been.calledWith(standardUri, true);
+    });
+
     test("Notification - Query complete", () => {
         // Setup:
 

--- a/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
@@ -518,6 +518,131 @@ suite("SqlOutputProvider Tests using mocks", () => {
         expect(batchMessage.link).to.be.undefined;
     });
 
+    test("Batch start messages are hidden when batch messages are disabled", async () => {
+        const uri = "test_uri";
+        getConfigurationStub.returns(
+            stubs.createWorkspaceConfiguration({
+                [Constants.configShowBatchMessages]: false,
+            }),
+        );
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleBatchStart({
+            ownerUri: uri,
+            batchSummary: {
+                hasError: false,
+                id: 0,
+                selection: {
+                    startLine: 0,
+                    startColumn: 0,
+                    endLine: 0,
+                    endColumn: 8,
+                },
+                resultSetSummaries: [],
+                executionElapsed: undefined,
+                executionEnd: undefined,
+                executionStart: new Date().toISOString(),
+            },
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.be.empty;
+    });
+
+    test("Hidden batch messages still update rows affected", async () => {
+        const uri = "test_uri";
+        getConfigurationStub.returns(
+            stubs.createWorkspaceConfiguration({
+                [Constants.configShowBatchMessages]: false,
+            }),
+        );
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleMessage({
+            ownerUri: uri,
+            message: {
+                message: "(7 rows affected)",
+                isError: false,
+                time: new Date().toISOString(),
+                batchId: -1,
+            },
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.be.empty;
+        expect(state.rowsAffected).to.equal(7);
+    });
+
+    test("Completion messages are hidden while execution state still updates", async () => {
+        const uri = "test_uri";
+        getConfigurationStub.returns(
+            stubs.createWorkspaceConfiguration({
+                [Constants.configShowBatchMessages]: false,
+            }),
+        );
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleBatchComplete({
+            ownerUri: uri,
+            batchSummary: {
+                hasError: false,
+                id: 0,
+                selection: undefined,
+                resultSetSummaries: [],
+                executionElapsed: "00:00:03",
+                executionEnd: new Date().toISOString(),
+                executionStart: new Date().toISOString(),
+            },
+        });
+        runner.handleQueryComplete({
+            ownerUri: uri,
+            batchSummaries: [],
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.be.empty;
+        expect(state.isExecuting).to.equal(false);
+        expect(state.executionElapsedMilliseconds).to.equal(3000);
+    });
+
+    test("Error messages remain visible when batch messages are disabled", async () => {
+        const uri = "test_uri";
+        const errorMessage = "Incorrect syntax near 'FROM'.";
+        getConfigurationStub.returns(
+            stubs.createWorkspaceConfiguration({
+                [Constants.configShowBatchMessages]: false,
+            }),
+        );
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleMessage({
+            ownerUri: uri,
+            message: {
+                message: errorMessage,
+                isError: true,
+                time: new Date().toISOString(),
+                batchId: -1,
+            },
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.have.length(1);
+        expect(state.messages[0]).to.deep.include({
+            message: errorMessage,
+            isError: true,
+            batchId: -1,
+            rowsAffected: undefined,
+        });
+    });
+
     test("runCurrentStatement calls runStatement with correct options when actual plan is enabled", async () => {
         const uri = "test_uri";
         const title = "test_title";

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9866,6 +9866,9 @@
     <trans-unit id="mssql.showBatchTime">
       <source xml:lang="en">[Optional] Should execution time be shown for individual batches</source>
     </trans-unit>
+    <trans-unit id="mssql.showBatchMessages">
+      <source xml:lang="en">[Optional] Show batch start and completion messages, including &apos;Started executing query at...&apos; and &apos;Commands completed successfully&apos;.</source>
+    </trans-unit>
     <trans-unit id="mssql.connection.profileName">
       <source xml:lang="en">[Optional] Specify a custom name for this connection profile to easily browse and search in the command palette of Visual Studio Code.</source>
     </trans-unit>


### PR DESCRIPTION
## Summary

Large SQL files can produce enough query lifecycle output to obscure actionable errors. This change adds a resource-scoped `mssql.showBatchMessages` setting so users can hide batch start, successful service, and elapsed completion messages.

The setting defaults to `true` to preserve existing behavior. When disabled, error messages remain visible and row counts and execution completion state continue to update normally.

## Behavior

- **Before:** Batch start and completion messages were always displayed.
- **After:** Set `mssql.showBatchMessages` to `false` for cleaner, SSMS-like output while retaining errors and execution metadata.

## Validation

- Targeted QueryRunner and SqlOutputContentProvider unit suites
- Full MSSQL unit suite
- MSSQL extension build and type checks
- MSSQL lint
- Online VSIX packaging

## Context

Ports and supersedes #20751, originally contributed by @adamhartford. The functionality was recreated on current `main` because the original branch had become too stale to update safely.