### PR TITLE
notebooks: add Copy As menu to result grids

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2933,7 +2933,7 @@
         "message": "Export toolbar for result set {0}",
         "comment": ["{0} is the result set number (1-based index)"]
     },
-    "Copy As": "Copy As",
+    "Copy as...": "Copy as...",
     "Copy as INSERT INTO": "Copy as INSERT INTO",
     "Copying as an IN clause requires selecting exactly one column.": "Copying as an IN clause requires selecting exactly one column.",
     "NULL": "NULL",

--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2935,6 +2935,7 @@
     },
     "Copy As": "Copy As",
     "Copy as INSERT INTO": "Copy as INSERT INTO",
+    "Copying as an IN clause requires selecting exactly one column.": "Copying as an IN clause requires selecting exactly one column.",
     "NULL": "NULL",
     "Blanks": "Blanks",
     "Search...": "Search...",

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -22,6 +22,7 @@ import type {
     NotebookQueryResultBlock,
     NotebookQueryResultGridBlock,
     NotebookQueryResultOutputData,
+    NotebookCopyAsCsvOptions,
     NotebookRendererMessage,
     NotebookSaveAsMessage,
 } from "../sharedInterfaces/notebookQueryResult";
@@ -265,6 +266,9 @@ export class SqlNotebookController implements vscode.Disposable {
                         break;
                     case "selectionSummary":
                         this.updateSelectionSummary(message.metrics);
+                        break;
+                    case "showError":
+                        void vscode.window.showErrorMessage(message.message);
                         break;
                 }
             }),
@@ -1066,7 +1070,7 @@ export class SqlNotebookController implements vscode.Disposable {
                 `[executeCell] executeQueryString: done canceled=${result.canceled} ` +
                     `batches=${result.batches.length}`,
             );
-            const outputs = this.buildBatchOutputs(result.batches, !result.canceled);
+            const outputs = this.buildBatchOutputs(result.batches, !result.canceled, notebook.uri);
 
             if (result.canceled) {
                 outputs.push(
@@ -1115,10 +1119,11 @@ export class SqlNotebookController implements vscode.Disposable {
     private buildBatchOutputs(
         batches: HeadlessBatchResult[],
         includeExecutionTime = true,
+        resource?: vscode.Uri,
     ): vscode.NotebookCellOutput[] {
         const blocks = this.buildBatchOutputBlocks(batches, includeExecutionTime);
         if (this.hasResultSetBlock(blocks)) {
-            return [this.buildRichBatchOutput(blocks)];
+            return [this.buildRichBatchOutput(blocks, resource)];
         }
 
         return this.buildPlainBatchOutputs(
@@ -1204,7 +1209,10 @@ export class SqlNotebookController implements vscode.Disposable {
         return blocks;
     }
 
-    private buildRichBatchOutput(blocks: NotebookQueryResultBlock[]): vscode.NotebookCellOutput {
+    private buildRichBatchOutput(
+        blocks: NotebookQueryResultBlock[],
+        resource?: vscode.Uri,
+    ): vscode.NotebookCellOutput {
         const plain = blocks
             .map((block) =>
                 block.type === "resultSet"
@@ -1215,12 +1223,28 @@ export class SqlNotebookController implements vscode.Disposable {
         const data: NotebookQueryResultOutputData = {
             version: 1,
             blocks,
+            copyAsCsvOptions: this.getCopyAsCsvOptions(resource),
         };
 
         return new vscode.NotebookCellOutput([
             vscode.NotebookCellOutputItem.json(data, MIME_NOTEBOOK_QUERY_RESULT),
             vscode.NotebookCellOutputItem.text(plain, MIME_TEXT_PLAIN),
         ]);
+    }
+
+    private getCopyAsCsvOptions(resource?: vscode.Uri): NotebookCopyAsCsvOptions {
+        const config = vscode.workspace.getConfiguration(
+            Constants.extensionConfigSectionName,
+            resource,
+        );
+        const csvConfig =
+            config.get<Partial<NotebookCopyAsCsvOptions>>(Constants.configSaveAsCsv) ?? {};
+        return {
+            delimiter: csvConfig.delimiter || ",",
+            includeHeaders: csvConfig.includeHeaders ?? true,
+            lineSeparator: csvConfig.lineSeparator || os.EOL,
+            textIdentifier: csvConfig.textIdentifier || '"',
+        };
     }
 
     private buildPlainBatchOutputs(

--- a/extensions/mssql/src/sharedInterfaces/notebookQueryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/notebookQueryResult.ts
@@ -30,6 +30,14 @@ export type NotebookQueryResultBlock =
 export interface NotebookQueryResultOutputData {
     version: 1;
     blocks: NotebookQueryResultBlock[];
+    copyAsCsvOptions?: NotebookCopyAsCsvOptions;
+}
+
+export interface NotebookCopyAsCsvOptions {
+    delimiter: string;
+    includeHeaders: boolean;
+    lineSeparator: string;
+    textIdentifier: string;
 }
 
 // Older notebook executions stored each result set as its own custom output item.
@@ -66,7 +74,12 @@ export interface NotebookSelectionSummaryMessage {
     metrics: SelectionSummaryMetrics | undefined;
 }
 
-/**
- * The union of messages the notebook result renderer posts to the extension host.
- */
-export type NotebookRendererMessage = NotebookSaveAsMessage | NotebookSelectionSummaryMessage;
+export interface NotebookShowErrorMessage {
+    type: "showError";
+    message: string;
+}
+
+export type NotebookRendererMessage =
+    | NotebookSaveAsMessage
+    | NotebookSelectionSummaryMessage
+    | NotebookShowErrorMessage;

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1167,7 +1167,7 @@ export class LocConstants {
                     args: [resultSetIndex],
                     comment: ["{0} is the result set number (1-based index)"],
                 }),
-            copyAs: l10n.t("Copy As"),
+            copyAs: l10n.t("Copy as..."),
             copyAsCsv: l10n.t("Copy as CSV"),
             copyAsJson: l10n.t("Copy as JSON"),
             copyAsInClause: l10n.t("Copy as IN clause"),

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -1172,6 +1172,9 @@ export class LocConstants {
             copyAsJson: l10n.t("Copy as JSON"),
             copyAsInClause: l10n.t("Copy as IN clause"),
             copyAsInsertInto: l10n.t("Copy as INSERT INTO"),
+            copyAsInClauseRequiresSingleColumn: l10n.t(
+                "Copying as an IN clause requires selecting exactly one column.",
+            ),
             null: l10n.t("NULL"),
             blankString: l10n.t("Blanks"),
             apply: l10n.t("Apply"),

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookContextMenu.plugin.ts
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookContextMenu.plugin.ts
@@ -3,33 +3,66 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/**
- * Context menu plugin for the notebook renderer grid.
- *
- * This is intentionally separate from QueryResult's ContextMenu because
- * the two share very little implementation:
- *  - QueryResult renders its menu via React (queryResultContext.showGridContextMenu)
- *    and delegates copy/format to the extension host via RPC;
- *  - The notebook renderer runs inside a VS Code notebook output iframe that
- *    has no access to extension host RPC, so it builds the menu with raw DOM
- *    and copies locally via the clipboard API using in-memory data.
- */
-
 import { locConstants } from "../../common/locConstants";
 import { IDisposableDataProvider } from "../QueryResult/table/dataProvider";
+import type { IDbColumn } from "../../../sharedInterfaces/queryResult";
+import type { NotebookCopyAsCsvOptions } from "../../../sharedInterfaces/notebookQueryResult";
+import { getEOL, isMac } from "../../common/utils";
 
-/** Actions available in the notebook grid context menu. */
+const getModKeyLabel = () => (isMac() ? "⌘" : "Ctrl+");
+
 enum NotebookContextMenuAction {
     SelectAll = "select-all",
     CopySelection = "copy-selection",
     CopyWithHeaders = "copy-with-headers",
     CopyHeaders = "copy-headers",
+    CopyAsCsv = "copy-as-csv",
+    CopyAsJson = "copy-as-json",
+    CopyAsInClause = "copy-as-in-clause",
+    CopyAsInsertInto = "copy-as-insert-into",
 }
 
 export class NotebookContextMenu<T extends Slick.SlickData> {
+    private static readonly NUMERIC_SQL_TYPES = new Set([
+        "int",
+        "bigint",
+        "smallint",
+        "tinyint",
+        "decimal",
+        "numeric",
+        "float",
+        "real",
+        "money",
+        "smallmoney",
+        "bit",
+    ]);
+
+    private static readonly JSON_NUMBER_TYPES = new Set([
+        "int",
+        "bigint",
+        "smallint",
+        "tinyint",
+        "decimal",
+        "numeric",
+        "float",
+        "real",
+        "money",
+        "smallmoney",
+    ]);
+    private static readonly JSON_NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+    private static readonly SQL_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+    private static readonly INSERT_ROW_LIMIT = 1000;
+
+    constructor(
+        private readonly columnInfo: IDbColumn[] = [],
+        private readonly copyAsCsvOptions?: NotebookCopyAsCsvOptions,
+        private readonly postMessage?: (message: unknown) => void,
+    ) {}
+
     private grid!: Slick.Grid<T>;
     private handler = new Slick.EventHandler();
     private menuElement: HTMLElement | null = null;
+    private submenuElement: HTMLElement | null = null;
     private dismissHandler: ((e: MouseEvent) => void) | null = null;
     private escapeHandler: ((e: KeyboardEvent) => void) | null = null;
     private scrollHandler: (() => void) | null = null;
@@ -38,6 +71,9 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         this.grid = grid;
         this.handler.subscribe(this.grid.onContextMenu, (e: Event) => this.handleContextMenu(e));
         this.handler.subscribe(this.grid.onHeaderClick, () => this.dismiss());
+        this.handler.subscribe(this.grid.onClick, () => {
+            if (this.menuElement) this.dismiss();
+        });
     }
 
     public destroy(): void {
@@ -45,19 +81,17 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         this.dismiss();
     }
 
-    // ── Menu display ─────────────────────────────────────────────────
-
     private handleContextMenu(e: Event): void {
         e.preventDefault();
         e.stopPropagation();
         this.dismiss();
 
         const mouseEvent = e as MouseEvent;
-        const menu = this.buildMenu();
+        const { menu, showSubmenu } = this.buildMenu();
+        menu.setAttribute("role", "menu");
         document.body.appendChild(menu);
         this.menuElement = menu;
 
-        // Position with viewport awareness
         const margin = 8;
         const menuRect = menu.getBoundingClientRect();
         const maxX = Math.max(margin, window.innerWidth - menuRect.width - margin);
@@ -68,34 +102,83 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         menu.style.left = `${x}px`;
         menu.style.top = `${y}px`;
 
-        // Dismiss on outside click
-        this.dismissHandler = (evt: MouseEvent) => {
-            if (!menu.contains(evt.target as Node)) {
+        menu.tabIndex = -1;
+        let focusedIdx = -1;
+        const menuItems = Array.from(menu.querySelectorAll<HTMLElement>(".nb-context-menu-item"));
+        const setMenuFocus = (next: number) => {
+            menuItems[focusedIdx]?.classList.remove("nb-context-menu-item--focused");
+            focusedIdx = (next + menuItems.length) % menuItems.length;
+            menuItems[focusedIdx]?.classList.add("nb-context-menu-item--focused");
+            menuItems[focusedIdx]?.focus();
+        };
+
+        menu.addEventListener("keydown", (evt: KeyboardEvent) => {
+            switch (evt.key) {
+                case "ArrowDown":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    setMenuFocus(focusedIdx + 1);
+                    break;
+                case "ArrowUp":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    setMenuFocus(focusedIdx < 0 ? menuItems.length - 1 : focusedIdx - 1);
+                    break;
+                case "ArrowRight":
+                    if (focusedIdx >= 0 && menuItems[focusedIdx]?.dataset.hasSubmenu) {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                        showSubmenu();
+                    }
+                    break;
+                case "Enter":
+                case " ":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    if (menuItems[focusedIdx]?.dataset.hasSubmenu) {
+                        showSubmenu();
+                    } else {
+                        menuItems[focusedIdx]?.click();
+                    }
+                    break;
+            }
+        });
+
+        const dismissHandler = (evt: MouseEvent) => {
+            const target = evt.target as Node;
+            if (!menu.contains(target) && !this.submenuElement?.contains(target)) {
                 this.dismiss();
             }
         };
-        // Use setTimeout so the current right-click event doesn't immediately dismiss
-        setTimeout(() => {
-            document.addEventListener("mousedown", this.dismissHandler!);
-        }, 0);
+        this.dismissHandler = dismissHandler;
 
-        // Dismiss on Escape
-        this.escapeHandler = (evt: KeyboardEvent) => {
-            if (evt.key === "Escape") {
-                this.dismiss();
+        // Wait until the current context-menu event has finished before listening for dismissal.
+        queueMicrotask(() => {
+            if (this.dismissHandler !== dismissHandler) {
+                return;
             }
+            setMenuFocus(0);
+            document.addEventListener("mousedown", dismissHandler);
+        });
+
+        this.escapeHandler = (evt: KeyboardEvent) => {
+            if (evt.key === "Escape") this.dismiss();
         };
         document.addEventListener("keydown", this.escapeHandler);
 
-        // Dismiss on scroll
         this.scrollHandler = () => this.dismiss();
         this.grid.getCanvasNode().addEventListener("scroll", this.scrollHandler);
     }
 
     private dismiss(): void {
+        const shouldRestoreGridFocus = this.menuElement !== null;
         if (this.menuElement) {
             this.menuElement.remove();
             this.menuElement = null;
+        }
+        if (this.submenuElement) {
+            this.submenuElement.remove();
+            this.submenuElement = null;
         }
         if (this.dismissHandler) {
             document.removeEventListener("mousedown", this.dismissHandler);
@@ -109,22 +192,19 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
             this.grid?.getCanvasNode()?.removeEventListener("scroll", this.scrollHandler);
             this.scrollHandler = null;
         }
+        if (shouldRestoreGridFocus) {
+            this.grid.focus();
+        }
     }
 
-    // ── Menu construction ────────────────────────────────────────────
-
-    private buildMenu(): HTMLElement {
+    private buildMenu(): { menu: HTMLElement; showSubmenu: () => void } {
         const menu = document.createElement("div");
         menu.className = "nb-context-menu";
-
-        const isMac =
-            typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
-        const modKey = isMac ? "\u2318" : "Ctrl+";
 
         this.addMenuItem(
             menu,
             locConstants.queryResult.selectAll,
-            `${modKey}A`,
+            `${getModKeyLabel()}A`,
             NotebookContextMenuAction.SelectAll,
         );
 
@@ -133,7 +213,7 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         this.addMenuItem(
             menu,
             locConstants.queryResult.copy,
-            `${modKey}C`,
+            `${getModKeyLabel()}C`,
             NotebookContextMenuAction.CopySelection,
         );
         this.addMenuItem(
@@ -149,7 +229,153 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
             NotebookContextMenuAction.CopyHeaders,
         );
 
-        return menu;
+        this.addSeparator(menu);
+
+        const showSubmenu = this.addSubmenuItem(menu, locConstants.queryResult.copyAs, [
+            {
+                label: locConstants.queryResult.copyAsCsv,
+                action: NotebookContextMenuAction.CopyAsCsv,
+            },
+            {
+                label: locConstants.queryResult.copyAsJson,
+                action: NotebookContextMenuAction.CopyAsJson,
+            },
+            {
+                label: locConstants.queryResult.copyAsInsertInto,
+                action: NotebookContextMenuAction.CopyAsInsertInto,
+            },
+            {
+                label: locConstants.queryResult.copyAsInClause,
+                action: NotebookContextMenuAction.CopyAsInClause,
+            },
+        ]);
+
+        return { menu, showSubmenu };
+    }
+
+    private addSubmenuItem(
+        parent: HTMLElement,
+        label: string,
+        subItems: Array<{ label: string; action: NotebookContextMenuAction }>,
+    ): () => void {
+        const item = document.createElement("div");
+        item.className = "nb-context-menu-item";
+        item.dataset.hasSubmenu = "true";
+        item.tabIndex = -1;
+        item.setAttribute("role", "menuitem");
+        item.setAttribute("aria-haspopup", "menu");
+        item.setAttribute("aria-expanded", "false");
+
+        const labelSpan = document.createElement("span");
+        labelSpan.className = "nb-context-menu-label";
+        labelSpan.textContent = label;
+        item.appendChild(labelSpan);
+
+        const submenu = document.createElement("div");
+        submenu.className = "nb-context-menu";
+        submenu.setAttribute("role", "menu");
+        submenu.style.display = "none";
+        submenu.style.flexDirection = "column";
+        submenu.tabIndex = -1;
+
+        const submenuItems: HTMLElement[] = [];
+        for (const subItem of subItems) {
+            submenuItems.push(this.addMenuItem(submenu, subItem.label, undefined, subItem.action));
+        }
+
+        document.body.appendChild(submenu);
+        this.submenuElement = submenu;
+
+        let submenuFocusedIdx = -1;
+
+        const clearFocus = () => {
+            if (submenuFocusedIdx >= 0) {
+                submenuItems[submenuFocusedIdx]?.classList.remove("nb-context-menu-item--focused");
+                submenuFocusedIdx = -1;
+            }
+        };
+
+        const setSubmenuFocus = (next: number) => {
+            submenuItems[submenuFocusedIdx]?.classList.remove("nb-context-menu-item--focused");
+            submenuFocusedIdx = (next + submenuItems.length) % submenuItems.length;
+            submenuItems[submenuFocusedIdx]?.classList.add("nb-context-menu-item--focused");
+            submenuItems[submenuFocusedIdx]?.focus();
+        };
+
+        const positionSubmenu = () => {
+            const rect = item.getBoundingClientRect();
+            submenu.style.visibility = "hidden";
+            submenu.style.display = "flex";
+            const submenuRect = submenu.getBoundingClientRect();
+            let left = rect.right;
+            if (left + submenuRect.width > window.innerWidth - 8) {
+                left = rect.left - submenuRect.width;
+            }
+            submenu.style.left = `${left}px`;
+            submenu.style.top = `${Math.max(8, Math.min(rect.top, window.innerHeight - submenuRect.height - 8))}px`;
+            submenu.style.visibility = "";
+            item.setAttribute("aria-expanded", "true");
+        };
+
+        const show = () => {
+            positionSubmenu();
+            setSubmenuFocus(0);
+        };
+
+        const hideSubmenu = (e: MouseEvent) => {
+            if (
+                !submenu.contains(e.relatedTarget as Node) &&
+                !item.contains(e.relatedTarget as Node)
+            ) {
+                submenu.style.display = "none";
+                item.setAttribute("aria-expanded", "false");
+                clearFocus();
+            }
+        };
+
+        item.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            show();
+        });
+        item.addEventListener("mouseenter", positionSubmenu);
+        item.addEventListener("mouseleave", hideSubmenu);
+        submenu.addEventListener("mouseleave", hideSubmenu);
+
+        submenu.addEventListener("keydown", (evt: KeyboardEvent) => {
+            switch (evt.key) {
+                case "ArrowDown":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    setSubmenuFocus(submenuFocusedIdx + 1);
+                    break;
+                case "ArrowUp":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    setSubmenuFocus(
+                        submenuFocusedIdx < 0 ? submenuItems.length - 1 : submenuFocusedIdx - 1,
+                    );
+                    break;
+                case "ArrowLeft":
+                case "Escape":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    submenu.style.display = "none";
+                    item.setAttribute("aria-expanded", "false");
+                    clearFocus();
+                    item.focus();
+                    break;
+                case "Enter":
+                case " ":
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    if (submenuFocusedIdx >= 0) submenuItems[submenuFocusedIdx]?.click();
+                    break;
+            }
+        });
+
+        parent.appendChild(item);
+        return show;
     }
 
     private addMenuItem(
@@ -157,9 +383,11 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         label: string,
         shortcut: string | undefined,
         action: NotebookContextMenuAction,
-    ): void {
+    ): HTMLElement {
         const item = document.createElement("div");
         item.className = "nb-context-menu-item";
+        item.tabIndex = -1;
+        item.setAttribute("role", "menuitem");
 
         const labelSpan = document.createElement("span");
         labelSpan.className = "nb-context-menu-label";
@@ -181,15 +409,15 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         });
 
         parent.appendChild(item);
+        return item;
     }
 
     private addSeparator(parent: HTMLElement): void {
         const sep = document.createElement("div");
         sep.className = "nb-context-menu-separator";
+        sep.setAttribute("role", "separator");
         parent.appendChild(sep);
     }
-
-    // ── Actions ──────────────────────────────────────────────────────
 
     private async handleAction(action: NotebookContextMenuAction): Promise<void> {
         const { ranges, columns, dataProvider } = this.getSelectionContext();
@@ -215,6 +443,24 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
             case NotebookContextMenuAction.CopyHeaders:
                 await this.copyToClipboard(this.formatHeaders(ranges, columns));
                 break;
+            case NotebookContextMenuAction.CopyAsCsv:
+                await this.copyToClipboard(this.formatAsCsv(ranges, columns, dataProvider));
+                break;
+            case NotebookContextMenuAction.CopyAsJson:
+                await this.copyToClipboard(this.formatAsJson(ranges, columns, dataProvider));
+                break;
+            case NotebookContextMenuAction.CopyAsInClause: {
+                const inClause = this.formatAsInClause(ranges, columns, dataProvider);
+                if (inClause === null) {
+                    this.showError(locConstants.queryResult.copyAsInClauseRequiresSingleColumn);
+                } else {
+                    await this.copyToClipboard(inClause);
+                }
+                break;
+            }
+            case NotebookContextMenuAction.CopyAsInsertInto:
+                await this.copyToClipboard(this.formatAsInsertInto(ranges, columns, dataProvider));
+                break;
         }
     }
 
@@ -226,7 +472,6 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         const selModel = this.grid.getSelectionModel();
         let ranges = selModel?.getSelectedRanges() ?? [];
 
-        // If no selection, select the entire grid
         if (ranges.length === 0) {
             const colCount = this.grid.getColumns().length;
             const rowCount = (this.grid.getData() as IDisposableDataProvider<T>).getLength();
@@ -240,7 +485,6 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         };
     }
 
-    /** Get data columns (excluding rowNumber) within the given cell range. */
     private getDataColumnsInRange(
         columns: Slick.Column<T>[],
         fromCell: number,
@@ -256,6 +500,29 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         return result;
     }
 
+    private getSelectedColumnIndices(ranges: Slick.Range[], columns: Slick.Column<T>[]): number[] {
+        const selected = new Set<number>();
+        for (const range of ranges) {
+            for (let c = range.fromCell; c <= range.toCell; c++) {
+                const col = columns[c];
+                if (col?.id !== "rowNumber" && col?.field) {
+                    selected.add(c);
+                }
+            }
+        }
+        return [...selected].sort((a, b) => a - b);
+    }
+
+    private isCellSelected(ranges: Slick.Range[], row: number, colIndex: number): boolean {
+        return ranges.some(
+            (rng) =>
+                row >= rng.fromRow &&
+                row <= rng.toRow &&
+                colIndex >= rng.fromCell &&
+                colIndex <= rng.toCell,
+        );
+    }
+
     private getCellDisplayValue(
         dataProvider: IDisposableDataProvider<T>,
         row: number,
@@ -269,11 +536,15 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
         return cellVal.isNull ? "NULL" : (cellVal.displayValue ?? "");
     }
 
+    private getColumnInfo(col: Slick.Column<T>): IDbColumn | undefined {
+        const colIndex = parseInt(col.field!, 10);
+        return !isNaN(colIndex) ? this.columnInfo[colIndex] : undefined;
+    }
+
     private async copyToClipboard(text: string): Promise<void> {
         try {
             await navigator.clipboard.writeText(text);
         } catch {
-            // Fallback: execCommand for environments where clipboard API is restricted
             const textarea = document.createElement("textarea");
             textarea.value = text;
             textarea.style.position = "fixed";
@@ -284,8 +555,6 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
             document.body.removeChild(textarea);
         }
     }
-
-    // ── Formatters ───────────────────────────────────────────────────
 
     private formatTabSeparated(
         ranges: Slick.Range[],
@@ -312,7 +581,7 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
                 lines.push(values.join("\t"));
             }
         }
-        return lines.join("\n");
+        return lines.join(getEOL());
     }
 
     private formatHeaders(ranges: Slick.Range[], columns: Slick.Column<T>[]): string {
@@ -321,6 +590,212 @@ export class NotebookContextMenu<T extends Slick.SlickData> {
             const dataCols = this.getDataColumnsInRange(columns, range.fromCell, range.toCell);
             headers.push(dataCols.map((c) => c.name ?? "").join("\t"));
         }
-        return headers.join("\n");
+        return headers.join(getEOL());
+    }
+
+    public formatAsCsv(
+        ranges: Slick.Range[],
+        columns: Slick.Column<T>[],
+        dataProvider: IDisposableDataProvider<T>,
+    ): string {
+        const {
+            delimiter = ",",
+            includeHeaders = true,
+            lineSeparator = getEOL(),
+            textIdentifier = '"',
+        } = this.copyAsCsvOptions ?? {};
+        const quote = (v: string): string => {
+            if (
+                v.includes(textIdentifier) ||
+                v.includes(delimiter) ||
+                v.includes("\n") ||
+                v.includes("\r")
+            ) {
+                return (
+                    textIdentifier +
+                    v.replaceAll(textIdentifier, textIdentifier + textIdentifier) +
+                    textIdentifier
+                );
+            }
+            return v;
+        };
+        const colIndices = this.getSelectedColumnIndices(ranges, columns);
+        const lines: string[] = [];
+        if (includeHeaders) {
+            lines.push(
+                colIndices
+                    .map((c) => quote(columns[c].toolTip ?? columns[c].name ?? ""))
+                    .join(delimiter),
+            );
+        }
+        for (const range of ranges) {
+            for (let r = range.fromRow; r <= range.toRow; r++) {
+                lines.push(
+                    colIndices
+                        .map((c) =>
+                            this.isCellSelected(ranges, r, c)
+                                ? quote(
+                                      this.getCellDisplayValue(dataProvider, r, columns[c].field!),
+                                  )
+                                : "",
+                        )
+                        .join(delimiter),
+                );
+            }
+        }
+        return lines.join(lineSeparator);
+    }
+
+    public formatAsJson(
+        ranges: Slick.Range[],
+        columns: Slick.Column<T>[],
+        dataProvider: IDisposableDataProvider<T>,
+    ): string {
+        const colMeta = this.getSelectedColumnIndices(ranges, columns).map((c) => {
+            const col = columns[c];
+            const typeName = this.getColumnInfo(col)?.dataTypeName?.toLowerCase();
+            return {
+                field: col.field!,
+                index: c,
+                key: JSON.stringify(col.toolTip ?? col.name ?? col.field!),
+                isJsonNumber: !!typeName && NotebookContextMenu.JSON_NUMBER_TYPES.has(typeName),
+            };
+        });
+
+        const eol = getEOL();
+        const rows: string[] = [];
+        for (const range of ranges) {
+            for (let r = range.fromRow; r <= range.toRow; r++) {
+                const item = dataProvider.getItem(r) as Slick.SlickData;
+                const pairs: string[] = [];
+                for (const { field, index, key, isJsonNumber } of colMeta) {
+                    const cellVal = item?.[field];
+                    let val: string;
+                    if (!this.isCellSelected(ranges, r, index) || cellVal?.isNull) {
+                        val = "null";
+                    } else {
+                        const displayVal = cellVal?.displayValue ?? "";
+                        val =
+                            isJsonNumber && NotebookContextMenu.JSON_NUMBER_PATTERN.test(displayVal)
+                                ? displayVal
+                                : JSON.stringify(displayVal);
+                    }
+                    pairs.push(`    ${key}: ${val}`);
+                }
+                rows.push(`  {${eol}${pairs.join(`,${eol}`)}${eol}  }`);
+            }
+        }
+        return `[${eol}${rows.join(`,${eol}`)}${eol}]`;
+    }
+
+    public formatAsInClause(
+        ranges: Slick.Range[],
+        columns: Slick.Column<T>[],
+        dataProvider: IDisposableDataProvider<T>,
+    ): string | null {
+        const valueLines: string[] = [];
+        let col: Slick.Column<T> | undefined;
+        let isNumeric = false;
+
+        for (const range of ranges) {
+            const rangeCols = this.getDataColumnsInRange(columns, range.fromCell, range.toCell);
+            if (rangeCols.length !== 1) return null;
+            if (col === undefined) {
+                col = rangeCols[0];
+                isNumeric = this.isNumericSqlType(this.getColumnInfo(col)?.dataTypeName);
+            } else if (rangeCols[0].field !== col.field) {
+                return null;
+            }
+
+            for (let r = range.fromRow; r <= range.toRow; r++) {
+                const item = dataProvider.getItem(r) as Slick.SlickData;
+                const cellVal = item?.[col.field!];
+                const rawVal = cellVal?.displayValue ?? "";
+                const val = cellVal?.isNull
+                    ? "NULL"
+                    : isNumeric && NotebookContextMenu.SQL_NUMBER_PATTERN.test(rawVal)
+                      ? rawVal
+                      : this.sqlStr(rawVal);
+                valueLines.push(val);
+            }
+        }
+
+        const indented = valueLines.map((v, i, a) => `    ${v}${i < a.length - 1 ? "," : ""}`);
+        return ["IN", "(", ...indented, ")"].join(getEOL());
+    }
+
+    private showError(message: string): void {
+        if (this.postMessage) {
+            this.postMessage({ type: "showError", message });
+        }
+    }
+
+    public formatAsInsertInto(
+        ranges: Slick.Range[],
+        columns: Slick.Column<T>[],
+        dataProvider: IDisposableDataProvider<T>,
+    ): string {
+        const colMeta = this.getSelectedColumnIndices(ranges, columns).map((c) => {
+            const col = columns[c];
+            return {
+                col,
+                index: c,
+                isNumeric: this.isNumericSqlType(this.getColumnInfo(col)?.dataTypeName),
+            };
+        });
+
+        const valueRows: string[] = [];
+        for (const range of ranges) {
+            for (let r = range.fromRow; r <= range.toRow; r++) {
+                const item = dataProvider.getItem(r) as Slick.SlickData;
+                const values = colMeta.map(({ col, index, isNumeric }) => {
+                    if (!this.isCellSelected(ranges, r, index)) {
+                        return "NULL";
+                    }
+                    const cellVal = item?.[col.field!];
+                    if (cellVal?.isNull) return "NULL";
+                    const val = cellVal?.displayValue ?? "";
+                    return isNumeric && NotebookContextMenu.SQL_NUMBER_PATTERN.test(val)
+                        ? val
+                        : this.sqlStr(val);
+                });
+                valueRows.push(`    (${values.join(", ")})`);
+            }
+        }
+
+        if (colMeta.length === 0 || valueRows.length === 0) {
+            return "";
+        }
+
+        const colNames = colMeta
+            .map(({ col }) => this.escapeSqlIdentifier(col.toolTip ?? col.name ?? col.field ?? ""))
+            .join(", ");
+        const statements: string[] = [];
+        for (
+            let start = 0;
+            start < valueRows.length;
+            start += NotebookContextMenu.INSERT_ROW_LIMIT
+        ) {
+            const batch = valueRows.slice(start, start + NotebookContextMenu.INSERT_ROW_LIMIT);
+            const rowLines = batch.map((row, i) => row + (i < batch.length - 1 ? "," : ";"));
+            statements.push(
+                [`INSERT INTO TableName (${colNames})`, "VALUES", ...rowLines].join(getEOL()),
+            );
+        }
+        return statements.join(getEOL() + getEOL());
+    }
+
+    private isNumericSqlType(dataTypeName: string | undefined): boolean {
+        return (
+            !!dataTypeName && NotebookContextMenu.NUMERIC_SQL_TYPES.has(dataTypeName.toLowerCase())
+        );
+    }
+
+    private sqlStr(v: string): string {
+        return "'" + v.replace(/'/g, "''") + "'";
+    }
+
+    private escapeSqlIdentifier(value: string): string {
+        return `[${value.replaceAll("]", "]]")}]`;
     }
 }

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookRendererEntry.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookRendererEntry.tsx
@@ -105,7 +105,11 @@ export const activate: ActivationFunction = (context: RendererContext) => {
                 const root = createRoot(element);
                 roots.set(data.id, root);
                 root.render(
-                    <NotebookResultsOutput blocks={parsedData.blocks} postMessage={postMessage} />,
+                    <NotebookResultsOutput
+                        blocks={parsedData.blocks}
+                        copyAsCsvOptions={parsedData.copyAsCsvOptions}
+                        postMessage={postMessage}
+                    />,
                 );
             } else if (isSavedNotebookResultSetOutputData(parsedData)) {
                 const root = createRoot(element);

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.css
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.css
@@ -297,11 +297,11 @@
     display: flex;
     flex-direction: column;
     padding: 4px 0;
-    background-color: var(--vscode-menu-background, var(--vscode-editorWidget-background, #252526));
-    border: 1px solid var(--vscode-menu-border, var(--vscode-editorWidget-border, #454545));
+    background-color: var(--vscode-menu-background);
+    border: 1px solid var(--vscode-menu-border);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.36);
-    color: var(--vscode-menu-foreground, var(--vscode-foreground, #ccc));
-    font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, sans-serif);
+    color: var(--vscode-menu-foreground);
+    font-family: var(--vscode-font-family);
     font-size: 13px;
 }
 
@@ -314,19 +314,26 @@
     gap: 16px;
 }
 
-.nb-context-menu-item:hover {
-    background-color: var(
-        --vscode-menu-selectionBackground,
-        var(--vscode-list-hoverBackground, #094771)
-    );
-    color: var(
-        --vscode-menu-selectionForeground,
-        var(--vscode-list-activeSelectionForeground, #fff)
-    );
+.nb-context-menu:focus {
+    outline: none;
+}
+
+.nb-context-menu-item:hover,
+.nb-context-menu-item--focused,
+.nb-context-menu-item:focus {
+    background-color: var(--vscode-menu-selectionBackground);
+    color: var(--vscode-menu-selectionForeground);
+    outline: none;
 }
 
 .nb-context-menu-label {
     flex: 1;
+}
+
+.nb-context-menu-item[data-has-submenu]::after {
+    content: "❯";
+    font-size: 14px;
+    flex-shrink: 0;
 }
 
 .nb-context-menu-shortcut {
@@ -339,10 +346,7 @@
 .nb-context-menu-separator {
     height: 1px;
     margin: 4px 0;
-    background-color: var(
-        --vscode-menu-separatorBackground,
-        var(--vscode-editorWidget-border, #454545)
-    );
+    background-color: var(--vscode-menu-separatorBackground);
 }
 
 /* ── Notebook results toolbar ──────────────────────────────────────────── */

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultGrid.tsx
@@ -18,7 +18,10 @@ import {
     summarizeSelectionCells,
     type SelectionCell,
 } from "../../../sharedInterfaces/selectionSummary";
-import type { NotebookSelectionSummaryMessage } from "../../../sharedInterfaces/notebookQueryResult";
+import type {
+    NotebookCopyAsCsvOptions,
+    NotebookSelectionSummaryMessage,
+} from "../../../sharedInterfaces/notebookQueryResult";
 import "./notebookResultGrid.css";
 import "../../media/slickgrid.css";
 import "../../media/table.css";
@@ -28,6 +31,7 @@ export interface NotebookResultGridProps {
     rows: DbCellValue[][];
     rowCount: number;
     addBottomSpacing?: boolean;
+    copyAsCsvOptions?: NotebookCopyAsCsvOptions;
     postMessage?: (message: unknown) => void;
 }
 
@@ -151,6 +155,7 @@ export function NotebookResultGrid({
     columnInfo,
     rows,
     addBottomSpacing,
+    copyAsCsvOptions,
     postMessage,
 }: NotebookResultGridProps) {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -300,7 +305,11 @@ export function NotebookResultGrid({
         selectionModel.onSelectedRangesChanged.subscribe(handleSelectedRangesChanged);
 
         // Register context menu (right-click) with copy operations
-        const contextMenu = new NotebookContextMenu<Slick.SlickData>();
+        const contextMenu = new NotebookContextMenu<Slick.SlickData>(
+            columnInfo,
+            copyAsCsvOptions,
+            postMessage,
+        );
         grid.registerPlugin(contextMenu);
 
         // Reuse Query Result auto-size behavior for double-clicking a resize handle.
@@ -379,7 +388,7 @@ export function NotebookResultGrid({
             grid.destroy();
             tableDataView.dispose();
         };
-    }, [columnInfo, rows, postMessage]);
+    }, [columnInfo, copyAsCsvOptions, rows, postMessage]);
 
     const className = addBottomSpacing
         ? "notebook-result-grid-container notebook-result-grid-container-spaced"

--- a/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultsOutput.tsx
+++ b/extensions/mssql/src/webviews/pages/NotebookRenderer/notebookResultsOutput.tsx
@@ -3,16 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { NotebookQueryResultBlock } from "../../../sharedInterfaces/notebookQueryResult";
+import type {
+    NotebookCopyAsCsvOptions,
+    NotebookQueryResultBlock,
+} from "../../../sharedInterfaces/notebookQueryResult";
 import { NotebookResultGrid } from "./notebookResultGrid";
 import { NotebookResultsToolbar } from "./notebookResultsToolbar";
 
 export interface NotebookResultsOutputProps {
     blocks: NotebookQueryResultBlock[];
+    copyAsCsvOptions?: NotebookCopyAsCsvOptions;
     postMessage?: (message: unknown) => void;
 }
 
-export function NotebookResultsOutput({ blocks, postMessage }: NotebookResultsOutputProps) {
+export function NotebookResultsOutput({
+    blocks,
+    copyAsCsvOptions,
+    postMessage,
+}: NotebookResultsOutputProps) {
     let resultSetCounter = 0;
     return (
         <div className="notebook-results-output">
@@ -32,6 +40,7 @@ export function NotebookResultsOutput({ blocks, postMessage }: NotebookResultsOu
                                     columnInfo={block.columnInfo}
                                     rows={block.rows}
                                     rowCount={block.rowCount}
+                                    copyAsCsvOptions={copyAsCsvOptions}
                                     postMessage={postMessage}
                                 />
                             </div>

--- a/extensions/mssql/test/unit/notebooks/notebookContextMenu.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookContextMenu.test.ts
@@ -1,0 +1,628 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { NotebookContextMenu } from "../../../src/webviews/pages/NotebookRenderer/notebookContextMenu.plugin";
+import type { IDbColumn } from "vscode-mssql";
+import type { IDisposableDataProvider } from "../../../src/webviews/pages/QueryResult/table/dataProvider";
+import type { NotebookCopyAsCsvOptions } from "../../../src/sharedInterfaces/notebookQueryResult";
+
+function makeRange(fromRow: number, toRow: number, fromCell: number, toCell: number): Slick.Range {
+    return { fromRow, toRow, fromCell, toCell } as unknown as Slick.Range;
+}
+
+function makeCol(index: number, name: string, toolTip?: string): Slick.Column<Slick.SlickData> {
+    return {
+        field: String(index),
+        id: String(index),
+        name,
+        toolTip,
+    } as Slick.Column<Slick.SlickData>;
+}
+
+function makeDbCol(dataTypeName: string): IDbColumn {
+    return { dataTypeName } as IDbColumn;
+}
+
+function makeCell(displayValue: string, isNull = false) {
+    return { displayValue, isNull };
+}
+
+type CellRow = Record<string, { displayValue: string; isNull: boolean }>;
+
+function makeProvider(rows: CellRow[]): IDisposableDataProvider<Slick.SlickData> {
+    return {
+        getItem: (row: number) => rows[row] ?? {},
+    } as unknown as IDisposableDataProvider<Slick.SlickData>;
+}
+
+function makeMenu(
+    columnInfo: IDbColumn[] = [],
+    copyAsCsvOptions: NotebookCopyAsCsvOptions = {
+        delimiter: ",",
+        includeHeaders: false,
+        lineSeparator: "\r\n",
+        textIdentifier: '"',
+    },
+): NotebookContextMenu<Slick.SlickData> {
+    return new NotebookContextMenu<Slick.SlickData>(columnInfo, copyAsCsvOptions);
+}
+
+const fmt = {
+    csv(
+        menu: NotebookContextMenu<Slick.SlickData>,
+        ranges: Slick.Range[],
+        cols: Slick.Column<Slick.SlickData>[],
+        provider: IDisposableDataProvider<Slick.SlickData>,
+    ): string {
+        return menu.formatAsCsv(ranges, cols, provider);
+    },
+
+    json(
+        menu: NotebookContextMenu<Slick.SlickData>,
+        ranges: Slick.Range[],
+        cols: Slick.Column<Slick.SlickData>[],
+        provider: IDisposableDataProvider<Slick.SlickData>,
+    ): string {
+        return menu.formatAsJson(ranges, cols, provider);
+    },
+
+    inClause(
+        menu: NotebookContextMenu<Slick.SlickData>,
+        ranges: Slick.Range[],
+        cols: Slick.Column<Slick.SlickData>[],
+        provider: IDisposableDataProvider<Slick.SlickData>,
+    ): string | null {
+        return menu.formatAsInClause(ranges, cols, provider);
+    },
+
+    insertInto(
+        menu: NotebookContextMenu<Slick.SlickData>,
+        ranges: Slick.Range[],
+        cols: Slick.Column<Slick.SlickData>[],
+        provider: IDisposableDataProvider<Slick.SlickData>,
+    ): string {
+        return menu.formatAsInsertInto(ranges, cols, provider);
+    },
+};
+
+suite("NotebookContextMenu formatters", () => {
+    const sandbox = sinon.createSandbox();
+    let navigatorDescriptor: PropertyDescriptor | undefined;
+    let slickDescriptor: PropertyDescriptor | undefined;
+
+    suiteSetup(() => {
+        navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+        slickDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Slick");
+
+        Object.defineProperty(globalThis, "navigator", {
+            value: {
+                platform: "Win32",
+                userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+                clipboard: {
+                    writeText: sandbox.stub().resolves(),
+                },
+            },
+            configurable: true,
+        });
+        Object.defineProperty(globalThis, "Slick", {
+            value: {
+                EventHandler: class {
+                    public subscribe = sandbox.stub();
+                    public unsubscribeAll = sandbox.stub();
+                },
+            },
+            configurable: true,
+        });
+    });
+
+    suiteTeardown(() => {
+        sandbox.restore();
+        restoreProperty("navigator", navigatorDescriptor);
+        restoreProperty("Slick", slickDescriptor);
+    });
+
+    function restoreProperty(name: string, descriptor: PropertyDescriptor | undefined): void {
+        if (descriptor) {
+            Object.defineProperty(globalThis, name, descriptor);
+        } else {
+            Reflect.deleteProperty(globalThis, name);
+        }
+    }
+
+    suite("formatAsCsv", () => {
+        test("emits data rows only, without a header row", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "Name"), makeCol(1, "Age")];
+            const rows: CellRow[] = [{ "0": makeCell("Alice"), "1": makeCell("30") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(result).to.equal("Alice,30");
+        });
+
+        test("uses configured headers and delimiters", () => {
+            const menu = makeMenu([], {
+                delimiter: ";",
+                includeHeaders: true,
+                lineSeparator: "\n",
+                textIdentifier: "'",
+            });
+            const cols = [makeCol(0, "Name"), makeCol(1, "Age")];
+            const rows: CellRow[] = [{ "0": makeCell("Alice"), "1": makeCell("30") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(result).to.equal("Name;Age\nAlice;30");
+        });
+
+        test("uses the configured text identifier", () => {
+            const menu = makeMenu([], {
+                delimiter: ",",
+                includeHeaders: false,
+                lineSeparator: "\n",
+                textIdentifier: "'",
+            });
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("O'Brien") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("'O''Brien'");
+        });
+
+        test("quotes values that contain a comma", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "City")];
+            const rows: CellRow[] = [{ "0": makeCell("Portland, OR") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal('"Portland, OR"');
+        });
+
+        test("escapes double-quotes inside quoted values", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "Quote")];
+            const rows: CellRow[] = [{ "0": makeCell('say "hello"') }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal('"say ""hello"""');
+        });
+
+        test("quotes values that contain a newline", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "Notes")];
+            const rows: CellRow[] = [{ "0": makeCell("line1\nline2") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal('"line1\nline2"');
+        });
+
+        test("emits NULL for null cells", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "Val")];
+            const rows: CellRow[] = [{ "0": makeCell("", true) }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("NULL");
+        });
+
+        test("excludes the rowNumber column", () => {
+            const menu = makeMenu();
+            const rowNumCol = {
+                field: "rn",
+                id: "rowNumber",
+                name: "#",
+            } as unknown as Slick.Column<Slick.SlickData>;
+            const dataCol = makeCol(0, "ID");
+            const cols = [rowNumCol, dataCol];
+            const rows: CellRow[] = [{ "0": makeCell("1") }];
+            const result = fmt.csv(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(result).to.equal("1");
+        });
+
+        test("emits one data row per range row", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "X")];
+            const rows: CellRow[] = [
+                { "0": makeCell("a") },
+                { "0": makeCell("b") },
+                { "0": makeCell("c") },
+            ];
+            const result = fmt.csv(menu, [makeRange(0, 2, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("a\r\nb\r\nc");
+        });
+    });
+
+    suite("formatAsJson", () => {
+        test("outputs string columns as JSON strings", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("Alice") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Name: "Alice" }]);
+        });
+
+        test("outputs integer column as a JSON number", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Age")];
+            const rows: CellRow[] = [{ "0": makeCell("42") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Age: 42 }]);
+        });
+
+        test("outputs decimal column as a JSON number", () => {
+            const menu = makeMenu([makeDbCol("decimal")]);
+            const cols = [makeCol(0, "Price")];
+            const rows: CellRow[] = [{ "0": makeCell("9.99") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Price: 9.99 }]);
+        });
+
+        test("outputs bit column as a JSON string, not a number", () => {
+            const menu = makeMenu([makeDbCol("bit")]);
+            const cols = [makeCol(0, "Active")];
+            const rows: CellRow[] = [{ "0": makeCell("1") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Active: "1" }]);
+        });
+
+        test("outputs null cells as JSON null", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("", true) }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Id: null }]);
+        });
+
+        test("quotes an empty numeric display value", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Id: "" }]);
+        });
+
+        test("quotes a whitespace-only numeric display value", () => {
+            const menu = makeMenu([makeDbCol("decimal")]);
+            const cols = [makeCol(0, "Amount")];
+            const rows: CellRow[] = [{ "0": makeCell(" ") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Amount: " " }]);
+        });
+
+        test("preserves uppercase E in scientific notation from SQL Server", () => {
+            const menu = makeMenu([makeDbCol("float")]);
+            const cols = [makeCol(0, "Val")];
+            const rows: CellRow[] = [{ "0": makeCell("1.5E+10") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.include("1.5E+10");
+            expect(JSON.parse(result)[0].Val).to.equal(1.5e10);
+        });
+
+        test("outputs mixed-type columns correctly", () => {
+            const menu = makeMenu([makeDbCol("int"), makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Id"), makeCol(1, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("1"), "1": makeCell("Alice") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Id: 1, Name: "Alice" }]);
+        });
+
+        test("uses toolTip as JSON key when present", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "n", "full_name")];
+            const rows: CellRow[] = [{ "0": makeCell("Bob") }];
+            const result = fmt.json(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)[0]).to.have.property("full_name", "Bob");
+        });
+
+        test("outputs multiple rows as a JSON array", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("1") }, { "0": makeCell("2") }];
+            const result = fmt.json(menu, [makeRange(0, 1, 0, 0)], cols, makeProvider(rows));
+            expect(JSON.parse(result)).to.deep.equal([{ Id: 1 }, { Id: 2 }]);
+        });
+    });
+
+    suite("formatAsInClause", () => {
+        test("returns null when range spans more than one column", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "A"), makeCol(1, "B")];
+            const rows: CellRow[] = [{ "0": makeCell("x"), "1": makeCell("y") }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(result).to.be.null;
+        });
+
+        test("single-quotes string values", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("Alice") }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    'Alice'\r\n)");
+        });
+
+        test("leaves numeric values unquoted", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("42") }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    42\r\n)");
+        });
+
+        test("emits NULL keyword for null cells", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("", true) }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    NULL\r\n)");
+        });
+
+        test("single-quotes numeric values in E-notation", () => {
+            const menu = makeMenu([makeDbCol("float")]);
+            const cols = [makeCol(0, "Val")];
+            const rows: CellRow[] = [{ "0": makeCell("1.5E+10") }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    '1.5E+10'\r\n)");
+        });
+
+        test("comma-separates multiple values with no trailing comma on the last", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [
+                { "0": makeCell("1") },
+                { "0": makeCell("2") },
+                { "0": makeCell("3") },
+            ];
+            const result = fmt.inClause(menu, [makeRange(0, 2, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    1,\r\n    2,\r\n    3\r\n)");
+        });
+
+        test("escapes single quotes inside string values", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("O'Brien") }];
+            const result = fmt.inClause(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    'O''Brien'\r\n)");
+        });
+    });
+
+    suite("formatAsInsertInto", () => {
+        test("emits INSERT INTO with column name and single-quoted string value", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("Alice") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("INSERT INTO TableName ([Name])\r\nVALUES\r\n    ('Alice');");
+        });
+
+        test("leaves numeric column values unquoted", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [{ "0": makeCell("42") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("INSERT INTO TableName ([Id])\r\nVALUES\r\n    (42);");
+        });
+
+        test("emits NULL for null cells", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("", true) }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("INSERT INTO TableName ([Name])\r\nVALUES\r\n    (NULL);");
+        });
+
+        test("single-quotes numeric values in E-notation", () => {
+            const menu = makeMenu([makeDbCol("float")]);
+            const cols = [makeCol(0, "Val")];
+            const rows: CellRow[] = [{ "0": makeCell("1.5E+10") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal("INSERT INTO TableName ([Val])\r\nVALUES\r\n    ('1.5E+10');");
+        });
+
+        test("escapes single quotes inside string values", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("O'Brien") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal(
+                "INSERT INTO TableName ([Name])\r\nVALUES\r\n    ('O''Brien');",
+            );
+        });
+
+        test("comma after each row except the last which gets a semicolon", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows: CellRow[] = [
+                { "0": makeCell("1") },
+                { "0": makeCell("2") },
+                { "0": makeCell("3") },
+            ];
+            const result = fmt.insertInto(menu, [makeRange(0, 2, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.equal(
+                "INSERT INTO TableName ([Id])\r\nVALUES\r\n    (1),\r\n    (2),\r\n    (3);",
+            );
+        });
+
+        test("emits multiple columns in order", () => {
+            const menu = makeMenu([makeDbCol("int"), makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "Id"), makeCol(1, "Name")];
+            const rows: CellRow[] = [{ "0": makeCell("1"), "1": makeCell("Alice") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 1)], cols, makeProvider(rows));
+            expect(result).to.equal(
+                "INSERT INTO TableName ([Id], [Name])\r\nVALUES\r\n    (1, 'Alice');",
+            );
+        });
+
+        test("uses toolTip as column name when present", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "short", "full_col")];
+            const rows: CellRow[] = [{ "0": makeCell("1") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.include("([full_col])");
+        });
+
+        test("escapes closing brackets in column names", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Order] ID")];
+            const rows: CellRow[] = [{ "0": makeCell("1") }];
+            const result = fmt.insertInto(menu, [makeRange(0, 0, 0, 0)], cols, makeProvider(rows));
+            expect(result).to.include("([Order]] ID])");
+        });
+
+        test("splits more than 1000 rows into separate statements", () => {
+            const menu = makeMenu([makeDbCol("int")]);
+            const cols = [makeCol(0, "Id")];
+            const rows = Array.from({ length: 1001 }, (_, index) => ({
+                "0": makeCell(String(index)),
+            }));
+            const result = fmt.insertInto(
+                menu,
+                [makeRange(0, 1000, 0, 0)],
+                cols,
+                makeProvider(rows),
+            );
+            expect(result.match(/INSERT INTO TableName/g)).to.have.lengthOf(2);
+            expect(result).to.include("    (999);\r\n\r\nINSERT INTO TableName ([Id])");
+            expect(result.endsWith("    (1000);")).to.equal(true);
+        });
+
+        test("returns empty string when range contains no data columns", () => {
+            const menu = makeMenu();
+            const rowNumCol = {
+                field: "rn",
+                id: "rowNumber",
+                name: "#",
+            } as unknown as Slick.Column<Slick.SlickData>;
+            const rows: CellRow[] = [{ rn: makeCell("1") }];
+            const result = fmt.insertInto(
+                menu,
+                [makeRange(0, 0, 0, 0)],
+                [rowNumCol],
+                makeProvider(rows),
+            );
+            expect(result).to.equal("");
+        });
+    });
+
+    suite("multi-range selections", () => {
+        const sameRowRanges = () => [
+            makeRange(0, 1, 0, 0),
+            makeRange(0, 1, 2, 2),
+            makeRange(0, 1, 4, 4),
+        ];
+        const wideCols = () => [
+            makeCol(0, "FirstName"),
+            makeCol(1, "LastName"),
+            makeCol(2, "DateOfBirth"),
+            makeCol(3, "Gender"),
+            makeCol(4, "Email"),
+        ];
+        const wideRows = (): CellRow[] => [
+            {
+                "0": makeCell("John"),
+                "1": makeCell("Smith"),
+                "2": makeCell("2003-11-09"),
+                "3": makeCell("M"),
+                "4": makeCell("john.smith@example.com"),
+            },
+            {
+                "0": makeCell("Mariah"),
+                "1": makeCell("Jones"),
+                "2": makeCell("2004-01-30"),
+                "3": makeCell("F"),
+                "4": makeCell("mariah.jones@example.com"),
+            },
+        ];
+
+        test("csv merges ranges that share rows into fully populated rows", () => {
+            const menu = makeMenu();
+            const result = fmt.csv(menu, sameRowRanges(), wideCols(), makeProvider(wideRows()));
+            const row1 = "John,2003-11-09,john.smith@example.com";
+            const row2 = "Mariah,2004-01-30,mariah.jones@example.com";
+            expect(result).to.equal([row1, row2, row1, row2, row1, row2].join("\r\n"));
+        });
+
+        test("csv blanks out columns outside a range when ranges span different rows", () => {
+            const menu = makeMenu();
+            const cols = [makeCol(0, "A"), makeCol(1, "B")];
+            const rows: CellRow[] = [
+                { "0": makeCell("a0"), "1": makeCell("b0") },
+                { "0": makeCell("a1"), "1": makeCell("b1") },
+            ];
+            const ranges = [makeRange(0, 0, 0, 0), makeRange(1, 1, 1, 1)];
+            const result = fmt.csv(menu, ranges, cols, makeProvider(rows));
+            expect(result).to.equal("a0,\r\n,b1");
+        });
+
+        test("insertInto uses the union of columns across all ranges", () => {
+            const menu = makeMenu([
+                makeDbCol("nvarchar"),
+                makeDbCol("nvarchar"),
+                makeDbCol("date"),
+                makeDbCol("nvarchar"),
+                makeDbCol("nvarchar"),
+            ]);
+            const result = fmt.insertInto(
+                menu,
+                sameRowRanges(),
+                wideCols(),
+                makeProvider(wideRows()),
+            );
+            expect(result).to.contain(
+                "INSERT INTO TableName ([FirstName], [DateOfBirth], [Email])",
+            );
+            expect(result).to.contain("('John', '2003-11-09', 'john.smith@example.com')");
+            expect(result).to.contain("('Mariah', '2004-01-30', 'mariah.jones@example.com')");
+        });
+
+        test("insertInto emits NULL for columns outside a range spanning other rows", () => {
+            const menu = makeMenu([makeDbCol("nvarchar"), makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "A"), makeCol(1, "B")];
+            const rows: CellRow[] = [
+                { "0": makeCell("a0"), "1": makeCell("b0") },
+                { "0": makeCell("a1"), "1": makeCell("b1") },
+            ];
+            const ranges = [makeRange(0, 0, 0, 0), makeRange(1, 1, 1, 1)];
+            const result = fmt.insertInto(menu, ranges, cols, makeProvider(rows));
+            expect(result).to.equal(
+                "INSERT INTO TableName ([A], [B])\r\nVALUES\r\n    ('a0', NULL),\r\n    (NULL, 'b1');",
+            );
+        });
+
+        test("json gives every object the same key set", () => {
+            const menu = makeMenu([
+                makeDbCol("nvarchar"),
+                makeDbCol("nvarchar"),
+                makeDbCol("date"),
+                makeDbCol("nvarchar"),
+                makeDbCol("nvarchar"),
+            ]);
+            const result = fmt.json(menu, sameRowRanges(), wideCols(), makeProvider(wideRows()));
+            const parsed = JSON.parse(result);
+            expect(parsed).to.have.lengthOf(6);
+            for (const obj of parsed) {
+                expect(Object.keys(obj)).to.deep.equal(["FirstName", "DateOfBirth", "Email"]);
+            }
+            expect(parsed[0]).to.deep.equal({
+                FirstName: "John",
+                DateOfBirth: "2003-11-09",
+                Email: "john.smith@example.com",
+            });
+        });
+
+        test("inClause returns null when ranges cover different columns", () => {
+            const menu = makeMenu([makeDbCol("nvarchar"), makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "A"), makeCol(1, "B")];
+            const rows: CellRow[] = [{ "0": makeCell("a0"), "1": makeCell("b0") }];
+            const ranges = [makeRange(0, 0, 0, 0), makeRange(0, 0, 1, 1)];
+            expect(fmt.inClause(menu, ranges, cols, makeProvider(rows))).to.equal(null);
+        });
+
+        test("inClause accepts multiple ranges on the same column", () => {
+            const menu = makeMenu([makeDbCol("nvarchar")]);
+            const cols = [makeCol(0, "A")];
+            const rows: CellRow[] = [
+                { "0": makeCell("a0") },
+                { "0": makeCell("a1") },
+                { "0": makeCell("a2") },
+            ];
+            const ranges = [makeRange(0, 0, 0, 0), makeRange(2, 2, 0, 0)];
+            const result = fmt.inClause(menu, ranges, cols, makeProvider(rows));
+            expect(result).to.equal("IN\r\n(\r\n    'a0',\r\n    'a2'\r\n)");
+        });
+    });
+});

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1898,6 +1898,9 @@
     <trans-unit id="++CODE++d43b358b5e9ef2a45f199ba7a0da47d1fb8386373fa697097e8fe2be290c0e87">
       <source xml:lang="en">Copy-only Backup</source>
     </trans-unit>
+    <trans-unit id="++CODE++2f8ae7d0e784eed8f3eddb9e69ab86082813b39e7e7d7200de5e66cd261dee36">
+      <source xml:lang="en">Copying as an IN clause requires selecting exactly one column.</source>
+    </trans-unit>
     <trans-unit id="++CODE++35c380196401c05c48fe5f5fffd349ba06d9988118b87a1c12e1164a28175997">
       <source xml:lang="en">Copying results...</source>
     </trans-unit>

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1789,9 +1789,6 @@
     <trans-unit id="++CODE++7a1861e47d92e338be8a74dd8c9e93ebc0002af27499b52996ca43c9a8684555">
       <source xml:lang="en">Copy All</source>
     </trans-unit>
-    <trans-unit id="++CODE++7644dd0a33ff475c31116e369646b3410ca1463eb32dd1aabf3569f79cc02b4e">
-      <source xml:lang="en">Copy As</source>
-    </trans-unit>
     <trans-unit id="++CODE++96060c7cd5841d631c4c2cf65834a41409b3005fd80c393f48e902ade8901239">
       <source xml:lang="en">Copy Column Name</source>
     </trans-unit>
@@ -1833,6 +1830,9 @@
     </trans-unit>
     <trans-unit id="++CODE++fd4aee4cb3fa5d5963fc78a7261f20700d94a8ddbbb5b963e97a84c441149508">
       <source xml:lang="en">Copy as JSON</source>
+    </trans-unit>
+    <trans-unit id="++CODE++9f3caf9137006097dc46f53a5532c3ca91cbaf4a45dc05251e73d904a37b6b3f">
+      <source xml:lang="en">Copy as...</source>
     </trans-unit>
     <trans-unit id="++CODE++d2b6ebb67aeb8ede651aa24682be64c81d2e0a970c297908b470e55fd14c0bcc">
       <source xml:lang="en">Copy code and open webpage</source>


### PR DESCRIPTION
## Summary

Adds the Query Editor's **Copy As** options to SQL notebook result grids:

- Copy as CSV
- Copy as JSON
- Copy as INSERT INTO
- Copy as IN clause

The notebook renderer formats its in-memory result data locally, honors the configured CSV delimiter/header/line-separator/text-identifier settings, validates single-column IN-clause selections, and produces executable INSERT batches with escaped identifiers.

Keyboard navigation and menu semantics are included for accessibility.

Fixes #22209

## Validation

- Targeted notebook context-menu tests: 45 passed
- Full MSSQL unit suite: 3550 passed, 0 failed, 12 skipped
- MSSQL build/type-check: passed
- MSSQL lint: passed
- Online VSIX packaging: passed
- Release-gate code review: no blocking findings

## Screenshots

### Before

_Notebook result grid without Copy As submenu_

### After

_Notebook result grid with Copy As submenu_