### PR TITLE
Show missing index recommendations in the execution plan header

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -2811,6 +2811,13 @@
         "message": "Query {0}:  Query cost (relative to the script):  {1}%",
         "comment": ["{0} is the query number", "{1} is the query cost"]
     },
+    "Missing index": "Missing index",
+    "Impact {0}%/{0} is the estimated percentage improvement from creating the index": {
+        "message": "Impact {0}%",
+        "comment": ["{0} is the estimated percentage improvement from creating the index"]
+    },
+    "Missing index recommendations": "Missing index recommendations",
+    "Open the recommended index script in a new query editor": "Open the recommended index script in a new query editor",
     "Actual Elapsed Time": "Actual Elapsed Time",
     "Actual Elapsed CPU Time": "Actual Elapsed CPU Time",
     "Cost": "Cost",

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -946,6 +946,19 @@ export class LocConstants {
                     args: [index, costPercentage],
                     comment: ["{0} is the query number", "{1} is the query cost"],
                 }),
+            missingIndex: l10n.t("Missing index"),
+            missingIndexImpact: (impact: string) =>
+                l10n.t({
+                    message: "Impact {0}%",
+                    args: [impact],
+                    comment: [
+                        "{0} is the estimated percentage improvement from creating the index",
+                    ],
+                }),
+            missingIndexRecommendations: l10n.t("Missing index recommendations"),
+            openIndexRecommendationScript: l10n.t(
+                "Open the recommended index script in a new query editor",
+            ),
             equals: l10n.t("Equals"),
             contains: l10n.t("Contains"),
             actualElapsedTime: l10n.t("Actual Elapsed Time"),

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanGraph.tsx
@@ -6,6 +6,7 @@
 import "./executionPlan.css";
 
 import {
+    Badge,
     Button,
     Input,
     makeStyles,
@@ -18,24 +19,31 @@ import {
     Checkmark20Regular,
     Dismiss16Regular,
     Dismiss20Regular,
+    Lightbulb16Filled,
 } from "@fluentui/react-icons";
 import {
     KeyboardEvent as ReactKeyboardEvent,
     lazy,
     Suspense,
     useCallback,
+    useContext,
     useEffect,
     useRef,
     useState,
 } from "react";
 
 import { ExecutionPlanGraphController } from "./executionPlanGraphController";
-import { normalizeExecutionPlanQuery } from "./executionPlanQuery";
+import {
+    normalizeExecutionPlanQuery,
+    ParsedRecommendation,
+    parseRecommendationDisplayString,
+} from "./executionPlanQuery";
 import { FindNode } from "./findNodes";
 import { HighlightExpensiveOperations } from "./highlightExpensiveOperations";
 import { LegacyIconStack } from "./legacyIconMenu";
 import { PropertiesPane } from "./properties";
 import { ReactFlowIconStack } from "./reactFlowIconMenu";
+import { ExecutionPlanContext } from "./executionPlanStateProvider";
 import { locConstants } from "../../common/locConstants";
 import { useVscodeWebview } from "../../common/vscodeWebviewProvider";
 import { useExecutionPlanSelector } from "./executionPlanSelector";
@@ -129,6 +137,59 @@ const useStyles = makeStyles({
         paddingTop: "4px",
         borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
     },
+    recommendations: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        rowGap: "3px",
+        paddingTop: "6px",
+        // caps the header at roughly three recommendations before scrolling, so a plan
+        // with many missing indexes doesn't squeeze the graph out of view
+        maxHeight: "78px",
+        overflowY: "auto",
+    },
+    recommendationButton: {
+        display: "flex",
+        justifyContent: "flex-start",
+        alignItems: "center",
+        columnGap: "6px",
+        width: "100%",
+        minWidth: 0,
+        height: "auto",
+        minHeight: "22px",
+        padding: "2px 6px",
+        borderRadius: tokens.borderRadiusMedium,
+        border: `1px solid ${tokens.colorTransparentStroke}`,
+        backgroundColor: tokens.colorNeutralBackground3,
+        textAlign: "left",
+        ":hover": {
+            backgroundColor: tokens.colorNeutralBackground3Hover,
+            border: `1px solid ${tokens.colorNeutralStroke1}`,
+        },
+        ":hover:active": {
+            backgroundColor: tokens.colorNeutralBackground3Pressed,
+        },
+    },
+    recommendationIcon: {
+        flexShrink: 0,
+        color: tokens.colorPaletteYellowForeground2,
+    },
+    recommendationLabel: {
+        flexShrink: 0,
+        fontSize: "12px",
+        lineHeight: "17px",
+        fontWeight: tokens.fontWeightSemibold,
+        color: tokens.colorNeutralForeground1,
+    },
+    recommendationImpact: {
+        flexShrink: 0,
+    },
+    recommendationScript: {
+        flexGrow: 1,
+        minWidth: 0,
+        fontSize: "12px",
+        lineHeight: "17px",
+    },
     queryPlanParent: {
         opacity: 1,
         height: "100%",
@@ -193,14 +254,23 @@ interface ExecutionPlanGraphProps {
     graphIndex: number;
 }
 
+/** A recommendation split into the parts the header renders separately. */
+interface RecommendationView extends ParsedRecommendation {
+    /** Untouched server string, used as the button's accessible name and tooltip. */
+    accessibleName: string;
+    queryWithDescription: string;
+}
+
 export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphIndex }) => {
     const classes = useStyles();
     const { themeKind, extensionRpc } = useVscodeWebview();
+    const context = useContext(ExecutionPlanContext);
     const executionPlanState = useExecutionPlanSelector<ExecutionPlanState>(
         (s) => s.executionPlanState,
     );
     const [query, setQuery] = useState("");
     const [xml, setXml] = useState("");
+    const [recommendations, setRecommendations] = useState<RecommendationView[]>([]);
     const [cost, setCost] = useState(0);
     const [executionPlanView, setExecutionPlanView] = useState<ExecutionPlanGraphController | null>(
         null,
@@ -233,6 +303,13 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
 
         setQuery(normalizeExecutionPlanQuery(graph.query));
         setXml(graph.graphFile.graphFileContent);
+        setRecommendations(
+            (graph.recommendations ?? []).map((recommendation) => ({
+                ...parseRecommendationDisplayString(recommendation.displayString),
+                accessibleName: recommendation.displayString,
+                queryWithDescription: recommendation.queryWithDescription,
+            })),
+        );
     }, [executionPlanState, graph, graphIndex]);
 
     useEffect(() => {
@@ -288,6 +365,12 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
             graphIndex + 1,
             getQueryCostPercentage(),
         );
+    };
+
+    const handleRecommendationClick = (recommendation: RecommendationView) => {
+        // opens the CREATE INDEX script wrapped in its explanatory comment block, without
+        // running it, so the user can review and edit before executing
+        context?.showQuery(recommendation.queryWithDescription);
     };
 
     // this is for resizing the properties panel
@@ -355,7 +438,11 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
                             : "calc(100% - 35px)",
                     }}
                     aria-live="polite"
-                    aria-label={`${getQueryCostString()}, ${query}`}>
+                    aria-label={
+                        recommendations.length > 0
+                            ? `${getQueryCostString()}, ${query}, ${locConstants.executionPlan.missingIndexRecommendations}`
+                            : `${getQueryCostString()}, ${query}`
+                    }>
                     {isReactFlowActive ? (
                         <>
                             <div className={classes.queryCostSummary}>{getQueryCostString()}</div>
@@ -366,6 +453,51 @@ export const ExecutionPlanGraph: React.FC<ExecutionPlanGraphProps> = ({ graphInd
                                 showLineBreaks
                                 title={query}
                             />
+                            {recommendations.length > 0 && (
+                                <div
+                                    className={classes.recommendations}
+                                    role="group"
+                                    aria-label={
+                                        locConstants.executionPlan.missingIndexRecommendations
+                                    }>
+                                    {recommendations.map((recommendation, index) => (
+                                        <Button
+                                            key={index}
+                                            appearance="subtle"
+                                            className={classes.recommendationButton}
+                                            icon={
+                                                <Lightbulb16Filled
+                                                    className={classes.recommendationIcon}
+                                                />
+                                            }
+                                            aria-label={recommendation.accessibleName}
+                                            title={`${recommendation.accessibleName}\n\n${locConstants.executionPlan.openIndexRecommendationScript}`}
+                                            onClick={() =>
+                                                handleRecommendationClick(recommendation)
+                                            }>
+                                            <span className={classes.recommendationLabel}>
+                                                {locConstants.executionPlan.missingIndex}
+                                            </span>
+                                            {recommendation.impact !== undefined && (
+                                                <Badge
+                                                    appearance="tint"
+                                                    color="success"
+                                                    size="small"
+                                                    className={classes.recommendationImpact}>
+                                                    {locConstants.executionPlan.missingIndexImpact(
+                                                        recommendation.impact.toFixed(1),
+                                                    )}
+                                                </Badge>
+                                            )}
+                                            <SqlText
+                                                className={classes.recommendationScript}
+                                                text={recommendation.script}
+                                                singleLine
+                                            />
+                                        </Button>
+                                    ))}
+                                </div>
+                            )}
                         </>
                     ) : (
                         <>

--- a/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanQuery.ts
+++ b/extensions/mssql/src/webviews/pages/ExecutionPlan/executionPlanQuery.ts
@@ -10,3 +10,39 @@
 export function normalizeExecutionPlanQuery(query: string): string {
     return query.replace(/^(?:\s*;\s*)+/, "").trimStart();
 }
+
+/**
+ * Flattens a server-provided recommendation display string onto a single line so it fits
+ * the one-line-per-recommendation layout of the plan header.
+ */
+export function normalizeRecommendationDisplayString(displayString: string): string {
+    return displayString.replace(/\s+/g, " ").trim();
+}
+
+export interface ParsedRecommendation {
+    /** Estimated impact percentage, when the server string exposed one. */
+    impact?: number;
+    /** The index script on its own, or the whole string when no prefix was recognized. */
+    script: string;
+}
+
+/**
+ * Splits a recommendation such as "Missing Index (Impact 99.5): CREATE NONCLUSTERED INDEX ..."
+ * into its impact figure and its script so the two can be styled separately. Server strings are
+ * localized, so anything unrecognized falls back to rendering the text as-is rather than risking
+ * a mangled display.
+ */
+export function parseRecommendationDisplayString(displayString: string): ParsedRecommendation {
+    const normalized = normalizeRecommendationDisplayString(displayString);
+    const separatorIndex = normalized.indexOf(":");
+    const script = separatorIndex === -1 ? "" : normalized.slice(separatorIndex + 1).trim();
+
+    if (!script) {
+        return { script: normalized };
+    }
+
+    const impactMatch = normalized.slice(0, separatorIndex).match(/(\d+(?:[.,]\d+)?)/);
+    const impact = impactMatch ? Number(impactMatch[1].replace(",", ".")) : Number.NaN;
+
+    return { impact: Number.isFinite(impact) ? impact : undefined, script };
+}

--- a/extensions/mssql/test/unit/sqlText.test.ts
+++ b/extensions/mssql/test/unit/sqlText.test.ts
@@ -10,7 +10,11 @@ import {
     tokenizeSingleLineSqlText,
     tokenizeSqlText,
 } from "../../src/webviews/common/sqlText";
-import { normalizeExecutionPlanQuery } from "../../src/webviews/pages/ExecutionPlan/executionPlanQuery";
+import {
+    normalizeExecutionPlanQuery,
+    normalizeRecommendationDisplayString,
+    parseRecommendationDisplayString,
+} from "../../src/webviews/pages/ExecutionPlan/executionPlanQuery";
 
 suite("SqlText", () => {
     test("preserves the original SQL while assigning lightweight syntax token types", () => {
@@ -90,5 +94,44 @@ suite("ExecutionPlanQuery", () => {
         expect(normalizeExecutionPlanQuery("\r\n/* keep this */\r\nselect 1")).to.equal(
             "/* keep this */\r\nselect 1",
         );
+    });
+
+    test("flattens a multi-line missing index recommendation onto a single line", () => {
+        expect(
+            normalizeRecommendationDisplayString(
+                "\r\nMissing Index (Impact 99.4173):   CREATE NONCLUSTERED INDEX\r\n\t[<Name of Missing Index>] ON [dbo].[Orders] ([CustomerID])\r\n",
+            ),
+        ).to.equal(
+            "Missing Index (Impact 99.4173): CREATE NONCLUSTERED INDEX [<Name of Missing Index>] ON [dbo].[Orders] ([CustomerID])",
+        );
+        expect(normalizeRecommendationDisplayString("")).to.equal("");
+    });
+
+    test("splits a recommendation into its impact figure and index script", () => {
+        const parsed = parseRecommendationDisplayString(
+            "Missing Index (Impact 99.535):\r\n  CREATE NONCLUSTERED INDEX [<Name of Missing Index, sysname,>]\r\n  ON [dbo].[MissingIndexDemo] ([CustomerId],[Status])",
+        );
+
+        expect(parsed.impact).to.equal(99.535);
+        expect(parsed.script).to.equal(
+            "CREATE NONCLUSTERED INDEX [<Name of Missing Index, sysname,>] ON [dbo].[MissingIndexDemo] ([CustomerId],[Status])",
+        );
+    });
+
+    test("falls back to the whole string when the prefix is not recognizable", () => {
+        // localized or unexpected server strings must stay readable rather than be mangled
+        expect(
+            parseRecommendationDisplayString("CREATE NONCLUSTERED INDEX [x] ON [y] ([z])"),
+        ).to.deep.equal({ script: "CREATE NONCLUSTERED INDEX [x] ON [y] ([z])" });
+        expect(parseRecommendationDisplayString("Missing Index (Impact 12.5):")).to.deep.equal({
+            script: "Missing Index (Impact 12.5):",
+        });
+    });
+
+    test("omits the impact badge when the prefix carries no number", () => {
+        const parsed = parseRecommendationDisplayString("Missing Index: CREATE INDEX [a] ON [b]");
+
+        expect(parsed.impact).to.equal(undefined);
+        expect(parsed.script).to.equal("CREATE INDEX [a] ON [b]");
     });
 });

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -4064,6 +4064,10 @@
     <trans-unit id="++CODE++c4a77afa3d5cd701f32b5f09c195c635b256db8595687828c3ea0785ab5b72f4">
       <source xml:lang="en">Image tag</source>
     </trans-unit>
+    <trans-unit id="++CODE++45386a69d2b5eb577c53d296ecd652d7cc6583c3f759680582587663cff8539c">
+      <source xml:lang="en">Impact {0}%</source>
+      <note>{0} is the estimated percentage improvement from creating the index</note>
+    </trans-unit>
     <trans-unit id="++CODE++09b493255c6cc11aae4f73f97494b4d0123bb42869372d0a2182f0a324eb5ef5">
       <source xml:lang="en">Import BACPAC</source>
     </trans-unit>
@@ -4803,6 +4807,12 @@
     <trans-unit id="++CODE++c4cb38118e976f2ec6af215b6206c1aeadd0a3a1a95b4ab00681c97e9a276753">
       <source xml:lang="en">Missing connection reference. Please provide exactly one of connectionId or connectionName.</source>
     </trans-unit>
+    <trans-unit id="++CODE++c0ddd09f7b9ebbe309bc4e518e1aad4479cbbc1eb792cac263b398e11a85af5a">
+      <source xml:lang="en">Missing index</source>
+    </trans-unit>
+    <trans-unit id="++CODE++efb9ca4f5a017be57cf3a7cb05a528919e6419abddfe79c4a2d8937b2a901186">
+      <source xml:lang="en">Missing index recommendations</source>
+    </trans-unit>
     <trans-unit id="++CODE++910bb9ebcad74af9fe7fae916e94812f8a97c60f93e76a1167b4ca1583d70f27">
       <source xml:lang="en">Missing schema payload for replace_schema operation.</source>
     </trans-unit>
@@ -5518,6 +5528,9 @@
     </trans-unit>
     <trans-unit id="++CODE++eca206dacc5627de738a49f5b7cc3a89393f5c0d8e5da0dadfb8baec1c274678">
       <source xml:lang="en">Open the generated SELECT statement in a new editor</source>
+    </trans-unit>
+    <trans-unit id="++CODE++bcec92c3fcbd6a1012ed2ae1a5d10e462184bbb5ca83b2df5552cb49620c78cf">
+      <source xml:lang="en">Open the recommended index script in a new query editor</source>
     </trans-unit>
     <trans-unit id="++CODE++3a8e07b84d53ba502ae8ee669003537bdbbe321d6c8c6fb6cbd63019cb3d400e">
       <source xml:lang="en">Opening Publish Script. This may take a while...</source>


### PR DESCRIPTION
## Description

SSMS surfaces Missing Index recommendations above the execution plan; VS Code showed nothing. This adds them to the plan header.

<img width="1134" height="278" alt="image" src="https://github.com/user-attachments/assets/0b0606c9-df04-4856-9680-cccb98f334c0" />



Issue #22765

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`) — ran the affected suite only (`sqlText.test.js`, 9 passing) plus `build:webviews`, `build:extension:typecheck` and eslint; full suite not run locally, leaving to CI
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant — none added, consistent with the other `showQuery` entry points which are untracked
- [x] No regressions or UX breakage — verified manually against a 200k-row table producing a 99.5% impact recommendation

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
