### PR TITLE
Fix query results hanging when webview bootstrap is slow

### DIFF
--- a/extensions/mssql/src/controllers/webviewBaseController.ts
+++ b/extensions/mssql/src/controllers/webviewBaseController.ts
@@ -52,8 +52,6 @@ import * as Constants from "../constants/constants";
 import * as LocalizedConstants from "../constants/locConstants";
 import { getLocalizationFileContentsCached } from "./localizationCache";
 
-export const WEBVIEW_INIT_TIMEOUT_MS = 5_000;
-
 class WebviewControllerMessageReader extends AbstractMessageReader implements MessageReader {
     private _onData: Emitter<Message>;
     private _disposables: vscode.Disposable[] = [];
@@ -120,7 +118,6 @@ export abstract class WebviewBaseController<State, Reducers> implements vscode.D
      */
     private _webviewReady: Deferred<void> = new Deferred<void>();
     private _isWebviewReady: boolean = false;
-    private _webviewReadyTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     private _state: State;
     private _isFirstLoad: boolean = true;
@@ -339,22 +336,24 @@ export abstract class WebviewBaseController<State, Reducers> implements vscode.D
             const timeToLoad = timeStamp - this._loadStartTime;
             if (this._isFirstLoad) {
                 /**
-                 * This notification is sent from the webview when it has finished loading. We use
-                 * this to track when the webview is ready to receive messages.
+                 * This notification is sent from the webview when it has finished loading.
+                 * We use this to track when the webview is ready to receive messages.
                  */
-                this._isWebviewReady = true;
-                if (this._webviewReadyTimeoutHandle !== undefined) {
-                    clearTimeout(this._webviewReadyTimeoutHandle);
-                    this._webviewReadyTimeoutHandle = undefined;
-                }
-                this._webviewReady.resolve();
+                this.markWebviewReady();
 
                 this.logger.trace(
                     `Load stats for ${this._sourceFile}` + "\n" + `Total time: ${timeToLoad} ms`,
                 );
-                this._endLoadActivity.end(ActivityStatus.Succeeded, {
-                    type: this._sourceFile,
-                });
+                this._endLoadActivity.end(
+                    ActivityStatus.Succeeded,
+                    {
+                        type: this._sourceFile,
+                    },
+                    {
+                        timeToLoad,
+                        ...(message.stages ?? {}),
+                    },
+                );
                 this._isFirstLoad = false;
             }
         });
@@ -626,38 +625,28 @@ export abstract class WebviewBaseController<State, Reducers> implements vscode.D
         this._onDisposed.fire();
         this._disposables.forEach((d) => d.dispose());
         this._isDisposed = true;
-        if (this._webviewReadyTimeoutHandle !== undefined) {
-            clearTimeout(this._webviewReadyTimeoutHandle);
-            this._webviewReadyTimeoutHandle = undefined;
-        }
         this._webviewReady.reject(new Error(LocalizedConstants.Webview.webviewDisposedBeforeReady));
     }
 
     /**
      * Waits for the webview to become ready. This is useful for ensuring that the webview is ready to receive messages before sending any.
-     * @param timeoutMs Optional timeout in milliseconds to wait for the webview to become ready. Defaults to 5 seconds.
-     * @returns A promise that resolves when the webview is ready or rejects if there is an error or timeout.
+     * @returns A promise that resolves when the webview is ready or rejects if the webview is disposed first.
      */
-    public whenWebviewReady(timeoutMs: number = WEBVIEW_INIT_TIMEOUT_MS): Promise<void> {
+    public whenWebviewReady(): Promise<void> {
         if (this._isWebviewReady) {
             return Promise.resolve();
         }
 
-        if (this._webviewReadyTimeoutHandle === undefined) {
-            this._webviewReadyTimeoutHandle = setTimeout(() => {
-                this._webviewReadyTimeoutHandle = undefined;
-                this._webviewReady.reject(
-                    new Error(
-                        LocalizedConstants.Webview.webviewNotReadyTimeout(
-                            this._sourceFile,
-                            timeoutMs,
-                        ),
-                    ),
-                );
-            }, timeoutMs);
+        return this._webviewReady.promise;
+    }
+
+    private markWebviewReady(): void {
+        if (this._isWebviewReady) {
+            return;
         }
 
-        return this._webviewReady.promise;
+        this._isWebviewReady = true;
+        this._webviewReady.resolve();
     }
 
     private readKeyBindingsConfig(): Record<string, string> {

--- a/extensions/mssql/src/queryResult/queryResultWebViewController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebViewController.ts
@@ -399,24 +399,19 @@ export class QueryResultWebviewController extends WebviewViewController<
         controller.revealToForeground();
         this._queryResultWebviewPanelControllerMap.set(uri, controller);
         this.showSplashScreen();
-        try {
-            await controller.whenWebviewReady();
-        } catch (e) {
-            // If the webview was disposed or timed out before it became ready, clean up the
-            // panel controller entry so callers are not blocked indefinitely.
+        // Do not block query execution on webview bootstrap, and do not dispose
+        // the panel if ready is delayed or never arrives.
+        void controller.whenWebviewReady().catch((e) => {
             sendErrorEvent(
                 TelemetryViews.QueryResult,
                 TelemetryActions.CreatePanelController,
                 e instanceof Error ? e : new Error(String(e)),
                 true, // includeErrorMessage
             );
-            this._queryResultWebviewPanelControllerMap.delete(uri);
-            controller.panel.dispose();
-            void vscode.window.showErrorMessage(
-                LocalizedConstants.QueryResult.queryResultPanelFailedToLoad,
-            );
-            throw e;
-        }
+            if (controller.isDisposed) {
+                this._queryResultWebviewPanelControllerMap.delete(uri);
+            }
+        });
     }
 
     public addQueryResultState(uri: string, title: string, isExecutionPlan?: boolean): void {

--- a/extensions/mssql/src/sharedInterfaces/webview.ts
+++ b/extensions/mssql/src/sharedInterfaces/webview.ts
@@ -299,6 +299,10 @@ export namespace ReducerRequest {
 
 export interface LoadStatsParams {
     loadCompleteTimeStamp: number;
+    /**
+     * Elapsed milliseconds from webview JS start for each startup stage.
+     */
+    stages?: Record<string, number>;
 }
 
 export namespace LoadStatsNotification {

--- a/extensions/mssql/src/sharedInterfaces/webview.ts
+++ b/extensions/mssql/src/sharedInterfaces/webview.ts
@@ -300,7 +300,7 @@ export namespace ReducerRequest {
 export interface LoadStatsParams {
     loadCompleteTimeStamp: number;
     /**
-     * Elapsed milliseconds from webview JS start for each startup stage.
+     * Elapsed milliseconds from the start of the bootstrap sequence for each startup stage.
      */
     stages?: Record<string, number>;
 }

--- a/extensions/mssql/src/webviews/common/vscodeWebviewProvider.tsx
+++ b/extensions/mssql/src/webviews/common/vscodeWebviewProvider.tsx
@@ -159,8 +159,6 @@ export function VscodeWebviewProvider<State, Reducers>({ children }: VscodeWebvi
                         await l10n.config({
                             contents: fileContents,
                         });
-                        // Brief delay to ensure l10n is properly initialized
-                        await new Promise((resolve) => setTimeout(resolve, 100));
                         LocConstants.createInstance();
                     }
                 } catch (error) {

--- a/extensions/mssql/src/webviews/common/vscodeWebviewProvider.tsx
+++ b/extensions/mssql/src/webviews/common/vscodeWebviewProvider.tsx
@@ -132,76 +132,100 @@ export function VscodeWebviewProvider<State, Reducers>({ children }: VscodeWebvi
         });
 
         async function bootstrap() {
-            try {
-                // First paint gate: only wait for initial state.
-                const initialState = await extensionRpc.sendRequest(GetStateRequest.type<State>());
-                stateRef.current = initialState;
+            const bootstrapStart = Date.now();
+            const stages: Record<string, number> = {};
+            const mark = (stage: string) => {
+                stages[stage] = Date.now() - bootstrapStart;
+            };
 
+            // Non-critical initialization should not block first render.
+            void (async () => {
                 try {
-                    const keyboardShortcuts = await extensionRpc.sendRequest(
-                        GetKeyBindingsConfigRequest.type,
+                    const themeKind = await extensionRpc.sendRequest(GetThemeRequest.type);
+                    mark("getTheme");
+                    setTheme(themeKind);
+                } catch (error) {
+                    log.error("Theme bootstrap failed", error);
+                }
+            })();
+
+            void (async () => {
+                try {
+                    const fileContents = await extensionRpc.sendRequest(
+                        GetLocalizationRequest.type,
                     );
+                    mark("getLocalization");
+                    if (fileContents) {
+                        await l10n.config({
+                            contents: fileContents,
+                        });
+                        // Brief delay to ensure l10n is properly initialized
+                        await new Promise((resolve) => setTimeout(resolve, 100));
+                        LocConstants.createInstance();
+                    }
+                } catch (error) {
+                    log.error("Localization bootstrap failed", error);
+                } finally {
+                    setLocalization(true);
+                    mark("localizationReady");
+                }
+            })();
+
+            try {
+                const [initialState, keyboardShortcuts, eol] = await Promise.all([
+                    extensionRpc.sendRequest(GetStateRequest.type<State>()).then((value) => {
+                        mark("getState");
+                        return value;
+                    }),
+                    extensionRpc
+                        .sendRequest(GetKeyBindingsConfigRequest.type)
+                        .then((value) => {
+                            mark("getKeyBindings");
+                            return value;
+                        })
+                        .catch((error) => {
+                            log.error("KeyBindings bootstrap failed", error);
+                            return undefined;
+                        }),
+                    extensionRpc
+                        .sendRequest(GetEOLRequest.type)
+                        .then((value) => {
+                            mark("getEOL");
+                            return value;
+                        })
+                        .catch((error) => {
+                            log.error("EOL bootstrap failed", error);
+                            return undefined;
+                        }),
+                ]);
+
+                stateRef.current = initialState;
+                if (keyboardShortcuts !== undefined) {
                     setKeyBindings(parseWebviewKeyboardShortcutConfig(keyboardShortcuts));
-                } catch (error) {
-                    log.error("KeyBindings bootstrap failed", error);
                 }
-
-                try {
-                    const eol = await extensionRpc.sendRequest(GetEOLRequest.type);
+                if (eol !== undefined) {
                     setEOL(eol);
-                } catch (error) {
-                    log.error("EOL bootstrap failed", error);
                 }
-
-                setIsBootstrapComplete(true);
-                emit();
-
-                // Non-critical initialization should not block first render.
-                void (async () => {
-                    try {
-                        const theme = await extensionRpc.sendRequest(GetThemeRequest.type);
-                        setTheme(theme);
-                    } catch (error) {
-                        log.error("Theme bootstrap failed", error);
-                    }
-                })();
-
-                void (async () => {
-                    try {
-                        const fileContents = await extensionRpc.sendRequest(
-                            GetLocalizationRequest.type,
-                        );
-                        if (fileContents) {
-                            await l10n.config({
-                                contents: fileContents,
-                            });
-                            // Brief delay to ensure l10n is properly initialized
-                            await new Promise((resolve) => setTimeout(resolve, 100));
-                            LocConstants.createInstance();
-                        }
-                    } catch (error) {
-                        log.error("Localization bootstrap failed", error);
-                    } finally {
-                        setLocalization(true);
-                    }
-                })();
-
-                void extensionRpc
-                    .sendNotification(LoadStatsNotification.type, {
-                        loadCompleteTimeStamp: Date.now(),
-                    })
-                    .catch((error) => {
-                        log.error("Load stats notification failed", error);
-                    });
             } catch (error) {
                 log.error("Bootstrap failed", error);
                 // Prevent indefinite blank screen when initial state fetch fails.
                 if (stateRef.current === undefined) {
                     stateRef.current = {} as State;
                 }
-                setIsBootstrapComplete(true);
-                emit();
             }
+
+            mark("firstPaint");
+            setIsBootstrapComplete(true);
+            emit();
+
+            void extensionRpc
+                .sendNotification(LoadStatsNotification.type, {
+                    loadCompleteTimeStamp: Date.now(),
+                    stages,
+                })
+                .catch((error) => {
+                    log.error("Load stats notification failed", error);
+                });
         }
 
         void bootstrap();


### PR DESCRIPTION
## Description

Fixes query results hanging and disappearing when the results webview is slow to become ready. Related: #22769.

- Remove the 5s webview ready timeout so delayed bootstrap no longer fails query execution.
- Stop disposing the query results panel when ready is delayed or never arrives; query execution no longer waits on webview bootstrap.
- Parallelize first-paint bootstrap RPCs (`GetState`, `GetKeyBindings`, `GetEOL`) so the results UI can render sooner.
- Include per-stage startup timings on the existing `LoadStats` activity for webview load telemetry.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
