### PR TITLE
Restore Executing Query status bar item and add visibility setting (#22763)

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2420,6 +2420,12 @@
                     "default": true,
                     "scope": "window"
                 },
+                "mssql.statusBar.showQueryExecutionStatus": {
+                    "type": "boolean",
+                    "description": "%mssql.statusBar.showQueryExecutionStatus.description%",
+                    "default": true,
+                    "scope": "window"
+                },
                 "mssql.format.alignColumnDefinitionsInColumns": {
                     "type": "boolean",
                     "markdownDescription": "%mssql.format.alignColumnDefinitionsInColumns%",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -126,6 +126,7 @@
     "mssql.connection.order": "[Optional] A non-negative number used to sort this connection in the Object Explorer sidebar. Connections with an 'order' value are displayed first, lowest to highest; remaining connections follow in alphabetical order.",
     "mssql.enableConnectionPooling": "Enables connection pooling to improve overall connectivity performance. This setting is disabled by default. Visual Studio Code is required to be relaunched when the value is changed. To clear pooled connections, run the command: 'MS SQL: Clear Pooled Connections'. Note: May keep serverless databases active and prevent auto-pausing.",
     "mssql.statusBar.enableConnectionColor": "When enabled, colorizes the connection status bar item with the color of the connection group. This setting is disabled by default.  This uses the connection group folder's color directly, and does not alter it in order to ensure contrast with the current VS Code theme. Users should choose connection group colors that work well with their theme.",
+    "mssql.statusBar.showQueryExecutionStatus.description": "Controls whether the query execution status (executing, canceling, completed) is displayed in the status bar.",
     "mssql.shortcuts": "Shortcuts handled inside MSSQL views",
     "mssql.messagesDefaultOpen": "True for the messages pane to be open by default; false for closed",
     "mssql.messages.copyIncludeTimestamps": "When enabled, Copy All in the query result Messages pane includes message timestamps.",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -335,6 +335,7 @@ export const configShowActiveConnectionAsCodeLensSuggestion =
     "mssql.query.showActiveConnectionAsCodeLensSuggestion";
 export const configStatusBarConnectionInfoMaxLength = "statusBar.connectionInfoMaxLength";
 export const configStatusBarEnableConnectionColor = "mssql.statusBar.enableConnectionColor";
+export const configStatusBarShowQueryExecutionStatus = "statusBar.showQueryExecutionStatus";
 export const configSchemaDesignerEnableExpandCollapseButtons =
     "mssql.schemaDesigner.enableExpandCollapseButtons";
 export const configSavePasswordsUntilRestart =

--- a/extensions/mssql/src/views/statusView.ts
+++ b/extensions/mssql/src/views/statusView.ts
@@ -118,8 +118,8 @@ export default class StatusView implements vscode.Disposable {
 
     /**
      * Whether the in-webview query results footer preview is enabled. When enabled, the
-     * row count and execution time status bar items (and the query progress indicator) are
-     * suppressed because the footer surfaces that information inside the results view.
+     * row count and execution time status bar items are suppressed because the footer surfaces
+     * that information inside the results view.
      */
     private get isInWebviewFooterEnabled(): boolean {
         return previewService.isFeatureEnabled(PreviewFeature.BetaResultsGrid);
@@ -129,11 +129,9 @@ export default class StatusView implements vscode.Disposable {
      * Whether the query execution status bar item is enabled in settings.
      */
     private get isShowQueryExecutionStatusEnabled(): boolean {
-        return (
-            vscode.workspace
-                .getConfiguration(Constants.extensionConfigSectionName)
-                .get<boolean>(Constants.configStatusBarShowQueryExecutionStatus, true) ?? true
-        );
+        return vscode.workspace
+            .getConfiguration(Constants.extensionConfigSectionName)
+            .get<boolean>(Constants.configStatusBarShowQueryExecutionStatus, true);
     }
 
     // Create status bar item if needed
@@ -402,6 +400,7 @@ export default class StatusView implements vscode.Disposable {
 
     public cancelingQuery(fileUri: string): void {
         let bar = this.getStatusBar(fileUri);
+        clearInterval(bar.queryTimer);
         if (!this.isShowQueryExecutionStatusEnabled) {
             bar.statusQuery.hide();
             return;
@@ -411,8 +410,6 @@ export default class StatusView implements vscode.Disposable {
         bar.statusQuery.command = undefined;
         bar.statusQuery.text = LocalizedConstants.cancelingQueryLabel;
         this.showStatusBarItem(fileUri, bar.statusQuery);
-        this.showProgress(fileUri, LocalizedConstants.cancelingQueryLabel, bar.statusQuery);
-        clearInterval(bar.queryTimer);
     }
 
     public languageServiceStatusChanged(fileUri: string, status: string): void {

--- a/extensions/mssql/src/views/statusView.ts
+++ b/extensions/mssql/src/views/statusView.ts
@@ -77,9 +77,11 @@ export default class StatusView implements vscode.Disposable {
                         this.showStatusBarItem(fileUri, bar.statusChangeDatabase);
                         this.showStatusBarItem(fileUri, bar.statusLanguageService);
                         if (!this.isInWebviewFooterEnabled) {
-                            this.showStatusBarItem(fileUri, bar.statusQuery);
                             this.showStatusBarItem(fileUri, bar.rowCount);
                             this.showStatusBarItem(fileUri, bar.executionTime);
+                        }
+                        if (this.isShowQueryExecutionStatusEnabled) {
+                            this.showStatusBarItem(fileUri, bar.statusQuery);
                         } else {
                             bar.statusQuery.hide();
                         }
@@ -121,6 +123,17 @@ export default class StatusView implements vscode.Disposable {
      */
     private get isInWebviewFooterEnabled(): boolean {
         return previewService.isFeatureEnabled(PreviewFeature.BetaResultsGrid);
+    }
+
+    /**
+     * Whether the query execution status bar item is enabled in settings.
+     */
+    private get isShowQueryExecutionStatusEnabled(): boolean {
+        return (
+            vscode.workspace
+                .getConfiguration(Constants.extensionConfigSectionName)
+                .get<boolean>(Constants.configStatusBarShowQueryExecutionStatus, true) ?? true
+        );
     }
 
     // Create status bar item if needed
@@ -198,9 +211,11 @@ export default class StatusView implements vscode.Disposable {
         this.showStatusBarItem(fileUri, bar.statusChangeDatabase);
         this.showStatusBarItem(fileUri, bar.statusLanguageService);
         if (!this.isInWebviewFooterEnabled) {
-            this.showStatusBarItem(fileUri, bar.statusQuery);
             this.showStatusBarItem(fileUri, bar.rowCount);
             this.showStatusBarItem(fileUri, bar.executionTime);
+        }
+        if (this.isShowQueryExecutionStatusEnabled) {
+            this.showStatusBarItem(fileUri, bar.statusQuery);
         } else {
             bar.statusQuery.hide();
         }
@@ -352,7 +367,7 @@ export default class StatusView implements vscode.Disposable {
         let bar = this.getStatusBar(fileUri);
         clearInterval(bar.queryTimer);
         this.hideStatusBarItem(fileUri, bar.executionTime);
-        if (this.isInWebviewFooterEnabled) {
+        if (!this.isShowQueryExecutionStatusEnabled) {
             bar.statusQuery.hide();
             return;
         }
@@ -364,7 +379,7 @@ export default class StatusView implements vscode.Disposable {
 
     public executedQuery(fileUri: string): void {
         let bar = this.getStatusBar(fileUri);
-        if (this.isInWebviewFooterEnabled) {
+        if (!this.isShowQueryExecutionStatusEnabled) {
             bar.statusQuery.hide();
             return;
         }
@@ -387,7 +402,7 @@ export default class StatusView implements vscode.Disposable {
 
     public cancelingQuery(fileUri: string): void {
         let bar = this.getStatusBar(fileUri);
-        if (this.isInWebviewFooterEnabled) {
+        if (!this.isShowQueryExecutionStatusEnabled) {
             bar.statusQuery.hide();
             return;
         }

--- a/extensions/mssql/test/unit/statusView.test.ts
+++ b/extensions/mssql/test/unit/statusView.test.ts
@@ -268,6 +268,7 @@ suite("Status View Tests", () => {
         });
 
         test("executedQuery sets statusQuery text and hides when showQueryExecutionStatus is enabled", () => {
+            const clock = sandbox.useFakeTimers();
             sandbox.stub(vscode.workspace, "getConfiguration").returns({
                 get: sandbox.stub().callsFake((section: string, defaultValue: unknown) => {
                     if (section === "editor") {
@@ -283,6 +284,11 @@ suite("Status View Tests", () => {
             statusView.executedQuery(fileUri);
 
             expect(statusQuery.text).to.equal(LocalizedConstants.QueryExecutedLabel);
+            expect(statusQuery.hide).to.not.have.been.called;
+
+            clock.tick(200);
+
+            expect(statusQuery.hide).to.have.been.calledOnce;
             statusView.dispose();
         });
 

--- a/extensions/mssql/test/unit/statusView.test.ts
+++ b/extensions/mssql/test/unit/statusView.test.ts
@@ -6,6 +6,7 @@
 import * as sinon from "sinon";
 
 import StatusView from "../../src/views/statusView";
+import * as Constants from "../../src/constants/constants";
 import * as LocalizedConstants from "../../src/constants/locConstants";
 import { IServerInfo } from "vscode-mssql";
 import { IConnectionGroup, IConnectionProfile } from "../../src/models/interfaces";
@@ -14,6 +15,8 @@ import { ConnectionStore } from "../../src/models/connectionStore";
 import * as vscode from "vscode";
 import { ConfigurationTarget } from "vscode";
 import * as Utils from "../../src/models/utils";
+import { PreviewFeature } from "../../src/previews/previewService";
+import { stubPreviewService } from "./utils";
 
 suite("Status View Tests", () => {
     let sandbox: sinon.SinonSandbox;
@@ -152,6 +155,172 @@ suite("Status View Tests", () => {
 
         expect(executionTime.hide).to.have.been.called;
         statusView.dispose();
+    });
+
+    suite("Query execution status bar tests", () => {
+        const fileUri = "test_uri";
+
+        setup(() => {
+            sandbox.stub(vscode.window, "createStatusBarItem").callsFake(() => {
+                return createMockStatusBarItem();
+            });
+            sandbox.stub(Utils, "getActiveTextEditorUri").returns(fileUri);
+        });
+
+        test("executingQuery shows statusQuery when showQueryExecutionStatus is enabled (default)", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string, defaultValue: unknown) => {
+                    if (section === "editor") {
+                        return "off";
+                    }
+                    return defaultValue;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.executingQuery(fileUri);
+
+            expect(statusQuery.show).to.have.been.called;
+            expect(statusQuery.text).to.equal(LocalizedConstants.executeQueryLabel);
+            statusView.dispose();
+        });
+
+        test("executingQuery works when BetaResultsGrid is enabled and showQueryExecutionStatus is true", () => {
+            stubPreviewService(sandbox, { [PreviewFeature.BetaResultsGrid]: true });
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string, defaultValue: unknown) => {
+                    if (section === "editor") {
+                        return "off";
+                    }
+                    return defaultValue;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.executingQuery(fileUri);
+
+            expect(statusQuery.show).to.have.been.called;
+            expect(statusQuery.text).to.equal(LocalizedConstants.executeQueryLabel);
+            statusView.dispose();
+        });
+
+        test("executingQuery hides statusQuery when showQueryExecutionStatus is false", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string) => {
+                    if (section === Constants.configStatusBarShowQueryExecutionStatus) {
+                        return false;
+                    }
+                    return undefined;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.executingQuery(fileUri);
+
+            expect(statusQuery.hide).to.have.been.called;
+            expect(statusQuery.show).to.not.have.been.called;
+            statusView.dispose();
+        });
+
+        test("cancelingQuery shows statusQuery when showQueryExecutionStatus is enabled", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string, defaultValue: unknown) => {
+                    if (section === "editor") {
+                        return "off";
+                    }
+                    return defaultValue;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.cancelingQuery(fileUri);
+
+            expect(statusQuery.show).to.have.been.called;
+            expect(statusQuery.text).to.equal(LocalizedConstants.cancelingQueryLabel);
+            statusView.dispose();
+        });
+
+        test("cancelingQuery hides statusQuery when showQueryExecutionStatus is false", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string) => {
+                    if (section === Constants.configStatusBarShowQueryExecutionStatus) {
+                        return false;
+                    }
+                    return undefined;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.cancelingQuery(fileUri);
+
+            expect(statusQuery.hide).to.have.been.called;
+            statusView.dispose();
+        });
+
+        test("executedQuery sets statusQuery text and hides when showQueryExecutionStatus is enabled", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string, defaultValue: unknown) => {
+                    if (section === "editor") {
+                        return "off";
+                    }
+                    return defaultValue;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.executedQuery(fileUri);
+
+            expect(statusQuery.text).to.equal(LocalizedConstants.QueryExecutedLabel);
+            statusView.dispose();
+        });
+
+        test("executedQuery hides statusQuery when showQueryExecutionStatus is false", () => {
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().callsFake((section: string) => {
+                    if (section === Constants.configStatusBarShowQueryExecutionStatus) {
+                        return false;
+                    }
+                    return undefined;
+                }),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const statusQuery = statusView["getStatusBar"](fileUri).statusQuery;
+
+            statusView.executedQuery(fileUri);
+
+            expect(statusQuery.hide).to.have.been.called;
+            statusView.dispose();
+        });
+
+        test("setExecutionTime and showRowCount remain suppressed when BetaResultsGrid is enabled", () => {
+            stubPreviewService(sandbox, { [PreviewFeature.BetaResultsGrid]: true });
+            sandbox.stub(vscode.workspace, "getConfiguration").returns({
+                get: sandbox.stub().returns("off"),
+            } as unknown as vscode.WorkspaceConfiguration);
+
+            const statusView = new StatusView();
+            const bar = statusView["getStatusBar"](fileUri);
+
+            statusView.setExecutionTime(fileUri, "0:05");
+            expect(bar.executionTime.show).to.not.have.been.called;
+
+            statusView.showRowCount(fileUri, "(10 rows)");
+            expect(bar.rowCount.show).to.not.have.been.called;
+            statusView.dispose();
+        });
     });
 
     suite("Colorization tests", () => {

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9142,6 +9142,9 @@
     <trans-unit id="mssql.resultsGrid.inMemoryDataProcessingThreshold">
       <source xml:lang="en">Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.</source>
     </trans-unit>
+    <trans-unit id="mssql.statusBar.showQueryExecutionStatus.description">
+      <source xml:lang="en">Controls whether the query execution status (executing, canceling, completed) is displayed in the status bar.</source>
+    </trans-unit>
     <trans-unit id="mssql.copyAll">
       <source xml:lang="en">Copy All</source>
     </trans-unit>


### PR DESCRIPTION
## Description

Issue #22763

Restores the status bar item displaying query execution progress (e.g. `Executing query 0:02`, `Canceling query`) when running queries, which was inadvertently hidden when the beta results grid was enabled.

### Summary of Changes
- Restored `statusQuery` visibility in `StatusView` during query execution and cancellation regardless of the `betaResultsGrid` preview state.
- Added a new configuration setting `mssql.statusBar.showQueryExecutionStatus` (default: `true`) allowing users to toggle query execution status visibility in the status bar.
- Preserved suppression of completed query execution metrics (row count and execution time) in the status bar when the webview results grid footer is active.
- Added comprehensive unit tests in `statusView.test.ts` covering execution status behavior and configuration options.

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| Status bar during query execution (`mssql.preview.betaResultsGrid: true`) | <!-- Add before screenshot --> | <!-- Add after screenshot --> |
| Status bar during query execution (`mssql.statusBar.showQueryExecutionStatus: false`) | <!-- Add before screenshot --> | <!-- Add after screenshot --> |

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
