### PR TITLE
Add Open File action to notebook result exports

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -601,6 +601,7 @@
         "message": "Saved results to {0}",
         "comment": ["{0} is the saved file path"]
     },
+    "Failed to open saved results.": "Failed to open saved results.",
     "Error loading; refresh to try again": "Error loading; refresh to try again",
     "No items": "No items",
     "We couldn't connect using the current connection information. Would you like to retry the connection or edit the connection profile?": "We couldn't connect using the current connection information. Would you like to retry the connection or edit the connection profile?",

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -998,6 +998,7 @@ export class Notebooks {
             comment: ["{0} is the saved file path"],
         });
     }
+    public static openResultsFailed = l10n.t("Failed to open saved results.");
 }
 
 export class ObjectExplorer {

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -18,12 +18,13 @@ import { NotebookConnectionManager } from "./notebookConnectionManager";
 import { NotebookCodeLensProvider } from "./notebookCodeLensProvider";
 import { HeadlessBatchResult } from "../queryExecution/headlessQueryExecutor";
 import * as formatter from "./resultFormatter";
-import type {
-    NotebookQueryResultBlock,
-    NotebookQueryResultGridBlock,
-    NotebookQueryResultOutputData,
-    NotebookRendererMessage,
-    NotebookSaveAsMessage,
+import {
+    NotebookSaveAsFormat,
+    type NotebookQueryResultBlock,
+    type NotebookQueryResultGridBlock,
+    type NotebookQueryResultOutputData,
+    type NotebookRendererMessage,
+    type NotebookSaveAsMessage,
 } from "../sharedInterfaces/notebookQueryResult";
 import type { SelectionSummaryMetrics } from "../sharedInterfaces/queryResult";
 import { buildSelectionSummaryStatusBarStrings } from "../queryResult/selectionSummaryFormatter";
@@ -959,9 +960,21 @@ export class SqlNotebookController implements vscode.Disposable {
                 resultSetIndex: message.resultSetIndex,
             });
             if (saved) {
-                void vscode.window.showInformationMessage(
+                const action = await vscode.window.showInformationMessage(
                     LocalizedConstants.Notebooks.savedResultsTo(saved.fsPath),
+                    LocalizedConstants.Common.openFile,
                 );
+                if (action === LocalizedConstants.Common.openFile) {
+                    try {
+                        await this.openSavedResults(saved, message.format);
+                    } catch (err) {
+                        const errorMsg = err instanceof Error ? err.message : String(err);
+                        this.log.error(`[handleSaveAs] Failed to open saved results: ${errorMsg}`);
+                        void vscode.window.showErrorMessage(
+                            LocalizedConstants.Notebooks.openResultsFailed,
+                        );
+                    }
+                }
             }
         } catch (err) {
             const errorMsg = err instanceof Error ? err.message : String(err);
@@ -970,6 +983,24 @@ export class SqlNotebookController implements vscode.Disposable {
                 LocalizedConstants.Notebooks.saveResultsFailed(errorMsg),
             );
         }
+    }
+
+    private async openSavedResults(
+        savedUri: vscode.Uri,
+        format: NotebookSaveAsFormat,
+    ): Promise<void> {
+        if (format === NotebookSaveAsFormat.Excel) {
+            const opened = await vscode.env.openExternal(savedUri);
+            if (!opened) {
+                throw new Error("No application is available to open the Excel file.");
+            }
+            return;
+        }
+
+        await vscode.commands.executeCommand("vscode.open", savedUri, {
+            viewColumn: vscode.ViewColumn.Beside,
+            preview: false,
+        });
     }
 
     private async executeCells(

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -997,7 +997,8 @@ export class SqlNotebookController implements vscode.Disposable {
             return;
         }
 
-        await vscode.commands.executeCommand("vscode.open", savedUri, {
+        const doc = await vscode.workspace.openTextDocument(savedUri);
+        await vscode.window.showTextDocument(doc, {
             viewColumn: vscode.ViewColumn.Beside,
             preview: false,
         });

--- a/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
+++ b/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
@@ -18,9 +18,14 @@ import ConnectionManager from "../../../src/controllers/connectionManager";
 import { ConnectionSharingService } from "../../../src/connectionSharing/connectionSharingService";
 import type { HeadlessQueryResult } from "../../../src/queryExecution/headlessQueryExecutor";
 import { NotebookConnectionManager } from "../../../src/notebooks/notebookConnectionManager";
+import * as NotebookResultsSerializer from "../../../src/notebooks/notebookResultsSerializer";
 import { IDbColumn } from "../../../src/models/interfaces";
 import { BatchSummary } from "../../../src/models/contracts/queryExecute";
-import type { NotebookQueryResultOutputData } from "../../../src/sharedInterfaces/notebookQueryResult";
+import {
+    NotebookSaveAsFormat,
+    type NotebookQueryResultOutputData,
+    type NotebookSaveAsMessage,
+} from "../../../src/sharedInterfaces/notebookQueryResult";
 
 function makeQueryResult(overrides?: Partial<HeadlessQueryResult>): HeadlessQueryResult {
     return {
@@ -1468,6 +1473,79 @@ suite("SqlNotebookController", () => {
         test("hides the summary status bar item when there is no selection", () => {
             notebookMessage({ type: "selectionSummary", metrics: undefined });
             expect(mockSelectionSummaryStatusBarItem.hide).to.have.been.called;
+        });
+    });
+
+    suite("save results", () => {
+        const notebook = makeNotebook([], undefined, vscode.Uri.file("c:\\test.ipynb"));
+        const csvUri = vscode.Uri.file("c:\\test_resultset_1.csv");
+        const excelUri = vscode.Uri.file("c:\\test_resultset_1.xlsx");
+        const saveAsMessage: NotebookSaveAsMessage = {
+            type: "saveAs",
+            format: NotebookSaveAsFormat.Csv,
+            columnInfo: [makeColumn("id", "int")],
+            rows: [],
+            resultSetIndex: 0,
+        };
+
+        function stubSuccessfulSave(savedUri: vscode.Uri, action?: string): sinon.SinonStub {
+            sandbox.stub(NotebookResultsSerializer, "saveNotebookResults").resolves(savedUri);
+            const showInformationMessageStub: sinon.SinonStub = sandbox.stub(
+                vscode.window,
+                "showInformationMessage",
+            );
+            showInformationMessageStub.resolves(action);
+            return showInformationMessageStub;
+        }
+
+        test("shows an Open File action after saving results", async () => {
+            const showInformationMessageStub = stubSuccessfulSave(csvUri);
+
+            await controller["handleSaveAs"](notebook, saveAsMessage);
+
+            expect(showInformationMessageStub).to.have.been.calledWith(
+                LocalizedConstants.Notebooks.savedResultsTo(csvUri.fsPath),
+                LocalizedConstants.Common.openFile,
+            );
+        });
+
+        test("opens saved results beside the notebook when Open File is selected", async () => {
+            stubSuccessfulSave(csvUri, LocalizedConstants.Common.openFile);
+
+            await controller["handleSaveAs"](notebook, saveAsMessage);
+
+            expect(executeCommandStub).to.have.been.calledWith("vscode.open", csvUri, {
+                viewColumn: vscode.ViewColumn.Beside,
+                preview: false,
+            });
+        });
+
+        test("opens Excel results with the system application", async () => {
+            stubSuccessfulSave(excelUri, LocalizedConstants.Common.openFile);
+            const openExternalStub = sandbox.stub(vscode.env, "openExternal").resolves(true);
+
+            await controller["handleSaveAs"](notebook, {
+                ...saveAsMessage,
+                format: NotebookSaveAsFormat.Excel,
+            });
+
+            expect(openExternalStub).to.have.been.calledWith(excelUri);
+            expect(executeCommandStub).to.not.have.been.calledWith("vscode.open");
+        });
+
+        test("shows an error when saved results cannot be opened", async () => {
+            stubSuccessfulSave(excelUri, LocalizedConstants.Common.openFile);
+            sandbox.stub(vscode.env, "openExternal").resolves(false);
+            const showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+            await controller["handleSaveAs"](notebook, {
+                ...saveAsMessage,
+                format: NotebookSaveAsFormat.Excel,
+            });
+
+            expect(showErrorMessageStub).to.have.been.calledWith(
+                LocalizedConstants.Notebooks.openResultsFailed,
+            );
         });
     });
 

--- a/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
+++ b/extensions/mssql/test/unit/notebooks/sqlNotebookController.test.ts
@@ -1512,9 +1512,16 @@ suite("SqlNotebookController", () => {
         test("opens saved results beside the notebook when Open File is selected", async () => {
             stubSuccessfulSave(csvUri, LocalizedConstants.Common.openFile);
 
+            const doc = {} as unknown as vscode.TextDocument;
+            const openTextDocumentStub = sandbox.stub(vscode.workspace, "openTextDocument").resolves(doc);
+            const showTextDocumentStub = sandbox
+                .stub(vscode.window, "showTextDocument")
+                .resolves({} as unknown as vscode.TextEditor);
+
             await controller["handleSaveAs"](notebook, saveAsMessage);
 
-            expect(executeCommandStub).to.have.been.calledWith("vscode.open", csvUri, {
+            expect(openTextDocumentStub).to.have.been.calledWith(csvUri);
+            expect(showTextDocumentStub).to.have.been.calledWith(doc, {
                 viewColumn: vscode.ViewColumn.Beside,
                 preview: false,
             });

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -3434,6 +3434,9 @@
       <source xml:lang="en">Failed to open XEL file: {0}</source>
       <note>{0} is the error message</note>
     </trans-unit>
+    <trans-unit id="++CODE++c8592233c01453eb60f2fec0b468363d676d944f924d32a283286986d57c00e9">
+      <source xml:lang="en">Failed to open saved results.</source>
+    </trans-unit>
     <trans-unit id="++CODE++0b4d03ded989b13fa01f90e1cff6b70f68bdae9f9cd4e6ab5607a098baa80b20">
       <source xml:lang="en">Failed to open scmp file: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the open scmp operation</note>


### PR DESCRIPTION
## Description

Adds an `Open File` action to SQL Notebook export-success notifications, matching the Query Profiler workflow. CSV and JSON exports open beside the notebook, while Excel exports open with the system application. Open failures are reported with a localized error.

Fixes #22211

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All relevant tests pass (`SqlNotebookController`: 55 passed)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/wiki/contributing)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Contributor: Karunakar Kotha <kkotha@microsoft.com>