### PR TITLE
Fix SQL Server query result and schema workflows

### DIFF
--- a/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
+++ b/extensions/mssql/src/languageservice/sqlMoveToSchemaProvider.ts
@@ -175,8 +175,17 @@ export class SqlMoveToSchemaProvider implements vscode.CodeActionProvider {
             return;
         }
 
+        // Do not offer the schema the object already belongs to as a move target.
+        const targetSchemas = currentSchema
+            ? schemas.filter((schema) => schema.toLowerCase() !== currentSchema.toLowerCase())
+            : schemas;
+        if (targetSchemas.length === 0) {
+            void vscode.window.showInformationMessage(loc.noSchemasFound);
+            return;
+        }
+
         // Show QuickPick with schema dropdown
-        const items = schemas.map((s) => ({ label: s }));
+        const items = targetSchemas.map((s) => ({ label: s }));
         const selected = await vscode.window.showQuickPick(items, {
             placeHolder: loc.selectTargetSchemaPlaceholder(currentSchema),
             canPickMany: false,

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
@@ -419,6 +419,11 @@
     outline-offset: -1px;
 }
 
+/* Query results are read-only, so the SlickGrid drag-replace affordance is not actionable. */
+.fluent-result-grid .slick-drag-replace-handle {
+    display: none;
+}
+
 .fluent-result-grid.focused .slick-cell.active {
     background-color: var(--fluent-result-grid-list-focus-background);
     color: var(--fluent-result-grid-list-focus-foreground);

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultStateProvider.tsx
@@ -59,6 +59,7 @@ export interface QueryResultReactProvider
         x: number,
         y: number,
         onAction: (action: GridContextMenuAction) => void | Promise<void>,
+        options?: { showCopyAsInClause: boolean },
     ) => void;
     hideGridContextMenu: () => void;
     showColumnFilterPopup: (options: ColumnFilterPopupOptions) => void;
@@ -109,8 +110,9 @@ const QueryResultStateProvider: React.FC<QueryResultProviderProps> = ({ children
         open: boolean;
         x: number;
         y: number;
+        showCopyAsInClause: boolean;
         onAction?: (action: GridContextMenuAction) => void | Promise<void>;
-    }>({ open: false, x: 0, y: 0 });
+    }>({ open: false, x: 0, y: 0, showCopyAsInClause: false });
 
     const [filterPopupState, setFilterPopupState] = useState<ColumnFilterPopupOptions | undefined>(
         undefined,
@@ -176,9 +178,15 @@ const QueryResultStateProvider: React.FC<QueryResultProviderProps> = ({ children
             },
 
             // Grid context menu API
-            showGridContextMenu: (x: number, y: number, onAction) => {
+            showGridContextMenu: (x: number, y: number, onAction, options) => {
                 hideFilterPopup();
-                setMenuState({ open: true, x, y, onAction });
+                setMenuState({
+                    open: true,
+                    x,
+                    y,
+                    onAction,
+                    showCopyAsInClause: options?.showCopyAsInClause ?? false,
+                });
             },
             hideGridContextMenu: () => {
                 setMenuState((s) => ({ ...s, open: false }));
@@ -294,6 +302,7 @@ const QueryResultStateProvider: React.FC<QueryResultProviderProps> = ({ children
                     x={menuState.x}
                     y={menuState.y}
                     open={menuState.open}
+                    showCopyAsInClause={menuState.showCopyAsInClause}
                     onAction={async (action) => {
                         await menuState.onAction?.(action);
                         setMenuState((s) => ({ ...s, open: false }));

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/GridContextMenu.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/GridContextMenu.tsx
@@ -15,6 +15,7 @@ export interface GridContextMenuProps {
     x: number;
     y: number;
     open: boolean;
+    showCopyAsInClause: boolean;
     onAction: (action: GridContextMenuAction) => void;
     onClose: () => void;
 }
@@ -30,6 +31,7 @@ export const GridContextMenu: React.FC<GridContextMenuProps> = ({
     x,
     y,
     open,
+    showCopyAsInClause,
     onAction,
     onClose,
 }) => {
@@ -128,17 +130,19 @@ export const GridContextMenu: React.FC<GridContextMenuProps> = ({
                                         }>
                                         {locConstants.queryResult.copyAsInsertInto}
                                     </MenuItem>
-                                    <MenuItem
-                                        className={styles.menuItem}
-                                        secondaryContent={
-                                            keyBindings[WebviewAction.ResultGridCopyAsInClause]
-                                                ?.label
-                                        }
-                                        onClick={() =>
-                                            onAction(GridContextMenuAction.CopyAsInClause)
-                                        }>
-                                        {locConstants.queryResult.copyAsInClause}
-                                    </MenuItem>
+                                    {showCopyAsInClause && (
+                                        <MenuItem
+                                            className={styles.menuItem}
+                                            secondaryContent={
+                                                keyBindings[WebviewAction.ResultGridCopyAsInClause]
+                                                    ?.label
+                                            }
+                                            onClick={() =>
+                                                onAction(GridContextMenuAction.CopyAsInClause)
+                                            }>
+                                            {locConstants.queryResult.copyAsInClause}
+                                        </MenuItem>
+                                    )}
                                 </MenuList>
                             </MenuPopover>
                         </Menu>

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/contextMenu.plugin.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/contextMenu.plugin.ts
@@ -18,6 +18,7 @@ import { HybridDataProvider } from "../hybridDataProvider";
 import {
     convertDisplayedSelectionToActual,
     selectEntireGrid,
+    isSingleColumnSelection,
     tryCombineSelectionsForResults,
 } from "../utils";
 
@@ -61,6 +62,12 @@ export class ContextMenu<T extends Slick.SlickData> {
         const maxY = Math.max(margin, window.innerHeight - estimatedHeight - margin);
         const adjustedX = Math.min(Math.max(mouseEvent.pageX, margin), maxX);
         const adjustedY = Math.min(Math.max(mouseEvent.pageY, margin), maxY);
+        let selection = tryCombineSelectionsForResults(
+            this.grid.getSelectionModel().getSelectedRanges(),
+        );
+        if (selection.length === 0) {
+            selection = selectEntireGrid(this.grid);
+        }
 
         // Ask outer React app to show menu at coordinates
         this.queryResultContext.showGridContextMenu(
@@ -70,6 +77,7 @@ export class ContextMenu<T extends Slick.SlickData> {
                 await this.handleMenuAction(action);
                 this.queryResultContext.hideGridContextMenu();
             },
+            { showCopyAsInClause: isSingleColumnSelection(selection) },
         );
     }
 

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/utils.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/utils.ts
@@ -133,6 +133,10 @@ export function tryCombineSelectionsForResults(selections: ISlickRange[]): ISlic
     });
 }
 
+export function isSingleColumnSelection(selection: ISlickRange[]): boolean {
+    return selection.length > 0 && selection.every((range) => range.fromCell === range.toCell);
+}
+
 export function selectionToRange(selection: ISlickRange): RowRange {
     let range: RowRange = {
         start: selection.fromRow,

--- a/extensions/mssql/test/unit/gridSelectionUtils.test.ts
+++ b/extensions/mssql/test/unit/gridSelectionUtils.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 import {
     convertDisplayedSelectionToActual,
+    isSingleColumnSelection,
     tryCombineSelections,
     tryCombineSelectionsForResults,
     SLICKGRID_ROW_ID_PROP,
@@ -283,6 +284,27 @@ suite("Grid Selection Utils", () => {
             expect(result[0].toCell).to.equal(2);
             expect(result[1].fromCell).to.equal(0);
             expect(result[1].toCell).to.equal(2);
+        });
+    });
+
+    suite("isSingleColumnSelection", () => {
+        test("returns true when all selected ranges contain one column", () => {
+            expect(
+                isSingleColumnSelection([
+                    { fromRow: 0, toRow: 2, fromCell: 1, toCell: 1 },
+                    { fromRow: 4, toRow: 5, fromCell: 1, toCell: 1 },
+                ]),
+            ).to.equal(true);
+        });
+
+        test("returns false when a selected range contains multiple columns", () => {
+            expect(
+                isSingleColumnSelection([{ fromRow: 0, toRow: 2, fromCell: 1, toCell: 2 }]),
+            ).to.equal(false);
+        });
+
+        test("returns false when there is no selection", () => {
+            expect(isSingleColumnSelection([])).to.equal(false);
         });
     });
 });

--- a/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlSymbolRenameProvider.test.ts
@@ -705,6 +705,24 @@ suite("SqlMoveToSchemaProvider Tests", () => {
             );
         });
 
+        test("excludes the current schema from the target schema picker", async () => {
+            findFilesStub.resolves([vscode.Uri.file(defaultProjFile)]);
+            sendRequestStub
+                .withArgs(ListProjectSchemasRequest.type)
+                .resolves({ schemas: ["dbo", "HR"] });
+            showQuickPickStub.resolves(undefined);
+            const doc = makeMoveDocument(sandbox, {
+                lineText: "CREATE TABLE [dbo].[MyTable]",
+            });
+
+            await provider.runMoveToSchema(doc, new vscode.Position(0, 25));
+
+            expect(showQuickPickStub).to.have.been.calledWith(
+                [{ label: "HR" }],
+                sinon.match({ placeHolder: moveLoc.selectTargetSchemaPlaceholder("dbo") }),
+            );
+        });
+
         suite("applyMove", () => {
             let openTextDocumentStub: sinon.SinonStub;
             let applyEditStub: sinon.SinonStub;


### PR DESCRIPTION
Fixes three SQL Server extension usability issues:\n\n- Hide the invalid Copy as IN clause action for multi-column selections.\n- Exclude the current schema from the Move to Schema picker.\n- Hide the unsupported drag-replace handle in the read-only Beta Results Grid.\n\nValidated with build, lint, focused tests, and online packaging.