### PR TITLE
Stabilize selection-summary updates in Query Results

### DIFF
--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -90,6 +90,13 @@ export interface SummaryChanged extends SelectionSummary {
     continue?: Deferred<void>;
 }
 
+interface SelectionSummaryRequestContext {
+    id: string;
+    confirmation?: Deferred<void>;
+    cancel?: Deferred<void>;
+    isCanceled: boolean;
+}
+
 function getRowsAffectedFromMessage(message: string): number | undefined {
     const rowsAffectedMatch = message.match(/\(?\s*(\d+)\s+rows?\s+affected\s*\)?/i);
     if (!rowsAffectedMatch?.[1]) {
@@ -1082,8 +1089,7 @@ export default class QueryRunner {
         });
     }
 
-    private _requestID: string;
-    private _cancelConfirmation: Deferred<void>;
+    private _selectionSummaryRequest: SelectionSummaryRequestContext | undefined;
 
     public async generateSelectionSummaryData(
         selections: ISlickRange[],
@@ -1091,13 +1097,26 @@ export default class QueryRunner {
         resultId: number,
         showThresholdWarning: boolean = true,
     ): Promise<void> {
+        const previousRequest = this._selectionSummaryRequest;
+        // Unblock an old confirmation so its async operation can observe that it was superseded.
+        // Rejecting an old cancel handle prevents it from sending a service cancellation.
+        previousRequest?.confirmation?.resolve();
+        previousRequest?.cancel?.reject();
+
+        const request: SelectionSummaryRequestContext = {
+            id: uuid(),
+            isCanceled: false,
+        };
+        this._selectionSummaryRequest = request;
+
+        const isCurrentRequest = () => this._selectionSummaryRequest === request;
+
         /** Ask the user to proceed for large selections. */
-        const waitForUserToProceed = async (
-            requestId: string,
-            totalRows: number,
-        ): Promise<void> => {
+        const waitForUserToProceed = async (totalRows: number): Promise<boolean> => {
             const proceed = new Deferred<void>();
-            this.fireSummaryChangedEvent(requestId, {
+            request.confirmation = proceed;
+            this.fireSummaryChangedEvent(request, {
+                status: "confirmation",
                 command: {
                     title: Constants.cmdHandleSummaryOperation,
                     command: Constants.cmdHandleSummaryOperation,
@@ -1111,10 +1130,32 @@ export default class QueryRunner {
                 resultId,
             });
             await proceed.promise;
+            if (request.confirmation === proceed) {
+                request.confirmation = undefined;
+            }
+            return isCurrentRequest();
         };
 
+        if (selections.length === 0) {
+            this.fireSummaryChangedEvent(request, {
+                status: "idle",
+                stats: undefined,
+                text: undefined,
+                tooltip: undefined,
+                uri: this.uri,
+                command: undefined,
+                continue: undefined,
+                batchId,
+                resultId,
+            });
+            return;
+        }
+
+        const totalRows = this.getTotalSelectedRows(selections);
+
         const showProgress = (cancelConfirmation: Deferred<void>) => {
-            this.fireSummaryChangedEvent(this._requestID, {
+            this.fireSummaryChangedEvent(request, {
+                status: "loading",
                 command: {
                     title: Constants.cmdHandleSummaryOperation,
                     command: Constants.cmdHandleSummaryOperation,
@@ -1129,35 +1170,35 @@ export default class QueryRunner {
             });
         };
 
-        // create a new request and cancel any in-flight run
-        this._requestID = uuid();
-        const requestId = this._requestID;
-        this._cancelConfirmation?.resolve();
-        this._cancelConfirmation = undefined;
-
-        const totalRows = this.getTotalSelectedRows(selections);
-
         const threshold = getInMemoryGridDataProcessingThreshold();
 
         // optional “are you sure?” for large selections
         if (showThresholdWarning && totalRows > threshold) {
-            await waitForUserToProceed(requestId, totalRows);
+            if (!(await waitForUserToProceed(totalRows))) {
+                return;
+            }
         }
 
         const sendCancelSummaryEvent = async () => {
+            if (!isCurrentRequest()) {
+                return;
+            }
             // Reset and allow user to start a new summary operation
-            this._cancelConfirmation = undefined;
-            await waitForUserToProceed(requestId, totalRows);
-            await this.generateSelectionSummaryData(selections, batchId, resultId, false);
+            request.cancel = undefined;
+            if (await waitForUserToProceed(totalRows)) {
+                await this.generateSelectionSummaryData(selections, batchId, resultId, false);
+            }
         };
 
-        this._cancelConfirmation = new Deferred<void>();
-        const cancel = this._cancelConfirmation;
-        let isCanceled = false;
+        const cancel = new Deferred<void>();
+        request.cancel = cancel;
         // Set up cancellation handling
         cancel.promise
             .then(async () => {
-                isCanceled = true;
+                if (!isCurrentRequest()) {
+                    return;
+                }
+                request.isCanceled = true;
                 await this._client.sendNotification(CancelGridSelectionSummaryNotification.type, {
                     ownerUri: this.uri,
                 });
@@ -1187,8 +1228,7 @@ export default class QueryRunner {
                 selections: simpleSelections,
             });
 
-            if (isCanceled) {
-                await sendCancelSummaryEvent();
+            if (!isCurrentRequest() || request.isCanceled) {
                 return;
             }
 
@@ -1210,11 +1250,11 @@ export default class QueryRunner {
             const { text, tooltip } = buildSelectionSummaryStatusBarStrings(stats);
 
             // Resolve the cancel confirmation to clean up
-            if (!isCanceled) {
-                cancel.reject();
-            }
+            cancel.reject();
+            request.cancel = undefined;
 
-            this.fireSummaryChangedEvent(requestId, {
+            this.fireSummaryChangedEvent(request, {
+                status: "success",
                 stats,
                 text,
                 tooltip,
@@ -1225,12 +1265,15 @@ export default class QueryRunner {
                 resultId,
             });
         } catch (error) {
-            // Clean up on error
-            if (!isCanceled) {
-                cancel.reject(error);
+            if (!isCurrentRequest() || request.isCanceled) {
+                return;
             }
+            // Clean up on error
+            cancel.reject(error);
+            request.cancel = undefined;
 
-            this.fireSummaryChangedEvent(requestId, {
+            this.fireSummaryChangedEvent(request, {
+                status: "error",
                 text: `$(error) ${LocalizedConstants.QueryResult.errorLoadingSummary}`,
                 tooltip: LocalizedConstants.QueryResult.errorLoadingSummaryTooltip(
                     getErrorMessage(error),
@@ -1245,9 +1288,12 @@ export default class QueryRunner {
         }
     }
 
-    private fireSummaryChangedEvent(requestId: string, summary: SummaryChanged): void {
-        if (this._requestID === requestId) {
-            this._onSummaryChangedEmitter.fire(summary);
+    private fireSummaryChangedEvent(
+        request: SelectionSummaryRequestContext,
+        summary: SummaryChanged,
+    ): void {
+        if (this._selectionSummaryRequest === request) {
+            this._onSummaryChangedEmitter.fire({ ...summary, requestId: request.id });
         }
     }
 

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -1121,9 +1121,9 @@ export default class QueryRunner {
         resultId: number,
         showThresholdWarning: boolean = true,
     ): Promise<void> {
-        // A new service request supersedes an old one for the same owner. When no replacement
-        // request will be sent, explicitly cancel any service work for the cleared selection.
-        void this.invalidateSelectionSummaryRequest(selections.length === 0);
+        // Invalidate local state immediately and cancel any service work before starting a
+        // replacement request for the same owner.
+        const previousCancellation = this.invalidateSelectionSummaryRequest(true);
 
         const request: SelectionSummaryRequestContext = {
             id: uuid(),
@@ -1171,6 +1171,11 @@ export default class QueryRunner {
                 batchId,
                 resultId,
             });
+            return;
+        }
+
+        await previousCancellation;
+        if (!isCurrentRequest()) {
             return;
         }
 

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -95,6 +95,7 @@ interface SelectionSummaryRequestContext {
     confirmation?: Deferred<void>;
     cancel?: Deferred<void>;
     isCanceled: boolean;
+    serviceRequestInFlight: boolean;
 }
 
 function getRowsAffectedFromMessage(message: string): number | undefined {
@@ -306,6 +307,7 @@ export default class QueryRunner {
      * Resets the query runner to a clean state if we want to run another query on it.
      */
     public async resetQueryRunner(): Promise<void> {
+        await this.invalidateSelectionSummaryRequest(true);
         try {
             await this.cancel();
         } catch {
@@ -515,6 +517,7 @@ export default class QueryRunner {
      * @param _selection Optional selection metadata associated with a document-based execution.
      */
     public setupQueryExecution(_selection?: ISelectionData): void {
+        void this.invalidateSelectionSummaryRequest(true);
         this._logger.info(LocalizedConstants.msgStartedExecute(this._ownerUri));
         this._isExecuting = true;
         this._totalElapsedMilliseconds = 0;
@@ -666,6 +669,7 @@ export default class QueryRunner {
      * @returns A promise that will be rejected if a problem occured
      */
     public async dispose(): Promise<void> {
+        await this.invalidateSelectionSummaryRequest(true);
         let disposeDetails = new QueryDisposeParams();
         disposeDetails.ownerUri = this.uri;
         try {
@@ -1091,21 +1095,40 @@ export default class QueryRunner {
 
     private _selectionSummaryRequest: SelectionSummaryRequestContext | undefined;
 
+    private async invalidateSelectionSummaryRequest(cancelServiceWork: boolean): Promise<void> {
+        const request = this._selectionSummaryRequest;
+        this._selectionSummaryRequest = undefined;
+        request?.confirmation?.resolve();
+        request?.cancel?.reject();
+        if (request) {
+            request.isCanceled = true;
+        }
+
+        if (cancelServiceWork && request?.serviceRequestInFlight) {
+            try {
+                await this._client.sendNotification(CancelGridSelectionSummaryNotification.type, {
+                    ownerUri: this.uri,
+                });
+            } catch {
+                // The local request is already invalidated; cancellation is best effort.
+            }
+        }
+    }
+
     public async generateSelectionSummaryData(
         selections: ISlickRange[],
         batchId: number,
         resultId: number,
         showThresholdWarning: boolean = true,
     ): Promise<void> {
-        const previousRequest = this._selectionSummaryRequest;
-        // Unblock an old confirmation so its async operation can observe that it was superseded.
-        // Rejecting an old cancel handle prevents it from sending a service cancellation.
-        previousRequest?.confirmation?.resolve();
-        previousRequest?.cancel?.reject();
+        // A new service request supersedes an old one for the same owner. When no replacement
+        // request will be sent, explicitly cancel any service work for the cleared selection.
+        void this.invalidateSelectionSummaryRequest(selections.length === 0);
 
         const request: SelectionSummaryRequestContext = {
             id: uuid(),
             isCanceled: false,
+            serviceRequestInFlight: false,
         };
         this._selectionSummaryRequest = request;
 
@@ -1219,14 +1242,21 @@ export default class QueryRunner {
                 toColumn: range.toCell,
             }));
 
-            const result = await this._client.sendRequest(GridSelectionSummaryRequest.type, {
-                ownerUri: this.uri,
-                batchIndex: batchId,
-                resultSetIndex: resultId,
-                rowsStartIndex: 0,
-                rowsCount: 0,
-                selections: simpleSelections,
-            });
+            request.serviceRequestInFlight = true;
+            const result = await (async () => {
+                try {
+                    return await this._client.sendRequest(GridSelectionSummaryRequest.type, {
+                        ownerUri: this.uri,
+                        batchIndex: batchId,
+                        resultSetIndex: resultId,
+                        rowsStartIndex: 0,
+                        rowsCount: 0,
+                        selections: simpleSelections,
+                    });
+                } finally {
+                    request.serviceRequestInFlight = false;
+                }
+            })();
 
             if (!isCurrentRequest() || request.isCanceled) {
                 return;

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -1094,8 +1094,9 @@ export default class QueryRunner {
     }
 
     private _selectionSummaryRequest: SelectionSummaryRequestContext | undefined;
+    private _selectionSummaryCancellation: Promise<void> = Promise.resolve();
 
-    private async invalidateSelectionSummaryRequest(cancelServiceWork: boolean): Promise<void> {
+    private invalidateSelectionSummaryRequest(cancelServiceWork: boolean): Promise<void> {
         const request = this._selectionSummaryRequest;
         this._selectionSummaryRequest = undefined;
         request?.confirmation?.resolve();
@@ -1105,14 +1106,21 @@ export default class QueryRunner {
         }
 
         if (cancelServiceWork && request?.serviceRequestInFlight) {
-            try {
-                await this._client.sendNotification(CancelGridSelectionSummaryNotification.type, {
-                    ownerUri: this.uri,
-                });
-            } catch {
-                // The local request is already invalidated; cancellation is best effort.
-            }
+            this._selectionSummaryCancellation = this._selectionSummaryCancellation.then(
+                async () => {
+                    try {
+                        await this._client.sendNotification(
+                            CancelGridSelectionSummaryNotification.type,
+                            { ownerUri: this.uri },
+                        );
+                    } catch {
+                        // The local request is already invalidated; cancellation is best effort.
+                    }
+                },
+            );
         }
+
+        return this._selectionSummaryCancellation;
     }
 
     public async generateSelectionSummaryData(

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -752,6 +752,8 @@ export class SqlOutputContentProvider {
                     return;
                 }
                 state.selectionSummary = {
+                    status: e.status,
+                    requestId: e.requestId,
                     stats: e.stats,
                     text: e.text,
                     displayText: getSelectionSummaryDisplayText(e.text),

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -102,7 +102,11 @@ export interface SelectionSummaryMetrics {
     sum?: number;
 }
 
+export type SelectionSummaryStatus = "idle" | "loading" | "confirmation" | "success" | "error";
+
 export interface SelectionSummary {
+    status?: SelectionSummaryStatus;
+    requestId?: string;
     stats?: SelectionSummaryMetrics;
     text?: string;
     displayText?: string;

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
@@ -4,12 +4,41 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Tooltip, makeStyles, mergeClasses } from "@fluentui/react-components";
-import { Fragment, useContext, useEffect, useMemo, useState } from "react";
+import { Fragment, useContext, useEffect, useMemo, useRef, useState } from "react";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { locConstants } from "../../common/locConstants";
-import { getDisplayedRowsCount } from "./queryResultUtils";
+import {
+    getDisplayedRowsCount,
+    getSelectionSummaryResultKey,
+    getSelectionSummaryWithStableMetrics,
+} from "./queryResultUtils";
 import { useQueryResultSelector } from "./queryResultSelector";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
+
+function useDisplayedSelectionSummary(
+    selectionSummary: qr.SelectionSummary | undefined,
+    executionStartTime: number | undefined,
+) {
+    const summariesByResultRef = useRef(new Map<string, qr.SelectionSummary>());
+    const summaryKey = getSelectionSummaryResultKey(selectionSummary, executionStartTime);
+
+    useEffect(() => {
+        summariesByResultRef.current.clear();
+    }, [executionStartTime]);
+
+    useEffect(() => {
+        if (selectionSummary?.status === "success" && summaryKey) {
+            summariesByResultRef.current.set(summaryKey, selectionSummary);
+        }
+    }, [selectionSummary, summaryKey]);
+
+    // Keep completed metrics stable while their replacement loads, but retain the current
+    // loading command and tooltip so the operation can still be canceled.
+    return getSelectionSummaryWithStableMetrics(
+        selectionSummary,
+        summaryKey ? summariesByResultRef.current.get(summaryKey) : undefined,
+    );
+}
 
 const useStyles = makeStyles({
     footer: {
@@ -356,6 +385,10 @@ export const QueryResultSummaryFooter = ({
     const tabStates = useQueryResultSelector((state) => state.tabStates);
     const isExecuting = useQueryResultSelector((state) => state.isExecuting ?? false);
     const executionStartTime = useQueryResultSelector((state) => state.executionStartTime);
+    const displayedSelectionSummary = useDisplayedSelectionSummary(
+        selectionSummary,
+        executionStartTime,
+    );
     const executionElapsedMilliseconds = useQueryResultSelector(
         (state) => state.executionElapsedMilliseconds,
     );
@@ -404,10 +437,11 @@ export const QueryResultSummaryFooter = ({
                 ? locConstants.queryResult.runningLabel
                 : locConstants.queryResult.runningWithDuration(compactExecutionText)
             : compactExecutionText;
-    const selectionStats = selectionSummary?.stats;
-    const selectionCommand = selectionSummary?.command;
+    const selectionStats = displayedSelectionSummary?.stats;
+    const selectionCommand = displayedSelectionSummary?.command;
     const selectionActionUri = selectionCommand?.arguments[0];
-    const selectionStatusText = selectionSummary?.displayText ?? selectionSummary?.text ?? "";
+    const selectionStatusText =
+        displayedSelectionSummary?.displayText ?? displayedSelectionSummary?.text ?? "";
     const selectionDisplayContent = selectionStats
         ? renderSelectionMetricsInline(selectionStats, classes)
         : (selectionStatusText ?? "") || locConstants.queryResult.noSelectionSummary;
@@ -415,7 +449,7 @@ export const QueryResultSummaryFooter = ({
         renderSelectionMetricsTooltip(selectionStats, classes)
     ) : (
         <span className={classes.selectionTooltipText}>
-            {selectionSummary?.tooltip ||
+            {displayedSelectionSummary?.tooltip ||
                 selectionStatusText ||
                 locConstants.queryResult.noSelectionSummary}
         </span>

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Tooltip, makeStyles, mergeClasses } from "@fluentui/react-components";
+import { Spinner, Tooltip, makeStyles, mergeClasses } from "@fluentui/react-components";
 import { Fragment, useContext, useEffect, useMemo, useRef, useState } from "react";
 import * as qr from "../../../sharedInterfaces/queryResult";
 import { locConstants } from "../../common/locConstants";
@@ -11,6 +11,7 @@ import {
     getDisplayedRowsCount,
     getSelectionSummaryResultKey,
     getSelectionSummaryWithStableMetrics,
+    isSelectionSummaryLoading,
 } from "./queryResultUtils";
 import { useQueryResultSelector } from "./queryResultSelector";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
@@ -128,6 +129,12 @@ const useStyles = makeStyles({
         cursor: "pointer",
         fontSize: "11px",
         fontWeight: 600,
+    },
+    loadingSelectionContent: {
+        minWidth: 0,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
     },
     selectionTooltipText: {
         whiteSpace: "pre-line",
@@ -442,18 +449,32 @@ export const QueryResultSummaryFooter = ({
     const selectionActionUri = selectionCommand?.arguments[0];
     const selectionStatusText =
         displayedSelectionSummary?.displayText ?? displayedSelectionSummary?.text ?? "";
-    const selectionDisplayContent = selectionStats
-        ? renderSelectionMetricsInline(selectionStats, classes)
-        : (selectionStatusText ?? "") || locConstants.queryResult.noSelectionSummary;
-    const selectionTooltipContent = selectionStats ? (
-        renderSelectionMetricsTooltip(selectionStats, classes)
-    ) : (
-        <span className={classes.selectionTooltipText}>
-            {displayedSelectionSummary?.tooltip ||
-                selectionStatusText ||
-                locConstants.queryResult.noSelectionSummary}
+    const selectionIsLoading = isSelectionSummaryLoading(displayedSelectionSummary);
+    const selectionDisplayContent = selectionStats ? (
+        <span className={classes.loadingSelectionContent}>
+            {renderSelectionMetricsInline(selectionStats, classes)}
+            {selectionIsLoading && (
+                <Spinner
+                    size="extra-tiny"
+                    aria-label={
+                        displayedSelectionSummary?.tooltip || selectionStatusText || undefined
+                    }
+                />
+            )}
         </span>
+    ) : (
+        (selectionStatusText ?? "") || locConstants.queryResult.noSelectionSummary
     );
+    const selectionTooltipContent =
+        selectionStats && !selectionIsLoading ? (
+            renderSelectionMetricsTooltip(selectionStats, classes)
+        ) : (
+            <span className={classes.selectionTooltipText}>
+                {displayedSelectionSummary?.tooltip ||
+                    selectionStatusText ||
+                    locConstants.queryResult.noSelectionSummary}
+            </span>
+        );
     const compactRowsText = typeof rowsCount === "number" ? rowsCount.toLocaleString() : "0";
     const isTextResultsView =
         tabStates?.resultPaneTab === qr.QueryResultPaneTabs.Results &&

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultSummaryFooter.tsx
@@ -16,12 +16,18 @@ import {
 import { useQueryResultSelector } from "./queryResultSelector";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
 
+const SELECTION_SUMMARY_LOADING_GRACE_PERIOD_MS = 200;
+
 function useDisplayedSelectionSummary(
     selectionSummary: qr.SelectionSummary | undefined,
     executionStartTime: number | undefined,
 ) {
     const summariesByResultRef = useRef(new Map<string, qr.SelectionSummary>());
     const summaryKey = getSelectionSummaryResultKey(selectionSummary, executionStartTime);
+    const loadingRequestId = isSelectionSummaryLoading(selectionSummary)
+        ? selectionSummary?.requestId
+        : undefined;
+    const [visibleLoadingRequestId, setVisibleLoadingRequestId] = useState<string>();
 
     useEffect(() => {
         summariesByResultRef.current.clear();
@@ -33,12 +39,30 @@ function useDisplayedSelectionSummary(
         }
     }, [selectionSummary, summaryKey]);
 
-    // Keep completed metrics stable while their replacement loads, but retain the current
-    // loading command and tooltip so the operation can still be canceled.
-    return getSelectionSummaryWithStableMetrics(
-        selectionSummary,
-        summaryKey ? summariesByResultRef.current.get(summaryKey) : undefined,
-    );
+    useEffect(() => {
+        if (!loadingRequestId) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setVisibleLoadingRequestId(loadingRequestId);
+        }, SELECTION_SUMMARY_LOADING_GRACE_PERIOD_MS);
+        return () => window.clearTimeout(timer);
+    }, [loadingRequestId]);
+
+    const completedSummary = summaryKey ? summariesByResultRef.current.get(summaryKey) : undefined;
+    const showLoadingAffordance =
+        loadingRequestId !== undefined && visibleLoadingRequestId === loadingRequestId;
+
+    // Keep the completed footer unchanged during the grace period. Slow replacements retain
+    // stable metrics while exposing the current loading command and tooltip.
+    return {
+        displayedSelectionSummary:
+            loadingRequestId && !showLoadingAffordance
+                ? completedSummary
+                : getSelectionSummaryWithStableMetrics(selectionSummary, completedSummary),
+        showLoadingAffordance,
+    };
 }
 
 const useStyles = makeStyles({
@@ -392,7 +416,7 @@ export const QueryResultSummaryFooter = ({
     const tabStates = useQueryResultSelector((state) => state.tabStates);
     const isExecuting = useQueryResultSelector((state) => state.isExecuting ?? false);
     const executionStartTime = useQueryResultSelector((state) => state.executionStartTime);
-    const displayedSelectionSummary = useDisplayedSelectionSummary(
+    const { displayedSelectionSummary, showLoadingAffordance } = useDisplayedSelectionSummary(
         selectionSummary,
         executionStartTime,
     );
@@ -445,11 +469,13 @@ export const QueryResultSummaryFooter = ({
                 : locConstants.queryResult.runningWithDuration(compactExecutionText)
             : compactExecutionText;
     const selectionStats = displayedSelectionSummary?.stats;
-    const selectionCommand = displayedSelectionSummary?.command;
+    const selectionCommand = showLoadingAffordance
+        ? selectionSummary?.command
+        : displayedSelectionSummary?.command;
     const selectionActionUri = selectionCommand?.arguments[0];
     const selectionStatusText =
         displayedSelectionSummary?.displayText ?? displayedSelectionSummary?.text ?? "";
-    const selectionIsLoading = isSelectionSummaryLoading(displayedSelectionSummary);
+    const selectionIsLoading = showLoadingAffordance && isSelectionSummaryLoading(selectionSummary);
     const selectionDisplayContent = selectionStats ? (
         <span className={classes.loadingSelectionContent}>
             {renderSelectionMetricsInline(selectionStats, classes)}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
@@ -107,3 +107,29 @@ export function getDisplayedRowsCount(
 
     return rowsAffected;
 }
+
+export function isSelectionSummaryLoading(
+    selectionSummary: qr.SelectionSummary | undefined,
+): boolean {
+    return selectionSummary?.status === "loading";
+}
+
+export function getSelectionSummaryResultKey(
+    selectionSummary: qr.SelectionSummary | undefined,
+    executionStartTime?: number,
+): string | undefined {
+    return selectionSummary?.batchId !== undefined && selectionSummary.resultId !== undefined
+        ? `${executionStartTime ?? "unknown"}_${selectionSummary.batchId}_${selectionSummary.resultId}`
+        : undefined;
+}
+
+export function getSelectionSummaryWithStableMetrics(
+    selectionSummary: qr.SelectionSummary | undefined,
+    completedSummary: qr.SelectionSummary | undefined,
+): qr.SelectionSummary | undefined {
+    if (!isSelectionSummaryLoading(selectionSummary) || !completedSummary?.stats) {
+        return selectionSummary;
+    }
+
+    return { ...selectionSummary, stats: completedSummary.stats };
+}

--- a/extensions/mssql/test/unit/queryResultSummaryFooter.test.ts
+++ b/extensions/mssql/test/unit/queryResultSummaryFooter.test.ts
@@ -7,7 +7,10 @@ import { expect } from "chai";
 import * as qr from "../../src/sharedInterfaces/queryResult";
 import {
     getDisplayedRowsCount,
+    getSelectionSummaryResultKey,
+    getSelectionSummaryWithStableMetrics,
     getTotalResultSetRowCount,
+    isSelectionSummaryLoading,
 } from "../../src/webviews/pages/QueryResult/queryResultUtils";
 
 suite("QueryResultSummaryFooter row count", () => {
@@ -61,5 +64,56 @@ suite("QueryResultSummaryFooter row count", () => {
 
     test("sums row counts only when result sets have row counts", () => {
         expect(getTotalResultSetRowCount({})).to.equal(undefined);
+    });
+
+    test("identifies only the loading selection-summary state", () => {
+        expect(
+            isSelectionSummaryLoading({
+                status: "loading",
+                text: "translated loading text",
+            }),
+        ).to.equal(true);
+        expect(
+            isSelectionSummaryLoading({
+                status: "confirmation",
+                text: "translated confirmation text",
+            }),
+        ).to.equal(false);
+        expect(
+            isSelectionSummaryLoading({
+                status: "success",
+                text: "translated result text",
+            }),
+        ).to.equal(false);
+    });
+
+    test("keys selection summaries by their execution and result grid", () => {
+        expect(getSelectionSummaryResultKey({ batchId: 2, resultId: 3 }, 1000)).to.equal(
+            "1000_2_3",
+        );
+        expect(getSelectionSummaryResultKey({ batchId: 2 })).to.equal(undefined);
+        expect(getSelectionSummaryResultKey(undefined)).to.equal(undefined);
+    });
+
+    test("keeps completed metrics without hiding the current loading command", () => {
+        const command = {
+            title: "cancel",
+            command: "cancelSummary",
+            arguments: ["uri"],
+        };
+        const result = getSelectionSummaryWithStableMetrics(
+            { status: "loading", command, tooltip: "cancel loading" },
+            {
+                status: "success",
+                stats: { count: 4, distinctCount: 3, nullCount: 1 },
+            },
+        );
+
+        expect(result).to.deep.equal({
+            status: "loading",
+            command,
+            tooltip: "cancel loading",
+            stats: { count: 4, distinctCount: 3, nullCount: 1 },
+        });
     });
 });

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -19,7 +19,9 @@ import {
     CopyResults2Request,
     CancelCopy2Notification,
     CopyType,
+    GridSelectionSummaryRequest,
 } from "../../src/models/contracts/queryExecute";
+import type { SelectionSummary } from "../../src/sharedInterfaces/queryResult";
 import StatusView from "../../src/views/statusView";
 import * as Constants from "../../src/constants/constants";
 import * as QueryExecuteContracts from "../../src/models/contracts/queryExecute";
@@ -761,6 +763,84 @@ suite("Query Runner tests", () => {
             QueryExecuteContracts.QueryExecuteStatementRequest.type,
             expectedParams,
         );
+    });
+
+    suite("selection summary lifecycle", () => {
+        const selection = [{ fromRow: 0, toRow: 1, fromCell: 0, toCell: 1 }];
+
+        test("clears the summary without sending a service request", async () => {
+            const queryRunner = createQueryRunner();
+            const summaries: SelectionSummary[] = [];
+            const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
+
+            await queryRunner.generateSelectionSummaryData([], 2, 3);
+            listener.dispose();
+
+            expect(summaries).to.have.length(1);
+            expect(summaries[0]).to.include({
+                status: "idle",
+                batchId: 2,
+                resultId: 3,
+            });
+            expect(summaries[0].requestId).to.be.a("string").and.not.be.empty;
+            expect(testSqlToolsServerClient.sendRequest).to.not.have.been.calledWith(
+                GridSelectionSummaryRequest.type,
+                sinon.match.object,
+            );
+        });
+
+        test("unblocks a superseded threshold confirmation", async () => {
+            setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 0 });
+            const queryRunner = createQueryRunner();
+            const summaries: SelectionSummary[] = [];
+            const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
+
+            const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            const secondRequest = queryRunner.generateSelectionSummaryData([], 1, 0);
+            await Promise.all([firstRequest, secondRequest]);
+            listener.dispose();
+
+            expect(summaries.map((summary) => summary.status)).to.deep.equal([
+                "confirmation",
+                "idle",
+            ]);
+            expect(summaries[0].requestId).to.not.equal(summaries[1].requestId);
+            expect(testSqlToolsServerClient.sendRequest).to.not.have.been.calledWith(
+                GridSelectionSummaryRequest.type,
+                sinon.match.object,
+            );
+        });
+
+        test("does not publish a stale service response after the selection is cleared", async () => {
+            setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
+            const queryRunner = createQueryRunner();
+            const summaries: SelectionSummary[] = [];
+            const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
+            let resolveSummary:
+                | ((value: QueryExecuteContracts.GridSelectionSummaryResponse) => void)
+                | undefined;
+            const serviceResponse = new Promise<QueryExecuteContracts.GridSelectionSummaryResponse>(
+                (resolve) => {
+                    resolveSummary = resolve;
+                },
+            );
+            testSqlToolsServerClient.sendRequest
+                .withArgs(GridSelectionSummaryRequest.type, sinon.match.object)
+                .returns(serviceResponse);
+
+            const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await queryRunner.generateSelectionSummaryData([], 0, 0);
+            resolveSummary?.({
+                count: 2,
+                distinctCount: 2,
+                nullCount: 0,
+                sum: 3,
+            });
+            await firstRequest;
+            listener.dispose();
+
+            expect(summaries.map((summary) => summary.status)).to.deep.equal(["loading", "idle"]);
+        });
     });
 
     suite("Copy Results", () => {

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -797,6 +797,7 @@ suite("Query Runner tests", () => {
             const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
 
             const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await Promise.resolve();
             const secondRequest = queryRunner.generateSelectionSummaryData([], 1, 0);
             await Promise.all([firstRequest, secondRequest]);
             listener.dispose();
@@ -830,6 +831,7 @@ suite("Query Runner tests", () => {
                 .returns(serviceResponse);
 
             const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await Promise.resolve();
             await queryRunner.generateSelectionSummaryData([], 0, 0);
             resolveSummary?.({
                 count: 2,
@@ -898,6 +900,76 @@ suite("Query Runner tests", () => {
             ]);
         });
 
+        test("waits for pending cancellation before starting the latest summary", async () => {
+            setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
+            const queryRunner = createQueryRunner();
+            let resolveFirstSummary:
+                | ((value: QueryExecuteContracts.GridSelectionSummaryResponse) => void)
+                | undefined;
+            let resolveCancellation!: () => void;
+            const summaryRequestStub = testSqlToolsServerClient.sendRequest.withArgs(
+                GridSelectionSummaryRequest.type,
+                sinon.match.object,
+            );
+            summaryRequestStub.onFirstCall().returns(
+                new Promise<QueryExecuteContracts.GridSelectionSummaryResponse>((resolve) => {
+                    resolveFirstSummary = resolve;
+                }),
+            );
+            summaryRequestStub.onSecondCall().resolves({
+                count: 1,
+                distinctCount: 1,
+                nullCount: 0,
+                sum: 5,
+            });
+            testSqlToolsServerClient.sendNotification
+                .withArgs(CancelGridSelectionSummaryNotification.type, {
+                    ownerUri: standardUri,
+                })
+                .returns(
+                    new Promise<void>((resolve) => {
+                        resolveCancellation = resolve;
+                    }),
+                );
+            const intermediateSelection = [{ fromRow: 3, toRow: 3, fromCell: 0, toCell: 0 }];
+            const latestSelection = [{ fromRow: 5, toRow: 5, fromCell: 0, toCell: 0 }];
+            const latestServiceSelection = [{ fromRow: 5, toRow: 5, fromColumn: 0, toColumn: 0 }];
+
+            const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await Promise.resolve();
+            const intermediateRequest = queryRunner.generateSelectionSummaryData(
+                intermediateSelection,
+                0,
+                0,
+            );
+            const latestRequest = queryRunner.generateSelectionSummaryData(latestSelection, 0, 0);
+
+            expect(testSqlToolsServerClient.sendRequest).to.not.have.been.calledWith(
+                GridSelectionSummaryRequest.type,
+                sinon.match({ selections: latestServiceSelection }),
+            );
+
+            resolveCancellation();
+            resolveFirstSummary?.({
+                count: 2,
+                distinctCount: 2,
+                nullCount: 0,
+                sum: 3,
+            });
+            await Promise.all([firstRequest, intermediateRequest, latestRequest]);
+
+            expect(testSqlToolsServerClient.sendRequest).to.have.been.calledWith(
+                GridSelectionSummaryRequest.type,
+                sinon.match({ selections: latestServiceSelection }),
+            );
+            expect(testSqlToolsServerClient.sendRequest).to.not.have.been.calledWith(
+                GridSelectionSummaryRequest.type,
+                sinon.match({
+                    selections: [{ fromRow: 3, toRow: 3, fromColumn: 0, toColumn: 0 }],
+                }),
+            );
+        });
+
         test("invalidates an in-flight summary when the query runner is reset", async () => {
             setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
             const queryRunner = createQueryRunner();
@@ -915,6 +987,7 @@ suite("Query Runner tests", () => {
                 );
 
             const summaryRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await Promise.resolve();
             await queryRunner.resetQueryRunner();
             resolveSummary?.({
                 count: 2,

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -847,6 +847,57 @@ suite("Query Runner tests", () => {
             );
         });
 
+        test("cancels service work before starting a replacement summary", async () => {
+            setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
+            const queryRunner = createQueryRunner();
+            const summaries: SelectionSummary[] = [];
+            const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
+            let resolveFirstSummary:
+                | ((value: QueryExecuteContracts.GridSelectionSummaryResponse) => void)
+                | undefined;
+            const summaryRequestStub = testSqlToolsServerClient.sendRequest.withArgs(
+                GridSelectionSummaryRequest.type,
+                sinon.match.object,
+            );
+            summaryRequestStub.onFirstCall().returns(
+                new Promise<QueryExecuteContracts.GridSelectionSummaryResponse>((resolve) => {
+                    resolveFirstSummary = resolve;
+                }),
+            );
+            summaryRequestStub.onSecondCall().resolves({
+                count: 1,
+                distinctCount: 1,
+                nullCount: 0,
+                sum: 4,
+            });
+
+            const firstRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await Promise.resolve();
+            const secondRequest = queryRunner.generateSelectionSummaryData(
+                [{ fromRow: 3, toRow: 3, fromCell: 0, toCell: 0 }],
+                0,
+                0,
+            );
+            resolveFirstSummary?.({
+                count: 2,
+                distinctCount: 2,
+                nullCount: 0,
+                sum: 3,
+            });
+            await Promise.all([firstRequest, secondRequest]);
+            listener.dispose();
+
+            expect(testSqlToolsServerClient.sendNotification).to.have.been.calledWith(
+                CancelGridSelectionSummaryNotification.type,
+                { ownerUri: standardUri },
+            );
+            expect(summaries.map((summary) => summary.status)).to.deep.equal([
+                "loading",
+                "loading",
+                "success",
+            ]);
+        });
+
         test("invalidates an in-flight summary when the query runner is reset", async () => {
             setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
             const queryRunner = createQueryRunner();

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -20,6 +20,7 @@ import {
     CancelCopy2Notification,
     CopyType,
     GridSelectionSummaryRequest,
+    CancelGridSelectionSummaryNotification,
 } from "../../src/models/contracts/queryExecute";
 import type { SelectionSummary } from "../../src/sharedInterfaces/queryResult";
 import StatusView from "../../src/views/statusView";
@@ -840,6 +841,44 @@ suite("Query Runner tests", () => {
             listener.dispose();
 
             expect(summaries.map((summary) => summary.status)).to.deep.equal(["loading", "idle"]);
+            expect(testSqlToolsServerClient.sendNotification).to.have.been.calledWith(
+                CancelGridSelectionSummaryNotification.type,
+                { ownerUri: standardUri },
+            );
+        });
+
+        test("invalidates an in-flight summary when the query runner is reset", async () => {
+            setupWorkspaceConfig({ [Constants.configInMemoryDataProcessingThreshold]: 5000 });
+            const queryRunner = createQueryRunner();
+            const summaries: SelectionSummary[] = [];
+            const listener = queryRunner.onSummaryChanged((summary) => summaries.push(summary));
+            let resolveSummary:
+                | ((value: QueryExecuteContracts.GridSelectionSummaryResponse) => void)
+                | undefined;
+            testSqlToolsServerClient.sendRequest
+                .withArgs(GridSelectionSummaryRequest.type, sinon.match.object)
+                .returns(
+                    new Promise<QueryExecuteContracts.GridSelectionSummaryResponse>((resolve) => {
+                        resolveSummary = resolve;
+                    }),
+                );
+
+            const summaryRequest = queryRunner.generateSelectionSummaryData(selection, 0, 0);
+            await queryRunner.resetQueryRunner();
+            resolveSummary?.({
+                count: 2,
+                distinctCount: 2,
+                nullCount: 0,
+                sum: 3,
+            });
+            await summaryRequest;
+            listener.dispose();
+
+            expect(summaries.map((summary) => summary.status)).to.deep.equal(["loading"]);
+            expect(testSqlToolsServerClient.sendNotification).to.have.been.calledWith(
+                CancelGridSelectionSummaryNotification.type,
+                { ownerUri: standardUri },
+            );
         });
     });
 


### PR DESCRIPTION
## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

- Models selection-summary state explicitly instead of inferring it from localized display text.
- Keeps completed footer metrics stable while recalculation is in progress and preserves the active cancel command.
- Scopes cancellation and confirmation handles to each request so superseded work cannot publish stale results.
- Clears the summary immediately for an empty selection and ignores late service responses.

Related issue: [#22786](https://github.com/microsoft/vscode-mssql/issues/22786)

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| Query Results footer while repeatedly changing a Beta Grid selection |  <img width="319" height="77" alt="msrdc_cEOZX0szF2" src="https://github.com/user-attachments/assets/18f31233-a3b0-443f-a400-fcc1e893070b" />  |  |
 


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
