### PR TITLE
Add an opt-in default for freezing the first results column

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2819,6 +2819,11 @@
                     "default": false,
                     "description": "%mssql.resultsGrid.alternatingRowColors%"
                 },
+                "mssql.resultsGrid.freezeFirstColumnByDefault": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%mssql.resultsGrid.freezeFirstColumnByDefault%"
+                },
                 "mssql.resultsGrid.showGridLines": {
                     "type": "string",
                     "default": "both",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -191,6 +191,7 @@
     "mssql.resultsGrid.disableAutoSizingEnumDescription": "Disable automatic column sizing",
     "mssql.resultsGrid.inMemoryDataProcessingThreshold": "Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled. Warning: Increasing this may impact performance.",
     "mssql.resultsGrid.alternatingRowColors": "Enable alternating row background colors (zebra striping) in the results grid. The color is derived from the current VS Code theme.",
+    "mssql.resultsGrid.freezeFirstColumnByDefault": "Freeze the first data column by default in new result grids. Existing saved grid state takes precedence.",
     "mssql.resultsGrid.showGridLines": "Control which grid lines are visible in the results grid.",
     "mssql.resultsGrid.showGridLines.both": "Show both horizontal and vertical grid lines",
     "mssql.resultsGrid.showGridLines.horizontal": "Show only horizontal grid lines",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -325,6 +325,7 @@ export const configAutoColumnSizingMode = "resultsGrid.autoSizeColumnsMode";
 export const configInMemoryDataProcessingThreshold =
     "mssql.resultsGrid.inMemoryDataProcessingThreshold";
 export const configResultsGridAlternatingRowColors = "resultsGrid.alternatingRowColors";
+export const configResultsGridFreezeFirstColumnByDefault = "resultsGrid.freezeFirstColumnByDefault";
 export const configResultsGridShowGridLines = "resultsGrid.showGridLines";
 export const configResultsGridRowPadding = "resultsGrid.rowPadding";
 export const configAutoDisableNonTSqlLanguageService = "mssql.autoDisableNonTSqlLanguageService";

--- a/extensions/mssql/src/queryResult/queryResultWebViewController.ts
+++ b/extensions/mssql/src/queryResult/queryResultWebViewController.ts
@@ -166,6 +166,7 @@ export class QueryResultWebviewController extends WebviewViewController<
                 }
                 if (
                     e.affectsConfiguration("mssql.resultsGrid.alternatingRowColors") ||
+                    e.affectsConfiguration("mssql.resultsGrid.freezeFirstColumnByDefault") ||
                     e.affectsConfiguration("mssql.resultsGrid.showGridLines") ||
                     e.affectsConfiguration("mssql.resultsGrid.rowPadding")
                 ) {
@@ -498,6 +499,9 @@ export class QueryResultWebviewController extends WebviewViewController<
         return {
             alternatingRowColors:
                 (config.get(Constants.configResultsGridAlternatingRowColors) as boolean) ?? false,
+            freezeFirstColumnByDefault:
+                (config.get(Constants.configResultsGridFreezeFirstColumnByDefault) as boolean) ??
+                false,
             showGridLines,
             rowPadding: config.get(Constants.configResultsGridRowPadding) as number | undefined,
         };

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -65,6 +65,7 @@ export type GridLinesMode = "both" | "horizontal" | "vertical" | "none";
 
 export interface GridSettings {
     alternatingRowColors?: boolean;
+    freezeFirstColumnByDefault?: boolean;
     showGridLines?: GridLinesMode;
     rowPadding?: number | null;
 }

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
@@ -13,12 +13,25 @@ import type { FluentResultGridState } from "../types/fluentResultGridState";
 import {
     FLUENT_RESULT_GRID_DEFAULT_COLUMN_WIDTH,
     FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE,
+    FLUENT_RESULT_GRID_FIRST_DATA_CELL_INDEX,
     FLUENT_RESULT_GRID_ROW_NUMBER_COLUMN_ID,
 } from "./fluentResultGridConstants";
 import type { FluentResultGridDataRow } from "./fluentResultGridDataView";
 import { getFluentResultGridDataSelectionsFromRanges } from "./fluentResultGridSelection";
 
 export const FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX = 0;
+
+export function getFluentResultGridInitialFrozenColumnIndex(
+    savedFrozenColumnIndex: number | undefined,
+    freezeFirstColumnByDefault: boolean,
+): number {
+    return (
+        savedFrozenColumnIndex ??
+        (freezeFirstColumnByDefault
+            ? FLUENT_RESULT_GRID_FIRST_DATA_CELL_INDEX
+            : FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX)
+    );
+}
 
 export function normalizeFluentResultGridRowPadding(rowPadding: number | null | undefined): number {
     return typeof rowPadding === "number" && Number.isFinite(rowPadding)

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
@@ -29,6 +29,7 @@ import { QueryResultsGridView } from "./queryResultsGridView";
 import { QueryResultCommandsContext } from "./queryResultStateProvider";
 import { useQueryResultSelector } from "./queryResultSelector";
 import type { ResultGridHandle, ResultGridProps } from "./resultGrid";
+import { getFluentResultGridInitialFrozenColumnIndex } from "../../common/FluentResultGrid/internal/fluentResultGridState";
 
 const DEFAULT_FONT_SIZE = 12;
 const BASE_ROW_PADDING = 12;
@@ -487,6 +488,7 @@ function areResultSetSummariesEquivalent(
 
 const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps>((props, ref) => {
     const context = useContext(QueryResultCommandsContext);
+    const extensionRpc = context?.extensionRpc;
     const uri = useQueryResultSelector((state) => state.uri);
     const fontSettings = useQueryResultSelector((state) => state.fontSettings);
     const gridSettings = useQueryResultSelector((state) => state.gridSettings);
@@ -508,9 +510,11 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
     const filtersSignatureRef = useRef<string | undefined>(undefined);
     const gridViewStateSignatureRef = useRef<string | undefined>(undefined);
     const scrollPositionSignatureRef = useRef<string | undefined>(undefined);
+    const freezeFirstColumnByDefaultRef = useRef(gridSettings?.freezeFirstColumnByDefault ?? false);
+    freezeFirstColumnByDefaultRef.current = gridSettings?.freezeFirstColumnByDefault ?? false;
 
     useEffect(() => {
-        if (!context || !uri) {
+        if (!extensionRpc || !uri) {
             return;
         }
 
@@ -519,19 +523,19 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
         setIsInitialStateLoaded(false);
         void (async () => {
             const [filters, columnWidths, gridViewState, scrollPosition] = await Promise.all([
-                context.extensionRpc.sendRequest(qr.GetFiltersRequest.type, {
+                extensionRpc.sendRequest(qr.GetFiltersRequest.type, {
                     uri,
                     gridId: props.gridId,
                 }),
-                context.extensionRpc.sendRequest(qr.GetColumnWidthsRequest.type, {
+                extensionRpc.sendRequest(qr.GetColumnWidthsRequest.type, {
                     uri,
                     gridId: props.gridId,
                 }),
-                context.extensionRpc.sendRequest(qr.GetGridViewStateRequest.type, {
+                extensionRpc.sendRequest(qr.GetGridViewStateRequest.type, {
                     uri,
                     gridId: props.gridId,
                 }),
-                context.extensionRpc.sendRequest(qr.GetGridScrollPositionRequest.type, {
+                extensionRpc.sendRequest(qr.GetGridScrollPositionRequest.type, {
                     uri,
                     gridId: props.gridId,
                 }),
@@ -543,6 +547,10 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
 
             const nextInitialState: FluentResultGridState = {
                 ...(gridViewState ?? {}),
+                frozenColumnIndex: getFluentResultGridInitialFrozenColumnIndex(
+                    gridViewState?.frozenColumnIndex,
+                    freezeFirstColumnByDefaultRef.current,
+                ),
                 columnWidths,
                 filters: filters ?? {},
                 sort: getSortStateFromFilters(filters),
@@ -560,18 +568,18 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
         return () => {
             disposed = true;
         };
-    }, [context, props.gridId, uri]);
+    }, [extensionRpc, props.gridId, uri]);
 
     const dataSource = useMemo(
         () => ({
             kind: "windowed" as const,
             rowCount: latestDataSourceRowCountRef.current,
             getRows: async (offset: number, count: number) => {
-                if (!context || !uri) {
+                if (!extensionRpc || !uri) {
                     return [];
                 }
 
-                const response = await context.extensionRpc.sendRequest(qr.GetRowsRequest.type, {
+                const response = await extensionRpc.sendRequest(qr.GetRowsRequest.type, {
                     uri,
                     batchId: props.batchId,
                     resultId: props.resultId,
@@ -581,7 +589,7 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
                 return response?.rows ?? [];
             },
         }),
-        [context, props.batchId, props.resultId, uri],
+        [extensionRpc, props.batchId, props.resultId, uri],
     );
 
     const handleStateChange = useCallback(

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridTransforms";
 import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
+    getFluentResultGridInitialFrozenColumnIndex,
     normalizeFluentResultGridFrozenColumnIndex,
     stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
@@ -130,6 +131,13 @@ suite("Fluent Result Grid", () => {
     });
 
     suite("state helpers", () => {
+        test("uses the optional freeze-first-column default only when no saved state exists", () => {
+            expect(getFluentResultGridInitialFrozenColumnIndex(undefined, false)).to.equal(0);
+            expect(getFluentResultGridInitialFrozenColumnIndex(undefined, true)).to.equal(1);
+            expect(getFluentResultGridInitialFrozenColumnIndex(0, true)).to.equal(0);
+            expect(getFluentResultGridInitialFrozenColumnIndex(3, false)).to.equal(3);
+        });
+
         test("clamps frozen column index to the valid column range", () => {
             expect(normalizeFluentResultGridFrozenColumnIndex(undefined, 5)).to.equal(
                 FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,

--- a/extensions/mssql/test/unit/queryResultWebViewController.test.ts
+++ b/extensions/mssql/test/unit/queryResultWebViewController.test.ts
@@ -124,6 +124,16 @@ suite("QueryResultWebviewController", () => {
         expect(resolve).to.not.have.been.called;
     });
 
+    test("keeps freeze-first-column disabled by default and reads an explicit opt-in", () => {
+        expect(controller.getGridSettingsConfig().freezeFirstColumnByDefault).to.be.false;
+
+        configuration.get
+            .withArgs(Constants.configResultsGridFreezeFirstColumnByDefault)
+            .returns(true);
+
+        expect(controller.getGridSettingsConfig().freezeFirstColumnByDefault).to.be.true;
+    });
+
     test("moves current result to a tab when the setting is enabled through configuration change", async () => {
         openResultsInTabByDefault = true;
         const createPanelControllerStub = sandbox

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -9365,6 +9365,9 @@
     <trans-unit id="mssql.walkthroughs.nextSteps.objectExplorerFilters.title">
       <source xml:lang="en">Filter your Object Explorer Tree</source>
     </trans-unit>
+    <trans-unit id="mssql.resultsGrid.freezeFirstColumnByDefault">
+      <source xml:lang="en">Freeze the first data column by default in new result grids. Existing saved grid state takes precedence.</source>
+    </trans-unit>
     <trans-unit id="mssql.sqlScriptsSubmenu">
       <source xml:lang="en">Generate Script</source>
     </trans-unit>


### PR DESCRIPTION
## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

- Adds an opt-in setting to freeze the first data column in newly created Beta result grids.
- Keeps the setting disabled by default.
- Preserves saved per-grid frozen-column state instead of overriding an existing user choice.
- Refreshes grid settings when the configuration changes and covers default/opt-in behavior with tests.

Related issue: [#22782](https://github.com/microsoft/vscode-mssql/issues/22782)

## Screenshots

| View / state | Screenshot |
| --- | --- |
| Results Grid settings and a new Beta Grid with freeze-first-column enabled | <img width="792" height="152" alt="image" src="https://github.com/user-attachments/assets/bc6cd001-7d3c-4441-b989-ed74646462bc" /> |

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
