### PR TITLE
Support Ctrl+Insert for copying result selections

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboard.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridKeyboard.ts
@@ -12,6 +12,7 @@ import {
     FluentResultGridCommand,
     type FluentResultGridBuiltInCommandId,
 } from "../types/fluentResultGridCommandIds";
+import { isCtrlInsertCopyShortcut } from "../../keyboardUtils";
 
 export type FluentResultGridKeyboardShortcutEvent = Pick<
     KeyboardEvent,
@@ -88,6 +89,10 @@ export function getFluentResultGridKeyboardAction(
     event: FluentResultGridKeyboardShortcutEvent,
     keyBindings: FluentResultGridKeyBindingMap,
 ): FluentResultGridKeyboardAction | undefined {
+    if (isCtrlInsertCopyShortcut(event)) {
+        return { kind: "command", commandId: FluentResultGridCommand.CopySelection };
+    }
+
     const shortcutOnlyCommands = [
         FluentResultGridCommand.CopySelection,
         FluentResultGridCommand.CopyWithHeaders,

--- a/extensions/mssql/src/webviews/common/keyboardUtils.ts
+++ b/extensions/mssql/src/webviews/common/keyboardUtils.ts
@@ -286,3 +286,18 @@ export function eventMatchesShortcut(
     // If neither code nor key specified, we can't match.
     return false;
 }
+
+/**
+ * Returns whether the keyboard event is the standard Ctrl+Insert Copy alternative.
+ */
+export function isCtrlInsertCopyShortcut(
+    event: Pick<KeyboardEvent, "altKey" | "code" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+): boolean {
+    return (
+        event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        (event.code === "Insert" || event.key === "Insert")
+    );
+}

--- a/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/table/plugins/copyKeybind.plugin.ts
@@ -23,7 +23,7 @@ import {
 } from "../utils";
 import { QueryResultReactProvider } from "../../queryResultStateProvider";
 import { WebviewAction, WebviewKeyBindings } from "../../../../../sharedInterfaces/webview";
-import { eventMatchesShortcut } from "../../../../common/keyboardUtils";
+import { eventMatchesShortcut, isCtrlInsertCopyShortcut } from "../../../../common/keyboardUtils";
 
 /**
  * Implements the various additional navigation keybindings we want out of slickgrid
@@ -61,7 +61,8 @@ export class CopyKeybind<T extends Slick.SlickData> implements Slick.Plugin<T> {
             eventMatchesShortcut(
                 e,
                 this.keyBindings[WebviewAction.ResultGridCopySelection].keyCombination,
-            )
+            ) ||
+            isCtrlInsertCopyShortcut(e)
         ) {
             handled = true;
             await this.copySelection(false);

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -182,6 +182,18 @@ suite("Fluent Result Grid", () => {
             });
         });
 
+        test("maps Ctrl+Insert to Copy selection", () => {
+            const action = getFluentResultGridKeyboardAction(
+                keyboardEvent({ code: "Insert", ctrlKey: true, key: "Insert" }),
+                {},
+            );
+
+            expect(action).to.deep.equal({
+                kind: "command",
+                commandId: FluentResultGridCommand.CopySelection,
+            });
+        });
+
         test("maps fallback select-all and shift-arrow shortcuts", () => {
             expect(
                 getFluentResultGridKeyboardAction(

--- a/extensions/mssql/test/unit/keyboardUtils.test.ts
+++ b/extensions/mssql/test/unit/keyboardUtils.test.ts
@@ -9,6 +9,7 @@ import {
     getShortcutInfo,
     parseWebviewKeyboardShortcutConfig,
     eventMatchesShortcut,
+    isCtrlInsertCopyShortcut,
 } from "../../src/webviews/common/keyboardUtils";
 import {
     WebviewAction,
@@ -30,6 +31,37 @@ suite("keyboardUtils Tests", () => {
 
     teardown(() => {
         sandbox.restore();
+    });
+
+    suite("isCtrlInsertCopyShortcut", () => {
+        test("matches Ctrl+Insert without additional modifiers", () => {
+            expect(
+                isCtrlInsertCopyShortcut({
+                    altKey: false,
+                    code: "Insert",
+                    ctrlKey: true,
+                    key: "Insert",
+                    metaKey: false,
+                    shiftKey: false,
+                }),
+            ).to.equal(true);
+        });
+
+        test("rejects Insert without Ctrl and Ctrl+Shift+Insert", () => {
+            const event = {
+                altKey: false,
+                code: "Insert",
+                ctrlKey: false,
+                key: "Insert",
+                metaKey: false,
+                shiftKey: false,
+            };
+
+            expect(isCtrlInsertCopyShortcut(event)).to.equal(false);
+            expect(isCtrlInsertCopyShortcut({ ...event, ctrlKey: true, shiftKey: true })).to.equal(
+                false,
+            );
+        });
     });
 
     suite("getShortcutInfo", () => {


### PR DESCRIPTION
## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

- Adds Ctrl+Insert as an alternative shortcut for copying the current result-grid selection.
- Uses the same shortcut detection in the old and Beta result grids while preserving the configurable Ctrl/Cmd+C primary shortcut.
- Requires the exact Ctrl+Insert combination so shortcuts with additional modifiers keep their existing behavior.

Related issue: [#22759](https://github.com/microsoft/vscode-mssql/issues/22759)

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| Old Query Results grid after pressing Ctrl+Insert on a selection | <!-- Add before screenshot --> | <!-- Add after screenshot --> |
| Beta Query Results grid after pressing Ctrl+Insert on a selection | <!-- Add before screenshot --> | <!-- Add after screenshot --> |

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
