### PR TITLE
Preserve Beta Grid selection on secondary-button drag

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridCellRangeSelector.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridCellRangeSelector.ts
@@ -21,6 +21,22 @@ export function isFluentResultGridAppendSelectionEvent(
 }
 
 /**
+ * True when a drag gesture was started with a mouse button other than the primary one.
+ *
+ * SlickEventData proxies the native event's properties but does not declare them, so the button
+ * is read from either the wrapper or the native event it carries. Touch and keyboard gestures
+ * report no button and are always treated as primary.
+ */
+export function isFluentResultGridSecondaryButtonEvent(event: unknown): boolean {
+    const source = event as
+        | { button?: number; nativeEvent?: { button?: number } | null }
+        | null
+        | undefined;
+    const button = source?.button ?? source?.nativeEvent?.button;
+    return button !== undefined && button !== 0;
+}
+
+/**
  * SlickGrid applies grid options with a jQuery-style deep extend, which keeps the default array
  * entries when an empty array is supplied. Its drag service captures the resulting array by
  * reference during initialization; clearing that array in place enables modifier drags.
@@ -44,7 +60,34 @@ export class FluentResultGridCellRangeSelector extends SlickCellRangeSelector {
         return this._appendToSelection;
     }
 
+    /**
+     * Range selection is a primary-button gesture. The drag service this grid uses binds
+     * `mousedown` for every button, so without this a right-click that moves even slightly is
+     * processed as a fresh single-cell drag and replaces a Ctrl/Cmd-built selection before the
+     * context menu opens. The Production Grid gets the same protection from its drag library.
+     */
+    protected override handleDragInit(eventData: SlickEventData, dragData: DragRowMove): void {
+        if (isFluentResultGridSecondaryButtonEvent(eventData)) {
+            return;
+        }
+        super.handleDragInit(eventData, dragData);
+    }
+
+    protected override handleDragStart(
+        eventData: SlickEventData,
+        dragData: DragRowMove,
+    ): HTMLDivElement | undefined {
+        if (isFluentResultGridSecondaryButtonEvent(eventData)) {
+            return undefined;
+        }
+        return super.handleDragStart(eventData, dragData);
+    }
+
     protected override handleDragEnd(eventData: SlickEventData, dragData: DragRowMove): void {
+        if (isFluentResultGridSecondaryButtonEvent(eventData)) {
+            return;
+        }
+
         this._appendToSelection = isFluentResultGridAppendSelectionEvent(eventData);
         try {
             // onCellRangeSelected is raised synchronously inside the base implementation.

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -47,6 +47,7 @@ import type { SlickGrid } from "slickgrid-react";
 import {
     enableFluentResultGridModifierDrag,
     isFluentResultGridAppendSelectionEvent,
+    isFluentResultGridSecondaryButtonEvent,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCellRangeSelector";
 
 function cell(value: string | null): DbCellValue {
@@ -181,6 +182,23 @@ suite("Fluent Result Grid", () => {
             expect(isFluentResultGridAppendSelectionEvent({})).to.be.false;
             expect(isFluentResultGridAppendSelectionEvent({ ctrlKey: true })).to.be.true;
             expect(isFluentResultGridAppendSelectionEvent({ metaKey: true })).to.be.true;
+        });
+
+        test("treats non-primary mouse buttons as secondary drag gestures", () => {
+            // Right-click must not start a range selection: the drag service binds mousedown for
+            // every button, so an unguarded right-drag replaces a Ctrl-built selection.
+            expect(isFluentResultGridSecondaryButtonEvent({ button: 2 })).to.be.true;
+            expect(isFluentResultGridSecondaryButtonEvent({ button: 1 })).to.be.true;
+            expect(isFluentResultGridSecondaryButtonEvent({ nativeEvent: { button: 2 } })).to.be
+                .true;
+
+            expect(isFluentResultGridSecondaryButtonEvent({ button: 0 })).to.be.false;
+            expect(isFluentResultGridSecondaryButtonEvent({ nativeEvent: { button: 0 } })).to.be
+                .false;
+            // Touch and keyboard gestures report no button at all.
+            expect(isFluentResultGridSecondaryButtonEvent({})).to.be.false;
+            expect(isFluentResultGridSecondaryButtonEvent(undefined)).to.be.false;
+            expect(isFluentResultGridSecondaryButtonEvent({ nativeEvent: null })).to.be.false;
         });
 
         test("removes SlickGrid's option-merged modifier drag blockers in place", () => {


### PR DESCRIPTION
## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

Related to #22806.

- Restricts Beta Grid cell-range drag selection to primary-button gestures.
- Preserves Ctrl/Cmd-built multi-cell selections when secondary-button movement precedes the context menu.
- Adds unit coverage for primary, secondary, native-event, touch, and keyboard button detection.

## Validation

- `npm run build:webviews -- --pretty false`
- Pre-commit ESLint checks completed successfully.

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| Beta query results grid with a Ctrl/Cmd multi-cell selection while opening the context menu | <!-- Add before screenshot --> | <!-- Add after screenshot --> |

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
