### PR TITLE
Changelog updates for 1.45.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Version 1.45.1
+
+- Release date: August 26, 2026
+- Release status: GA
+
+### What's new in 1.45.1
+
+- Improved cell selection in the new Query Results Grid (Preview) to match the familiar classic grid experience, including support for multi-cell selection with Ctrl/Cmd+click
+- Fixed an issue where running a query could get stuck on "Executing query" and results would never appear
+- Restored the "Executing query" timer in the status bar while queries run, with a new `mssql.statusBar.showQueryExecutionStatus` setting to hide it if you prefer
+- Added an option to always freeze the first column of query results, so key values stay visible while scrolling wide result sets. Enable with `mssql.resultsGrid.freezeFirstColumnByDefault` in settings
+- Added Ctrl+Insert as an alternative shortcut for copying selected results
+- Added a Preview Grid toggle to the Query Results toolbar so you can switch between the new and classic results grids without editing settings
+- Added missing index recommendations to the execution plan view, making it easy to spot indexing opportunities for slow queries
+
 ## Version 1.45.0
 
 - Release date: August 19, 2026

--- a/extensions/mssql/CHANGELOG.md
+++ b/extensions/mssql/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Version 1.45.1
+
+- Release date: August 26, 2026
+- Release status: GA
+
+### What's new in 1.45.1
+
+- Improved cell selection in the new Query Results Grid (Preview) to match the familiar classic grid experience, including support for multi-cell selection with Ctrl/Cmd+click
+- Fixed an issue where running a query could get stuck on "Executing query" and results would never appear
+- Restored the "Executing query" timer in the status bar while queries run, with a new `mssql.statusBar.showQueryExecutionStatus` setting to hide it if you prefer
+- Added an option to always freeze the first column of query results, so key values stay visible while scrolling wide result sets. Enable with `mssql.resultsGrid.freezeFirstColumnByDefault` in settings
+- Added Ctrl+Insert as an alternative shortcut for copying selected results
+- Added a Preview Grid toggle to the Query Results toolbar so you can switch between the new and classic results grids without editing settings
+- Added missing index recommendations to the execution plan view, making it easy to spot indexing opportunities for slow queries
+
 ## Version 1.45.0
 
 - Release date: August 19, 2026


### PR DESCRIPTION
## Description

Addresses #22790

Adds the 1.45.1 changelog section to `CHANGELOG.md` and `extensions/mssql/CHANGELOG.md`, covering the fixes and features ported to `release/1.45` for the August 2026 Hotfix 1 release:

- Query Results Grid (Preview) selection improvements — #22792, #22807
- Query results hang fix — #22773
- "Executing query" status bar restore + `mssql.statusBar.showQueryExecutionStatus` — #22774
- Freeze first column option (`mssql.resultsGrid.freezeFirstColumnByDefault`) — #22794
- Ctrl+Insert copy shortcut — #22795
- Preview Grid toggle in the results toolbar — #22808
- Missing index recommendations in the execution plan view — #22768

## Code Changes Checklist

- [ ] New or updated **unit tests** added (N/A — changelog only)
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant (N/A)
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)