### PR TITLE
Fix signed-out tenant browsing

### DIFF
--- a/extensions/mssql/src/connectionconfig/azureHelpers.ts
+++ b/extensions/mssql/src/connectionconfig/azureHelpers.ts
@@ -264,11 +264,34 @@ export class VsCodeAzureHelper {
             account = typeof account === "string" ? await this.getAccountById(account) : account;
 
             const auth: VSCodeAzureSubscriptionProvider = VsCodeAzureHelper.getProvider();
+            const accountSignedIn = await auth.isSignedIn(undefined, account);
+
+            if (!accountSignedIn) {
+                const homeTenantId = this.getHomeTenantIdForAccount(account);
+                if (!homeTenantId) {
+                    azureHelperLogger.warn(
+                        "Tenant discovery cannot offer home-tenant sign-in because the account ID does not contain a tenant ID.",
+                    );
+                    return [];
+                }
+
+                return [
+                    {
+                        tenantId: homeTenantId,
+                        displayName: homeTenantId,
+                        account,
+                    },
+                ];
+            }
+
             const tenants = [...(await auth.getTenants(account))]; // spread operator to create a new array since sort() mutates the array
 
             return tenants.sort((a, b) => a.displayName.localeCompare(b.displayName));
         } catch (error) {
-            azureHelperLogger.error("Error fetching tenants for account", getErrorMessage(error));
+            azureHelperLogger.error(
+                "Tenant discovery failed while fetching tenants for account",
+                getErrorMessage(error),
+            );
             return [];
         }
     }

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -2475,18 +2475,25 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
     ): Promise<boolean> {
         const azureAccount = await VsCodeAzureHelper.getAccountById(state.selectedAccountId);
         const auth = VsCodeAzureHelper.getProvider();
+        const homeTenantId = VsCodeAzureHelper.getHomeTenantIdForAccount(azureAccount);
 
-        const signedIn = await auth.signIn(tenantId, azureAccount);
+        const signedIn = await auth.signIn(
+            tenantId === homeTenantId ? undefined : tenantId,
+            azureAccount,
+        );
 
-        // Refresh isSignedIn status for all tenants so the UI reflects the change
+        // Reload tenant metadata after sign-in so a home-tenant fallback is replaced by the full list.
         if (signedIn) {
+            const tenants = await VsCodeAzureHelper.getTenantsForAccount(azureAccount);
             const statuses = await Promise.all(
-                state.azureTenants.map((t) => auth.isSignedIn(t.id, azureAccount)),
+                tenants.map((tenant) => auth.isSignedIn(tenant.tenantId, azureAccount)),
             );
-            state.azureTenants = state.azureTenants.map((t, i) => ({
-                ...t,
-                isSignedIn: statuses[i],
+            state.azureTenants = tenants.map((tenant, index) => ({
+                id: tenant.tenantId!,
+                name: tenant.displayName!,
+                isSignedIn: statuses[index],
             }));
+            state.selectedTenantId = tenantId;
             this.updateState(state);
         }
 

--- a/extensions/mssql/test/unit/azureHelpers.test.ts
+++ b/extensions/mssql/test/unit/azureHelpers.test.ts
@@ -144,6 +144,7 @@ suite("Azure Helpers", () => {
             const account = mockAccounts.signedInAccount;
 
             sandbox.stub(azureHelpers.VsCodeAzureHelper, "getProvider").returns({
+                isSignedIn: () => Promise.resolve(true),
                 getTenants: (account) => {
                     // only the first account is signed in for this mock
                     if (account.id === mockAccounts.signedInAccount.id) {
@@ -157,6 +158,28 @@ suite("Azure Helpers", () => {
 
             const tenants = await azureHelpers.VsCodeAzureHelper.getTenantsForAccount(account);
             expect(tenants).to.deep.equal([mockTenants[1], mockTenants[0]]); // Tenants are returned alphabetically
+        });
+
+        test("getTenantsForAccount returns the home tenant when the account is signed out", async () => {
+            const provider = sandbox.createStubInstance(VSCodeAzureSubscriptionProvider);
+            provider.isSignedIn.resolves(false);
+            sandbox.stub(azureHelpers.VsCodeAzureHelper, "getProvider").returns(provider);
+
+            const tenants = await azureHelpers.VsCodeAzureHelper.getTenantsForAccount(
+                mockAccounts.notSignedInAccount,
+            );
+
+            const homeTenantId = azureHelpers.VsCodeAzureHelper.getHomeTenantIdForAccount(
+                mockAccounts.notSignedInAccount,
+            );
+            expect(tenants).to.deep.equal([
+                {
+                    tenantId: homeTenantId,
+                    displayName: homeTenantId,
+                    account: mockAccounts.notSignedInAccount,
+                },
+            ]);
+            expect(provider.getTenants.notCalled).to.be.true;
         });
 
         test("getSubscriptionsForTenant", async () => {

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -808,6 +808,53 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 expect(azureAutoLoad.calledOnce).to.be.true;
                 expect(fabricLoad.notCalled).to.be.true;
             });
+
+            test("reloads all tenants after signing into a signed-out tenant", async () => {
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getAccountById")
+                    .resolves(mockAccounts.signedInAccount);
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getTenantsForAccount")
+                    .resolves(mockTenants.slice(0, 2));
+                sandbox
+                    .stub(AzureHelpers.VsCodeAzureHelper, "getHomeTenantIdForAccount")
+                    .returns(mockTenants[0].tenantId);
+
+                const provider = sandbox.createStubInstance(VSCodeAzureSubscriptionProvider);
+                provider.signIn.resolves(true);
+                provider.isSignedIn.resolves(true);
+                sandbox.stub(AzureHelpers.VsCodeAzureHelper, "getProvider").returns(provider);
+                sandbox.stub(controller["_azureBrowseProvider"], "loadCollections").resolves();
+                sandbox.stub(controller["_azureBrowseProvider"], "autoLoadContents").resolves();
+
+                const selectedTenant = mockTenants[0];
+                controller.state.selectedAccountId = mockAccounts.signedInAccount.id;
+                controller.state.selectedInputMode = ConnectionInputMode.AzureBrowse;
+                controller.state.azureTenants = [
+                    {
+                        id: selectedTenant.tenantId,
+                        name: selectedTenant.tenantId,
+                        isSignedIn: false,
+                    },
+                ];
+
+                await controller["_reducerHandlers"].get("setSelectedTenantId")(controller.state, {
+                    tenantId: selectedTenant.tenantId,
+                });
+
+                expect(controller.state.azureTenants).to.deep.equal(
+                    mockTenants.slice(0, 2).map((tenant) => ({
+                        id: tenant.tenantId,
+                        name: tenant.displayName,
+                        isSignedIn: true,
+                    })),
+                );
+                expect(controller.state.selectedTenantId).to.equal(selectedTenant.tenantId);
+                expect(provider.signIn).to.have.been.calledWith(
+                    undefined,
+                    mockAccounts.signedInAccount,
+                );
+            });
         });
 
         suite("signIntoAzureForBrowse", () => {


### PR DESCRIPTION
## Summary

- show the account's home tenant when Azure tenant discovery is blocked by a signed-out account
- use account-level sign-in for the home tenant, then refresh the complete tenant list and sign-in statuses
- add unit coverage for the signed-out fallback and post-sign-in tenant refresh

## Testing

Unit tests will be run after this draft PR is created, per the requested workflow.