### PR TITLE
Adjust MSSQL extension log levels

### DIFF
--- a/extensions/mssql/src/azure/accountStore.ts
+++ b/extensions/mssql/src/azure/accountStore.ts
@@ -63,7 +63,7 @@ export class AccountStore implements IAccountStore {
         let accounts =
             this._context.globalState.get<IAccount[]>(Constants.configAzureAccount) ?? [];
 
-        this._logger.info(`Retrieved ${accounts.length} Entra accounts from account store.`);
+        this._logger.debug(`Retrieved ${accounts.length} Entra accounts from account store.`);
         return accounts;
     }
 

--- a/extensions/mssql/src/azure/fileEncryptionHelper.ts
+++ b/extensions/mssql/src/azure/fileEncryptionHelper.ts
@@ -135,7 +135,7 @@ export class FileEncryptionHelper {
                 (result) => {
                     status = result;
                     if (result) {
-                        this._logger.info(
+                        this._logger.debug(
                             `FileEncryptionHelper: Successfully saved encryption key ${prefixedCredentialId} for persistent cache encryption in system credential store.`,
                         );
                     }

--- a/extensions/mssql/src/azure/msal/msalAzureAuth.ts
+++ b/extensions/mssql/src/azure/msal/msalAzureAuth.ts
@@ -186,7 +186,7 @@ export abstract class MsalAzureAuth {
         }
 
         let authority = this.loginEndpointUrl + tenantId;
-        this.logger.info(`Authority URL set to: ${authority}`);
+        this.logger.debug(`Authority URL set to: ${authority}`);
 
         // construct request
         // forceRefresh needs to be set true here in order to fetch the correct token, due to this issue
@@ -325,7 +325,7 @@ export abstract class MsalAzureAuth {
                     tenantList.push(tenantInfo.displayName);
                 } else {
                     tenantList.push(tenantInfo.tenantId);
-                    this.logger.info("Tenant display name found empty: {0}", tenantInfo.tenantId);
+                    this.logger.debug("Tenant display name found empty: {0}", tenantInfo.tenantId);
                 }
                 return {
                     id: tenantInfo.tenantId,
@@ -476,7 +476,7 @@ export abstract class MsalAzureAuth {
                 displayName: "Microsoft Account",
             };
         } else {
-            this.logger.info(
+            this.logger.debug(
                 "Could not find tenant information from tokenClaims, falling back to common Tenant.",
             );
         }

--- a/extensions/mssql/src/azure/msal/msalAzureCodeGrant.ts
+++ b/extensions/mssql/src/azure/msal/msalAzureCodeGrant.ts
@@ -79,7 +79,7 @@ export class MsalAzureCodeGrant extends MsalAzureAuth {
         const effectiveScopes = scopes ?? this.scopes;
 
         let authority = this.loginEndpointUrl + tenant.id;
-        this.logger.info(`Authority URL set to: ${authority}`);
+        this.logger.debug(`Authority URL set to: ${authority}`);
 
         try {
             let authUrlRequest: AuthorizationUrlRequest;

--- a/extensions/mssql/src/azure/msal/msalAzureDeviceCode.ts
+++ b/extensions/mssql/src/azure/msal/msalAzureDeviceCode.ts
@@ -34,7 +34,7 @@ export class MsalAzureDeviceCode extends MsalAzureAuth {
         );
 
         let authority = this.loginEndpointUrl + tenant.id;
-        this.logger.info(`Authority URL set to: ${authority}`);
+        this.logger.debug(`Authority URL set to: ${authority}`);
 
         const effectiveScopes = scopes ?? this.scopes;
 

--- a/extensions/mssql/src/backgroundTasks/backgroundTasksService.ts
+++ b/extensions/mssql/src/backgroundTasks/backgroundTasksService.ts
@@ -322,7 +322,7 @@ export class BackgroundTasksService {
 
         this.trimFinishedTasks();
         this._refreshCallback();
-        this._logger.info("Completed background task", {
+        this._logger.debug("Completed background task", {
             ...getTaskLogContext(task),
             finalState,
         });

--- a/extensions/mssql/src/connectionSharing/connectionSharingService.ts
+++ b/extensions/mssql/src/connectionSharing/connectionSharingService.ts
@@ -166,7 +166,9 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
                     );
 
                     if (response !== LocalizedConstants.ConnectionSharing.Clear) {
-                        this._logger.info("User canceled clearing connection sharing permissions.");
+                        this._logger.debug(
+                            "User canceled clearing connection sharing permissions.",
+                        );
                         return;
                     }
                     await this.setApprovedExtensions({});
@@ -246,16 +248,16 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
         const currentPermission = await this.getExtensionPermission(extensionId);
 
         if (currentPermission === "approved") {
-            this._logger.info(`Connection sharing already approved for extension: ${extensionId}`);
+            this._logger.debug(`Connection sharing already approved for extension: ${extensionId}`);
             return true;
         }
 
         if (currentPermission === "denied") {
-            this._logger.info(`Connection sharing denied for extension: ${extensionId}`);
+            this._logger.debug(`Connection sharing denied for extension: ${extensionId}`);
             return false;
         }
 
-        this._logger.info(
+        this._logger.debug(
             `No existing permission for extension: ${extensionId}, requesting approval`,
         );
 
@@ -267,7 +269,7 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
         );
 
         if (!userChoice) {
-            this._logger.info(
+            this._logger.debug(
                 `User canceled connection sharing request for extension: ${extensionId}`,
             );
             return false;
@@ -729,7 +731,7 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
         extensionId?: string,
     ): Promise<ExtensionPermission | undefined> {
         this.recordConnectionSharingApiCall("editConnectionSharingPermissions", extensionId);
-        this._logger.info(
+        this._logger.debug(
             `Editing connection sharing permissions for extension: ${extensionId ?? "not specified"}`,
         );
         if (!extensionId) {
@@ -800,7 +802,7 @@ export class ConnectionSharingService implements mssql.IConnectionSharingService
 
         const newApproval: ExtensionPermission = newPermission.detail as ExtensionPermission;
         await this.updateExtensionPermission(extensionId, newApproval);
-        this._logger.info(
+        this._logger.debug(
             `Updated permission for extension "${extensionDisplayName}" (${extensionId}) to: ${newApproval}`,
         );
         return newApproval;

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1472,7 +1472,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         if (erroredInputs.length > 0) {
             this.state.connectionStatus = ApiStatus.Error;
             this.updateState(state);
-            this.logger.warn("One more more inputs have errors: " + erroredInputs.join(", "));
+            this.logger.debug("One more more inputs have errors: " + erroredInputs.join(", "));
             return undefined;
         }
 

--- a/extensions/mssql/src/controllers/localizationCache.ts
+++ b/extensions/mssql/src/controllers/localizationCache.ts
@@ -37,7 +37,7 @@ export async function getLocalizationFileContentsCached(): Promise<string | unde
             localizationFileCache = fileContents;
             return fileContents;
         } catch (err) {
-            logger.error(`Error reading localization file: ${getErrorMessage(err)}`);
+            logger.warn(`Error reading localization file: ${getErrorMessage(err)}`);
             throw err;
         } finally {
             localizationFileReadPromise = undefined;

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -533,7 +533,7 @@ export default class MainController implements vscode.Disposable {
                             });
                         } else {
                             // The editor already contains text
-                            this._logger.warn("Chat with database: unable to open editor");
+                            this._logger.error("Chat with database: unable to open editor");
                         }
                     } else {
                         // The editor was somehow not created
@@ -2499,7 +2499,7 @@ export default class MainController implements vscode.Disposable {
             let uri = Utils.getActiveTextEditorUri();
             await this._outputContentProvider.cancelQuery(uri);
         } catch (err) {
-            this._logger.warn(`Unexpected error cancelling query: ${getErrorMessage(err)}`);
+            this._logger.error(`Unexpected error cancelling query: ${getErrorMessage(err)}`);
         }
     }
 
@@ -2826,7 +2826,7 @@ export default class MainController implements vscode.Disposable {
                 title,
             );
         } catch (err) {
-            self._logger.warn(
+            self._logger.error(
                 `Unexpected error running current statement: ${getErrorMessage(err)}`,
             );
         }
@@ -2896,7 +2896,7 @@ export default class MainController implements vscode.Disposable {
                 executionPlanOptions,
             );
         } catch (err) {
-            this._logger.warn(`Unexpected error running query: ${getErrorMessage(err)}`);
+            this._logger.error(`Unexpected error running query: ${getErrorMessage(err)}`);
         }
     }
 

--- a/extensions/mssql/src/controllers/sqlDocumentService.ts
+++ b/extensions/mssql/src/controllers/sqlDocumentService.ts
@@ -161,7 +161,7 @@ export default class SqlDocumentService implements vscode.Disposable {
             connectionStrategy = ConnectionStrategy.PromptForConnection;
         }
 
-        this._logger.info("Opening new query", {
+        this._logger.debug("Opening new query", {
             strategy: connectionStrategy,
             nodeType,
             hasConnectionInfo: Boolean(sourceNode?.connectionProfile),
@@ -186,7 +186,7 @@ export default class SqlDocumentService implements vscode.Disposable {
         }
 
         const newEditorUri = getUriKey(newEditor.document.uri);
-        this._logger.info("Created new query editor", { uri: newEditorUri });
+        this._logger.debug("Created new query editor", { uri: newEditorUri });
 
         const connectionResult = this._connectionMgr.getConnectionInfo(newEditorUri);
 
@@ -244,7 +244,7 @@ export default class SqlDocumentService implements vscode.Disposable {
 
         // While not strictly necessary, we check the document signature to avoid false positives in case of multiple SQL documents.
         if (getDocumentSignature(activeUntitledDocument) === getDocumentSignature(newDocument)) {
-            this._logger.info("Transferring document state during save", {
+            this._logger.debug("Transferring document state during save", {
                 oldUri: getUriKey(activeUntitledDocument?.uri),
                 newUri: getUriKey(event.document.uri),
             });
@@ -269,7 +269,7 @@ export default class SqlDocumentService implements vscode.Disposable {
             if (!this._connectionMgr?.isConnected(oldUri)) {
                 continue;
             }
-            this._logger.info("Transferring document state during rename", { oldUri, newUri });
+            this._logger.debug("Transferring document state during rename", { oldUri, newUri });
             this._uriBeingRenamedOrSaved.add(oldUri);
             this._newUriFromRenameOrSave.add(newUri);
             await this.updateUri(oldUri, newUri);
@@ -408,7 +408,7 @@ export default class SqlDocumentService implements vscode.Disposable {
         if (behavior === Constants.NewEditorConnectionBehavior.DefaultConnection) {
             const defaultProfile = await this.getDefaultConnectionProfile();
             if (defaultProfile) {
-                this._logger.info("Auto-connecting opened SQL document from default connection", {
+                this._logger.debug("Auto-connecting opened SQL document from default connection", {
                     uri: docUri,
                 });
                 await this._connectionMgr.connect(docUri, Utils.deepClone(defaultProfile));
@@ -422,7 +422,7 @@ export default class SqlDocumentService implements vscode.Disposable {
             return;
         }
 
-        this._logger.info("Auto-connecting opened SQL document from last active connection", {
+        this._logger.debug("Auto-connecting opened SQL document from last active connection", {
             uri: docUri,
         });
         await this._connectionMgr.connect(docUri, Utils.deepClone(this._lastActiveConnectionInfo));
@@ -582,7 +582,7 @@ export default class SqlDocumentService implements vscode.Disposable {
             connectionConfig?.connectionInfo &&
             this._connectionMgr
         ) {
-            this._logger.info("Connecting new query document", { uri: documentKey });
+            this._logger.debug("Connecting new query document", { uri: documentKey });
             const connectionResult = await this._connectionMgr.connect(
                 documentKey,
                 connectionConfig.connectionInfo,

--- a/extensions/mssql/src/copilot/chatAgentRequestHandler.ts
+++ b/extensions/mssql/src/copilot/chatAgentRequestHandler.ts
@@ -89,29 +89,29 @@ export const createSqlAgentRequestHandler = (
 
         let referenceTexts: string[] = [];
         const activeEditor = vscode.window.activeTextEditor;
-        logger.debug(activeEditor ? "Active editor found." : "No active editor found.");
+        logger.trace(activeEditor ? "Active editor found." : "No active editor found.");
 
         async function findEditorFromReferences(
             references: readonly vscode.ChatPromptReference[],
         ): Promise<vscode.TextEditor | undefined> {
-            logger.debug("in findEditorFromReferences");
+            logger.trace("in findEditorFromReferences");
             const tabGroups = vscode.window.tabGroups.all;
 
             // Function to check if document is SQL
             function isSqlDocument(document: vscode.TextDocument): boolean {
-                logger.debug("in isSqlDocument");
-                logger.debug(`Checking if document is SQL: ${document.languageId}`);
+                logger.trace("in isSqlDocument");
+                logger.trace(`Checking if document is SQL: ${document.languageId}`);
                 // Check if the document is an SQL file
                 // You can add more language IDs as needed
                 // For example, you might want to include "sql" or "mssql" for SQL files
                 const sqlLanguageIds = ["sql", "mssql"];
                 const isSql = sqlLanguageIds.includes(document.languageId);
-                logger.debug(`Is SQL document: ${isSql ? "Yes" : "No"}`);
-                logger.debug("Exiting isSqlDocument");
+                logger.trace(`Is SQL document: ${isSql ? "Yes" : "No"}`);
+                logger.trace("Exiting isSqlDocument");
                 return isSql;
             }
 
-            logger.debug("Checking references...");
+            logger.trace("Checking references...");
             for (const reference of references) {
                 const value = reference.value;
                 let referenceUri: vscode.Uri | undefined;
@@ -122,10 +122,10 @@ export const createSqlAgentRequestHandler = (
                     referenceUri = value;
                 }
 
-                logger.debug(referenceUri ? "Found a reference URI." : "No reference URI found.");
+                logger.trace(referenceUri ? "Found a reference URI." : "No reference URI found.");
 
                 if (referenceUri) {
-                    logger.debug("Looking for matching visible editor...");
+                    logger.trace("Looking for matching visible editor...");
 
                     // Try to find this URI in the visible editors, but only if it's an SQL file
                     const matchingEditor = vscode.window.visibleTextEditors.find(
@@ -135,11 +135,11 @@ export const createSqlAgentRequestHandler = (
                     );
 
                     if (matchingEditor) {
-                        logger.debug("Returning matching visible editor.");
+                        logger.trace("Returning matching visible editor.");
                         return matchingEditor;
                     }
 
-                    logger.debug("No matching visible editor found. Checking tab groups...");
+                    logger.trace("No matching visible editor found. Checking tab groups...");
                     // Try to find this URI in tab groups
                     for (const group of tabGroups) {
                         const activeTab = group.activeTab;
@@ -152,13 +152,13 @@ export const createSqlAgentRequestHandler = (
                                 /* eslint-enable @typescript-eslint/no-explicit-any */
 
                                 if (tabUri && tabUri.toString() === referenceUri.toString()) {
-                                    logger.debug("Found tab URI that matches reference URI.");
+                                    logger.trace("Found tab URI that matches reference URI.");
                                     const editor = vscode.window.visibleTextEditors.find(
                                         (ed) => ed.document.uri.toString() === tabUri.toString(),
                                     );
                                     // Only return the editor if it's an SQL document
                                     if (editor && isSqlDocument(editor.document)) {
-                                        logger.debug("Returning matching SQL editor.");
+                                        logger.trace("Returning matching SQL editor.");
                                         return editor;
                                     }
                                 }
@@ -170,7 +170,7 @@ export const createSqlAgentRequestHandler = (
                 }
             }
 
-            logger.debug("No matching editor found in references. Checking tab groups...");
+            logger.trace("No matching editor found in references. Checking tab groups...");
             // If no match found, try to get any active SQL tab from tab groups
             for (const group of tabGroups) {
                 const activeTab = group.activeTab;
@@ -189,7 +189,7 @@ export const createSqlAgentRequestHandler = (
                             );
                             // Only return the editor if it's an SQL document
                             if (editor && isSqlDocument(editor.document)) {
-                                logger.debug("Returning active SQL editor from tab group.");
+                                logger.trace("Returning active SQL editor from tab group.");
                                 return editor;
                             }
                         }
@@ -199,22 +199,22 @@ export const createSqlAgentRequestHandler = (
                 }
             }
 
-            logger.debug("Exiting findEditorFromReferences");
-            logger.debug("No matching editor found in tab groups. Returning undefined.");
+            logger.trace("Exiting findEditorFromReferences");
+            logger.trace("No matching editor found in tab groups. Returning undefined.");
             return undefined;
         }
 
         // Process references using the appropriate editor
-        logger.debug("Process references using the appropriate editor...");
+        logger.trace("Process references using the appropriate editor...");
         if (request.references) {
             // Use activeEditor if available, otherwise try to find one from references
             const editorToUse =
                 activeEditor || (await findEditorFromReferences(request.references));
-            logger.debug(editorToUse ? "Using editor found." : "No editor found.");
+            logger.trace(editorToUse ? "Using editor found." : "No editor found.");
 
             // Use the preferred editor's URI if available
             connectionUri = editorToUse?.document.uri.toString() ?? connectionUri;
-            logger.debug(
+            logger.trace(
                 connectionUri
                     ? "Using the preferred editor's connection URI."
                     : "No connection URI found.",
@@ -262,7 +262,7 @@ export const createSqlAgentRequestHandler = (
 
         try {
             if (!model) {
-                logger.info("No model found.");
+                logger.error("No model found.");
                 activity.endFailed(new Error("No chat model found."), true, undefined, undefined, {
                     correlationId: correlationId,
                 });
@@ -279,7 +279,7 @@ export const createSqlAgentRequestHandler = (
             const copilotDebugLogging = vscode.workspace
                 .getConfiguration()
                 .get(Constants.copilotDebugLogging, false);
-            logger.debug(
+            logger.trace(
                 copilotDebugLogging ? "Debug logging enabled." : "Debug logging disabled.",
             );
             if (copilotDebugLogging) {
@@ -293,7 +293,7 @@ export const createSqlAgentRequestHandler = (
 
             const connection = controller.connectionManager.getConnectionInfo(connectionUri);
             if (!connectionUri || !connection) {
-                logger.debug(
+                logger.trace(
                     "No connection URI/connection was found. Sending prompt to default language model.",
                 );
 
@@ -425,7 +425,7 @@ export const createSqlAgentRequestHandler = (
             let printTextout = false;
 
             while (continuePollingMessages) {
-                logger.debug(`Continue polling messages for '${conversationUri}'`);
+                logger.trace(`Continue polling messages for '${conversationUri}'`);
 
                 // Default continuePollingMessages to true at the start of each loop
                 continuePollingMessages = true;
@@ -436,7 +436,7 @@ export const createSqlAgentRequestHandler = (
                 }
 
                 // Process tool calls and get the result
-                logger.debug("Processing tool calls and awaiting for the result...");
+                logger.trace("Processing tool calls and awaiting for the result...");
                 const result = await processToolCalls(
                     stream,
                     sqlTools,
@@ -455,7 +455,7 @@ export const createSqlAgentRequestHandler = (
                 // Handle different message types
                 switch (result.messageType) {
                     case MessageType.Complete:
-                        logger.debug("Processing complete message...");
+                        logger.trace("Processing complete message...");
                         activity.end(ActivityStatus.Succeeded, {
                             correlationId: correlationId,
                         });
@@ -469,7 +469,7 @@ export const createSqlAgentRequestHandler = (
 
                     case MessageType.RequestLLM:
                     case MessageType.RequestDirectLLM:
-                        logger.debug("Processing LLM message...");
+                        logger.trace("Processing LLM message...");
                         const { text, tools, print } = await handleRequestLLMMessage(
                             conversationUri,
                             result,
@@ -506,7 +506,7 @@ export const createSqlAgentRequestHandler = (
                         break;
                 }
 
-                logger.debug(`Done processing message for '${conversationUri}'`);
+                logger.trace(`Done processing message for '${conversationUri}'`);
                 // Output reply text if needed
                 if (printTextout) {
                     UserSurvey.getInstance().promptUserForNPSFeedback("copilot_askMode");
@@ -543,7 +543,7 @@ export const createSqlAgentRequestHandler = (
         correlationId: string,
         logger: ILogger,
     ): Promise<GetNextMessageResponse> {
-        logger.debug("in processToolCalls");
+        logger.trace("in processToolCalls");
 
         if (sqlTools.length === 0) {
             sendErrorEvent(
@@ -563,7 +563,7 @@ export const createSqlAgentRequestHandler = (
         let result: GetNextMessageResponse;
         for (const toolCall of sqlTools) {
             try {
-                logger.debug(`Getting next message for conversationUri: ${conversationUri}`);
+                logger.trace(`Getting next message for conversationUri: ${conversationUri}`);
 
                 result = await withTimeout(
                     copilotService.getNextMessage(
@@ -576,7 +576,7 @@ export const createSqlAgentRequestHandler = (
                 );
 
                 if (result.messageType === MessageType.Complete) {
-                    logger.debug(
+                    logger.trace(
                         `Message type is complete for conversationUri: ${conversationUri}`,
                     );
                     break;
@@ -612,7 +612,7 @@ export const createSqlAgentRequestHandler = (
             throw new Error("All tool calls failed or timed out.");
         }
 
-        logger.debug(`Finished processing tool calls for conversationUri: ${conversationUri}`);
+        logger.trace(`Finished processing tool calls for conversationUri: ${conversationUri}`);
         return result;
     }
 
@@ -622,7 +622,7 @@ export const createSqlAgentRequestHandler = (
         referenceTexts: string[],
         logger: ILogger,
     ): vscode.LanguageModelChatMessage[] {
-        logger.debug("in prepareRequestMessages");
+        logger.trace("in prepareRequestMessages");
 
         // Get all messages from requestMessages
         const requestMessages = result.requestMessages;
@@ -744,7 +744,7 @@ export const createSqlAgentRequestHandler = (
         tools: LanguageModelChatTool[],
         logger: ILogger,
     ): vscode.LanguageModelChatTool[] {
-        logger.debug("in mapRequestTools...");
+        logger.trace("in mapRequestTools...");
 
         return tools.map((tool, index): vscode.LanguageModelChatTool => {
             try {
@@ -791,7 +791,7 @@ export const createSqlAgentRequestHandler = (
         toolsCalled: { tool: LanguageModelChatTool; parameters: string }[];
         printTextout: boolean;
     }> {
-        logger.debug("in processResponseParts...");
+        logger.trace("in processResponseParts...");
         const toolsCalled: {
             tool: LanguageModelChatTool;
             parameters: string;
@@ -814,13 +814,13 @@ export const createSqlAgentRequestHandler = (
                     logger,
                 );
                 if (tool) {
-                    logger.debug(`Pushing ${tool.functionName} to toolsCalled`);
+                    logger.trace(`Pushing ${tool.functionName} to toolsCalled`);
                     toolsCalled.push({ tool, parameters });
                 }
             }
         }
 
-        logger.debug("Finished processing response parts.");
+        logger.trace("Finished processing response parts.");
         return { replyText, toolsCalled, printTextout };
     }
 
@@ -839,7 +839,7 @@ export const createSqlAgentRequestHandler = (
         tools: { tool: LanguageModelChatTool; parameters: string }[];
         print: boolean;
     }> {
-        logger.debug("in handleRequestLLMMessage");
+        logger.trace("in handleRequestLLMMessage");
         const requestTools = mapRequestTools(result.tools, logger);
         const options: vscode.LanguageModelChatRequestOptions = {
             justification: "Azure SQL Copilot agent requires access to language model.",
@@ -847,7 +847,7 @@ export const createSqlAgentRequestHandler = (
         };
 
         if (result.messageType === MessageType.RequestLLM) {
-            logger.debug("result.messageType is RequestLLM");
+            logger.trace("result.messageType is RequestLLM");
             options.tools = requestTools;
         }
 
@@ -862,7 +862,7 @@ export const createSqlAgentRequestHandler = (
             logger,
         );
 
-        logger.debug("Finished handling request LLM message.");
+        logger.trace("Finished handling request LLM message.");
         return {
             text: replyText,
             tools: toolsCalled,
@@ -881,7 +881,7 @@ export const createSqlAgentRequestHandler = (
         sqlTool: LanguageModelChatTool | undefined;
         sqlToolParameters: string | undefined;
     }> {
-        logger.debug("in processToolCall");
+        logger.trace("in processToolCall");
         // Initialize variables to return
         let sqlTool: LanguageModelChatTool | undefined;
         let sqlToolParameters: string | undefined;
@@ -894,7 +894,7 @@ export const createSqlAgentRequestHandler = (
         logger.trace("Looking up tool");
         const tool = resultTools.find((tool) => tool.functionName === part.name);
         if (!tool) {
-            logger.debug(`No tool was found for: ${part.name} - ${JSON.stringify(part.input)}}`);
+            logger.trace(`No tool was found for: ${part.name} - ${JSON.stringify(part.input)}}`);
             if (copilotDebugLogging) {
                 stream.markdown(loc.toolLookupFor(part.name, JSON.stringify(part.input)));
             }
@@ -930,7 +930,7 @@ export const createSqlAgentRequestHandler = (
         }
 
         // Log tool call
-        logger.debug(`Calling tool: ${tool.functionName} with ${sqlToolParameters}`);
+        logger.trace(`Calling tool: ${tool.functionName} with ${sqlToolParameters}`);
         if (copilotDebugLogging) {
             stream.progress(loc.callingTool(tool.functionName, sqlToolParameters));
         }
@@ -941,7 +941,7 @@ export const createSqlAgentRequestHandler = (
             correlationId: correlationId,
         });
 
-        logger.debug("Finished processing tool call.");
+        logger.trace("Finished processing tool call.");
 
         return { sqlTool, sqlToolParameters };
     }
@@ -952,7 +952,7 @@ export const createSqlAgentRequestHandler = (
         correlationId: string,
         logger: ILogger,
     ): void {
-        logger.debug("in handleLanguageModelError");
+        logger.trace("in handleLanguageModelError");
         logger.error("Language Model Error:", getErrorMessage(err), "Code:", err.code);
 
         const errorMessages: Record<string, string> = {
@@ -988,7 +988,7 @@ export const createSqlAgentRequestHandler = (
         correlationId: string,
         logger: ILogger,
     ): Promise<void> {
-        logger.debug("in sendToDefaultLanguageModel");
+        logger.trace("in sendToDefaultLanguageModel");
         try {
             logger.info(`Using ${model.name} to process your request...`);
             stream.progress(loc.usingModelToProcessRequest(model.name));
@@ -999,7 +999,7 @@ export const createSqlAgentRequestHandler = (
                 tools: [], // No tools involved for this fallback
             };
 
-            logger.debug("Sending request to default language model.");
+            logger.trace("Sending request to default language model.");
             const chatResponse = await model.sendRequest(messages, options, token);
 
             let replyText = "";
@@ -1010,7 +1010,7 @@ export const createSqlAgentRequestHandler = (
             }
 
             if (replyText) {
-                logger.debug("Received response from default language model.");
+                logger.trace("Received response from default language model.");
                 activity.end(ActivityStatus.Succeeded, {
                     correlationId: correlationId,
                     message: "The default language model succeeded.",
@@ -1032,7 +1032,7 @@ export const createSqlAgentRequestHandler = (
             logger.error("Error in fallback language model call:", getErrorMessage(err));
             stream.markdown(loc.errorOccurredWhileProcessingRequest);
         }
-        logger.debug("Finished sending request to default language model.");
+        logger.trace("Finished sending request to default language model.");
     }
 
     function handleError(
@@ -1041,7 +1041,7 @@ export const createSqlAgentRequestHandler = (
         correlationId: string,
         logger: ILogger,
     ): void {
-        logger.debug("in handleError");
+        logger.trace("in handleError");
 
         if (err instanceof vscode.LanguageModelError) {
             handleLanguageModelError(err, stream, correlationId, logger);

--- a/extensions/mssql/src/credentialstore/credentialstore.ts
+++ b/extensions/mssql/src/credentialstore/credentialstore.ts
@@ -54,13 +54,13 @@ export class CredentialStore implements ICredentialStore {
     public async readCredential(credentialId: string): Promise<Credential> {
         const vscodeCodeCred = await this._secretStorage.get(credentialId);
         if (vscodeCodeCred === undefined) {
-            this._logger.info(
+            this._logger.debug(
                 `No credential found for id ${credentialId} in VS Code Secret Storage.`,
             );
             return undefined;
         }
 
-        this._logger.info(
+        this._logger.debug(
             `Retrieved credential for id ${credentialId} from VS Code Secret Storage.`,
         );
 

--- a/extensions/mssql/src/dab/dabContainer.ts
+++ b/extensions/mssql/src/dab/dabContainer.ts
@@ -196,7 +196,7 @@ export async function startDabDockerContainer(
             port,
         };
     } catch (e) {
-        dockerLogger.info(`Failed to start DAB container: ${getErrorMessage(e)}`);
+        dockerLogger.error(`Failed to start DAB container: ${getErrorMessage(e)}`);
         return {
             success: false,
             error: LocalContainers.dabStartContainerError,
@@ -229,7 +229,7 @@ export async function checkIfDabContainerIsReady(
         const filteredLogs = filterDabContainerLogsForDisplay(logs);
 
         if (logStream?.hasLaunchFailure()) {
-            dockerLogger.info(`DAB container logs:\n${logs}`);
+            dockerLogger.debug(`DAB container logs:\n${logs}`);
             return {
                 success: false,
                 error: dabLaunchFailureText,
@@ -241,7 +241,7 @@ export async function checkIfDabContainerIsReady(
         // Check timeout before polling
         if (Date.now() - start > timeoutMs) {
             if (logs) {
-                dockerLogger.info(`DAB container logs:\n${logs}`);
+                dockerLogger.debug(`DAB container logs:\n${logs}`);
             }
             return {
                 success: false,
@@ -291,24 +291,24 @@ export async function stopAndRemoveDabContainer(
     try {
         const container = await getContainerByName(containerName);
         if (!container) {
-            dockerLogger.info(`DAB container ${containerName} does not exist.`);
+            dockerLogger.debug(`DAB container ${containerName} does not exist.`);
             return { success: true }; // Container doesn't exist, consider it removed
         }
 
-        dockerLogger.info(`Stopping DAB container: ${containerName}`);
+        dockerLogger.debug(`Stopping DAB container: ${containerName}`);
         try {
             await container.stop();
         } catch {
             // Container might already be stopped
         }
 
-        dockerLogger.info(`Removing DAB container: ${containerName}`);
+        dockerLogger.debug(`Removing DAB container: ${containerName}`);
         await container.remove();
 
-        dockerLogger.info(`DAB container ${containerName} stopped and removed.`);
+        dockerLogger.debug(`DAB container ${containerName} stopped and removed.`);
         return { success: true };
     } catch (e) {
-        dockerLogger.info(`Failed to stop/remove DAB container: ${getErrorMessage(e)}`);
+        dockerLogger.error(`Failed to stop/remove DAB container: ${getErrorMessage(e)}`);
         return {
             success: false,
             error: LocalContainers.dabStopContainerError,

--- a/extensions/mssql/src/integration/azureResourcesIntegration.ts
+++ b/extensions/mssql/src/integration/azureResourcesIntegration.ts
@@ -85,7 +85,7 @@ export class AzureResourcesExtensionIntegration {
             `${vscode.env.uriScheme}://ms-mssql.mssql/connect?${params.toString()}`,
         );
 
-        this._logger.info(
+        this._logger.debug(
             `Invoking mssql extension to open connection to ${serverName} (profile name: ${profileName}); URI: ${uri.toString()}`,
         );
 

--- a/extensions/mssql/src/languageservice/decompressProvider.ts
+++ b/extensions/mssql/src/languageservice/decompressProvider.ts
@@ -16,7 +16,7 @@ export default class DecompressProvider implements IDecompressProvider {
         return new Promise<void>((resolve, reject) => {
             yauzl.open(pkg.tmpFile.name, { lazyEntries: true }, (err, zipfile) => {
                 if (err) {
-                    logger.info(`[ERROR] ${err}`);
+                    logger.error(`[ERROR] ${err}`);
                     reject(err);
                     return;
                 }
@@ -31,7 +31,7 @@ export default class DecompressProvider implements IDecompressProvider {
                         // Create directory
                         fs.mkdir(dirPath, { recursive: true }, (err) => {
                             if (err) {
-                                logger.info(
+                                logger.error(
                                     `[ERROR] Failed to create directory ${dirPath}: ${err}`,
                                 );
                                 reject(err);
@@ -47,7 +47,7 @@ export default class DecompressProvider implements IDecompressProvider {
                         // Ensure parent directory exists first
                         fs.mkdir(dirPath, { recursive: true }, (err) => {
                             if (err) {
-                                logger.info(
+                                logger.error(
                                     `[ERROR] Failed to create directory ${dirPath}: ${err}`,
                                 );
                                 reject(err);
@@ -57,7 +57,7 @@ export default class DecompressProvider implements IDecompressProvider {
                             // Now extract the file
                             zipfile.openReadStream(entry, (err, readStream) => {
                                 if (err) {
-                                    logger.info(`[ERROR] ${err}`);
+                                    logger.error(`[ERROR] ${err}`);
                                     reject(err);
                                     return;
                                 }
@@ -66,7 +66,7 @@ export default class DecompressProvider implements IDecompressProvider {
 
                                 // Handle write stream errors
                                 writeStream.on("error", (err) => {
-                                    logger.info(`[ERROR] Failed to write ${filePath}: ${err}`);
+                                    logger.error(`[ERROR] Failed to write ${filePath}: ${err}`);
                                     reject(err);
                                 });
 
@@ -78,7 +78,9 @@ export default class DecompressProvider implements IDecompressProvider {
 
                                 // Handle read stream errors
                                 readStream.on("error", (err) => {
-                                    logger.info(`[ERROR] Read error for ${entry.fileName}: ${err}`);
+                                    logger.error(
+                                        `[ERROR] Read error for ${entry.fileName}: ${err}`,
+                                    );
                                     reject(err);
                                 });
 
@@ -94,7 +96,7 @@ export default class DecompressProvider implements IDecompressProvider {
                 });
 
                 zipfile.on("error", (err) => {
-                    logger.info(`[ERROR] Zipfile error: ${err}`);
+                    logger.error(`[ERROR] Zipfile error: ${err}`);
                     reject(err);
                 });
             });
@@ -111,7 +113,7 @@ export default class DecompressProvider implements IDecompressProvider {
                     totalFiles++;
                 },
                 onwarn: (warn) => {
-                    logger.info(`[ERROR] ${warn}`);
+                    logger.warn(`[ERROR] ${warn}`);
                 },
             },
             () => {

--- a/extensions/mssql/src/notebooks/notebookConnectionManager.ts
+++ b/extensions/mssql/src/notebooks/notebookConnectionManager.ts
@@ -120,7 +120,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
      */
     private async connectInternal(connectionInfo: IConnectionInfo): Promise<string> {
         const uri = generateQueryUri().toString();
-        this.log.debug(
+        this.log.trace(
             `[connectInternal] begin adhocUri=${uri} ` +
                 `server=${connectionInfo.server} database=${connectionInfo.database ?? "(default)"}`,
         );
@@ -137,7 +137,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
             );
             throw err;
         }
-        this.log.debug(
+        this.log.trace(
             `[connectInternal] connect returned success=${success} ` +
                 `after ${Date.now() - started}ms uri=${uri}`,
         );
@@ -152,18 +152,18 @@ export class NotebookConnectionManager implements vscode.Disposable {
      * otherwise prompts the user to pick one.
      */
     async ensureConnection(): Promise<string> {
-        this.log.debug(
+        this.log.trace(
             `[ensureConnection] begin currentUri=${this.connectionUri ?? "none"} ` +
                 `hasStoredInfo=${!!this.connectionInfo}`,
         );
         if (this.connectionUri) {
             const alive = this.connectionSharingService.isConnected(this.connectionUri);
-            this.log.debug(`[ensureConnection] existing uri alive=${alive}`);
+            this.log.trace(`[ensureConnection] existing uri alive=${alive}`);
             if (alive) {
                 return this.connectionUri;
             }
             // Connection went stale
-            this.log.info(`[ensureConnection] Connection stale, clearing: ${this.connectionUri}`);
+            this.log.debug(`[ensureConnection] Connection stale, clearing: ${this.connectionUri}`);
             this.connectionUri = undefined;
             this.connectionLabel = "";
             this.invalidateCellRegistrations();
@@ -171,7 +171,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
 
         // Try reconnecting with stored connection info (within-session stale connection)
         if (this.connectionInfo) {
-            this.log.info("[ensureConnection] Attempting reconnect with stored connection info");
+            this.log.debug("[ensureConnection] Attempting reconnect with stored connection info");
             try {
                 const uri = await this.connectInternal(this.connectionInfo);
                 this.connectionUri = uri;
@@ -185,7 +185,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
         }
 
         // No alive connection — prompt the user
-        this.log.info("[ensureConnection] No connection, prompting user");
+        this.log.debug("[ensureConnection] No connection, prompting user");
         return this.promptAndConnect();
     }
 
@@ -218,18 +218,18 @@ export class NotebookConnectionManager implements vscode.Disposable {
                 !connectionInfo.database &&
                 savedServer?.toLowerCase() === connectionInfo.server.toLowerCase()
             ) {
-                this.log.info(`[promptAndConnect] Restoring saved database context: ${savedDb}`);
+                this.log.debug(`[promptAndConnect] Restoring saved database context: ${savedDb}`);
                 connectionInfo = { ...connectionInfo, database: savedDb };
             }
 
-            this.log.info(
+            this.log.debug(
                 `[promptAndConnect] server=${connectionInfo.server}, database=${connectionInfo.database}`,
             );
             const uri = await this.connectInternal(connectionInfo);
-            this.log.info(`[promptAndConnect] connect() → URI=${uri}`);
+            this.log.debug(`[promptAndConnect] connect() → URI=${uri}`);
 
             const actualDb = this.getActualDatabase(uri);
-            this.log.info(`[promptAndConnect] Actual DB: ${actualDb}`);
+            this.log.debug(`[promptAndConnect] Actual DB: ${actualDb}`);
             this.connectionLabel = formatConnectionLabel(connectionInfo.server, actualDb);
 
             this.connectionUri = uri;
@@ -257,13 +257,13 @@ export class NotebookConnectionManager implements vscode.Disposable {
         try {
             const server = connectionInfo.server;
             const database = connectionInfo.database;
-            this.log.info(`[connectWith] server=${server}, database=${database}`);
+            this.log.debug(`[connectWith] server=${server}, database=${database}`);
 
             const uri = await this.connectInternal(connectionInfo);
-            this.log.info(`[connectWith] connect() → URI=${uri}`);
+            this.log.debug(`[connectWith] connect() → URI=${uri}`);
 
             const actualDb = this.getActualDatabase(uri);
-            this.log.info(`[connectWith] Connected to database: ${actualDb}`);
+            this.log.debug(`[connectWith] Connected to database: ${actualDb}`);
 
             this.connectionUri = uri;
             this.connectionInfo = { ...connectionInfo, database: actualDb || database };
@@ -296,7 +296,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
         if (!this.connectionInfo) {
             throw new Error(LocalizedConstants.Notebooks.noActiveConnection);
         }
-        this.log.info(`[changeDatabase] Switching to [${database}]`);
+        this.log.debug(`[changeDatabase] Switching to [${database}]`);
 
         sendActionEvent(TelemetryViews.SqlNotebooks, TelemetryActions.NotebookChangeDatabase);
 
@@ -308,11 +308,11 @@ export class NotebookConnectionManager implements vscode.Disposable {
         // Reconnect with the new database
         const newInfo = { ...this.connectionInfo, database };
         const uri = await this.connectInternal(newInfo);
-        this.log.info(`[changeDatabase] Reconnected → URI=${uri}`);
+        this.log.debug(`[changeDatabase] Reconnected → URI=${uri}`);
 
         // Get the actual database name from the connection info that STS populated
         const actualDb = this.getActualDatabase(uri);
-        this.log.info(`[changeDatabase] Verified: ${actualDb}`);
+        this.log.debug(`[changeDatabase] Verified: ${actualDb}`);
 
         this.connectionUri = uri;
         this.connectionInfo = newInfo;
@@ -333,7 +333,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
             throw new Error(LocalizedConstants.Notebooks.noActiveConnection);
         }
         const alive = this.connectionSharingService.isConnected(this.connectionUri);
-        this.log.debug(
+        this.log.trace(
             `[executeQueryString] dispatch uri=${this.connectionUri} ` +
                 `aliveAtDispatch=${alive} sqlLen=${sql.length}`,
         );
@@ -348,7 +348,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
     }
 
     disconnect(): void {
-        this.log.info(`[disconnect] URI=${this.connectionUri ?? "none"}`);
+        this.log.debug(`[disconnect] URI=${this.connectionUri ?? "none"}`);
         if (this.connectionUri) {
             sendActionEvent(TelemetryViews.SqlNotebooks, TelemetryActions.NotebookDisconnect);
             this.connectionSharingService.disconnect(this.connectionUri);
@@ -367,7 +367,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
      * connection after a new one has been established.
      */
     disconnectUri(uri: string): void {
-        this.log.info(`[disconnectUri] URI=${uri}`);
+        this.log.debug(`[disconnectUri] URI=${uri}`);
         this.connectionSharingService.disconnect(uri);
     }
 
@@ -410,7 +410,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
      */
     async connectCellForIntellisense(cellDocumentUri: string): Promise<void> {
         if (!this.connectionInfo) {
-            this.log.debug(
+            this.log.trace(
                 `[connectCellForIntellisense] Skipped (no connectionInfo) cell=${cellDocumentUri}`,
             );
             return;
@@ -448,7 +448,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
             // ignore parse errors
         }
         const authType = connectionDetails.options?.authenticationType ?? "unknown";
-        this.log.debug(
+        this.log.trace(
             `[connectCellForIntellisense] Sending connect request scheme=${cellUriScheme} server=${sourceInfo.server} database=${sourceInfo.database || "(default)"} auth=${authType} cell=${cellDocumentUri}`,
         );
 
@@ -487,7 +487,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
             );
 
             if (generation !== this.connectionGeneration) {
-                this.log.debug(
+                this.log.trace(
                     `[connectCellForIntellisense] connection changed mid-request (gen ${generation} → ${this.connectionGeneration}); dropping stale registration cell=${cellDocumentUri}`,
                 );
                 if (completeParams?.connectionId) {
@@ -520,7 +520,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
                 return;
             }
 
-            this.log.debug(
+            this.log.trace(
                 `[connectCellForIntellisense] STS connection complete connectionId=${completeParams.connectionId} cell=${cellDocumentUri}`,
             );
         } catch (err: any) {
@@ -592,7 +592,7 @@ export class NotebookConnectionManager implements vscode.Disposable {
         const params: DisconnectParams = { ownerUri: uri };
         void this.connectionMgr.sendRequest(DisconnectRequest.type, params).then(
             (disconnected) =>
-                this.log.debug(
+                this.log.trace(
                     `[disconnectCellUri] disconnect result=${String(disconnected)} cell=${uri}`,
                 ),
             (err: any) =>

--- a/extensions/mssql/src/notebooks/sqlNotebookController.ts
+++ b/extensions/mssql/src/notebooks/sqlNotebookController.ts
@@ -200,7 +200,7 @@ export class SqlNotebookController implements vscode.Disposable {
             this.controller.onDidChangeSelectedNotebooks(({ notebook, selected }) => {
                 if (selected) {
                     this.selectedNotebooks.add(notebook);
-                    this.log.info(
+                    this.log.debug(
                         `[onDidChangeSelectedNotebooks] Selected for ${notebook.uri.toString()}`,
                     );
                     this.ensureSqlCellLanguage(notebook);
@@ -293,7 +293,7 @@ export class SqlNotebookController implements vscode.Disposable {
                     return;
                 }
                 const cellUri = doc.uri.toString();
-                this.log.debug(`[onDidOpenTextDocument] Registering opened cell ${cellUri}`);
+                this.log.trace(`[onDidOpenTextDocument] Registering opened cell ${cellUri}`);
                 void mgr.connectCellForIntellisense(cellUri);
             }),
         );
@@ -316,14 +316,14 @@ export class SqlNotebookController implements vscode.Disposable {
                 const mgr = this.connections.get(notebookKey);
                 if (!mgr) {
                     if (this.selectedNotebooks.has(e.notebook)) {
-                        this.log.debug(
+                        this.log.trace(
                             `[onDidChangeNotebookDocument] Skipped ${totalAdded} added cell(s) (no manager) notebook=${notebookKey}`,
                         );
                     }
                     return;
                 }
                 if (!mgr.isConnected()) {
-                    this.log.debug(
+                    this.log.trace(
                         `[onDidChangeNotebookDocument] Skipped ${totalAdded} added cell(s) (not connected) notebook=${notebookKey}`,
                     );
                     return;
@@ -346,7 +346,7 @@ export class SqlNotebookController implements vscode.Disposable {
                         }
                     }
                 }
-                this.log.debug(
+                this.log.trace(
                     `[onDidChangeNotebookDocument] Registered ${registered} added cell(s), skipped ${skippedNonSql} non-SQL code cell(s), skipped ${skippedNonCode} non-code cell(s) notebook=${notebookKey}`,
                 );
             }),
@@ -375,7 +375,7 @@ export class SqlNotebookController implements vscode.Disposable {
             const name = String(kernelspec.name ?? "").toLowerCase();
             const displayName = String(kernelspec.display_name ?? "").toLowerCase();
             if (name.includes("sql-notebook") || name === "sql" || displayName === "sql") {
-                this.log.info(
+                this.log.debug(
                     `[setAffinityIfSql] Matched kernelspec for ${notebook.uri.toString()}`,
                 );
                 this.controller.updateNotebookAffinity(
@@ -395,7 +395,7 @@ export class SqlNotebookController implements vscode.Disposable {
             metadata?.custom?.metadata?.language_info;
 
         if (languageInfo?.name?.toLowerCase() === "sql") {
-            this.log.info(
+            this.log.debug(
                 `[setAffinityIfSql] Matched language_info for ${notebook.uri.toString()}`,
             );
             this.controller.updateNotebookAffinity(
@@ -413,7 +413,7 @@ export class SqlNotebookController implements vscode.Disposable {
             .getCells()
             .filter((c) => c.kind === vscode.NotebookCellKind.Code);
         if (codeCells.length > 0 && codeCells.every((c) => c.document.languageId === "sql")) {
-            this.log.info(
+            this.log.debug(
                 `[setAffinityIfSql] All code cells are SQL for ${notebook.uri.toString()}`,
             );
             this.controller.updateNotebookAffinity(
@@ -434,7 +434,7 @@ export class SqlNotebookController implements vscode.Disposable {
     private ensureSqlCellLanguage(notebook: vscode.NotebookDocument): void {
         for (const cell of notebook.getCells()) {
             if (cell.kind === vscode.NotebookCellKind.Code && cell.document.languageId !== "sql") {
-                this.log.info(
+                this.log.debug(
                     `[ensureSqlCellLanguage] Cell ${cell.index}: "${cell.document.languageId}" → "sql"`,
                 );
                 vscode.languages.setTextDocumentLanguage(cell.document, "sql");
@@ -487,19 +487,19 @@ export class SqlNotebookController implements vscode.Disposable {
         const notebookKey = notebook.uri.toString();
         const mgr = this.connections.get(notebookKey);
         if (!mgr) {
-            this.log.debug(
+            this.log.trace(
                 `[connectCellsForIntellisense] Skipped (no manager) trigger=${trigger} notebook=${notebookKey}`,
             );
             return;
         }
         if (!mgr.isConnected()) {
-            this.log.debug(
+            this.log.trace(
                 `[connectCellsForIntellisense] Skipped (not connected) trigger=${trigger} notebook=${notebookKey}`,
             );
             return;
         }
         if (!mgr.getConnectionInfo()) {
-            this.log.debug(
+            this.log.trace(
                 `[connectCellsForIntellisense] Skipped (no connectionInfo) trigger=${trigger} notebook=${notebookKey}`,
             );
             return;
@@ -521,7 +521,7 @@ export class SqlNotebookController implements vscode.Disposable {
             sqlCellCount++;
             void mgr.connectCellForIntellisense(cell.document.uri.toString());
         }
-        this.log.debug(
+        this.log.trace(
             `[connectCellsForIntellisense] trigger=${trigger} notebook=${notebookKey} sqlCells=${sqlCellCount} nonSqlCells=${nonSqlCellCount} nonCodeCells=${nonCodeCellCount}`,
         );
     }
@@ -546,7 +546,7 @@ export class SqlNotebookController implements vscode.Disposable {
             // notebook reconnects to its original database instead of master.
             const savedContext = this.readConnectionMetadata(notebook);
             if (savedContext) {
-                this.log.info(
+                this.log.debug(
                     `[getConnectionManager] Restored context: ${savedContext.server} / ${savedContext.database}`,
                 );
                 mgr.setReconnectionContext(savedContext.server, savedContext.database);
@@ -576,7 +576,7 @@ export class SqlNotebookController implements vscode.Disposable {
         // If URI changed and we have a manager under the old key, re-key it
         if (oldKey && oldKey !== newKey && this.connections.has(oldKey)) {
             const mgr = this.connections.get(oldKey)!;
-            this.log.info(`[rekeyConnectionOnSave] Re-keying connection: ${oldKey} → ${newKey}`);
+            this.log.debug(`[rekeyConnectionOnSave] Re-keying connection: ${oldKey} → ${newKey}`);
             this.connections.delete(oldKey);
             this.connections.set(newKey, mgr);
             return true;
@@ -688,7 +688,7 @@ export class SqlNotebookController implements vscode.Disposable {
             return;
         }
 
-        this.log.info(`[handleNotebookClosed] Disposing manager for ${key}`);
+        this.log.debug(`[handleNotebookClosed] Disposing manager for ${key}`);
         mgr.dispose();
     }
 
@@ -738,7 +738,7 @@ export class SqlNotebookController implements vscode.Disposable {
         if (superseded) {
             clearTimeout(superseded.timer);
             this.pendingSaveAdoptions.delete(oldKey);
-            this.log.info(
+            this.log.debug(
                 `[parkManagerForAdoption] Superseding parked manager for reused key ${oldKey}`,
             );
             superseded.mgr.dispose();
@@ -752,14 +752,14 @@ export class SqlNotebookController implements vscode.Disposable {
             const parked = this.pendingSaveAdoptions.get(oldKey);
             if (parked?.mgr === mgr) {
                 this.pendingSaveAdoptions.delete(oldKey);
-                this.log.info(
+                this.log.debug(
                     `[parkManagerForAdoption] No adoption within ${SAVE_ADOPTION_TTL_MS}ms for ${oldKey}; disposing manager`,
                 );
                 mgr.dispose();
             }
         }, SAVE_ADOPTION_TTL_MS);
         this.pendingSaveAdoptions.set(oldKey, { mgr, signature, timer });
-        this.log.info(`[parkManagerForAdoption] Parked connected manager for ${oldKey}`);
+        this.log.debug(`[parkManagerForAdoption] Parked connected manager for ${oldKey}`);
 
         // If the file-based notebook opened BEFORE the untitled one closed,
         // it is already in the workspace — adopt immediately. Only notebooks
@@ -852,7 +852,7 @@ export class SqlNotebookController implements vscode.Disposable {
     ): void {
         this.connections.set(newKey, mgr);
         this.notebookToUri.set(notebook, newKey);
-        this.log.info(`[adoptManager] Transferred connection ${oldKey} → ${newKey}`);
+        this.log.debug(`[adoptManager] Transferred connection ${oldKey} → ${newKey}`);
 
         // The old cell URIs belong to the replaced untitled notebook; release
         // their STS registrations and register the new cell URIs.
@@ -998,27 +998,27 @@ export class SqlNotebookController implements vscode.Disposable {
 
         const code = cell.document.getText().trim();
 
-        this.log.debug(
+        this.log.trace(
             `[executeCell] start order=${execution.executionOrder} cellIndex=${cell.index} ` +
                 `notebook=${notebook.uri.scheme}:${notebook.isUntitled ? "untitled" : notebook.uri.path.split("/").pop()} ` +
                 `codeLen=${code.length}`,
         );
 
         if (!code) {
-            this.log.debug(`[executeCell] empty cell, skipping`);
+            this.log.trace(`[executeCell] empty cell, skipping`);
             execution.end(true, Date.now());
             return;
         }
 
         const connMgr = this.getConnectionManager(notebook);
-        this.log.debug(
+        this.log.trace(
             `[executeCell] preConn existingUri=${connMgr.getConnectionUri() ?? "none"} ` +
                 `isConnected=${connMgr.isConnected()}`,
         );
 
         // Handle magic commands
         if (code.startsWith("%%")) {
-            this.log.debug(`[executeCell] magic command path`);
+            this.log.trace(`[executeCell] magic command path`);
             await this.handleMagic(code, execution, connMgr, notebook);
             this.updateStatusBar(notebook);
             this.codeLensProvider.refresh();
@@ -1027,9 +1027,9 @@ export class SqlNotebookController implements vscode.Disposable {
 
         // Ensure we have a connection (one per notebook, reused across cells)
         try {
-            this.log.debug(`[executeCell] ensureConnection: begin`);
+            this.log.trace(`[executeCell] ensureConnection: begin`);
             const ensuredUri = await connMgr.ensureConnection();
-            this.log.debug(
+            this.log.trace(
                 `[executeCell] ensureConnection: ok uri=${ensuredUri} ` +
                     `isConnected=${connMgr.isConnected()}`,
             );
@@ -1061,12 +1061,12 @@ export class SqlNotebookController implements vscode.Disposable {
         );
 
         try {
-            this.log.debug(
+            this.log.trace(
                 `[executeCell] executeQueryString: begin uri=${connMgr.getConnectionUri() ?? "none"} ` +
                     `sqlLen=${code.length}`,
             );
             const result = await connMgr.executeQueryString(code, execution.token);
-            this.log.debug(
+            this.log.trace(
                 `[executeCell] executeQueryString: done canceled=${result.canceled} ` +
                     `batches=${result.batches.length}`,
             );

--- a/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerFilter.ts
@@ -68,7 +68,7 @@ export class ObjectExplorerFilterWebviewController extends WebviewPanelControlle
                 }
             } catch (error) {
                 // Applying a filter must not depend on the optional recent-filter cache.
-                this.logger.error("Failed to save the Object Explorer filter history", error);
+                this.logger.warn("Failed to save the Object Explorer filter history", error);
             }
             this._onSubmit.fire(payload.filters);
             this.panel.dispose();
@@ -112,7 +112,7 @@ export class ObjectExplorerFilterWebviewController extends WebviewPanelControlle
             const filterPresets = await update();
             return { ...state, filterPresets };
         } catch (error) {
-            this.logger.error("Failed to update the Object Explorer filter presets", error);
+            this.logger.warn("Failed to update the Object Explorer filter presets", error);
             return state;
         }
     }

--- a/extensions/mssql/src/profiler/profilerController.ts
+++ b/extensions/mssql/src/profiler/profilerController.ts
@@ -1014,29 +1014,29 @@ export class ProfilerController {
             // New Session - disabled in read-only disconnected mode
             onCreateSession: async () => {
                 // No-op for read-only disconnected sessions
-                this._logger.debug(
+                this._logger.trace(
                     "Create session ignored for read-only disconnected XEL file session",
                 );
             },
             // Start Session - disabled in read-only disconnected mode
             onStartSession: async () => {
                 // No-op for read-only disconnected sessions
-                this._logger.debug(
+                this._logger.trace(
                     "Start session ignored for read-only disconnected XEL file session",
                 );
             },
             // Pause/Resume - disabled for read-only file sessions
             onPauseResume: async () => {
                 // No-op for read-only sessions
-                this._logger.debug("Pause/Resume ignored for read-only XEL file session");
+                this._logger.trace("Pause/Resume ignored for read-only XEL file session");
             },
             // Stop - disabled for read-only file sessions
             onStop: async () => {
                 // No-op for read-only sessions
-                this._logger.debug("Stop ignored for read-only XEL file session");
+                this._logger.trace("Stop ignored for read-only XEL file session");
             },
             onViewChange: (viewId: string) => {
-                this._logger.debug(`View changed to: ${viewId}`);
+                this._logger.trace(`View changed to: ${viewId}`);
             },
         });
     }

--- a/extensions/mssql/src/schemaCompare/schemaCompareUtils.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareUtils.ts
@@ -184,10 +184,10 @@ export async function generateScript(
     schemaCompareService: mssql.ISchemaCompareService,
     logger?: ILogger,
 ): Promise<mssql.ResultStatus> {
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] generateScript called - operationId: ${operationId}, taskExecutionMode: ${taskExecutionMode} - OperationId: ${operationId}`,
     );
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] Payload - hasTargetServerName: ${!!payload?.targetServerName}, hasTargetDatabaseName: ${!!payload?.targetDatabaseName} - OperationId: ${operationId}`,
     );
     logger?.debug(
@@ -201,12 +201,12 @@ export async function generateScript(
         taskExecutionMode,
     );
 
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] schemaCompareService.generateScript returned - success: ${result?.success}, hasErrorMessage: ${!!result?.errorMessage} - OperationId: ${operationId}`,
     );
 
     if (result) {
-        logger?.info(
+        logger?.debug(
             `[schemaCompareUtils] Result object type: ${typeof result}, keys: ${Object.keys(result).join(", ")} - OperationId: ${operationId}`,
         );
         logger?.debug(
@@ -224,7 +224,7 @@ export async function generateScript(
         );
     }
 
-    logger?.info(`[schemaCompareUtils] Returning result - OperationId: ${operationId}`);
+    logger?.debug(`[schemaCompareUtils] Returning result - OperationId: ${operationId}`);
     return result;
 }
 
@@ -295,7 +295,7 @@ export async function includeExcludeNode(
     schemaCompareService: mssql.ISchemaCompareService,
     logger?: ILogger,
 ): Promise<mssql.SchemaCompareIncludeExcludeResult> {
-    logger?.info(
+    logger?.trace(
         `[schemaCompareUtils] includeExcludeNode called - operationId: ${operationId}, includeRequest: ${payload.includeRequest}, diffEntry type: ${payload.diffEntry?.name}`,
     );
     logger?.debug(
@@ -311,12 +311,12 @@ export async function includeExcludeNode(
     );
 
     const elapsed = Date.now() - startTime;
-    logger?.info(
+    logger?.trace(
         `[schemaCompareUtils] includeExcludeNode service returned after ${elapsed}ms - success: ${result?.success}`,
     );
 
     if (result) {
-        logger?.info(
+        logger?.trace(
             `[schemaCompareUtils] Affected dependencies: ${result.affectedDependencies?.length || 0}, Blocking dependencies: ${result.blockingDependencies?.length || 0}`,
         );
 
@@ -346,13 +346,13 @@ export async function includeExcludeAllNodes(
     schemaCompareService: mssql.ISchemaCompareService,
     logger?: ILogger,
 ): Promise<mssql.SchemaCompareIncludeExcludeAllResult> {
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] includeExcludeAllNodes called - operationId: ${operationId}, includeRequest: ${payload.includeRequest}`,
     );
     logger?.debug(`[schemaCompareUtils] taskExecutionMode: ${taskExecutionMode}`);
 
     const startTime = Date.now();
-    logger?.info(`[schemaCompareUtils] Calling schemaCompareService.includeExcludeAllNodes`);
+    logger?.debug(`[schemaCompareUtils] Calling schemaCompareService.includeExcludeAllNodes`);
 
     const result = await schemaCompareService.includeExcludeAllNodes(
         operationId,
@@ -361,12 +361,12 @@ export async function includeExcludeAllNodes(
     );
 
     const elapsed = Date.now() - startTime;
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] includeExcludeAllNodes service returned after ${elapsed}ms - success: ${result?.success}`,
     );
 
     if (result) {
-        logger?.info(
+        logger?.debug(
             `[schemaCompareUtils] Result differences count: ${result.allIncludedOrExcludedDifferences?.length || 0}`,
         );
 
@@ -400,30 +400,30 @@ export async function openScmp(
     schemaCompareService: mssql.ISchemaCompareService,
     logger?: ILogger,
 ): Promise<mssql.SchemaCompareOpenScmpResult> {
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] openScmp called with file path length: ${filePath?.length || 0}`,
     );
     logger?.debug(`[schemaCompareUtils] Calling schemaCompareService.openScmp`);
 
     const result = await schemaCompareService.openScmp(filePath);
 
-    logger?.info(
+    logger?.debug(
         `[schemaCompareUtils] openScmp service returned - success: ${result?.success}, hasErrorMessage: ${!!result?.errorMessage}`,
     );
 
     if (result) {
-        logger?.info(
+        logger?.debug(
             `[schemaCompareUtils] Result has sourceEndpointInfo: ${!!result.sourceEndpointInfo}, targetEndpointInfo: ${!!result.targetEndpointInfo}`,
         );
 
         if (result.sourceEndpointInfo) {
-            logger?.info(
+            logger?.debug(
                 `[schemaCompareUtils] Source endpoint type: ${result.sourceEndpointInfo.endpointType}`,
             );
         }
 
         if (result.targetEndpointInfo) {
-            logger?.info(
+            logger?.debug(
                 `[schemaCompareUtils] Target endpoint type: ${result.targetEndpointInfo.endpointType}`,
             );
         }

--- a/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
+++ b/extensions/mssql/src/schemaDesigner/schemaDesignerWebviewController.ts
@@ -705,7 +705,7 @@ export class SchemaDesignerWebviewController extends WebviewPanelController<
                 return;
             }
 
-            this.logger.info("Progress", progress);
+            this.logger.debug("Progress", progress);
 
             try {
                 void this.sendNotification(

--- a/extensions/mssql/src/services/dabService.ts
+++ b/extensions/mssql/src/services/dabService.ts
@@ -293,7 +293,7 @@ export class DabService implements Dab.IDabService {
             encoding: "utf8",
             mode: 0o600,
         });
-        dockerLogger.info(`DAB config written to: ${configFilePath}`);
+        dockerLogger.debug(`DAB config written to: ${configFilePath}`);
 
         return configFilePath;
     }
@@ -314,7 +314,7 @@ export class DabService implements Dab.IDabService {
                 await fs.promises.rmdir(configDir);
             }
 
-            dockerLogger.info(`Cleaned up DAB config: ${configFilePath}`);
+            dockerLogger.debug(`Cleaned up DAB config: ${configFilePath}`);
         } catch (e) {
             dockerLogger.warn(`Failed to cleanup DAB config file: ${getErrorMessage(e)}`);
         }

--- a/extensions/mssql/src/sqlToolsMcp/registerSqlToolsMcpServer.ts
+++ b/extensions/mssql/src/sqlToolsMcp/registerSqlToolsMcpServer.ts
@@ -31,7 +31,7 @@ export function registerSqlToolsMcpServer(
             success: "false",
             reason: "mcpApiUnavailable",
         });
-        logger.info("VS Code MCP server definition API is not available.");
+        logger.debug("VS Code MCP server definition API is not available.");
         return;
     }
 

--- a/extensions/mssql/src/tableDesigner/tableDesignerWebviewController.ts
+++ b/extensions/mssql/src/tableDesigner/tableDesignerWebviewController.ts
@@ -635,7 +635,7 @@ export class TableDesignerWebviewController extends WebviewPanelController<
                 return;
             }
 
-            this.logger.info("Progress", progress);
+            this.logger.debug("Progress", progress);
             this.appendOperationProgress(progress.operation, progress.message, progress.status);
 
             try {

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -1234,7 +1234,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("openScriptInEditor", async (state) => {
-            this.logger.info(`Opening script in SQL editor - OperationId: ${this.operationId}`);
+            this.logger.debug(`Opening script in SQL editor - OperationId: ${this.operationId}`);
 
             sendActionEvent(TelemetryViews.TableExplorer, TelemetryActions.Open, {
                 operationId: this.operationId,
@@ -1249,7 +1249,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     });
                     await vscode.window.showTextDocument(doc);
 
-                    this.logger.info(
+                    this.logger.debug(
                         `Script opened in SQL editor successfully - OperationId: ${this.operationId}`,
                     );
                 } else {
@@ -1268,7 +1268,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("copyScriptToClipboard", async (state) => {
-            this.logger.info(`Copying script to clipboard - OperationId: ${this.operationId}`);
+            this.logger.debug(`Copying script to clipboard - OperationId: ${this.operationId}`);
 
             sendActionEvent(TelemetryViews.TableExplorer, TelemetryActions.CopyResults, {
                 operationId: this.operationId,
@@ -1282,7 +1282,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                         LocConstants.TableExplorer.scriptCopiedToClipboard,
                     );
 
-                    this.logger.info(
+                    this.logger.debug(
                         `Script copied to clipboard successfully - OperationId: ${this.operationId}`,
                     );
                 } else {
@@ -1326,7 +1326,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("saveResults", async (state, payload) => {
-            this.logger.info(
+            this.logger.debug(
                 `Saving results as ${payload.format} - OperationId: ${this.operationId}`,
             );
 
@@ -1384,7 +1384,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                             LocConstants.TableExplorer.exportSuccessful(uri.fsPath),
                         );
 
-                        this.logger.info(
+                        this.logger.debug(
                             `Results saved to ${uri.fsPath} - OperationId: ${this.operationId}`,
                         );
 
@@ -1439,7 +1439,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("runTableQuery", async (state, payload) => {
-            this.logger.info(`Running custom table query - OperationId: ${this.operationId}`);
+            this.logger.debug(`Running custom table query - OperationId: ${this.operationId}`);
 
             const startTime = Date.now();
             // Only operator type names (e.g. "equals", "lessThan") flow through this
@@ -1569,7 +1569,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("modifyTable", async (state, _payload) => {
-            this.logger.info(`Opening Table Designer - OperationId: ${this.operationId}`);
+            this.logger.debug(`Opening Table Designer - OperationId: ${this.operationId}`);
 
             const startTime = Date.now();
             const endActivity = startActivity(
@@ -1585,7 +1585,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
             try {
                 await vscode.commands.executeCommand(Constants.cmdEditTable, this._targetNode);
 
-                this.logger.info(
+                this.logger.debug(
                     `Table Designer opened successfully - OperationId: ${this.operationId}`,
                 );
 
@@ -1618,7 +1618,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         });
 
         this.registerReducer("viewTableDiagram", async (state, _payload) => {
-            this.logger.info(`Opening Schema Designer - OperationId: ${this.operationId}`);
+            this.logger.debug(`Opening Schema Designer - OperationId: ${this.operationId}`);
 
             const startTime = Date.now();
             const endActivity = startActivity(
@@ -1644,7 +1644,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     filterTable,
                 );
 
-                this.logger.info(
+                this.logger.debug(
                     `Schema Designer opened successfully - OperationId: ${this.operationId}`,
                 );
 
@@ -1728,7 +1728,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
 
         // Handle the user's choice
         if (result === LocConstants.TableExplorer.Save) {
-            this.logger.info("User chose to save changes before closing");
+            this.logger.debug("User chose to save changes before closing");
 
             try {
                 await this._tableExplorerService.commit(this.state.ownerUri);
@@ -1736,7 +1736,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     LocConstants.TableExplorer.changesSavedSuccessfully,
                 );
 
-                this.logger.info("Changes saved successfully before closing");
+                this.logger.debug("Changes saved successfully before closing");
             } catch (error) {
                 this.logger.error(`Error saving changes before closing: ${error}`);
                 vscode.window.showErrorMessage(
@@ -1744,9 +1744,9 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 );
             }
         } else if (result === LocConstants.TableExplorer.Discard) {
-            this.logger.info("User chose to discard changes");
+            this.logger.debug("User chose to discard changes");
         } else {
-            this.logger.info("User dismissed the prompt - treating as discard");
+            this.logger.debug("User dismissed the prompt - treating as discard");
         }
 
         // Always return undefined to allow disposal to continue
@@ -1759,7 +1759,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
      */
     public override dispose(): void {
         if (this.state.ownerUri) {
-            this.logger.info(
+            this.logger.debug(
                 `Disposing Table Explorer resources for ownerUri: ${this.state.ownerUri}`,
             );
 

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/fabricBrowsePage.tsx
@@ -94,7 +94,7 @@ export const FabricBrowsePage = () => {
 
                 return;
             default:
-                log.error("Unknown server type selected.");
+                log.warn("Unknown server type selected.");
         }
     }
 

--- a/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
+++ b/extensions/mssql/src/webviews/pages/DacpacDialog/dacpacDialogForm.tsx
@@ -692,7 +692,7 @@ export const DacpacDialogForm = () => {
         // Only check for errors, not warnings
         const hasErrors = Object.values(validationMessages).some((msg) => msg.severity === "error");
         Object.values(validationMessages).forEach((msg) => {
-            log?.debug(msg.message);
+            log?.trace(msg.message);
         });
         return !hasErrors;
     };

--- a/extensions/mssql/test/unit/azureResourcesIntegration.test.ts
+++ b/extensions/mssql/test/unit/azureResourcesIntegration.test.ts
@@ -18,6 +18,7 @@ import {
     mockServerName,
     mockSubscriptions,
 } from "./azureHelperStubs";
+import { createStubLogger } from "./utils";
 
 chai.use(sinonChai);
 
@@ -55,10 +56,7 @@ suite("AzureResourcesExtensionIntegration Tests", () => {
 
         // Silence the internal logger to avoid writing to the output channel during tests.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (integration as any)._logger = {
-            info: sandbox.stub(),
-            error: sandbox.stub(),
-        };
+        (integration as any)._logger = createStubLogger(sandbox);
     });
 
     teardown(() => {


### PR DESCRIPTION
## Description

Adjust logger levels across the MSSQL extension so default output emphasizes meaningful lifecycle events, warnings, and failures while moving routine, per-item, and high-frequency diagnostics to debug or trace. This also raises several genuine failure paths that were previously logged at info or warning.

The changes include the credential-store lookup messages, connection and notebook diagnostics, schema compare and table explorer instrumentation, Copilot request processing, DAB/container operations, and selected webview logging.

## Validation

- Changed-file ESLint completed with 0 errors (53 existing warnings).
- VS Code diagnostics reported no errors in the edited source files.
- `npm run build -- --target mssql` reached extension typechecking but was blocked by existing missing dependencies: `extract-zip` and `promisify-child-process`.
- The full lint target is currently obscured by checkout-wide CRLF Prettier diagnostics.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)