### PR TITLE
Fix database loading for copied connections

### DIFF
--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -1959,6 +1959,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         await this.handleAzureMFAEdits("authenticationType");
         await this.handleAzureMFAEdits("accountId");
         await this.checkReadyToConnect();
+        this.triggerDatabaseFetchIfReady();
     }
 
     private async initializeConnectionForDialog(

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -1110,6 +1110,8 @@ suite("ConnectionDialogWebviewController Tests", () => {
 
         test("loadConnectionAsNewDraft", async () => {
             controller.state.formMessage = { message: "Sample error" };
+            connectionManager.connect.resolves(true);
+            connectionManager.listDatabases.resolves(["SavedDatabase", "OtherDatabase"]);
 
             const testConnection = {
                 id: "existing-profile-id",
@@ -1137,6 +1139,8 @@ suite("ConnectionDialogWebviewController Tests", () => {
             expect(controller.state.editingConnectionDisplayName).to.be.undefined;
             expect(controller.state.formMessage).to.be.undefined;
             expect(controller.state.readyToConnect).to.be.true;
+            expect(controller.state.connectionProfile.database).to.equal("SavedDatabase");
+            expect(connectionManager.connect).to.have.been.called;
 
             // Ensure source object wasn't mutated
             expect(testConnection.id).to.equal("existing-profile-id");


### PR DESCRIPTION
## Summary

- trigger background database-list loading after copying a recent or saved connection into a new draft
- preserve the copied database as the default selected target while options load
- add regression coverage for the copied-connection flow

Fixes #22846

## Testing

- `connectionDialogWebviewController.test.ts`: 72 passed
- `npm --prefix extensions/mssql run build:extension:typecheck`