### PR TITLE
Remove duplicate watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "build": "node scripts/workspaces.mjs build",
         "build:mssql:prod": "node scripts/workspaces.mjs build --target mssql --prod",
         "watch": "node scripts/workspaces.mjs watch",
-        "watch:all": "node scripts/workspaces.mjs watch",
         "test": "node scripts/workspaces.mjs test",
         "smoketest": "node scripts/workspaces.mjs smoketest",
         "lint": "node scripts/workspaces.mjs lint",

--- a/scripts/workspaces.mjs
+++ b/scripts/workspaces.mjs
@@ -77,7 +77,6 @@ function printUsage() {
     console.log(`Usage:
   npm run build [-- --target <name>[,<name>]] [--prod]
   npm run watch [-- --target <name>[,<name>]]
-  npm run watch:all
   npm run test [-- --target <name>[,<name>]] [-- <target args>]
   npm run smoketest [-- --target <name>[,<name>]] [-- <target args>]
   npm run lint [-- --target <name>[,<name>]]


### PR DESCRIPTION
## Summary

- remove the redundant root `watch:all` alias, which ran the same workspace command as `watch`
- remove the obsolete alias from the workspace runner help output

## Validation

- `node --check scripts/workspaces.mjs`
- `npx prettier --check package.json scripts/workspaces.mjs`
- `git diff --check origin/main...HEAD`
- confirmed no remaining `watch:all` references in package scripts, workspace help, documentation, extensions, or workflows