### PR TITLE
Query Results: Preserve PRINT messages when batch messages are hidden

### DIFF
--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -668,11 +668,9 @@ export default class QueryRunner {
         message.time = new Date(message.time).toLocaleTimeString();
         message.rowsAffected = getRowsAffectedFromMessage(message.message);
 
-        if (message.isError || Utils.shouldShowBatchMessages()) {
-            // save the message into the batch summary so it can be restored on view refresh
-            if (message.batchId >= 0 && this._batchSetMessages[message.batchId] !== undefined) {
-                this._batchSetMessages[message.batchId].push(message);
-            }
+        // save the message into the batch summary so it can be restored on view refresh
+        if (message.batchId >= 0 && this._batchSetMessages[message.batchId] !== undefined) {
+            this._batchSetMessages[message.batchId].push(message);
         }
 
         // Send the message so non-display state, such as rows affected, remains current

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -684,7 +684,7 @@ export class SqlOutputContentProvider {
                 );
 
                 const showBatchMessages = Utils.shouldShowBatchMessages();
-                if (message.isError || showBatchMessages) {
+                if (message.isError || message.batchId >= 0 || showBatchMessages) {
                     resultWebviewState.messages.push(
                         showBatchMessages ? message : { ...message, batchId: undefined },
                     );

--- a/extensions/mssql/test/unit/queryRunner.test.ts
+++ b/extensions/mssql/test/unit/queryRunner.test.ts
@@ -488,7 +488,7 @@ suite("Query Runner tests", () => {
         expect(queryRunner.batchSetMessages[message.message.batchId].length).to.equal(1);
     });
 
-    test("Notification - Message does not cache non-error messages when disabled", () => {
+    test("Notification - Message preserves non-error messages when batch messages are disabled", () => {
         const config = stubs.createWorkspaceConfiguration({
             [Constants.configResultsShowBatchMessages]: false,
         });
@@ -497,7 +497,7 @@ suite("Query Runner tests", () => {
             message: {
                 batchId: 0,
                 isError: false,
-                message: "Commands completed successfully.",
+                message: "hello",
                 time: new Date().toISOString(),
             },
             ownerUri: standardUri,
@@ -509,13 +509,14 @@ suite("Query Runner tests", () => {
 
         queryRunner.handleMessage(message);
 
-        expect(queryRunner.batchSetMessages[message.message.batchId]).to.be.empty;
+        expect(queryRunner.batchSetMessages[message.message.batchId]).to.deep.equal([
+            message.message,
+        ]);
         expect(messageListener).to.have.been.calledWith(message.message);
         expect(testStatusView.showRowCount).to.have.been.calledWith(
             standardUri,
             message.message.message,
         );
-        expect(getConfigurationStub).to.have.been.calledWith(Constants.extensionConfigSectionName);
     });
 
     test("Notification - Message preserves errors when batch messages are disabled", () => {

--- a/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
@@ -577,6 +577,37 @@ suite("SqlOutputProvider Tests using mocks", () => {
         expect(state.rowsAffected).to.equal(7);
     });
 
+    test("Print messages remain visible when batch messages are disabled", async () => {
+        const uri = "test_uri";
+        const printMessage = "hello";
+        getConfigurationStub.returns(
+            stubs.createWorkspaceConfiguration({
+                [Constants.configResultsShowBatchMessages]: false,
+            }),
+        );
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleMessage({
+            ownerUri: uri,
+            message: {
+                message: printMessage,
+                isError: false,
+                time: new Date().toISOString(),
+                batchId: 0,
+            },
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.have.length(1);
+        expect(state.messages[0]).to.deep.include({
+            message: printMessage,
+            isError: false,
+            batchId: undefined,
+        });
+    });
+
     test("Completion messages are hidden while execution state still updates", async () => {
         const uri = "test_uri";
         getConfigurationStub.returns(


### PR DESCRIPTION
## Description

Preserve SQL `PRINT` output in the Query Results Messages tab when `mssql.results.showBatchMessages` is disabled. The setting continues to hide extension-generated batch lifecycle messages and unscoped rows-affected status messages, while server-originated batch messages and errors remain visible.

Fixes #22845

## Screenshots

**Before:**

_Add a screenshot showing the missing `PRINT` output here._

**After:**

_Add a screenshot showing the restored `PRINT` output here._

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

Full MSSQL test run: affected suites and SQL Database Projects pass; eight unrelated Windows path/sound tests fail consistently in isolation. Build, lint, and online packaging pass.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)