### PR TITLE
Promote VS Code Entra authentication

### DIFF
--- a/extensions/mssql/README.md
+++ b/extensions/mssql/README.md
@@ -156,7 +156,7 @@ Configure the MSSQL extension in user preferences (`Cmd+,`) or workspace setting
   "mssql.connectionManagement.rememberPasswordsUntilRestart": true,  // Keep passwords in memory until VS Code restarts
   "mssql.enableConnectionPooling": false,                  // Enable connection pooling for improved performance
   "mssql.azureActiveDirectory": "AuthCodeGrant"            // Azure AD auth method: "AuthCodeGrant" or "DeviceCode"
-  "mssql.preview.useVscodeAccountsForEntraMFA": true,      // Whether to use accounts signed into VS Code for authenticating to databases with Microsoft Entra ID Universal with MFA
+  "mssql.useMsalEntraMfaAuth": false,                      // Whether to use MSAL for Microsoft Entra MFA authentication instead of accounts signed into VS Code
   "mssql.newEditorConnectionBehavior": "transferACtive",   // How to connect a newly-opened .SQL file or query editor: "none" | "transferActive" | "defaultConnection"
   "mssql.defaultConnectionId": "",                         // Connection ID (GUID) of the connection to auto-connect new editors with. Only applicable when "mssql.newEditorConnectionBehavior" is set to "defaultConnection"
 }

--- a/extensions/mssql/README.md
+++ b/extensions/mssql/README.md
@@ -155,7 +155,7 @@ Configure the MSSQL extension in user preferences (`Cmd+,`) or workspace setting
   "mssql.maxRecentConnections": 5,                         // Number of recent connections to display (0-50)
   "mssql.connectionManagement.rememberPasswordsUntilRestart": true,  // Keep passwords in memory until VS Code restarts
   "mssql.enableConnectionPooling": false,                  // Enable connection pooling for improved performance
-  "mssql.azureActiveDirectory": "AuthCodeGrant"            // Azure AD auth method: "AuthCodeGrant" or "DeviceCode"
+  "mssql.azureActiveDirectory": "AuthCodeGrant",           // Azure AD auth method: "AuthCodeGrant" or "DeviceCode"
   "mssql.useMsalEntraMfaAuth": false,                      // Whether to use MSAL for Microsoft Entra MFA authentication instead of accounts signed into VS Code
   "mssql.newEditorConnectionBehavior": "transferACtive",   // How to connect a newly-opened .SQL file or query editor: "none" | "transferActive" | "defaultConnection"
   "mssql.defaultConnectionId": "",                         // Connection ID (GUID) of the connection to auto-connect new editors with. Only applicable when "mssql.newEditorConnectionBehavior" is set to "defaultConnection"

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -1027,11 +1027,11 @@
                 },
                 {
                     "command": "mssql.addAadAccount",
-                    "when": "!config.mssql.preview.useVscodeAccountsForEntraMFA"
+                    "when": "config.mssql.useMsalEntraMfaAuth"
                 },
                 {
                     "command": "mssql.removeAadAccount",
-                    "when": "!config.mssql.preview.useVscodeAccountsForEntraMFA"
+                    "when": "config.mssql.useMsalEntraMfaAuth"
                 },
                 {
                     "command": "mssql.objectExplorerNewQuery",
@@ -1997,13 +1997,10 @@
                     "description": "%mssql.preview.betaExecutionPlan.description%",
                     "scope": "application"
                 },
-                "mssql.preview.useVscodeAccountsForEntraMFA": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "default": true,
-                    "description": "%mssql.preview.useVscodeAccountsForEntraMFA.description%",
+                "mssql.useMsalEntraMfaAuth": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%mssql.useMsalEntraMfaAuth.description%",
                     "scope": "application"
                 },
                 "mssql.openQueryResultsInTabByDefault": {

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -246,7 +246,7 @@
     "mssql.preview.betaResultsGrid.description": "Enables the preview query results grid experience with improved state management and more column customization options, including showing, hiding, and freezing columns.",
     "mssql.preview.betaObjectExplorerFilter.description": "Enables the preview Object Explorer filter experience with saved filter presets and recently applied filters. Disable this setting to use the existing Object Explorer filter experience.",
     "mssql.preview.betaExecutionPlan.description": "Enables the preview query execution plan experience with improved layout, keyboard navigation, tooltips, SQL text display, and toolbar interactions. Disable this setting to use the existing execution plan experience.",
-    "mssql.preview.useVscodeAccountsForEntraMFA.description": "Uses VS Code signed-in accounts for Microsoft Entra ID MFA authentication to SQL. Restart Visual Studio Code after changing this setting.",
+    "mssql.useMsalEntraMfaAuth.description": "Uses MSAL for Microsoft Entra MFA authentication instead of VS Code signed-in accounts. Restart Visual Studio Code after changing this setting.",
     "mssql.authCodeGrant.description": "Prompts users to sign in using their browser.",
     "mssql.deviceCode.description": "Allows users to sign in to input-constrained devices.",
     "mssql.objectExplorer.collapseConnectionGroupsOnStartupDescription": "When enabled, connection groups will be collapsed instead of expanded at startup.",

--- a/extensions/mssql/src/azure/utils.ts
+++ b/extensions/mssql/src/azure/utils.ts
@@ -16,6 +16,7 @@ import * as Constants from "./constants";
 import { TokenCredentialWrapper } from "./credentialWrapper";
 import { getLogger } from "../models/logger";
 import { getErrorMessage } from "../utils/utils";
+import * as ExtensionConstants from "../constants/constants";
 
 const configAzureAD = "azureActiveDirectory";
 const logger = getLogger("AzureUtils");
@@ -91,6 +92,14 @@ export function getEnableConnectionPoolingConfig(): boolean {
         }
     }
     return false; // default setting
+}
+
+export function getUseMsalEntraMfaAuthConfig(): boolean {
+    return (
+        vscode.workspace
+            .getConfiguration()
+            .get<boolean>(ExtensionConstants.configUseMsalEntraMfaAuth, false) ?? false
+    );
 }
 
 export function getAppDataPath(): string {

--- a/extensions/mssql/src/azure/utils.ts
+++ b/extensions/mssql/src/azure/utils.ts
@@ -95,11 +95,9 @@ export function getEnableConnectionPoolingConfig(): boolean {
 }
 
 export function getUseMsalEntraMfaAuthConfig(): boolean {
-    return (
-        vscode.workspace
-            .getConfiguration()
-            .get<boolean>(ExtensionConstants.configUseMsalEntraMfaAuth, false) ?? false
-    );
+    return vscode.workspace
+        .getConfiguration()
+        .get<boolean>(ExtensionConstants.configUseMsalEntraMfaAuth, false);
 }
 
 export function getAppDataPath(): string {

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -77,7 +77,7 @@ import {
     getVscodeEntraTenantOptions,
     resolveVscodeEntraAccount,
 } from "../azure/vscodeEntraMfaUtils";
-import { PreviewFeature, previewService } from "../previews/previewService";
+import { getUseMsalEntraMfaAuthConfig } from "../azure/utils";
 import { getCloudId } from "../azure/providerSettings";
 import {
     AzureBrowseProvider,
@@ -226,9 +226,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         initialConnectionGroup?: IConnectionGroup,
         openAsNewDraft?: boolean,
     ): Promise<void> {
-        const useVscodeAccounts = previewService.isFeatureEnabled(
-            PreviewFeature.UseVscodeAccountsForEntraMFA,
-        );
+        const useVscodeAccounts = !getUseMsalEntraMfaAuthConfig();
 
         // Load connection form components
         this.state.formComponents = await generateConnectionComponents(
@@ -763,10 +761,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
 
             // If they signed in with a new account and they're using VS Code accounts for EntraMFA auth,
             // then add it to the MFA auth account list and select it.
-            if (
-                newlyAddedAccountId &&
-                previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)
-            ) {
+            if (newlyAddedAccountId && !getUseMsalEntraMfaAuthConfig()) {
                 const accountComponent = this.getFormComponent(state, "accountId");
 
                 if (accountComponent) {
@@ -1088,7 +1083,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             hiddenProperties.push("accountId", "tenantId");
         }
         if (this.state.connectionProfile.authenticationType === AuthenticationType.AzureMFA) {
-            if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+            if (!getUseMsalEntraMfaAuthConfig()) {
                 const accountId = this.state.connectionProfile.accountId;
                 const cachedTenants = accountId
                     ? this._cachedEntraTenants.get(accountId)
@@ -2004,7 +1999,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             return this._cachedEntraAccounts;
         }
 
-        if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+        if (!getUseMsalEntraMfaAuthConfig()) {
             this._cachedEntraAccounts = await getVscodeEntraAccountOptions();
         } else {
             this._cachedEntraAccounts = await getAccounts(
@@ -2026,7 +2021,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         }
 
         if (!this._cachedEntraTenants.has(accountId)) {
-            if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+            if (!getUseMsalEntraMfaAuthConfig()) {
                 this._cachedEntraTenants.set(
                     accountId,
                     await getVscodeEntraTenantOptions(accountId),
@@ -2078,7 +2073,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             label: LocalizedConstants.ConnectionDialog.signIn,
             id: "azureSignIn",
             callback: async () => {
-                if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+                if (!getUseMsalEntraMfaAuthConfig()) {
                     const existingAccountIds = new Set(
                         (this._cachedEntraAccounts ?? []).map((a) => a.value),
                     );
@@ -2158,9 +2153,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         }
 
         const tenantComponent = this.getFormComponent(this.state, "tenantId");
-        const useVscodeAccounts = previewService.isFeatureEnabled(
-            PreviewFeature.UseVscodeAccountsForEntraMFA,
-        );
+        const useVscodeAccounts = !getUseMsalEntraMfaAuthConfig();
 
         // If background loading hasn't finished, show spinner on account and
         // await the deferred. updateItemVisibility is called for authenticationType
@@ -2515,7 +2508,7 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             toProfile.authenticationType === AuthenticationType.AzureMFA &&
             toProfile.user !== undefined
         ) {
-            if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+            if (!getUseMsalEntraMfaAuthConfig()) {
                 const matchingAccount = await resolveVscodeEntraAccount(undefined, toProfile.user);
                 if (matchingAccount) {
                     toProfile.accountId = matchingAccount.id;

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -322,6 +322,7 @@ export const configEnableQueryHistoryFeature = "enableQueryHistoryFeature";
 export const configQueryCompletionSoundEnabled = "query.playCompletionSound";
 export const configQueryCompletionSoundFile = "query.completionSoundFile";
 export const configEnableExperimentalFeatures = "mssql.enableExperimentalFeatures";
+export const configUseMsalEntraMfaAuth = "mssql.useMsalEntraMfaAuth";
 export const configOpenQueryResultsInTabByDefault = "mssql.openQueryResultsInTabByDefault";
 export const configOpenQueryResultsInTabByDefaultDoNotShowPrompt =
     "mssql.openQueryResultsInTabByDefaultDoNotShowPrompt";

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -69,7 +69,7 @@ import { getServerTypes, canCheckDatabasePauseStatus } from "../models/connectio
 import * as AzureConstants from "../azure/constants";
 import { ChangePasswordService } from "../services/changePasswordService";
 import { checkIfConnectionIsDockerContainer } from "../docker/dockerUtils";
-import { PreviewFeature, previewService } from "../previews/previewService";
+import { getUseMsalEntraMfaAuthConfig } from "../azure/utils";
 
 /**
  * Maximum number of connection retries when a target serverless Azure SQL database is
@@ -633,9 +633,7 @@ export default class ConnectionManager {
         const self = this;
         return (params: ConnectionContracts.RefreshTokenParams): void => {
             void (async () => {
-                const useVscodeAccountsForEntraMFA = previewService.isFeatureEnabled(
-                    PreviewFeature.UseVscodeAccountsForEntraMFA,
-                );
+                const useVscodeAccountsForEntraMFA = !getUseMsalEntraMfaAuthConfig();
 
                 // Always send a tokenRefreshed notification back to STS so it can unblock
                 // IntelliSense (via TokenUpdateUris). On failure, send empty token/expiresOn=0;
@@ -1272,7 +1270,7 @@ export default class ConnectionManager {
 
         // 2. If the user is using VS Code accounts for Entra MFA, use that flow to refresh the token.
         // STS cannot read VS Code auth sessions, so this path still needs to pass a token.
-        if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+        if (!getUseMsalEntraMfaAuthConfig()) {
             const expiry = Utils.epochToDisplay(connectionInfo.expiresOn * 1000);
 
             if (
@@ -2542,7 +2540,7 @@ export default class ConnectionManager {
             let acquireToken: (accountId: string, tenantId: string) => Promise<IToken | undefined>;
             let onSignIn: () => Promise<string | undefined>;
 
-            if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
+            if (!getUseMsalEntraMfaAuthConfig()) {
                 this._logger.debug("AKV token request received (VS Code accounts path)");
                 getAccounts = async () => {
                     const accounts = await VsCodeAzureHelper.getAccounts();

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -1136,10 +1136,9 @@ export default class MainController implements vscode.Disposable {
                 experimentalFeaturesEnabled: previewService.experimentalFeaturesEnabled.toString(),
                 cloudType: getCloudId(),
                 previewFeatureOverrides: JSON.stringify(previewService.getNonDefaultOverrides()),
-                useMsalEntraMfaAuth: vscode.workspace
-                    .getConfiguration()
-                    .get<boolean>(Constants.configUseMsalEntraMfaAuth, false)
-                    .toString(),
+useMsalEntraMfaAuth: String(
+    vscode.workspace.getConfiguration().get(Constants.configUseMsalEntraMfaAuth, false) ?? false,
+),
                 newEditorConnectionBehavior: vscode.workspace
                     .getConfiguration()
                     .get<string>(

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -1136,9 +1136,11 @@ export default class MainController implements vscode.Disposable {
                 experimentalFeaturesEnabled: previewService.experimentalFeaturesEnabled.toString(),
                 cloudType: getCloudId(),
                 previewFeatureOverrides: JSON.stringify(previewService.getNonDefaultOverrides()),
-useMsalEntraMfaAuth: String(
-    vscode.workspace.getConfiguration().get(Constants.configUseMsalEntraMfaAuth, false) ?? false,
-),
+                useMsalEntraMfaAuth: String(
+                    vscode.workspace
+                        .getConfiguration()
+                        .get(Constants.configUseMsalEntraMfaAuth, false) ?? false,
+                ),
                 newEditorConnectionBehavior: vscode.workspace
                     .getConfiguration()
                     .get<string>(

--- a/extensions/mssql/src/controllers/mainController.ts
+++ b/extensions/mssql/src/controllers/mainController.ts
@@ -59,10 +59,8 @@ import { sendActionEvent, sendErrorEvent, VscodeHttpClient } from "extension-too
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
 import { TableDesignerService } from "../services/tableDesignerService";
 import {
-    getPreviewConfigKey,
     PrivatePreviewContextKey,
     PrivatePreviewFeature,
-    PreviewFeature,
     previewService,
 } from "../previews/previewService";
 import { TableDesignerWebviewController } from "../tableDesigner/tableDesignerWebviewController";
@@ -1138,6 +1136,10 @@ export default class MainController implements vscode.Disposable {
                 experimentalFeaturesEnabled: previewService.experimentalFeaturesEnabled.toString(),
                 cloudType: getCloudId(),
                 previewFeatureOverrides: JSON.stringify(previewService.getNonDefaultOverrides()),
+                useMsalEntraMfaAuth: vscode.workspace
+                    .getConfiguration()
+                    .get<boolean>(Constants.configUseMsalEntraMfaAuth, false)
+                    .toString(),
                 newEditorConnectionBehavior: vscode.workspace
                     .getConfiguration()
                     .get<string>(
@@ -3560,7 +3562,7 @@ export default class MainController implements vscode.Disposable {
             Constants.configSovereignCloudEnvironment,
             Constants.configSovereignCloudCustomEnvironment,
             Constants.configCustomEnvironment,
-            getPreviewConfigKey(PreviewFeature.UseVscodeAccountsForEntraMFA),
+            Constants.configUseMsalEntraMfaAuth,
         ];
 
         if (configSettingsRequiringReload.some((setting) => e.affectsConfiguration(setting))) {

--- a/extensions/mssql/src/languageservice/serviceclient.ts
+++ b/extensions/mssql/src/languageservice/serviceclient.ts
@@ -35,11 +35,15 @@ import { ServerStatusView } from "./serverStatus";
 import StatusView from "../views/statusView";
 import * as LanguageServiceContracts from "../models/contracts/languageService";
 import { getErrorMessage } from "../utils/utils";
-import { getAppDataPath, getEnableConnectionPoolingConfig } from "../azure/utils";
+import {
+    getAppDataPath,
+    getEnableConnectionPoolingConfig,
+    getUseMsalEntraMfaAuthConfig,
+} from "../azure/utils";
 import { serviceName } from "../azure/constants";
 import { sendActionEvent, sendErrorEvent } from "extension-toolkit/vscode";
 import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry";
-import { PrivatePreviewFeature, PreviewFeature, previewService } from "../previews/previewService";
+import { PrivatePreviewFeature, previewService } from "../previews/previewService";
 import { getRuntimeConfigPath, ServiceExecutable } from "./serviceExecutablePaths";
 import { config } from "../configurations/config";
 
@@ -706,12 +710,10 @@ export default class SqlToolsServiceClient {
             args.push("--vscode-debug-launch");
         }
 
-        // When the VS Code accounts preview is enabled, delegate MFA token acquisition to the
-        // client via AccessTokenCallback. Otherwise use MSAL via SqlAuthenticationProvider.
-        if (previewService.isFeatureEnabled(PreviewFeature.UseVscodeAccountsForEntraMFA)) {
-            args.push("--request-mfa-token-from-client");
-        } else {
+        if (getUseMsalEntraMfaAuthConfig()) {
             args.push("--enable-sql-authentication-provider");
+        } else {
+            args.push("--request-mfa-token-from-client");
         }
 
         // Enable Connection pooling to improve connection performance

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -61,7 +61,7 @@ import { getErrorMessage, uuid } from "../utils/utils";
 import { ConnectionConfig } from "../connectionconfig/connectionconfig";
 import { MissingEntraAuthAccountError } from "../azure/vscodeEntraMfaUtils";
 import { AzureSqlDatabaseStatus, VsCodeAzureHelper } from "../connectionconfig/azureHelpers";
-import { PreviewFeature, previewService } from "../previews/previewService";
+import { getUseMsalEntraMfaAuthConfig } from "../azure/utils";
 import { getNodeDescriptor } from "./nodes/nodeUtils";
 
 export class CancelableLoadingNode extends vscode.TreeItem {
@@ -1035,11 +1035,7 @@ export class ObjectExplorerService {
                 if (choice === LocalizedConstants.ObjectExplorer.FailedOEConnectionErrorSignIn) {
                     try {
                         // User chose to sign in to the missing account; try again.
-                        if (
-                            previewService.isFeatureEnabled(
-                                PreviewFeature.UseVscodeAccountsForEntraMFA,
-                            )
-                        ) {
+                        if (!getUseMsalEntraMfaAuthConfig()) {
                             await VsCodeAzureHelper.signIn(true /* forceSignInPrompt */);
                         } else {
                             await this._connectionManager.addAccount();

--- a/extensions/mssql/src/previews/previewService.ts
+++ b/extensions/mssql/src/previews/previewService.ts
@@ -14,7 +14,6 @@ export enum PreviewFeature {
     BetaResultsGrid = "betaResultsGrid",
     BetaObjectExplorerFilter = "betaObjectExplorerFilter",
     BetaExecutionPlan = "betaExecutionPlan",
-    UseVscodeAccountsForEntraMFA = "useVscodeAccountsForEntraMFA",
 }
 
 /**

--- a/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
+++ b/extensions/mssql/test/unit/connectionDialogWebviewController.test.ts
@@ -49,8 +49,8 @@ import {
     stubGetCapabilitiesRequest,
     stubInstantiationService,
     stubMessageBoxes,
-    stubPreviewService,
     stubTelemetry,
+    stubUseMsalEntraMfaAuthConfig,
     stubUserSurvey,
 } from "./utils";
 import {
@@ -73,7 +73,6 @@ import { FirewallRuleSpec } from "../../src/sharedInterfaces/firewallRule";
 import { FirewallService } from "../../src/firewall/firewallService";
 import { AddFirewallRuleState } from "../../src/sharedInterfaces/addFirewallRule";
 import { deepClone } from "../../src/models/utils";
-import { PreviewFeature } from "../../src/previews/previewService";
 
 chai.use(sinonChai);
 
@@ -865,10 +864,8 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 sandbox.stub(controller["_fabricBrowseProvider"], "autoLoadContents").resolves();
             });
 
-            test("refreshes auth account options and selects the newly added account when the VS Code Entra MFA preview is enabled", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+            test("refreshes auth account options and selects the newly added account when VS Code Entra authentication is used", async () => {
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 stubVscodeAzureSignIn(sandbox);
                 sandbox
                     .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
@@ -908,10 +905,8 @@ suite("ConnectionDialogWebviewController Tests", () => {
                 );
             });
 
-            test("does not alter auth form account options or connectionProfile.accountId when the VS Code Entra MFA preview is disabled", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
-                });
+            test("does not alter auth form account options or connectionProfile.accountId when MSAL Entra MFA authentication is used", async () => {
+                stubUseMsalEntraMfaAuthConfig(sandbox, true);
                 stubVscodeAzureSignIn(sandbox);
                 sandbox
                     .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
@@ -945,9 +940,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
             });
 
             test("leaves the existing auth selection unchanged when no new account was added", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 stubVscodeAzureSignIn(sandbox);
                 sandbox
                     .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
@@ -983,9 +976,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
             });
 
             test("applies the same event-scoped auth synchronization for FabricBrowse", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 stubVscodeAzureSignIn(sandbox);
                 sandbox
                     .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
@@ -1196,7 +1187,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
         });
 
         test("loadConnection normalizes legacy Entra account ids when VS Code account mode is enabled", async () => {
-            stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: true });
+            stubUseMsalEntraMfaAuthConfig(sandbox, false);
             sandbox
                 .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
                 .resolves([mockAccounts.signedInAccount]);
@@ -1228,7 +1219,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
         });
 
         test("does not load tenants for every VS Code account in the background", async () => {
-            stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: true });
+            stubUseMsalEntraMfaAuthConfig(sandbox, false);
             sandbox
                 .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")
                 .resolves([mockAccounts.signedInAccount, mockAccounts.notSignedInAccount]);
@@ -1534,13 +1525,11 @@ suite("ConnectionDialogWebviewController Tests", () => {
 
         suite("loadFromConnectionString", () => {
             setup(() => {
-                // Pin the preview feature to a deterministic value so the Azure MFA
+                // Pin the authentication mode so the Azure MFA
                 // path uses the stubbed azureAccountService instead of waiting on the
                 // background VS Code Entra data load (`_entraDataLoaded`), which depends
                 // on real `vscode.authentication` APIs and hangs in CI.
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, true);
             });
 
             async function runConnectionStringScenario(
@@ -1691,7 +1680,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
 
     test("getAzureActionButtons", async () => {
         // Tests the MSAL path (non-VS-Code-accounts)
-        stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: false });
+        stubUseMsalEntraMfaAuthConfig(sandbox, true);
         controller.state.connectionProfile.authenticationType = AuthenticationType.AzureMFA;
         controller.state.connectionProfile.accountId = "TestEntraAccountId";
 
@@ -2001,7 +1990,7 @@ suite("ConnectionDialogWebviewController Tests", () => {
 
     test("getAzureActionButtons uses VS Code sign-in when VS Code account mode is enabled", async () => {
         loadVscodeEntraDataAsyncStub.restore();
-        stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: true });
+        stubUseMsalEntraMfaAuthConfig(sandbox, false);
 
         sandbox
             .stub(AzureHelpers.VsCodeAzureHelper, "getAccounts")

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -34,14 +34,13 @@ import { TestPrompter } from "./stubs";
 import {
     stubExtensionContext,
     stubMessageBoxes,
-    stubPreviewService,
     createStubLogger,
     stubInstantiationService,
+    stubUseMsalEntraMfaAuthConfig,
 } from "./utils";
 import { Deferred } from "../../src/protocol";
 import { Perf } from "../../src/perf/perfTelemetry";
 import { MsalAzureController } from "../../src/azure/msal/msalAzureController";
-import { PreviewFeature } from "../../src/previews/previewService";
 import * as vscodeEntraMfaUtils from "../../src/azure/vscodeEntraMfaUtils";
 import * as azureHelpers from "../../src/connectionconfig/azureHelpers";
 import * as telemetry from "extension-toolkit/vscode/telemetry";
@@ -325,7 +324,7 @@ suite("ConnectionManager Tests", () => {
     suite("Token request handling", () => {
         setup(() => {
             // Test the MSAL (non-VS-Code-accounts) path
-            stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: false });
+            stubUseMsalEntraMfaAuthConfig(sandbox, true);
             connectionManager = createConnectionManager();
         });
         test("should return cached token when valid", async () => {
@@ -413,9 +412,7 @@ suite("ConnectionManager Tests", () => {
         let acquireTokenStub: sinon.SinonStub;
 
         setup(() => {
-            stubPreviewService(sandbox, {
-                [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-            });
+            stubUseMsalEntraMfaAuthConfig(sandbox, false);
             connectionManager = createConnectionManager();
             acquireTokenStub = sandbox.stub(
                 vscodeEntraMfaUtils,
@@ -545,9 +542,7 @@ suite("ConnectionManager Tests", () => {
         }
 
         setup(() => {
-            stubPreviewService(sandbox, {
-                [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
-            });
+            stubUseMsalEntraMfaAuthConfig(sandbox, true);
             connectionManager = createConnectionManager();
             sendNotificationStub = mockServiceClient.sendNotification as sinon.SinonStub;
             sendNotificationStub.reset();
@@ -743,9 +738,7 @@ suite("ConnectionManager Tests", () => {
         }
 
         setup(async () => {
-            stubPreviewService(sandbox, {
-                [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-            });
+            stubUseMsalEntraMfaAuthConfig(sandbox, false);
             connectionManager = createConnectionManager();
             acquireTokenStub = sandbox.stub(
                 vscodeEntraMfaUtils,
@@ -816,7 +809,7 @@ suite("ConnectionManager Tests", () => {
 
         setup(async () => {
             // Test the MSAL (non-VS-Code-accounts) path
-            stubPreviewService(sandbox, { [PreviewFeature.UseVscodeAccountsForEntraMFA]: false });
+            stubUseMsalEntraMfaAuthConfig(sandbox, true);
 
             mockAccountStore = sandbox.createStubInstance(AccountStore);
             mockAzureController = sandbox.createStubInstance(MsalAzureController);

--- a/extensions/mssql/test/unit/objectExplorerService.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerService.test.ts
@@ -60,12 +60,11 @@ import {
     initializeIconUtils,
     stubLogger,
     stubMessageBoxes,
-    stubPreviewService,
+    stubUseMsalEntraMfaAuthConfig,
 } from "./utils";
 import { ObjectExplorerUtils } from "../../src/objectExplorer/objectExplorerUtils";
 import * as vscodeEntraMfaUtils from "../../src/azure/vscodeEntraMfaUtils";
 import * as azureHelpers from "../../src/connectionconfig/azureHelpers";
-import { PreviewFeature } from "../../src/previews/previewService";
 const { MissingEntraAuthAccountError } = vscodeEntraMfaUtils;
 
 chai.use(sinonChai);
@@ -2857,9 +2856,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should prompt with Sign In and Edit options when MissingVsCodeEntraAuthError is thrown", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 mockConnectionManager.prepareConnectionInfo.rejects(authError);
                 // User dismisses the dialog
@@ -2889,9 +2886,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should call signIn and retry prepareConnectionInfo when user chooses Sign In and Retry", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 const connectionProfile = createMockConnectionProfile({
                     authenticationType: "AzureMFA",
@@ -2927,9 +2922,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should return undefined if retry after sign-in also fails", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 const connectionProfile = createMockConnectionProfile({
                     authenticationType: "AzureMFA",
@@ -2955,9 +2948,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should open connection dialog when user chooses Edit Connection Profile", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 mockConnectionManager.prepareConnectionInfo.rejects(authError);
 
@@ -2987,9 +2978,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should return undefined without prompting when user dismisses the error dialog", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 mockConnectionManager.prepareConnectionInfo.rejects(authError);
                 messageBoxes.showErrorMessage.resolves(undefined);
@@ -3009,9 +2998,7 @@ suite("OE Service Tests", () => {
             });
 
             test("should return undefined for non-MissingVsCodeEntraAuthError errors when Entra MFA is enabled", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: true,
-                });
+                stubUseMsalEntraMfaAuthConfig(sandbox, false);
                 const genericError = new Error("Some unexpected error");
                 mockConnectionManager.prepareConnectionInfo.rejects(genericError);
 
@@ -3027,10 +3014,8 @@ suite("OE Service Tests", () => {
                 ).to.be.false;
             });
 
-            test("should prompt with Sign In and Edit options and use addAccount when useVscodeAccountsForEntraMfa is disabled", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
-                });
+            test("should prompt with Sign In and Edit options and use addAccount when MSAL Entra MFA authentication is enabled", async () => {
+                stubUseMsalEntraMfaAuthConfig(sandbox, true);
 
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 mockConnectionManager.prepareConnectionInfo.rejects(authError);
@@ -3055,10 +3040,8 @@ suite("OE Service Tests", () => {
                 ).to.be.false;
             });
 
-            test("should call addAccount and retry when useVscodeAccountsForEntraMfa is disabled and user chooses Sign In", async () => {
-                stubPreviewService(sandbox, {
-                    [PreviewFeature.UseVscodeAccountsForEntraMFA]: false,
-                });
+            test("should call addAccount and retry when MSAL Entra MFA authentication is enabled and user chooses Sign In", async () => {
+                stubUseMsalEntraMfaAuthConfig(sandbox, true);
 
                 const authError = new MissingEntraAuthAccountError("Account not available");
                 const connectionProfile = createMockConnectionProfile({

--- a/extensions/mssql/test/unit/utils.ts
+++ b/extensions/mssql/test/unit/utils.ts
@@ -19,6 +19,7 @@ import { ILogger } from "../../src/sharedInterfaces/logger";
 import { logger as baseLogger } from "../../src/models/logger";
 import { PreviewFeature, previewService } from "../../src/previews/previewService";
 import { IInstantiationService, InstantiationService } from "extension-toolkit/base";
+import * as AzureUtils from "../../src/azure/utils";
 
 // Stubs the telemetry code
 export function stubTelemetry(sandbox?: sinon.SinonSandbox): {
@@ -390,6 +391,10 @@ export function stubPreviewService(
     sandbox
         .stub(previewService, "isFeatureEnabled")
         .callsFake((feature: PreviewFeature) => previews[feature] ?? experimentalFeaturesEnabled);
+}
+
+export function stubUseMsalEntraMfaAuthConfig(sandbox: sinon.SinonSandbox, enabled: boolean): void {
+    sandbox.stub(AzureUtils, "getUseMsalEntraMfaAuthConfig").returns(enabled);
 }
 
 /**

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -10801,8 +10801,8 @@
     <trans-unit id="mssql.format.enablePreviewFormatter">
       <source xml:lang="en">Use the preview SQL formatter. Disable this setting to temporarily use the existing formatter.</source>
     </trans-unit>
-    <trans-unit id="mssql.preview.useVscodeAccountsForEntraMFA.description">
-      <source xml:lang="en">Uses VS Code signed-in accounts for Microsoft Entra ID MFA authentication to SQL. Restart Visual Studio Code after changing this setting.</source>
+    <trans-unit id="mssql.useMsalEntraMfaAuth.description">
+      <source xml:lang="en">Uses MSAL for Microsoft Entra MFA authentication instead of VS Code signed-in accounts. Restart Visual Studio Code after changing this setting.</source>
     </trans-unit>
     <trans-unit id="mssql.viewBackgroundTaskLogs">
       <source xml:lang="en">View Task Logs</source>


### PR DESCRIPTION
## Description

Promotes VS Code account-based Microsoft Entra authentication out of preview and makes it the default. Replaces `mssql.preview.useVscodeAccountsForEntraMFA` with the `mssql.useMsalEntraMfaAuth` escape hatch, which defaults to `false`, and records the new setting in extension activation telemetry.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Validation

- `npm run build -- --target mssql`
- 175 focused unit tests across connection dialog, connection manager, and object explorer service
- Focused ESLint and Prettier checks for all changed files

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)