### PR TITLE
Make execution error line numbers clickable in Query Results

### DIFF
--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -1507,6 +1507,12 @@ export default class QueryRunner {
                 selection.endColumn,
             );
             editor.selection = querySelection;
+            // Scroll the target into view; without this the cursor moves but a long script stays
+            // where it was, which defeats jumping to an error far from the current position.
+            editor.revealRange(
+                querySelection,
+                vscode.TextEditorRevealType.InCenterIfOutsideViewport,
+            );
             return;
         }
     }

--- a/extensions/mssql/src/models/interfaces.ts
+++ b/extensions/mssql/src/models/interfaces.ts
@@ -164,6 +164,7 @@ export interface IResultMessage {
     isError: boolean;
     time: string;
     message: string;
+    errorSelection?: ISelectionData;
     rowsAffected?: number;
 }
 

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -20,7 +20,7 @@ import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry"
 import * as qr from "../sharedInterfaces/queryResult";
 import { ExecutionPlanService } from "../services/executionPlanService";
 import { countResultSets, isOpenQueryResultsInTabByDefaultEnabled } from "../queryResult/utils";
-import { createErrorLineLink } from "../queryResult/messageLinks";
+import { createErrorMessageNavigation } from "../queryResult/messageLinks";
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { getErrorMessage } from "../utils/utils";
 import { getLogger } from "./logger";
@@ -688,26 +688,20 @@ export class SqlOutputContentProvider {
 
                 const showBatchMessages = Utils.shouldShowBatchMessages();
                 if (message.isError || message.batchId >= 0 || showBatchMessages) {
-                    // An execution error names the line it failed on, counted from the start of
-                    // its batch. Turn that into a link back to the line in the document.
-                    let errorLink: IMessage["link"];
-                    let errorSelection: IMessage["selection"];
-                    if (message.isError) {
-                        const link = createErrorLineLink(
-                            message.message,
-                            queryRunner.batchSets[message.batchId]?.selection,
-                        );
-                        if (link) {
-                            errorLink = { text: link.text, uri: queryRunner.uri };
-                            errorSelection = link.selection;
-                        }
-                    }
+                    const { errorSelection, ...displayMessage } = message;
+                    const errorNavigation = message.isError
+                        ? createErrorMessageNavigation(
+                              message.message,
+                              errorSelection,
+                              queryRunner.uri,
+                          )
+                        : undefined;
 
                     resultWebviewState.messages.push({
-                        ...message,
+                        ...displayMessage,
                         batchId: showBatchMessages ? message.batchId : undefined,
-                        link: errorLink,
-                        selection: errorSelection,
+                        link: errorNavigation?.link,
+                        selection: errorNavigation?.selection,
                     });
                 }
                 if (typeof message.rowsAffected === "number") {

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -20,6 +20,7 @@ import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry"
 import * as qr from "../sharedInterfaces/queryResult";
 import { ExecutionPlanService } from "../services/executionPlanService";
 import { countResultSets, isOpenQueryResultsInTabByDefaultEnabled } from "../queryResult/utils";
+import { createErrorLineLink } from "../queryResult/messageLinks";
 import { ApiStatus } from "../sharedInterfaces/webview";
 import { getErrorMessage } from "../utils/utils";
 import { getLogger } from "./logger";
@@ -687,9 +688,27 @@ export class SqlOutputContentProvider {
 
                 const showBatchMessages = Utils.shouldShowBatchMessages();
                 if (message.isError || message.batchId >= 0 || showBatchMessages) {
-                    resultWebviewState.messages.push(
-                        showBatchMessages ? message : { ...message, batchId: undefined },
-                    );
+                    // An execution error names the line it failed on, counted from the start of
+                    // its batch. Turn that into a link back to the line in the document.
+                    let errorLink: IMessage["link"];
+                    let errorSelection: IMessage["selection"];
+                    if (message.isError) {
+                        const link = createErrorLineLink(
+                            message.message,
+                            queryRunner.batchSets[message.batchId]?.selection,
+                        );
+                        if (link) {
+                            errorLink = { text: link.text, uri: queryRunner.uri };
+                            errorSelection = link.selection;
+                        }
+                    }
+
+                    resultWebviewState.messages.push({
+                        ...message,
+                        batchId: showBatchMessages ? message.batchId : undefined,
+                        link: errorLink,
+                        selection: errorSelection,
+                    });
                 }
                 if (typeof message.rowsAffected === "number") {
                     resultWebviewState.rowsAffected = message.rowsAffected;

--- a/extensions/mssql/src/queryResult/messageLinks.ts
+++ b/extensions/mssql/src/queryResult/messageLinks.ts
@@ -29,6 +29,7 @@ export function createErrorMessageNavigation(
         return undefined;
     }
 
+    // Match either a Windows CRLF or Unix LF line ending so only the error header is inspected.
     const header = message.split(/\r?\n/, 1)[0];
     const linkText = header.slice(header.lastIndexOf(",") + 1).trim();
     if (!linkText) {

--- a/extensions/mssql/src/queryResult/messageLinks.ts
+++ b/extensions/mssql/src/queryResult/messageLinks.ts
@@ -4,98 +4,39 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ISelectionData } from "../models/interfaces";
+import { IMessageLink } from "../sharedInterfaces/queryResult";
 
 /**
- * Matches the header SQL Server puts in front of an execution error and captures the line it
- * reports, for example "Msg 102, Level 15, State 1, Line 11". The header may name a procedure
- * before the line, and may be followed by "[Batch Start Line N]", so the line is taken from the
- * first "Line" after the state.
- *
- * Only the English header is matched. A server running under another language reports a
- * translated header, and those messages are left without a link rather than guessed at.
+ * Navigation metadata for a query error message.
  */
-const sqlErrorHeader = /^Msg\s+\d+,\s*Level\s+\d+,\s*State\s+\d+,.*?\b(Line\s+(\d+))/;
-
-export interface ParsedErrorLine {
-    /**
-     * The matched text, for example "Line 11". Used verbatim as the link label so that it lines
-     * up with the text already in the message.
-     */
-    text: string;
-    /** The line the server reported: 1-based, and relative to the batch rather than the file. */
-    batchLine: number;
+export interface ErrorMessageNavigation {
+    link: IMessageLink;
+    selection: ISelectionData;
 }
 
 /**
- * Reads the line number out of a SQL Server error message, or returns undefined when the message
- * is not an error header this can understand.
+ * Builds navigation for an error when SQL Tools Service supplies an absolute source selection.
+ * SQL Server puts the source line in the final comma-delimited segment of the error header. Using
+ * that segment keeps the rest of the error styled as an error without depending on localized
+ * header labels.
  */
-export function parseErrorLine(message: string | undefined): ParsedErrorLine | undefined {
-    if (!message) {
-        return undefined;
-    }
-
-    const match = sqlErrorHeader.exec(message);
-    if (!match) {
-        return undefined;
-    }
-
-    const batchLine = Number(match[2]);
-    if (!Number.isSafeInteger(batchLine) || batchLine < 1) {
-        return undefined;
-    }
-
-    return { text: match[1], batchLine };
-}
-
-/**
- * Turns a line the server reported into a position in the document. The server counts from the
- * start of the batch it was given, so the batch's own position in the document is added back.
- * @param batchSelection Where the executed batch sits in the document.
- * @param batchLine The 1-based line reported by the server, relative to the batch.
- */
-export function toDocumentSelection(
-    batchSelection: ISelectionData,
-    batchLine: number,
-): ISelectionData {
-    const line = batchSelection.startLine + batchLine - 1;
-    return {
-        startLine: line,
-        startColumn: 0,
-        endLine: line,
-        endColumn: 0,
-    };
-}
-
-/**
- * Builds the link and target for an error message, when the message names a line and the batch it
- * came from is known. Returns undefined when the message should stay as plain text.
- */
-export function createErrorLineLink(
+export function createErrorMessageNavigation(
     message: string | undefined,
-    batchSelection: ISelectionData | undefined,
-): { text: string; selection: ISelectionData } | undefined {
-    if (!batchSelection) {
+    errorSelection: ISelectionData | undefined,
+    uri: string,
+): ErrorMessageNavigation | undefined {
+    if (!message || !errorSelection) {
         return undefined;
     }
 
-    const parsed = parseErrorLine(message);
-    if (!parsed) {
+    const header = message.split(/\r?\n/, 1)[0];
+    const linkText = header.slice(header.lastIndexOf(",") + 1).trim();
+    if (!linkText) {
         return undefined;
     }
 
-    const selection = toDocumentSelection(batchSelection, parsed.batchLine);
-    if (selection.startLine < 0) {
-        return undefined;
-    }
-
-    return { text: parsed.text, selection };
-}
-
-/**
- * Whether a rendered message line should carry the link. A message can span several lines once it
- * is split for display, and the link belongs on the line whose text it was taken from.
- */
-export function lineOwnsLink(lineText: string, linkText: string | undefined): boolean {
-    return !!linkText && lineText.includes(linkText);
+    return {
+        link: { text: linkText, uri },
+        selection: errorSelection,
+    };
 }

--- a/extensions/mssql/src/queryResult/messageLinks.ts
+++ b/extensions/mssql/src/queryResult/messageLinks.ts
@@ -31,8 +31,16 @@ export function createErrorMessageNavigation(
 
     // Match either a Windows CRLF or Unix LF line ending so only the error header is inspected.
     const header = message.split(/\r?\n/, 1)[0];
-    const linkText = header.slice(header.lastIndexOf(",") + 1).trim();
-    if (!linkText) {
+    const lastComma = header.lastIndexOf(",");
+    if (lastComma === -1) {
+        return undefined;
+    }
+
+    const linkText = header.slice(lastComma + 1).trim();
+    // Capture the trailing number without depending on the localized label preceding it.
+    const lineNumberMatch = /(?:^|\s)(\d+)$/.exec(linkText);
+    const expectedLineNumber = errorSelection.startLine + 1;
+    if (!lineNumberMatch || Number(lineNumberMatch[1]) !== expectedLineNumber) {
         return undefined;
     }
 

--- a/extensions/mssql/src/queryResult/messageLinks.ts
+++ b/extensions/mssql/src/queryResult/messageLinks.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ISelectionData } from "../models/interfaces";
+
+/**
+ * Matches the header SQL Server puts in front of an execution error and captures the line it
+ * reports, for example "Msg 102, Level 15, State 1, Line 11". The header may name a procedure
+ * before the line, and may be followed by "[Batch Start Line N]", so the line is taken from the
+ * first "Line" after the state.
+ *
+ * Only the English header is matched. A server running under another language reports a
+ * translated header, and those messages are left without a link rather than guessed at.
+ */
+const sqlErrorHeader = /^Msg\s+\d+,\s*Level\s+\d+,\s*State\s+\d+,.*?\b(Line\s+(\d+))/;
+
+export interface ParsedErrorLine {
+    /**
+     * The matched text, for example "Line 11". Used verbatim as the link label so that it lines
+     * up with the text already in the message.
+     */
+    text: string;
+    /** The line the server reported: 1-based, and relative to the batch rather than the file. */
+    batchLine: number;
+}
+
+/**
+ * Reads the line number out of a SQL Server error message, or returns undefined when the message
+ * is not an error header this can understand.
+ */
+export function parseErrorLine(message: string | undefined): ParsedErrorLine | undefined {
+    if (!message) {
+        return undefined;
+    }
+
+    const match = sqlErrorHeader.exec(message);
+    if (!match) {
+        return undefined;
+    }
+
+    const batchLine = Number(match[2]);
+    if (!Number.isSafeInteger(batchLine) || batchLine < 1) {
+        return undefined;
+    }
+
+    return { text: match[1], batchLine };
+}
+
+/**
+ * Turns a line the server reported into a position in the document. The server counts from the
+ * start of the batch it was given, so the batch's own position in the document is added back.
+ * @param batchSelection Where the executed batch sits in the document.
+ * @param batchLine The 1-based line reported by the server, relative to the batch.
+ */
+export function toDocumentSelection(
+    batchSelection: ISelectionData,
+    batchLine: number,
+): ISelectionData {
+    const line = batchSelection.startLine + batchLine - 1;
+    return {
+        startLine: line,
+        startColumn: 0,
+        endLine: line,
+        endColumn: 0,
+    };
+}
+
+/**
+ * Builds the link and target for an error message, when the message names a line and the batch it
+ * came from is known. Returns undefined when the message should stay as plain text.
+ */
+export function createErrorLineLink(
+    message: string | undefined,
+    batchSelection: ISelectionData | undefined,
+): { text: string; selection: ISelectionData } | undefined {
+    if (!batchSelection) {
+        return undefined;
+    }
+
+    const parsed = parseErrorLine(message);
+    if (!parsed) {
+        return undefined;
+    }
+
+    const selection = toDocumentSelection(batchSelection, parsed.batchLine);
+    if (selection.startLine < 0) {
+        return undefined;
+    }
+
+    return { text: parsed.text, selection };
+}
+
+/**
+ * Whether a rendered message line should carry the link. A message can span several lines once it
+ * is split for display, and the link belongs on the line whose text it was taken from.
+ */
+export function lineOwnsLink(lineText: string, linkText: string | undefined): boolean {
+    return !!linkText && lineText.includes(linkText);
+}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryMessageTab.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryMessageTab.tsx
@@ -85,9 +85,8 @@ export const QueryMessageTab = () => {
                             selectionData: item.selection,
                         });
                     };
-                    // An execution error already names the line in its own text, so make that
-                    // text the link rather than repeating it. Anything else gets the link
-                    // appended, which is how the batch start message reads.
+                    // Structured query errors link only their line segment. Other messages append
+                    // their link, which is how the batch start message reads.
                     const linkStart = item.message.indexOf(item.link.text);
                     return (
                         <DataGridCell focusMode="group" style={{ minHeight: "18px" }}>

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryMessageTab.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryMessageTab.tsx
@@ -79,24 +79,36 @@ export const QueryMessageTab = () => {
             renderHeaderCell: () => <>{locConstants.queryResult.message}</>,
             renderCell: (item) => {
                 if (item.link?.text && item.selection) {
+                    const navigate = async () => {
+                        await context.extensionRpc.sendRequest(qr.SetEditorSelectionRequest.type, {
+                            uri: item.link?.uri,
+                            selectionData: item.selection,
+                        });
+                    };
+                    // An execution error already names the line in its own text, so make that
+                    // text the link rather than repeating it. Anything else gets the link
+                    // appended, which is how the batch start message reads.
+                    const linkStart = item.message.indexOf(item.link.text);
                     return (
                         <DataGridCell focusMode="group" style={{ minHeight: "18px" }}>
-                            <div style={{ whiteSpace: "pre" }}>
-                                {item.message}{" "}
-                                <Link
-                                    className={classes.messagesLink}
-                                    onClick={async () => {
-                                        await context.extensionRpc.sendRequest(
-                                            qr.SetEditorSelectionRequest.type,
-                                            {
-                                                uri: item.link?.uri,
-                                                selectionData: item.selection,
-                                            },
-                                        );
-                                    }}
-                                    inline>
-                                    {item?.link?.text}
+                            <div
+                                style={{
+                                    whiteSpace: "pre",
+                                    color: item.isError
+                                        ? "var(--vscode-errorForeground)"
+                                        : undefined,
+                                }}>
+                                {linkStart === -1 ? (
+                                    <>{item.message} </>
+                                ) : (
+                                    item.message.slice(0, linkStart)
+                                )}
+                                <Link className={classes.messagesLink} onClick={navigate} inline>
+                                    {item.link.text}
                                 </Link>
+                                {linkStart === -1
+                                    ? undefined
+                                    : item.message.slice(linkStart + item.link.text.length)}
                             </div>
                         </DataGridCell>
                     );

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
@@ -48,9 +48,17 @@ export const splitMessages = (messages: qr.IMessage[] | undefined | null): qr.IM
     }
     return messages.flatMap((message) => {
         const lines = message.message.split(/\r?\n/);
-        return lines.map((line) => {
+        // A link points at one place in the message, so once the message is split it belongs to
+        // the line it was taken from. Errors span two lines and would otherwise repeat the link.
+        const linkText = message.link?.text;
+        const linkedLine = linkText ? lines.findIndex((line) => line.includes(linkText)) : 0;
+        return lines.map((line, index) => {
             let newMessage = { ...message };
             newMessage.message = line;
+            if (index !== (linkedLine === -1 ? 0 : linkedLine)) {
+                newMessage.link = undefined;
+                newMessage.selection = undefined;
+            }
             return newMessage;
         });
     });

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultUtils.ts
@@ -47,6 +47,7 @@ export const splitMessages = (messages: qr.IMessage[] | undefined | null): qr.IM
         return [];
     }
     return messages.flatMap((message) => {
+        // Match both Windows CRLF and Unix LF line endings before rendering each display row.
         const lines = message.message.split(/\r?\n/);
         // A link points at one place in the message, so once the message is split it belongs to
         // the line it was taken from. Errors span two lines and would otherwise repeat the link.

--- a/extensions/mssql/test/unit/messageLinks.test.ts
+++ b/extensions/mssql/test/unit/messageLinks.test.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import {
+    createErrorLineLink,
+    parseErrorLine,
+    toDocumentSelection,
+} from "../../src/queryResult/messageLinks";
+import { ISelectionData } from "../../src/models/interfaces";
+import { splitMessages } from "../../src/webviews/pages/QueryResult/queryResultUtils";
+import * as qr from "../../src/sharedInterfaces/queryResult";
+
+const batchAt = (startLine: number): ISelectionData => ({
+    startLine,
+    startColumn: 0,
+    endLine: startLine + 20,
+    endColumn: 0,
+});
+
+suite("Query message links", () => {
+    suite("parseErrorLine", () => {
+        test("reads the line out of a standard error header", () => {
+            const parsed = parseErrorLine("Msg 102, Level 15, State 1, Line 11");
+
+            expect(parsed).to.deep.equal({ text: "Line 11", batchLine: 11 });
+        });
+
+        test("reads the line when the header names a procedure", () => {
+            const parsed = parseErrorLine("Msg 2812, Level 16, State 62, Procedure myProc, Line 4");
+
+            expect(parsed).to.deep.equal({ text: "Line 4", batchLine: 4 });
+        });
+
+        test("takes the error line rather than the batch start line that follows it", () => {
+            const parsed = parseErrorLine(
+                "Msg 208, Level 16, State 1, Line 3 [Batch Start Line 0]",
+            );
+
+            expect(parsed).to.deep.equal({ text: "Line 3", batchLine: 3 });
+        });
+
+        test("reads a line from a message that continues onto another line", () => {
+            const parsed = parseErrorLine(
+                "Msg 102, Level 15, State 1, Line 11\r\nIncorrect syntax near ','.",
+            );
+
+            expect(parsed?.batchLine).to.equal(11);
+        });
+
+        test("ignores text that is not an error header", () => {
+            expect(parseErrorLine("Commands completed successfully.")).to.be.undefined;
+            expect(parseErrorLine("(3 rows affected)")).to.be.undefined;
+            // "Line" on its own is not enough; the message must be an error header
+            expect(parseErrorLine("Started executing query at Line 5")).to.be.undefined;
+        });
+
+        test("ignores an empty or missing message", () => {
+            expect(parseErrorLine(undefined)).to.be.undefined;
+            expect(parseErrorLine("")).to.be.undefined;
+        });
+
+        test("ignores a header that reports a line of zero", () => {
+            expect(parseErrorLine("Msg 102, Level 15, State 1, Line 0")).to.be.undefined;
+        });
+    });
+
+    suite("toDocumentSelection", () => {
+        test("maps the first line of a batch to the batch's own start line", () => {
+            const selection = toDocumentSelection(batchAt(0), 1);
+
+            expect(selection).to.deep.equal({
+                startLine: 0,
+                startColumn: 0,
+                endLine: 0,
+                endColumn: 0,
+            });
+        });
+
+        test("offsets the reported line by where the batch starts", () => {
+            // batch starts on document line 40 (0-based), server reports its line 11
+            const selection = toDocumentSelection(batchAt(40), 11);
+
+            expect(selection.startLine).to.equal(50);
+            expect(selection.endLine).to.equal(50);
+        });
+
+        test("collapses to a cursor position rather than selecting a range", () => {
+            const selection = toDocumentSelection(batchAt(7), 3);
+
+            expect(selection.startLine).to.equal(selection.endLine);
+            expect(selection.startColumn).to.equal(0);
+            expect(selection.endColumn).to.equal(0);
+        });
+    });
+
+    suite("createErrorLineLink", () => {
+        test("builds a link for an error inside a batch further down the file", () => {
+            const link = createErrorLineLink(
+                "Msg 102, Level 15, State 1, Line 11\nIncorrect syntax near ','.",
+                batchAt(40),
+            );
+
+            expect(link?.text).to.equal("Line 11");
+            expect(link?.selection.startLine).to.equal(50);
+        });
+
+        test("produces nothing when the batch is unknown", () => {
+            const link = createErrorLineLink("Msg 102, Level 15, State 1, Line 11", undefined);
+
+            expect(link).to.be.undefined;
+        });
+
+        test("produces nothing for a message with no line in it", () => {
+            expect(createErrorLineLink("Incorrect syntax near ','.", batchAt(0))).to.be.undefined;
+        });
+    });
+
+    suite("splitMessages", () => {
+        test("keeps the link only on the line whose text it came from", () => {
+            const messages: qr.IMessage[] = [
+                {
+                    message: "Msg 102, Level 15, State 1, Line 11\nIncorrect syntax near ','.",
+                    isError: true,
+                    link: { text: "Line 11", uri: "file:///q.sql" },
+                    selection: { startLine: 50, startColumn: 0, endLine: 50, endColumn: 0 },
+                },
+            ];
+
+            const split = splitMessages(messages);
+
+            expect(split).to.have.lengthOf(2);
+            expect(split[0].link?.text).to.equal("Line 11");
+            expect(split[0].selection?.startLine).to.equal(50);
+            // the continuation line must not repeat the link
+            expect(split[1].link).to.be.undefined;
+            expect(split[1].selection).to.be.undefined;
+        });
+
+        test("leaves a single line message with its link", () => {
+            const messages: qr.IMessage[] = [
+                {
+                    message: "Started executing query at ",
+                    isError: false,
+                    link: { text: "Line 5", uri: "file:///q.sql" },
+                    selection: { startLine: 4, startColumn: 0, endLine: 4, endColumn: 0 },
+                },
+            ];
+
+            const split = splitMessages(messages);
+
+            expect(split).to.have.lengthOf(1);
+            expect(split[0].link?.text).to.equal("Line 5");
+        });
+
+        test("still splits messages that carry no link", () => {
+            const messages: qr.IMessage[] = [{ message: "one\ntwo\nthree", isError: false }];
+
+            const split = splitMessages(messages);
+
+            expect(split.map((m) => m.message)).to.deep.equal(["one", "two", "three"]);
+        });
+
+        test("returns an empty array for no messages", () => {
+            expect(splitMessages([])).to.deep.equal([]);
+            expect(splitMessages(undefined)).to.deep.equal([]);
+            expect(splitMessages(null)).to.deep.equal([]);
+        });
+    });
+});

--- a/extensions/mssql/test/unit/messageLinks.test.ts
+++ b/extensions/mssql/test/unit/messageLinks.test.ts
@@ -4,148 +4,85 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import {
-    createErrorLineLink,
-    parseErrorLine,
-    toDocumentSelection,
-} from "../../src/queryResult/messageLinks";
 import { ISelectionData } from "../../src/models/interfaces";
-import { splitMessages } from "../../src/webviews/pages/QueryResult/queryResultUtils";
+import { createErrorMessageNavigation } from "../../src/queryResult/messageLinks";
 import * as qr from "../../src/sharedInterfaces/queryResult";
-
-const batchAt = (startLine: number): ISelectionData => ({
-    startLine,
-    startColumn: 0,
-    endLine: startLine + 20,
-    endColumn: 0,
-});
+import { splitMessages } from "../../src/webviews/pages/QueryResult/queryResultUtils";
 
 suite("Query message links", () => {
-    suite("parseErrorLine", () => {
-        test("reads the line out of a standard error header", () => {
-            const parsed = parseErrorLine("Msg 102, Level 15, State 1, Line 11");
+    const errorSelection: ISelectionData = {
+        startLine: 50,
+        startColumn: 0,
+        endLine: 50,
+        endColumn: 0,
+    };
 
-            expect(parsed).to.deep.equal({ text: "Line 11", batchLine: 11 });
-        });
-
-        test("reads the line when the header names a procedure", () => {
-            const parsed = parseErrorLine("Msg 2812, Level 16, State 62, Procedure myProc, Line 4");
-
-            expect(parsed).to.deep.equal({ text: "Line 4", batchLine: 4 });
-        });
-
-        test("takes the error line rather than the batch start line that follows it", () => {
-            const parsed = parseErrorLine(
-                "Msg 208, Level 16, State 1, Line 3 [Batch Start Line 0]",
+    suite("createErrorMessageNavigation", () => {
+        test("uses the structured service selection without recalculating it", () => {
+            const navigation = createErrorMessageNavigation(
+                "Msg 102, Level 15, State 1, Line 51\nIncorrect syntax near ','.",
+                errorSelection,
+                "file:///q.sql",
             );
 
-            expect(parsed).to.deep.equal({ text: "Line 3", batchLine: 3 });
-        });
-
-        test("reads a line from a message that continues onto another line", () => {
-            const parsed = parseErrorLine(
-                "Msg 102, Level 15, State 1, Line 11\r\nIncorrect syntax near ','.",
-            );
-
-            expect(parsed?.batchLine).to.equal(11);
-        });
-
-        test("ignores text that is not an error header", () => {
-            expect(parseErrorLine("Commands completed successfully.")).to.be.undefined;
-            expect(parseErrorLine("(3 rows affected)")).to.be.undefined;
-            // "Line" on its own is not enough; the message must be an error header
-            expect(parseErrorLine("Started executing query at Line 5")).to.be.undefined;
-        });
-
-        test("ignores an empty or missing message", () => {
-            expect(parseErrorLine(undefined)).to.be.undefined;
-            expect(parseErrorLine("")).to.be.undefined;
-        });
-
-        test("ignores a header that reports a line of zero", () => {
-            expect(parseErrorLine("Msg 102, Level 15, State 1, Line 0")).to.be.undefined;
-        });
-    });
-
-    suite("toDocumentSelection", () => {
-        test("maps the first line of a batch to the batch's own start line", () => {
-            const selection = toDocumentSelection(batchAt(0), 1);
-
-            expect(selection).to.deep.equal({
-                startLine: 0,
-                startColumn: 0,
-                endLine: 0,
-                endColumn: 0,
+            expect(navigation).to.deep.equal({
+                link: {
+                    text: "Line 51",
+                    uri: "file:///q.sql",
+                },
+                selection: errorSelection,
             });
         });
 
-        test("offsets the reported line by where the batch starts", () => {
-            // batch starts on document line 40 (0-based), server reports its line 11
-            const selection = toDocumentSelection(batchAt(40), 11);
-
-            expect(selection.startLine).to.equal(50);
-            expect(selection.endLine).to.equal(50);
-        });
-
-        test("collapses to a cursor position rather than selecting a range", () => {
-            const selection = toDocumentSelection(batchAt(7), 3);
-
-            expect(selection.startLine).to.equal(selection.endLine);
-            expect(selection.startColumn).to.equal(0);
-            expect(selection.endColumn).to.equal(0);
-        });
-    });
-
-    suite("createErrorLineLink", () => {
-        test("builds a link for an error inside a batch further down the file", () => {
-            const link = createErrorLineLink(
-                "Msg 102, Level 15, State 1, Line 11\nIncorrect syntax near ','.",
-                batchAt(40),
+        test("does not parse localized server error text", () => {
+            const navigation = createErrorMessageNavigation(
+                "Mensaje 102, Nivel 15, Estado 1, Línea 51\nSintaxis incorrecta.",
+                errorSelection,
+                "file:///q.sql",
             );
 
-            expect(link?.text).to.equal("Line 11");
-            expect(link?.selection.startLine).to.equal(50);
+            expect(navigation?.link.text).to.equal("Línea 51");
+            expect(navigation?.selection).to.equal(errorSelection);
         });
 
-        test("produces nothing when the batch is unknown", () => {
-            const link = createErrorLineLink("Msg 102, Level 15, State 1, Line 11", undefined);
-
-            expect(link).to.be.undefined;
-        });
-
-        test("produces nothing for a message with no line in it", () => {
-            expect(createErrorLineLink("Incorrect syntax near ','.", batchAt(0))).to.be.undefined;
+        test("returns nothing without a message or service selection", () => {
+            expect(createErrorMessageNavigation("Msg 102", undefined, "file:///q.sql")).to.be
+                .undefined;
+            expect(createErrorMessageNavigation(undefined, errorSelection, "file:///q.sql")).to.be
+                .undefined;
         });
     });
 
     suite("splitMessages", () => {
-        test("keeps the link only on the line whose text it came from", () => {
+        test("keeps navigation only on the linked display line", () => {
             const messages: qr.IMessage[] = [
                 {
-                    message: "Msg 102, Level 15, State 1, Line 11\nIncorrect syntax near ','.",
+                    message: "Msg 102, Level 15, State 1, Line 51\nIncorrect syntax near ','.",
                     isError: true,
-                    link: { text: "Line 11", uri: "file:///q.sql" },
-                    selection: { startLine: 50, startColumn: 0, endLine: 50, endColumn: 0 },
+                    link: {
+                        text: "Line 51",
+                        uri: "file:///q.sql",
+                    },
+                    selection: errorSelection,
                 },
             ];
 
             const split = splitMessages(messages);
 
             expect(split).to.have.lengthOf(2);
-            expect(split[0].link?.text).to.equal("Line 11");
-            expect(split[0].selection?.startLine).to.equal(50);
-            // the continuation line must not repeat the link
+            expect(split[0].link?.text).to.equal("Line 51");
+            expect(split[0].selection).to.equal(errorSelection);
             expect(split[1].link).to.be.undefined;
             expect(split[1].selection).to.be.undefined;
         });
 
-        test("leaves a single line message with its link", () => {
+        test("preserves an appended batch-start link", () => {
             const messages: qr.IMessage[] = [
                 {
                     message: "Started executing query at ",
                     isError: false,
                     link: { text: "Line 5", uri: "file:///q.sql" },
-                    selection: { startLine: 4, startColumn: 0, endLine: 4, endColumn: 0 },
+                    selection: { ...errorSelection, startLine: 4, endLine: 4 },
                 },
             ];
 
@@ -155,12 +92,10 @@ suite("Query message links", () => {
             expect(split[0].link?.text).to.equal("Line 5");
         });
 
-        test("still splits messages that carry no link", () => {
-            const messages: qr.IMessage[] = [{ message: "one\ntwo\nthree", isError: false }];
+        test("still splits messages without navigation", () => {
+            const split = splitMessages([{ message: "one\ntwo\nthree", isError: false }]);
 
-            const split = splitMessages(messages);
-
-            expect(split.map((m) => m.message)).to.deep.equal(["one", "two", "three"]);
+            expect(split.map((message) => message.message)).to.deep.equal(["one", "two", "three"]);
         });
 
         test("returns an empty array for no messages", () => {

--- a/extensions/mssql/test/unit/messageLinks.test.ts
+++ b/extensions/mssql/test/unit/messageLinks.test.ts
@@ -34,7 +34,7 @@ suite("Query message links", () => {
             });
         });
 
-        test("does not parse localized server error text", () => {
+        test("supports localized error header labels", () => {
             const navigation = createErrorMessageNavigation(
                 "Mensaje 102, Nivel 15, Estado 1, Línea 51\nSintaxis incorrecta.",
                 errorSelection,
@@ -43,6 +43,26 @@ suite("Query message links", () => {
 
             expect(navigation?.link.text).to.equal("Línea 51");
             expect(navigation?.selection).to.equal(errorSelection);
+        });
+
+        test("returns nothing when the header has no comma-delimited line segment", () => {
+            const navigation = createErrorMessageNavigation(
+                "Unexpected error on line 51",
+                errorSelection,
+                "file:///q.sql",
+            );
+
+            expect(navigation).to.be.undefined;
+        });
+
+        test("returns nothing when the header line does not match the selection", () => {
+            const navigation = createErrorMessageNavigation(
+                "Msg 102, Level 15, State 1, Line 52",
+                errorSelection,
+                "file:///q.sql",
+            );
+
+            expect(navigation).to.be.undefined;
         });
 
         test("returns nothing without a message or service selection", () => {

--- a/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
+++ b/extensions/mssql/test/unit/sqlOutputContentProvider.test.ts
@@ -676,6 +676,40 @@ suite("SqlOutputProvider Tests using mocks", () => {
         });
     });
 
+    test("Error messages use the absolute selection supplied by SQL Tools Service", async () => {
+        const uri = "test_uri";
+        const errorMessage = "Msg 102, Level 15, State 1, Line 30\nIncorrect syntax near 'FROM'.";
+        const errorSelection: ISelectionData = {
+            startLine: 29,
+            startColumn: 0,
+            endLine: 29,
+            endColumn: 0,
+        };
+        sandbox.stub(QueryRunner.prototype, "runQuery").resolves();
+
+        await contentProvider.runQuery(statusViewInstance, uri, undefined, "test_title");
+        const runner = contentProvider.getQueryRunner(uri);
+        runner.handleMessage({
+            ownerUri: uri,
+            message: {
+                message: errorMessage,
+                isError: true,
+                time: new Date().toISOString(),
+                batchId: 0,
+                errorSelection,
+            },
+        });
+
+        const state = contentProvider.queryResultWebviewController.getQueryResultState(uri);
+        expect(state.messages).to.have.length(1);
+        expect(state.messages[0].selection).to.deep.equal(errorSelection);
+        expect(state.messages[0].link).to.deep.equal({
+            text: "Line 30",
+            uri,
+        });
+        expect(state.messages[0]).not.to.have.property("errorSelection");
+    });
+
     test("runCurrentStatement calls runStatement with correct options when actual plan is enabled", async () => {
         const uri = "test_uri";
         const title = "test_title";


### PR DESCRIPTION
## Description

_Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)._

- Make execution-error line numbers navigate to the source editor using structured `errorSelection` data from [microsoft/sqltoolsservice#2809](https://github.com/microsoft/sqltoolsservice/pull/2809).
- Remove localized error-text parsing and reveal the target line after navigation.
- Fixes #22548.

Validation: lint, extension/webview type checks, and query-message utility tests pass.

| View / state | Before | After |
| --- | --- | --- |
| Query Results → Messages error | <img width="818" height="266" alt="image" src="https://github.com/user-attachments/assets/71a243ea-7fb7-44c4-9d35-8943b422da7f" /> | <img width="689" height="250" alt="image" src="https://github.com/user-attachments/assets/7443a699-81aa-4c71-9567-ecf2bee37517" /> |

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
