### PR TITLE
Improve flat file data type selection for wide columns

### DIFF
--- a/extensions/mssql/src/webviews/pages/FlatFileImport/flatFileColumnSettingsPage.tsx
+++ b/extensions/mssql/src/webviews/pages/FlatFileImport/flatFileColumnSettingsPage.tsx
@@ -7,10 +7,8 @@ import { useContext, useEffect, useMemo, useState } from "react";
 import {
     Checkbox,
     createTableColumn,
-    Dropdown,
     Input,
     makeStyles,
-    Option,
     Table,
     TableBody,
     TableCell,
@@ -22,6 +20,7 @@ import {
     TableRow,
     Text,
     tokens,
+    useArrowNavigationGroup,
     useTableColumnSizing_unstable,
     useTableFeatures,
 } from "@fluentui/react-components";
@@ -29,6 +28,8 @@ import { locConstants } from "../../common/locConstants";
 import { FlatFileContext } from "./flatFileStateProvider";
 import { ColumnChanges } from "../../../sharedInterfaces/flatFileImport";
 import { useFlatFileSelector } from "./flatFileSelector";
+import { getDataTypeOptions } from "./flatFileDataTypeUtils";
+import { SearchableDropdown } from "../../common/searchableDropdown.component";
 
 const useStyles = makeStyles({
     outerDiv: {
@@ -129,21 +130,16 @@ const useStyles = makeStyles({
     dropdown: {
         width: "100%",
         minWidth: "60px",
-
-        "& button": {
-            minHeight: "24px",
-            height: "24px",
-            padding: "0 6px",
-            fontSize: "11px",
-        },
+        height: "24px",
     },
 
     input: {
         width: "100%",
         minWidth: "60px",
+        height: "24px",
 
         "& input": {
-            height: "24px",
+            height: "100%",
             padding: "0 6px",
             fontSize: "11px",
         },
@@ -180,6 +176,7 @@ export const FlatFileColumnSettingsPage = ({
     onColumnChangesChanged,
 }: FlatFileColumnSettingsPageProps) => {
     const classes = useStyles();
+    const keyboardNavAttr = useArrowNavigationGroup({ axis: "grid" });
     const context = useContext(FlatFileContext);
 
     if (!context) return null;
@@ -192,42 +189,6 @@ export const FlatFileColumnSettingsPage = ({
     const NEW_PRIMARY_KEY_COL_INDEX = 2;
     const NEW_NULLABLE_COL_INDEX = 3;
 
-    const dataTypeCategoryValues = [
-        { name: "bigint", displayName: "bigint" },
-        { name: "binary(50)", displayName: "binary(50)" },
-        { name: "bit", displayName: "bit" },
-        { name: "char(10)", displayName: "char(10)" },
-        { name: "date", displayName: "date" },
-        { name: "datetime", displayName: "datetime" },
-        { name: "datetime2(7)", displayName: "datetime2(7)" },
-        { name: "datetimeoffset(7)", displayName: "datetimeoffset(7)" },
-        { name: "decimal(18, 10)", displayName: "decimal(18, 10)" },
-        { name: "float", displayName: "float" },
-        { name: "geography", displayName: "geography" },
-        { name: "geometry", displayName: "geometry" },
-        { name: "hierarchyid", displayName: "hierarchyid" },
-        { name: "int", displayName: "int" },
-        { name: "money", displayName: "money" },
-        { name: "nchar(10)", displayName: "nchar(10)" },
-        { name: "ntext", displayName: "ntext" },
-        { name: "numeric(18, 0)", displayName: "numeric(18, 0)" },
-        { name: "nvarchar(50)", displayName: "nvarchar(50)" },
-        { name: "nvarchar(MAX)", displayName: "nvarchar(MAX)" },
-        { name: "real", displayName: "real" },
-        { name: "smalldatetime", displayName: "smalldatetime" },
-        { name: "smallint", displayName: "smallint" },
-        { name: "smallmoney", displayName: "smallmoney" },
-        { name: "sql_variant", displayName: "sql_variant" },
-        { name: "text", displayName: "text" },
-        { name: "time(7)", displayName: "time(7)" },
-        { name: "timestamp", displayName: "timestamp" },
-        { name: "tinyint", displayName: "tinyint" },
-        { name: "uniqueidentifier", displayName: "uniqueidentifier" },
-        { name: "varbinary(50)", displayName: "varbinary(50)" },
-        { name: "varbinary(MAX)", displayName: "varbinary(MAX)" },
-        { name: "varchar(50)", displayName: "varchar(50)" },
-        { name: "varchar(MAX)", displayName: "varchar(MAX)" },
-    ];
     const columnInfo = [
         { header: locConstants.flatFileImport.columnName, inputType: INPUT_TYPE },
         { header: locConstants.flatFileImport.dataType, inputType: DROPDOWN_TYPE },
@@ -383,19 +344,26 @@ export const FlatFileColumnSettingsPage = ({
 
             case DROPDOWN_TYPE:
                 return (
-                    <Dropdown
-                        size="small"
-                        defaultValue={cell.value.toString()}
-                        className={classes.dropdown}
-                        onOptionSelect={(_event, data) =>
-                            handleColumnChange(rowIndex, "newDataType", data.optionValue as string)
-                        }>
-                        {dataTypeCategoryValues.map((option) => (
-                            <Option key={option.name} text={option.displayName}>
-                                {option.displayName}
-                            </Option>
-                        ))}
-                    </Dropdown>
+                    <div className={classes.dropdown}>
+                        <SearchableDropdown
+                            size="small"
+                            style={{ width: "100%", minWidth: "60px", height: "24px" }}
+                            options={getDataTypeOptions(tablePreview!.columnInfo[rowIndex]).map(
+                                (option) => ({
+                                    value: option.name,
+                                    text: option.displayName,
+                                }),
+                            )}
+                            selectedOption={{
+                                value: cell.value.toString(),
+                                text: cell.value.toString(),
+                            }}
+                            ariaLabel={locConstants.flatFileImport.dataType}
+                            onSelect={(option) =>
+                                handleColumnChange(rowIndex, "newDataType", option.value)
+                            }
+                        />
+                    </div>
                 );
 
             case CHECKBOX_TYPE:
@@ -490,8 +458,10 @@ export const FlatFileColumnSettingsPage = ({
         <div className={classes.outerDiv}>
             <div className={classes.tableDiv}>
                 <Table
+                    {...keyboardNavAttr}
+                    as="table"
                     className={classes.table}
-                    size="small"
+                    size="extra-small"
                     ref={tableFeatures.tableRef}
                     {...tableFeatures.columnSizing_unstable.getTableProps()}>
                     <TableHeader className={classes.tableHeader}>

--- a/extensions/mssql/src/webviews/pages/FlatFileImport/flatFileDataTypeUtils.ts
+++ b/extensions/mssql/src/webviews/pages/FlatFileImport/flatFileDataTypeUtils.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ColumnInfo } from "../../../models/contracts/flatFile";
+
+export interface DataTypeOption {
+    name: string;
+    displayName: string;
+}
+
+const dataTypeNames = [
+    "bigint",
+    "binary(50)",
+    "bit",
+    "char(10)",
+    "date",
+    "datetime",
+    "datetime2(7)",
+    "datetimeoffset(7)",
+    "decimal(18, 10)",
+    "float",
+    "geography",
+    "geometry",
+    "hierarchyid",
+    "int",
+    "money",
+    "nchar(10)",
+    "ntext",
+    "numeric(18, 0)",
+    "nvarchar(50)",
+    "nvarchar(4000)",
+    "nvarchar(MAX)",
+    "real",
+    "smalldatetime",
+    "smallint",
+    "smallmoney",
+    "sql_variant",
+    "text",
+    "time(7)",
+    "timestamp",
+    "tinyint",
+    "uniqueidentifier",
+    "varbinary(50)",
+    "varbinary(MAX)",
+    "varchar(50)",
+    "varchar(8000)",
+    "varchar(MAX)",
+];
+
+const dataTypeOptions = dataTypeNames.map((name) => ({ name, displayName: name }));
+const variableCharacterTypePattern = /^(n?varchar)\((MAX|\d+)\)$/i;
+
+interface VariableCharacterType {
+    name: "nvarchar" | "varchar";
+    maximumBoundedLength: number;
+}
+
+function parseVariableCharacterType(sqlType: string): VariableCharacterType | undefined {
+    const match = variableCharacterTypePattern.exec(sqlType.trim());
+    if (!match) {
+        return undefined;
+    }
+
+    const name = match[1].toLowerCase() as VariableCharacterType["name"];
+
+    return {
+        name,
+        maximumBoundedLength: name === "nvarchar" ? 4000 : 8000,
+    };
+}
+
+/**
+ * Retains types inferred by the service that are outside the standard list, such as
+ * nvarchar(100), so the current selection remains available in the dropdown.
+ */
+export function getDataTypeOptions(column: ColumnInfo): DataTypeOption[] {
+    if (dataTypeNames.includes(column.sqlType)) {
+        return dataTypeOptions;
+    }
+
+    const type = parseVariableCharacterType(column.sqlType);
+    const insertionPoint = type ? `${type.name}(${type.maximumBoundedLength})` : column.sqlType;
+    const options = [...dataTypeOptions];
+    const index = options.findIndex((option) => option.name === insertionPoint);
+    const inferredType = { name: column.sqlType, displayName: column.sqlType };
+    options.splice(index >= 0 ? index : options.length, 0, inferredType);
+    return options;
+}

--- a/extensions/mssql/test/unit/webviews/flatFileImport/flatFileDataTypeUtils.test.ts
+++ b/extensions/mssql/test/unit/webviews/flatFileImport/flatFileDataTypeUtils.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { getDataTypeOptions } from "../../../../src/webviews/pages/FlatFileImport/flatFileDataTypeUtils";
+import { ColumnInfo } from "../../../../src/models/contracts/flatFile";
+
+function createColumn(sqlType: string): ColumnInfo {
+    return {
+        name: "column",
+        sqlType,
+        isNullable: true,
+    };
+}
+
+suite("Flat file data type utilities", () => {
+    test("includes bounded maximum and MAX options for variable character types", () => {
+        const optionNames = getDataTypeOptions(createColumn("nvarchar(MAX)")).map(
+            (option) => option.name,
+        );
+
+        expect(optionNames).to.include.members([
+            "nvarchar(50)",
+            "nvarchar(4000)",
+            "nvarchar(MAX)",
+            "varchar(50)",
+            "varchar(8000)",
+            "varchar(MAX)",
+        ]);
+    });
+
+    test("retains a bounded type inferred by the service", () => {
+        const optionNames = getDataTypeOptions(createColumn("nvarchar(100)")).map(
+            (option) => option.name,
+        );
+
+        expect(optionNames).to.include("nvarchar(100)");
+    });
+});


### PR DESCRIPTION
## Description

Adds bounded `nvarchar(4000)` and `varchar(8000)` options to Flat File Import, preserves service-inferred string lengths, and makes the data type selector searchable with Table Designer-style keyboard navigation.

Closes #22861

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)