### PR TITLE
Fix Flat File Import schema loading across databases

### DIFF
--- a/extensions/mssql/src/controllers/flatFileImportWebviewController.ts
+++ b/extensions/mssql/src/controllers/flatFileImportWebviewController.ts
@@ -24,9 +24,6 @@ import {
 import { FormItemSpec, FormItemType } from "../sharedInterfaces/form";
 import { defaultSchema, flatFileImportFileTypes } from "../constants/constants";
 import SqlToolsServiceClient from "../languageservice/serviceclient";
-import { RequestType } from "vscode-languageclient";
-import { SimpleExecuteResult } from "vscode-mssql";
-import { getSchemaNamesFromResult } from "../copilot/tools/listSchemasTool";
 import * as path from "path";
 import ConnectionManager from "./connectionManager";
 import { sendActionEvent, sendErrorEvent } from "extension-toolkit/vscode";
@@ -34,8 +31,20 @@ import { TelemetryActions, TelemetryViews } from "../sharedInterfaces/telemetry"
 import { Deferred } from "../protocol";
 import { getErrorMessage, uuid } from "../utils/utils";
 import { ConnectionProfile } from "../models/connectionProfile";
+import { listSchemas } from "../services/schemaService";
 
 const FLAT_FILE_IMPORT_VIEW_ID = "flatFileImport";
+const BUILT_IN_DATABASE_ROLE_SCHEMAS = new Set([
+    "db_accessadmin",
+    "db_backupoperator",
+    "db_datareader",
+    "db_datawriter",
+    "db_ddladmin",
+    "db_denydatareader",
+    "db_denydatawriter",
+    "db_owner",
+    "db_securityadmin",
+]);
 
 /**
  * Controller for the Flat File Import dialog
@@ -49,6 +58,8 @@ export class FlatFileImportWebviewController extends FormWebviewController<
     public readonly initialized: Deferred<void> = new Deferred<void>();
     private readonly operationId: string = uuid();
     private databases: string[] = [];
+    private _schemaConnectionUri: string | undefined;
+    private _schemaConnectionDatabase: string | undefined;
     constructor(
         context: vscode.ExtensionContext,
         private client: SqlToolsServiceClient,
@@ -330,8 +341,13 @@ export class FlatFileImportWebviewController extends FormWebviewController<
         _isBlur: boolean,
     ): Promise<void> {
         if (propertyName === "databaseName") {
-            void this.handleLoadSchemas();
+            await this.handleLoadSchemas();
         }
+    }
+
+    public override dispose(): void {
+        void this.disconnectSchemaConnection();
+        super.dispose();
     }
 
     private setFlatFileFormComponents(): Record<
@@ -418,23 +434,62 @@ export class FlatFileImportWebviewController extends FormWebviewController<
      * @returns A promise that resolves to an array of schema names
      */
     private async getSchemas(databaseName: string): Promise<string[]> {
-        const safeDbName = `[${databaseName.replace(/]/g, "]]")}]`;
-        const getSchemaQuery = `
-            SELECT name
-            FROM ${safeDbName}.sys.schemas
-            WHERE name NOT IN ('sys', 'information_schema')
-            ORDER BY name
-            `;
-        const result = await this.client.sendRequest(
-            new RequestType<{ ownerUri: string; queryString: string }, SimpleExecuteResult, void>(
-                "query/simpleexecute",
-            ),
-            {
-                ownerUri: this.ownerUri,
-                queryString: getSchemaQuery,
-            },
+        const schemaOwnerUri = await this.getSchemaConnectionUri(databaseName);
+        const schemas = await listSchemas(this.client, schemaOwnerUri);
+        return schemas.filter(
+            (schemaName) => !BUILT_IN_DATABASE_ROLE_SCHEMAS.has(schemaName.toLowerCase()),
         );
-        return getSchemaNamesFromResult(result);
+    }
+
+    /**
+     * Gets a connection scoped to the selected database. Azure SQL Database does not support
+     * querying another database with a three-part name, so schemas must be queried in the target
+     * database's connection context.
+     */
+    private async getSchemaConnectionUri(databaseName: string): Promise<string> {
+        if (databaseName === this.databaseName) {
+            await this.disconnectSchemaConnection();
+            return this.ownerUri;
+        }
+
+        if (
+            this._schemaConnectionDatabase === databaseName &&
+            this._schemaConnectionUri &&
+            this.connectionManager.isConnected(this._schemaConnectionUri)
+        ) {
+            return this._schemaConnectionUri;
+        }
+
+        await this.disconnectSchemaConnection();
+
+        const connectionUri = `flat-file-import-${this.operationId}`;
+        const didConnect = await this.connectionManager.connect(connectionUri, {
+            ...this.profile,
+            database: databaseName,
+        });
+
+        if (!didConnect) {
+            throw new Error(Loc.FlatFileImport.fetchSchemasError);
+        }
+
+        if (this.isDisposed) {
+            await this.connectionManager.disconnect(connectionUri);
+            throw new Error(Loc.FlatFileImport.fetchSchemasError);
+        }
+
+        this._schemaConnectionUri = connectionUri;
+        this._schemaConnectionDatabase = databaseName;
+        return connectionUri;
+    }
+
+    private async disconnectSchemaConnection(): Promise<void> {
+        const connectionUri = this._schemaConnectionUri;
+        this._schemaConnectionUri = undefined;
+        this._schemaConnectionDatabase = undefined;
+
+        if (connectionUri) {
+            await this.connectionManager.disconnect(connectionUri);
+        }
     }
 
     /**

--- a/extensions/mssql/src/copilot/queries.ts
+++ b/extensions/mssql/src/copilot/queries.ts
@@ -5,19 +5,16 @@
 
 // SQL queries for copilot tools
 // WARNING: These queries are tightly coupled with their corresponding tool implementations.
-// The result parsing logic assumes that the target items (tables, views, schemas, functions)
+// The result parsing logic assumes that the target items (tables, views, functions)
 // are returned in the FIRST COLUMN of the result set. Do not modify these queries in a way
 // that changes the column order or structure without updating the corresponding parsing methods
-// in the tool classes (getTableNamesFromResult, getViewNamesFromResult, getSchemaNamesFromResult, getFunctionNamesFromResult).
+// in the tool classes (getTableNamesFromResult, getViewNamesFromResult, getFunctionNamesFromResult).
 
 export const listTablesQuery =
     "SELECT CONCAT(SCHEMA_NAME(schema_id), '.', name) AS TableName FROM sys.tables ORDER BY SCHEMA_NAME(schema_id), name";
 
 export const listViewsQuery =
     "SELECT CONCAT(SCHEMA_NAME(schema_id), '.', name) AS ViewName FROM sys.views ORDER BY SCHEMA_NAME(schema_id), name";
-
-export const listSchemasQuery =
-    "SELECT name AS SchemaName FROM sys.schemas WHERE name NOT IN ('sys', 'information_schema') ORDER BY name";
 
 export const listFunctionsQuery =
     "SELECT CONCAT(SCHEMA_NAME(schema_id), '.', name) AS FunctionName FROM sys.objects WHERE type IN ('FN', 'IF', 'TF') ORDER BY SCHEMA_NAME(schema_id), name";

--- a/extensions/mssql/src/copilot/tools/listSchemasTool.ts
+++ b/extensions/mssql/src/copilot/tools/listSchemasTool.ts
@@ -11,9 +11,7 @@ import { MssqlChatAgent as loc } from "../../constants/locConstants";
 import { getDisplayNameForTool } from "./toolsUtils";
 import { getErrorMessage } from "../../utils/utils";
 import SqlToolsServiceClient from "../../languageservice/serviceclient";
-import { RequestType } from "vscode-languageclient";
-import { SimpleExecuteResult } from "vscode-mssql";
-import { listSchemasQuery } from "../queries";
+import { listSchemas } from "../../services/schemaService";
 
 export interface ListSchemasToolParams {
     connectionId: string;
@@ -50,18 +48,7 @@ export class ListSchemasTool extends ToolBase<ListSchemasToolParams> {
                 });
             }
 
-            const result = await this._client.sendRequest(
-                new RequestType<
-                    { ownerUri: string; queryString: string },
-                    SimpleExecuteResult,
-                    void
-                >("query/simpleexecute"),
-                {
-                    ownerUri: connectionId,
-                    queryString: listSchemasQuery,
-                },
-            );
-            const schemas = getSchemaNamesFromResult(result);
+            const schemas = await listSchemas(this._client, connectionId);
 
             return JSON.stringify({
                 success: true,
@@ -91,30 +78,4 @@ export class ListSchemasTool extends ToolBase<ListSchemasToolParams> {
         const invocationMessage = loc.ListSchemasToolInvocationMessage(displayName, connectionId);
         return { invocationMessage, confirmationMessages };
     }
-}
-
-/**
- * Helper function to extract schema names from the result of the list schemas query
- * @param result The result returned from executing the list schemas query
- * @returns An array of schema names, or an empty array if no schemas are found or if the result is invalid
- */
-export function getSchemaNamesFromResult(result: SimpleExecuteResult): string[] {
-    if (!result || !result.rows || result.rows.length === 0) {
-        return [];
-    }
-
-    const schemaNames: string[] = [];
-
-    // Extract schema names from each row
-    // Assuming the query returns schema names in the first column
-    for (const row of result.rows) {
-        if (row && row.length > 0 && row[0] && !row[0].isNull) {
-            const schemaName = row[0].displayValue.trim();
-            if (schemaName) {
-                schemaNames.push(schemaName);
-            }
-        }
-    }
-
-    return schemaNames;
 }

--- a/extensions/mssql/src/services/schemaService.ts
+++ b/extensions/mssql/src/services/schemaService.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SimpleExecuteResult } from "vscode-mssql";
+import { RequestType } from "vscode-languageclient";
+
+import SqlToolsServiceClient from "../languageservice/serviceclient";
+
+const LIST_SCHEMAS_QUERY =
+    "SELECT name AS SchemaName FROM sys.schemas WHERE name NOT IN ('sys', 'information_schema') ORDER BY name";
+
+const ListSchemasRequest = new RequestType<
+    { ownerUri: string; queryString: string },
+    SimpleExecuteResult,
+    void
+>("query/simpleexecute");
+
+/**
+ * Lists schemas in the database associated with the provided connection URI.
+ */
+export async function listSchemas(
+    client: SqlToolsServiceClient,
+    ownerUri: string,
+): Promise<string[]> {
+    const result = await client.sendRequest(ListSchemasRequest, {
+        ownerUri,
+        queryString: LIST_SCHEMAS_QUERY,
+    });
+
+    if (!result?.rows) {
+        return [];
+    }
+
+    return result.rows
+        .map((row) => row?.[0])
+        .filter((cell) => cell && !cell.isNull)
+        .map((cell) => cell.displayValue.trim())
+        .filter((schemaName) => schemaName.length > 0);
+}

--- a/extensions/mssql/test/unit/flatFileImportWebviewController.test.ts
+++ b/extensions/mssql/test/unit/flatFileImportWebviewController.test.ts
@@ -72,6 +72,13 @@ suite("FlatFileImportWebviewController", () => {
         return reducer!;
     }
 
+    function getLastSchemaQueryParams(): { ownerUri: string; queryString: string } {
+        return mockClient.sendRequest.lastCall.args[1] as {
+            ownerUri: string;
+            queryString: string;
+        };
+    }
+
     setup(async () => {
         sandbox = sinon.createSandbox();
 
@@ -81,6 +88,7 @@ suite("FlatFileImportWebviewController", () => {
         mockClient = sandbox.createStubInstance(SqlToolsServiceClient);
         mockConnectionManager = sandbox.createStubInstance(ConnectionManager);
         mockConnectionManager.listDatabases.resolves(databases);
+        mockConnectionManager.connect.resolves(true);
 
         mockConnectionProfile = new ConnectionProfile();
         mockConnectionProfile.server = "testServer";
@@ -150,6 +158,8 @@ suite("FlatFileImportWebviewController", () => {
     });
 
     test("handleLoadSchemas loads schemas successfully", async () => {
+        mockClient.sendRequest.resetHistory();
+
         await controller["handleLoadSchemas"]();
 
         expect(controller.state.schemaLoadStatus).to.equal(ApiStatus.Loaded);
@@ -157,6 +167,13 @@ suite("FlatFileImportWebviewController", () => {
         const schemaComponent = controller.state.formComponents["tableSchema"];
         expect(schemaComponent.options.map((o) => o.value)).to.include("dbo");
         expect(controller.state.formState.tableSchema).to.equal(defaultSchema);
+        expect(mockConnectionManager.connect).to.not.have.been.called;
+        const queryParams = getLastSchemaQueryParams();
+        expect(queryParams).to.include({
+            ownerUri: "ownerUri",
+        });
+        expect(queryParams.queryString).to.include("FROM sys.schemas");
+        expect(queryParams.queryString).to.not.include("[db1].sys.schemas");
     });
 
     test("handleLoadSchemas handles error", async () => {
@@ -166,6 +183,30 @@ suite("FlatFileImportWebviewController", () => {
 
         expect(controller.state.schemaLoadStatus).to.equal(ApiStatus.Error);
         expect(controller.state.errorMessage).to.equal(Loc.FlatFileImport.fetchSchemasError);
+    });
+
+    test("handleLoadSchemas hides fixed database-role schemas but keeps custom db_ schemas", async () => {
+        mockClient.sendRequest.resolves(
+            createSchemaQueryResult([
+                "dbo",
+                "db_accessadmin",
+                "db_backupoperator",
+                "db_datareader",
+                "db_datawriter",
+                "db_ddladmin",
+                "db_denydatareader",
+                "db_denydatawriter",
+                "db_owner",
+                "db_securityadmin",
+                "db_reporting",
+            ]),
+        );
+
+        await controller["handleLoadSchemas"]();
+
+        expect(
+            controller.state.formComponents["tableSchema"].options.map((option) => option.value),
+        ).to.deep.equal(["dbo", "db_reporting"]);
     });
 
     test("formAction reducer reloads schemas when database changes", async () => {
@@ -186,6 +227,50 @@ suite("FlatFileImportWebviewController", () => {
             { displayName: "sales", value: "sales" },
             { displayName: "reporting", value: "reporting" },
         ]);
+
+        expect(mockConnectionManager.connect).to.have.been.calledOnce;
+        const schemaConnectionUri = mockConnectionManager.connect.firstCall.args[0];
+        expect(mockConnectionManager.connect).to.have.been.calledWith(
+            schemaConnectionUri,
+            sinon.match({ database: "db2" }),
+        );
+        expect(getLastSchemaQueryParams()).to.include({
+            ownerUri: schemaConnectionUri,
+        });
+    });
+
+    test("disconnects the temporary schema connection when returning to the initial database", async () => {
+        await controller["getSchemas"]("db2");
+        const schemaConnectionUri = mockConnectionManager.connect.lastCall.args[0];
+
+        await controller["getSchemas"]("db1");
+
+        expect(mockConnectionManager.disconnect).to.have.been.calledWith(schemaConnectionUri);
+        expect(getLastSchemaQueryParams()).to.include({
+            ownerUri: "ownerUri",
+        });
+    });
+
+    test("reuses the temporary schema connection for the selected database", async () => {
+        await controller["getSchemas"]("db2");
+        const schemaConnectionUri = mockConnectionManager.connect.lastCall.args[0];
+        mockConnectionManager.isConnected.withArgs(schemaConnectionUri).returns(true);
+
+        await controller["getSchemas"]("db2");
+
+        expect(mockConnectionManager.connect).to.have.been.calledOnce;
+        expect(mockConnectionManager.disconnect).to.not.have.been.calledWith(schemaConnectionUri);
+    });
+
+    test("disconnects the temporary schema connection when disposed", async () => {
+        await controller["getSchemas"]("db2");
+        const schemaConnectionUri = mockConnectionManager.connect.lastCall.args[0];
+        mockConnectionManager.disconnect.resetHistory();
+
+        controller.dispose();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+        expect(mockConnectionManager.disconnect).to.have.been.calledWith(schemaConnectionUri);
     });
 
     test("setColumnChanges reducer updates state", async () => {


### PR DESCRIPTION
## Description

Loads Flat File Import schemas through a connection scoped to the selected database, fixing schema loading when the wizard is opened from Azure SQL `master`. It also hides only fixed database-role schemas while preserving custom `db_*` schemas.

Closes #22869

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)