### PR TITLE
Fix SCMP connection profile matching

### DIFF
--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -334,15 +334,28 @@ export class ConnectionMatcher {
         current: IConnectionProfile,
         expected: IConnectionProfile,
     ): boolean {
-        function normalizeServerName(server: string): string {
-            if (server === ".") {
-                return "localhost";
+        function normalizeServerName(profile: IConnectionProfile): string {
+            let server = profile.server?.trim();
+            let port = profile.port;
+
+            const commaIndex = server?.lastIndexOf(",") ?? -1;
+            if (commaIndex >= 0) {
+                const embeddedPort = server.substring(commaIndex + 1).trim();
+                if (/^\d+$/.test(embeddedPort)) {
+                    server = server.substring(0, commaIndex).trim();
+                    port = Number(embeddedPort);
+                }
             }
-            return server;
+
+            if (server === ".") {
+                server = "localhost";
+            }
+
+            return port ? `${server},${port}` : (server ?? "");
         }
 
-        const currentServer = normalizeServerName(current.server);
-        const expectedServer = normalizeServerName(expected.server);
+        const currentServer = normalizeServerName(current);
+        const expectedServer = normalizeServerName(expected);
 
         return currentServer === expectedServer;
     }
@@ -439,11 +452,17 @@ export function isSameConnectionInfo(
         : // Azure MFA connections
           expectedConn.authenticationType === Constants.azureMfa &&
             conn.authenticationType === Constants.azureMfa
-          ? expectedConn.server === conn.server &&
+          ? ConnectionMatcher.serverMatches(
+                conn as IConnectionProfile,
+                expectedConn as IConnectionProfile,
+            ) &&
             isSameDatabase(expectedConn.database, conn.database) &&
             isSameAccountKey(expectedConn.accountId, conn.accountId)
           : // Not Azure MFA connections
-            expectedConn.server === conn.server &&
+            ConnectionMatcher.serverMatches(
+                conn as IConnectionProfile,
+                expectedConn as IConnectionProfile,
+            ) &&
             isSameDatabase(expectedConn.database, conn.database) &&
             isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType) &&
             (conn.authenticationType === Constants.sqlAuthentication
@@ -473,11 +492,16 @@ export function isSameScmpConnection(
         conn.authenticationType === Constants.azureMfa
     ) {
         return (
-            expectedConn.server === conn.server &&
-            isSameAccountKey(expectedConn.accountId, conn.accountId)
+            ConnectionMatcher.serverMatches(
+                conn as IConnectionProfile,
+                expectedConn as IConnectionProfile,
+            ) && isSameAccountKey(expectedConn.accountId, conn.accountId)
         );
     } else if (
-        expectedConn.server === conn.server &&
+        ConnectionMatcher.serverMatches(
+            conn as IConnectionProfile,
+            expectedConn as IConnectionProfile,
+        ) &&
         isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType)
     ) {
         if (conn.authenticationType === Constants.sqlAuthentication) {

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -2658,11 +2658,7 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
                 `Processing Database endpoint for ${caller} - OperationId: ${this.operationId}`,
             );
 
-            const connectionOptions = { ...(endpoint.connectionDetails?.options ?? {}) };
-            // The original SCMP connection string is useful for reconnecting, but saved profile
-            // matching treats connection strings as exact identities. Match using the parsed
-            // fields so an equivalent saved profile can be found.
-            delete connectionOptions.connectionString;
+            const connectionOptions = endpoint.connectionDetails?.options ?? {};
             const connInfo = {
                 ...connectionOptions,
                 server: connectionOptions.server || endpoint.serverName,
@@ -2673,8 +2669,22 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
                 `Has connectionDetails: ${!!endpoint.connectionDetails}, Has options: ${!!endpoint.connectionDetails?.options} - OperationId: ${this.operationId}`,
             );
 
-            const { profile: connectionProfile, score } =
-                await this.connectionMgr.findMatchingProfile(connInfo as IConnectionProfile);
+            let profileMatch = await this.connectionMgr.findMatchingProfile(
+                connInfo as IConnectionProfile,
+            );
+            if (
+                (!profileMatch.profile || profileMatch.score === utils.MatchScore.NotMatch) &&
+                connInfo.connectionString
+            ) {
+                // Prefer an exact connection-string identity, then fall back to the parsed fields
+                // so equivalent saved profiles can still be found.
+                const parsedConnInfo = { ...connInfo };
+                delete parsedConnInfo.connectionString;
+                profileMatch = await this.connectionMgr.findMatchingProfile(
+                    parsedConnInfo as IConnectionProfile,
+                );
+            }
+            const { profile: connectionProfile, score } = profileMatch;
             let isConnected = false;
 
             if (connectionProfile && score !== utils.MatchScore.NotMatch) {

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -2658,7 +2658,11 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
                 `Processing Database endpoint for ${caller} - OperationId: ${this.operationId}`,
             );
 
-            const connectionOptions = endpoint.connectionDetails?.options ?? {};
+            const connectionOptions = { ...(endpoint.connectionDetails?.options ?? {}) };
+            // The original SCMP connection string is useful for reconnecting, but saved profile
+            // matching treats connection strings as exact identities. Match using the parsed
+            // fields so an equivalent saved profile can be found.
+            delete connectionOptions.connectionString;
             const connInfo = {
                 ...connectionOptions,
                 server: connectionOptions.server || endpoint.serverName,

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -976,6 +976,50 @@ suite("SchemaCompareWebViewController Tests", () => {
         openScmpStub.restore();
     });
 
+    test("SCMP endpoint profile matching ignores the embedded connection string", async () => {
+        const endpoint = {
+            endpointType: 0,
+            serverName: "localhost,2433",
+            databaseName: "OpsAnalytics",
+            connectionDetails: {
+                options: {
+                    connectionString:
+                        "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa",
+                    server: "localhost,2433",
+                    database: "OpsAnalytics",
+                    authenticationType: "SqlLogin",
+                    user: "sa",
+                },
+            },
+        } as unknown as mssql.SchemaCompareEndpointInfo;
+        const savedProfile = {
+            server: "localhost",
+            port: "2433",
+            authenticationType: "SqlLogin",
+            user: "sa",
+            id: "docker-profile",
+        } as unknown as IConnectionProfile;
+
+        connectionManagerStub.findMatchingProfile.resolves({
+            profile: savedProfile,
+            score: utils.MatchScore.ServerDatabaseAndAuth,
+        });
+        connectionManagerStub.getUriForScmpConnection.returns(undefined);
+        connectionManagerStub.connect.resolves(true);
+
+        await controller["constructEndpointInfo"](endpoint, "source");
+
+        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledWithMatch(
+            sinon.match((profile: IConnectionProfile) => {
+                return (
+                    profile.connectionString === undefined &&
+                    profile.server === "localhost,2433" &&
+                    profile.database === "OpsAnalytics"
+                );
+            }),
+        );
+    });
+
     test("saveScmp reducer - when called - completes successfully", async () => {
         const expectedResultMock = {
             success: true,

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -976,7 +976,7 @@ suite("SchemaCompareWebViewController Tests", () => {
         openScmpStub.restore();
     });
 
-    test("SCMP endpoint profile matching ignores the embedded connection string", async () => {
+    test("SCMP endpoint profile matching falls back to parsed connection fields", async () => {
         const endpoint = {
             endpointType: 0,
             serverName: "localhost,2433",
@@ -995,28 +995,72 @@ suite("SchemaCompareWebViewController Tests", () => {
         const savedProfile = {
             server: "localhost",
             port: "2433",
+            database: "OpsAnalytics",
             authenticationType: "SqlLogin",
             user: "sa",
             id: "docker-profile",
         } as unknown as IConnectionProfile;
 
+        connectionManagerStub.findMatchingProfile
+            .onFirstCall()
+            .resolves({ profile: undefined, score: utils.MatchScore.NotMatch })
+            .onSecondCall()
+            .resolves({
+                profile: savedProfile,
+                score: utils.MatchScore.ServerDatabaseAndAuth,
+            });
+        connectionManagerStub.getUriForScmpConnection.returns(undefined);
+        connectionManagerStub.connect.resolves(true);
+
+        await controller["constructEndpointInfo"](endpoint, "source");
+
+        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledTwice;
+        expect(connectionManagerStub.findMatchingProfile.firstCall.args[0]).to.include({
+            connectionString: "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa",
+            server: "localhost,2433",
+            database: "OpsAnalytics",
+        });
+        expect(connectionManagerStub.findMatchingProfile.secondCall.args[0]).to.deep.include({
+            server: "localhost,2433",
+            database: "OpsAnalytics",
+        });
+        expect(connectionManagerStub.findMatchingProfile.secondCall.args[0].connectionString).to.be
+            .undefined;
+    });
+
+    test("SCMP endpoint profile matching preserves exact connection string identity", async () => {
+        const connectionString =
+            "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa";
+        const endpoint = {
+            endpointType: 0,
+            serverName: "localhost,2433",
+            databaseName: "OpsAnalytics",
+            connectionDetails: {
+                options: {
+                    connectionString,
+                    server: "localhost,2433",
+                    database: "OpsAnalytics",
+                    authenticationType: "SqlLogin",
+                    user: "sa",
+                },
+            },
+        } as unknown as mssql.SchemaCompareEndpointInfo;
+        const savedProfile = {
+            connectionString,
+            id: "connection-string-profile",
+        } as unknown as IConnectionProfile;
+
         connectionManagerStub.findMatchingProfile.resolves({
             profile: savedProfile,
-            score: utils.MatchScore.ServerDatabaseAndAuth,
+            score: utils.MatchScore.AllAvailableProps,
         });
         connectionManagerStub.getUriForScmpConnection.returns(undefined);
         connectionManagerStub.connect.resolves(true);
 
         await controller["constructEndpointInfo"](endpoint, "source");
 
-        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledWithMatch(
-            sinon.match((profile: IConnectionProfile) => {
-                return (
-                    profile.connectionString === undefined &&
-                    profile.server === "localhost,2433" &&
-                    profile.database === "OpsAnalytics"
-                );
-            }),
+        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledOnceWith(
+            sinon.match({ connectionString }),
         );
     });
 

--- a/extensions/mssql/test/unit/utils.test.ts
+++ b/extensions/mssql/test/unit/utils.test.ts
@@ -509,6 +509,32 @@ suite("ConnectionMatcher", () => {
                 },
                 expected: Utils.MatchScore.AllAvailableProps,
             },
+            // Test equivalent server port formats used by saved profiles and .scmp files
+            {
+                conn1: {
+                    ...sqlAuthConn,
+                    server: "localhost",
+                    port: 2433,
+                },
+                conn2: {
+                    ...sqlAuthConn,
+                    server: "localhost,2433",
+                },
+                expected: Utils.MatchScore.AllAvailableProps,
+            },
+            // Test different server ports
+            {
+                conn1: {
+                    ...sqlAuthConn,
+                    server: "localhost",
+                    port: 1433,
+                },
+                conn2: {
+                    ...sqlAuthConn,
+                    server: "localhost,2433",
+                },
+                expected: Utils.MatchScore.NotMatch,
+            },
             // Test server and database match, but not auth
             {
                 conn1: sqlAuthConn,
@@ -629,6 +655,20 @@ suite("ConnectionMatcher", () => {
             profile: undefined,
             score: Utils.MatchScore.NotMatch,
         });
+    });
+
+    test("matches active SCMP connections when the port is stored separately", () => {
+        const activeConnection = {
+            ...sqlAuthConn,
+            server: "localhost",
+            port: 2433,
+        };
+        const scmpConnection = {
+            ...sqlAuthConn,
+            server: "localhost,2433",
+        };
+
+        expect(Utils.isSameScmpConnection(activeConnection, scmpConnection)).to.be.true;
     });
 });
 


### PR DESCRIPTION
## Description

Fixes opening `.scmp` files when equivalent saved connections represent the server port differently. Ignores the embedded connection string during profile lookup and normalizes embedded and separate ports.

Regression from #22746.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Reviewers: Please focus on

Connection matching for `.scmp` database endpoints.