### PR TITLE
Edit Data: clear restored cell dirty state

### DIFF
--- a/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
+++ b/extensions/mssql/src/sharedInterfaces/tableExplorer.ts
@@ -51,6 +51,11 @@ export interface EditCellResult {
     isRowDirty: boolean;
 }
 
+export interface CellUpdateAcknowledgement {
+    requestId: number;
+    isDirty: boolean;
+}
+
 export interface EditReferencedTableInfo {
     schemaName: string;
     tableName: string;
@@ -202,6 +207,7 @@ export interface TableExplorerWebViewState {
     currentPage?: number; // Track the current page number in the data grid
     failedCells?: string[]; // Track cells that failed to update (format: "rowId-columnId")
     originalCellValues?: Map<string, DbCellValue>; // Cache original cell values for reliable revert (key: "rowId-columnId")
+    cellUpdateAcknowledgements?: Record<string, CellUpdateAcknowledgement>;
 }
 
 export interface TableExplorerContextProps extends CoreRPCs {
@@ -209,7 +215,12 @@ export interface TableExplorerContextProps extends CoreRPCs {
     loadSubset: (rowCount: number) => Promise<void>;
     createRow: () => Promise<void>;
     deleteRow: (rowId: number) => Promise<void>;
-    updateCell: (rowId: number, columnId: number, newValue: string) => Promise<void>;
+    updateCell: (
+        rowId: number,
+        columnId: number,
+        newValue: string,
+        requestId: number,
+    ) => Promise<void>;
     revertCell: (rowId: number, columnId: number) => Promise<void>;
     revertRow: (rowId: number) => Promise<void>;
     generateScript: () => void;
@@ -234,7 +245,7 @@ export interface TableExplorerReducers {
     loadSubset: { rowCount: number };
     createRow: {};
     deleteRow: { rowId: number };
-    updateCell: { rowId: number; columnId: number; newValue: string };
+    updateCell: { rowId: number; columnId: number; newValue: string; requestId: number };
     revertCell: { rowId: number; columnId: number };
     revertRow: { rowId: number };
     generateScript: {};

--- a/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
+++ b/extensions/mssql/src/tableExplorer/tableExplorerWebViewController.ts
@@ -73,6 +73,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 currentPage: 1, // Start on page 1
                 failedCells: [], // Track cells that failed to update
                 originalCellValues: new Map<string, DbCellValue>(), // Cache original values for reliable revert
+                cellUpdateAcknowledgements: {},
             },
             {
                 title: qualifiedTableName,
@@ -418,6 +419,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
         state.deletedRows = [];
         state.failedCells = [];
         state.originalCellValues?.clear();
+        state.cellUpdateAcknowledgements = {};
         state.updateScript = undefined;
     }
 
@@ -510,6 +512,7 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                 state.deletedRows = [];
                 state.failedCells = [];
                 state.originalCellValues?.clear(); // Clear cached original values since they're now outdated
+                state.cellUpdateAcknowledgements = {};
                 this.showRestorePromptAfterClose = false;
 
                 this.logger.debug(
@@ -891,7 +894,18 @@ export class TableExplorerWebViewController extends WebviewPanelController<
                     payload.newValue,
                 );
 
-                this.showRestorePromptAfterClose = true;
+                state.cellUpdateAcknowledgements = {
+                    ...state.cellUpdateAcknowledgements,
+                    [cacheKey]: {
+                        requestId: payload.requestId,
+                        isDirty: updateCellResult.cell.isDirty,
+                    },
+                };
+
+                if (!updateCellResult.cell.isDirty) {
+                    state.originalCellValues?.delete(cacheKey);
+                }
+                this.showRestorePromptAfterClose = this.hasPendingChanges(state);
 
                 // Remove from failed cells tracking if it was previously failed
                 if (state.failedCells) {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableDataGrid.tsx
@@ -28,7 +28,11 @@ import {
     AppliedSortColumn,
     stripTrailingOrderByAndSemicolon,
 } from "../../../tableExplorer/tableQueryComposer";
-import { EditSubsetResult, ExportData } from "../../../sharedInterfaces/tableExplorer";
+import {
+    CellUpdateAcknowledgement,
+    EditSubsetResult,
+    ExportData,
+} from "../../../sharedInterfaces/tableExplorer";
 import { ColorThemeKind } from "../../../sharedInterfaces/webview";
 import { locConstants as loc } from "../../common/locConstants";
 import TableExplorerCustomPager from "./TableExplorerCustomPager";
@@ -43,6 +47,7 @@ import {
     enqueueTableExplorerCreateRow,
     hasPendingChangesForRow,
     isTableExplorerDataColumn,
+    removeAcknowledgedCleanCellChanges,
     runBeforeTableExplorerSessionReplacement,
     snapshotCellChangesForRow,
     TableExplorerLifecycleMutex,
@@ -80,11 +85,17 @@ interface TableDataGridProps {
     failedCells?: string[];
     deletedRows?: number[];
     newRowIds?: number[];
+    cellUpdateAcknowledgements?: Record<string, CellUpdateAcknowledgement>;
     tableQuery?: string;
     sessionKey: string;
     onCreateRow?: () => Promise<void>;
     onDeleteRow?: (rowId: number) => Promise<void>;
-    onUpdateCell?: (rowId: number, columnId: number, newValue: string) => Promise<void>;
+    onUpdateCell?: (
+        rowId: number,
+        columnId: number,
+        newValue: string,
+        requestId: number,
+    ) => Promise<void>;
     onRevertCell?: (rowId: number, columnId: number) => Promise<void>;
     onRevertRow?: (rowId: number) => Promise<void>;
     onCellChangeCountChanged?: (count: number) => void;
@@ -127,6 +138,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             failedCells,
             deletedRows,
             newRowIds,
+            cellUpdateAcknowledgements,
             tableQuery,
             sessionKey,
             onCreateRow,
@@ -149,6 +161,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
         const [currentTheme, setCurrentTheme] = useState<ColorThemeKind | undefined>(themeKind);
         const reactGridRef = useRef<SlickgridReactInstance | null>(null);
         const cellChangesRef = useRef<Map<string, any>>(new Map());
+        const nextCellUpdateRequestIdRef = useRef(0);
         const deletedRowsRef = useRef<Set<number>>(new Set());
         const newRowIdsRef = useRef<Set<number>>(new Set());
         const failedCellsRef = useRef<Set<string>>(new Set());
@@ -660,6 +673,18 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
             }
         }, [newRowIds]);
 
+        useEffect(() => {
+            if (
+                removeAcknowledgedCleanCellChanges(
+                    cellUpdateAcknowledgements,
+                    cellChangesRef.current,
+                )
+            ) {
+                onCellChangeCountChanged?.(cellChangesRef.current.size);
+                reactGridRef.current?.slickGrid?.invalidate();
+            }
+        }, [cellUpdateAcknowledgements, onCellChangeCountChanged]);
+
         // Auto-select the first cell once the dataset has rendered. Pairs with
         // the same call inside reactGridReady to cover either ordering.
         useEffect(() => {
@@ -1002,12 +1027,14 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
 
             // Track the change using original data column index (not visible cell index)
             const changeKey = `${rowId}-${dataColumnIndex}`;
+            const requestId = ++nextCellUpdateRequestIdRef.current;
             cellChangesRef.current.set(changeKey, {
                 rowId,
                 columnIndex: dataColumnIndex,
                 columnId: column?.id,
                 field: column?.field,
                 newValue: args.item[column?.field],
+                requestId,
             });
 
             // Notify parent of change count update
@@ -1020,7 +1047,7 @@ export const TableDataGrid = forwardRef<TableDataGridRef, TableDataGridProps>(
                 const newValue = args.item[column?.field];
                 void rowMutationQueueRef.current.enqueue(
                     rowId,
-                    () => onUpdateCell(rowId, dataColumnIndex, newValue),
+                    () => onUpdateCell(rowId, dataColumnIndex, newValue, requestId),
                     changeKey,
                 );
             }

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerPage.tsx
@@ -131,6 +131,9 @@ export const TableExplorerPage: React.FC = () => {
     const failedCells = useTableExplorerSelector((s) => s.failedCells);
     const deletedRows = useTableExplorerSelector((s) => s.deletedRows);
     const newRows = useTableExplorerSelector((s) => s.newRows);
+    const cellUpdateAcknowledgements = useTableExplorerSelector(
+        (s) => s.cellUpdateAcknowledgements,
+    );
     const showScriptPane = useTableExplorerSelector((s) => s.showScriptPane);
     const updateScript = useTableExplorerSelector((s) => s.updateScript);
     const sqlPaneMode = useTableExplorerSelector((s) => s.sqlPaneMode);
@@ -440,6 +443,7 @@ export const TableExplorerPage: React.FC = () => {
                                     failedCells={failedCells}
                                     deletedRows={deletedRows}
                                     newRowIds={newRows?.map((r) => r.id)}
+                                    cellUpdateAcknowledgements={cellUpdateAcknowledgements}
                                     tableQuery={tableQuery}
                                     sessionKey={ownerUri}
                                     onCreateRow={context?.createRow}

--- a/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/TableExplorerStateProvider.tsx
@@ -46,8 +46,14 @@ export const TableExplorerStateProvider: React.FC<{
                 rowId: number,
                 columnId: number,
                 newValue: string,
+                requestId: number,
             ): Promise<void> {
-                await extensionRpc.actionAndWait("updateCell", { rowId, columnId, newValue });
+                await extensionRpc.actionAndWait("updateCell", {
+                    rowId,
+                    columnId,
+                    newValue,
+                    requestId,
+                });
             },
 
             revertCell: async function (rowId: number, columnId: number): Promise<void> {

--- a/extensions/mssql/src/webviews/pages/TableExplorer/tableDataGridUtils.ts
+++ b/extensions/mssql/src/webviews/pages/TableExplorer/tableDataGridUtils.ts
@@ -11,6 +11,11 @@ interface TableExplorerCellChange {
     rowId: number;
 }
 
+interface CellUpdateAcknowledgement {
+    requestId: number;
+    isDirty: boolean;
+}
+
 export function isTableExplorerDataColumn(column: unknown): column is TableExplorerDataColumn {
     return (
         typeof column === "object" &&
@@ -62,6 +67,20 @@ export function clearRevertedCellChanges<T>(
             failedCells.delete(key);
         }
     }
+}
+
+export function removeAcknowledgedCleanCellChanges<T extends { requestId: number }>(
+    acknowledgements: Record<string, CellUpdateAcknowledgement> | undefined,
+    cellChanges: Map<string, T>,
+): boolean {
+    let changed = false;
+    for (const [cellKey, acknowledgement] of Object.entries(acknowledgements ?? {})) {
+        const trackedChange = cellChanges.get(cellKey);
+        if (!acknowledgement.isDirty && trackedChange?.requestId === acknowledgement.requestId) {
+            changed = cellChanges.delete(cellKey) || changed;
+        }
+    }
+    return changed;
 }
 
 export function tryLockTableExplorerRow(rowId: number, lockedRows: Set<number>): boolean {

--- a/extensions/mssql/test/unit/tableDataGridUtils.test.ts
+++ b/extensions/mssql/test/unit/tableDataGridUtils.test.ts
@@ -11,6 +11,7 @@ import {
     getTableExplorerFilterColumns,
     hasPendingChangesForRow,
     isTableExplorerDataColumn,
+    removeAcknowledgedCleanCellChanges,
     runBeforeTableExplorerSessionReplacement,
     runSessionReplacementAndUpdate,
     snapshotCellChangesForRow,
@@ -88,6 +89,46 @@ suite("tableDataGridUtils", () => {
             expect(cellChanges.has("5-1")).to.equal(false);
             expect(cellChanges.get("5-2")).to.equal(laterThirdCellChange);
             expect([...failedCells]).to.deep.equal(["5-0", "5-2"]);
+        });
+    });
+
+    suite("clean cell acknowledgement cleanup", () => {
+        test("removes the matching edit when the service reports it clean", () => {
+            const cellChanges = new Map([["5-0", { rowId: 5, requestId: 2 }]]);
+
+            const changed = removeAcknowledgedCleanCellChanges(
+                { "5-0": { requestId: 2, isDirty: false } },
+                cellChanges,
+            );
+
+            expect(changed).to.equal(true);
+            expect(cellChanges.has("5-0")).to.equal(false);
+        });
+
+        test("preserves a newer edit when an older clean acknowledgement arrives", () => {
+            const newerChange = { rowId: 5, requestId: 3 };
+            const cellChanges = new Map([["5-0", newerChange]]);
+
+            const changed = removeAcknowledgedCleanCellChanges(
+                { "5-0": { requestId: 2, isDirty: false } },
+                cellChanges,
+            );
+
+            expect(changed).to.equal(false);
+            expect(cellChanges.get("5-0")).to.equal(newerChange);
+        });
+
+        test("preserves a matching edit when the service reports it dirty", () => {
+            const cellChange = { rowId: 5, requestId: 2 };
+            const cellChanges = new Map([["5-0", cellChange]]);
+
+            const changed = removeAcknowledgedCleanCellChanges(
+                { "5-0": { requestId: 2, isDirty: true } },
+                cellChanges,
+            );
+
+            expect(changed).to.equal(false);
+            expect(cellChanges.get("5-0")).to.equal(cellChange);
         });
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -15,6 +15,7 @@ import {
     EditRow,
     EditRowState,
     EditCreateRowResult,
+    EditCell,
     EditCellResult,
     EditRevertRowResult,
     EditScriptResult,
@@ -526,6 +527,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Updated",
+                requestId: 1,
             });
 
             // Assert
@@ -538,6 +540,39 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 ),
             ).to.be.true;
             expect(controller.state.resultSet?.subset[0].cells[1].displayValue).to.equal("Updated");
+        });
+
+        test("should clear tracked state when the updated cell matches its original value", async () => {
+            controller.state.ownerUri = "test-owner-uri";
+            controller.state.resultSet = createMockSubsetResult(2);
+            controller.state.originalCellValues = new Map([
+                ["0-1", controller.state.resultSet.subset[0].cells[1]],
+            ]);
+            mockTableExplorerService.updateCell.resolves({
+                cell: {
+                    displayValue: "John",
+                    isNull: false,
+                    invariantCultureDisplayValue: "John",
+                    isDirty: false,
+                },
+                isRowDirty: false,
+            });
+
+            await controller["_reducerHandlers"].get("updateCell")(controller.state, {
+                rowId: 0,
+                columnId: 1,
+                newValue: "John",
+                requestId: 2,
+            });
+
+            expect(controller.state.originalCellValues.has("0-1")).to.equal(false);
+            expect(controller.state.cellUpdateAcknowledgements?.["0-1"]).to.deep.equal({
+                requestId: 2,
+                isDirty: false,
+            });
+            expect((controller.state.resultSet.subset[0].cells[1] as EditCell).isDirty).to.equal(
+                false,
+            );
         });
 
         test("should regenerate script if script pane is visible", async () => {
@@ -564,6 +599,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                 rowId: 0,
                 columnId: 1,
                 newValue: "Updated",
+                requestId: 1,
             });
 
             // Assert
@@ -584,6 +620,7 @@ suite("TableExplorerWebViewController - Reducers", () => {
                     rowId: 0,
                     columnId: 1,
                     newValue: "Updated",
+                    requestId: 1,
                 });
             } catch (updateError) {
                 caughtError = updateError;


### PR DESCRIPTION
## Description

Clears Edit Data dirty state when a cell is changed back to its original value. The grid now correlates each update with the SQL Tools Service response and removes local change tracking only when the matching update is reported clean, preserving newer queued edits.

Fixes #22736

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`) - the full local MSSQL run is blocked by missing generated extension-toolkit localization bundles; focused tests, extension/webview typechecks, changed-file lint, and formatting pass
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant (not applicable)
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)