### PR TITLE
Connections: Remove connection string profile support

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -1291,6 +1291,20 @@
         "message": "The connection with ID '{0}' does not have the 'server' property set and is being ignored.  Please set the 'server' property on this connection in order to use it.",
         "comment": ["{0} is the connection ID for the connection that has been ignored"]
     },
+    "The 'connectionString' property was removed from connection '{0}'. Removed connection string: '{1}'./{0} is the connection display name{1} is the connection string that was removed": {
+        "message": "The 'connectionString' property was removed from connection '{0}'. Removed connection string: '{1}'.",
+        "comment": [
+            "{0} is the connection display name",
+            "{1} is the connection string that was removed"
+        ]
+    },
+    "Connection '{0}' was deleted because its 'connectionString' property was removed and no 'server' property was defined. Removed connection string: '{1}'./{0} is the connection display name{1} is the connection string that was removed": {
+        "message": "Connection '{0}' was deleted because its 'connectionString' property was removed and no 'server' property was defined. Removed connection string: '{1}'.",
+        "comment": [
+            "{0} is the connection display name",
+            "{1} is the connection string that was removed"
+        ]
+    },
     "One or more connection groups reference parent groups that do not exist and have been ignored: {0}. Update your settings file to fix these entries./{0} is the comma separated list of connection group names": {
         "message": "One or more connection groups reference parent groups that do not exist and have been ignored: {0}. Update your settings file to fix these entries.",
         "comment": ["{0} is the comma separated list of connection group names"]

--- a/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
+++ b/extensions/mssql/src/connectionconfig/connectionDialogWebviewController.ts
@@ -54,7 +54,6 @@ import { Deferred } from "../protocol";
 import { cmdOpenAzureDataStudioMigration, defaultDatabase } from "../constants/constants";
 import * as AzureConstants from "../azure/constants";
 import { AddFirewallRuleState } from "../sharedInterfaces/addFirewallRule";
-import * as Utils from "../models/utils";
 import {
     createConnectionGroup,
     getDefaultConnectionGroupDialogProps,
@@ -1178,8 +1177,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             }
         }
 
-        cleanedConnection.connectionString = undefined;
-
         if (cleanedConnection.secureEnclaves !== "Enabled") {
             cleanedConnection.attestationProtocol = undefined;
             cleanedConnection.enclaveAttestationUrl = undefined;
@@ -1303,10 +1300,6 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
             savedConnection.profileName !== recentConnection.profileName
         ) {
             return false;
-        }
-
-        if (savedConnection.connectionString || recentConnection.connectionString) {
-            return savedConnection.connectionString === recentConnection.connectionString;
         }
 
         if (savedConnection.server !== recentConnection.server) {
@@ -1924,20 +1917,13 @@ export class ConnectionDialogWebviewController extends FormWebviewController<
         connection: IConnectionInfo,
     ): Promise<IConnectionDialogProfile> {
         // Load the password if it's saved
-        if (Utils.isEmpty(connection.connectionString)) {
-            if (!connection.password) {
-                // look up password in credential store if one isn't already set
-                const password =
-                    await this._mainController.connectionManager.connectionStore.lookupPassword(
-                        connection,
-                        false /* isConnectionString */,
-                    );
-                connection.password = password;
-            }
-        } else {
-            this.logger.debug(
-                "Connection string connection found in Connection Dialog initialization; should have been converted.",
-            );
+        if (!connection.password) {
+            // look up password in credential store if one isn't already set
+            const password =
+                await this._mainController.connectionManager.connectionStore.lookupPassword(
+                    connection,
+                );
+            connection.password = password;
         }
 
         // The server is serialized to config in "server,port" form; split the port into its own

--- a/extensions/mssql/src/connectionconfig/connectionconfig.ts
+++ b/extensions/mssql/src/connectionconfig/connectionconfig.ts
@@ -70,16 +70,26 @@ export class ConnectionConfig implements IConnectionConfig {
     private _hasDisplayedGroupParentWarning: boolean = false;
     private _hasDisplayedOrphanedConnectionWarning: boolean = false;
     private _hasDisplayedDefaultConnectionIdWarning: boolean = false;
+    private _ignoredConnectionProfileKeys = new Set<string>();
 
     /**
      * Constructor
      */
-    public constructor() {
-        this._logger = logger.withPrefix("ConnectionConfig");
+    public constructor(loggerOverride?: ILogger) {
+        this._logger = loggerOverride ?? logger.withPrefix("ConnectionConfig");
         void this.initialize();
     }
 
     private async initialize(): Promise<void> {
+        for (const profile of this.getRawConnectionsFromSettings()) {
+            if ((profile as unknown as Record<string, unknown>)["connectionString"] !== undefined) {
+                this._logger.warn(
+                    `Connection string found in connection profile '${profile.profileName || profile.server || profile.id || "unknown"}'. Recreate the connection to continue using it; this profile will be ignored.`,
+                );
+                this._ignoredConnectionProfileKeys.add(this.getConnectionProfileKey(profile));
+            }
+        }
+
         await this.addOrUpdateRootGroup();
         await this.assignConnectionGroupMissingIds();
         await this.assignConnectionMissingIds();
@@ -223,12 +233,7 @@ export class ConnectionConfig implements IConnectionConfig {
         if (profiles.length > 0) {
             profiles = profiles.filter((conn) => {
                 // filter out any connection missing a connection string and server name or the sample that's shown by default
-                if (
-                    !(
-                        conn.connectionString ||
-                        (!!conn.server && conn.server !== LocalizedConstants.SampleServerName)
-                    )
-                ) {
+                if (!conn.server || conn.server === LocalizedConstants.SampleServerName) {
                     vscode.window.showErrorMessage(
                         LocalizedConstants.Connection.missingConnectionInformation(conn.id),
                     );
@@ -496,18 +501,10 @@ export class ConnectionConfig implements IConnectionConfig {
         return found;
     }
 
-    /** Compare function for sorting by profile name if available, otherwise fall back to server name or connection string */
+    /** Compare function for sorting by profile name if available, otherwise fall back to server name. */
     private compareConnectionProfile(connA: IConnectionProfile, connB: IConnectionProfile): number {
-        const nameA = connA.profileName
-            ? connA.profileName
-            : connA.server
-              ? connA.server
-              : connA.connectionString;
-        const nameB = connB.profileName
-            ? connB.profileName
-            : connB.server
-              ? connB.server
-              : connB.connectionString;
+        const nameA = connA.profileName || connA.server;
+        const nameB = connB.profileName || connB.server;
 
         return nameA.localeCompare(nameB);
     }
@@ -730,7 +727,20 @@ export class ConnectionConfig implements IConnectionConfig {
             return { ...profile, configSource: ConfigurationTarget.Workspace as ConfigTarget };
         });
 
-        return [...globalConnections, ...workspaceConnections];
+        return [...globalConnections, ...workspaceConnections].filter(
+            (profile) =>
+                !this._ignoredConnectionProfileKeys.has(this.getConnectionProfileKey(profile)),
+        );
+    }
+
+    private getConnectionProfileKey(profile: IConnectionProfile): string {
+        if (profile.id) {
+            return profile.id;
+        }
+
+        const profileWithoutConfigSource = { ...profile };
+        delete profileWithoutConfigSource.configSource;
+        return JSON.stringify(profileWithoutConfigSource);
     }
 
     /**

--- a/extensions/mssql/src/connectionconfig/connectionconfig.ts
+++ b/extensions/mssql/src/connectionconfig/connectionconfig.ts
@@ -70,7 +70,6 @@ export class ConnectionConfig implements IConnectionConfig {
     private _hasDisplayedGroupParentWarning: boolean = false;
     private _hasDisplayedOrphanedConnectionWarning: boolean = false;
     private _hasDisplayedDefaultConnectionIdWarning: boolean = false;
-    private _ignoredConnectionProfileKeys = new Set<string>();
 
     /**
      * Constructor
@@ -81,18 +80,10 @@ export class ConnectionConfig implements IConnectionConfig {
     }
 
     private async initialize(): Promise<void> {
-        for (const profile of this.getRawConnectionsFromSettings()) {
-            if ((profile as unknown as Record<string, unknown>)["connectionString"] !== undefined) {
-                this._logger.warn(
-                    `Connection string found in connection profile '${profile.profileName || profile.server || profile.id || "unknown"}'. Recreate the connection to continue using it; this profile will be ignored.`,
-                );
-                this._ignoredConnectionProfileKeys.add(this.getConnectionProfileKey(profile));
-            }
-        }
-
         await this.addOrUpdateRootGroup();
         await this.assignConnectionGroupMissingIds();
         await this.assignConnectionMissingIds();
+        await this.removeConnectionStringsFromProfiles();
 
         this.initialized.resolve();
 
@@ -677,6 +668,47 @@ export class ConnectionConfig implements IConnectionConfig {
         }
     }
 
+    private async removeConnectionStringsFromProfiles(): Promise<void> {
+        const profiles = this.getRawConnectionsFromSettings();
+        const cleanedProfiles: IConnectionProfile[] = [];
+        let madeChanges = false;
+
+        for (const profile of profiles) {
+            const rawProfile = profile as unknown as Record<string, unknown>;
+            if (!Object.prototype.hasOwnProperty.call(rawProfile, "connectionString")) {
+                cleanedProfiles.push(profile);
+                continue;
+            }
+
+            madeChanges = true;
+            const connectionDisplayName = getConnectionDisplayName(profile);
+            const connectionString = String(rawProfile["connectionString"] ?? "");
+            let message: string;
+
+            if (profile.server) {
+                delete rawProfile["connectionString"];
+                cleanedProfiles.push(profile);
+                message = LocalizedConstants.Connection.connectionStringPropertyRemoved(
+                    connectionDisplayName,
+                    connectionString,
+                );
+            } else {
+                message =
+                    LocalizedConstants.Connection.connectionDeletedAfterConnectionStringRemoval(
+                        connectionDisplayName,
+                        connectionString,
+                    );
+            }
+
+            this._logger.warn(message);
+            void vscode.window.showInformationMessage(message);
+        }
+
+        if (madeChanges) {
+            await this.writeConnectionsToSettings(cleanedProfiles);
+        }
+    }
+
     //#endregion
 
     //#region Config Read/Write
@@ -727,20 +759,7 @@ export class ConnectionConfig implements IConnectionConfig {
             return { ...profile, configSource: ConfigurationTarget.Workspace as ConfigTarget };
         });
 
-        return [...globalConnections, ...workspaceConnections].filter(
-            (profile) =>
-                !this._ignoredConnectionProfileKeys.has(this.getConnectionProfileKey(profile)),
-        );
-    }
-
-    private getConnectionProfileKey(profile: IConnectionProfile): string {
-        if (profile.id) {
-            return profile.id;
-        }
-
-        const profileWithoutConfigSource = { ...profile };
-        delete profileWithoutConfigSource.configSource;
-        return JSON.stringify(profileWithoutConfigSource);
+        return [...globalConnections, ...workspaceConnections];
     }
 
     /**

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -2300,6 +2300,36 @@ export class Connection {
         });
     };
 
+    public static connectionStringPropertyRemoved = (
+        connectionDisplayName: string,
+        connectionString: string,
+    ) => {
+        return l10n.t({
+            message:
+                "The 'connectionString' property was removed from connection '{0}'. Removed connection string: '{1}'.",
+            args: [connectionDisplayName, connectionString],
+            comment: [
+                "{0} is the connection display name",
+                "{1} is the connection string that was removed",
+            ],
+        });
+    };
+
+    public static connectionDeletedAfterConnectionStringRemoval = (
+        connectionDisplayName: string,
+        connectionString: string,
+    ) => {
+        return l10n.t({
+            message:
+                "Connection '{0}' was deleted because its 'connectionString' property was removed and no 'server' property was defined. Removed connection string: '{1}'.",
+            args: [connectionDisplayName, connectionString],
+            comment: [
+                "{0} is the connection display name",
+                "{1} is the connection string that was removed",
+            ],
+        });
+    };
+
     public static orphanedConnectionGroupsWarning = (groupNames: string) => {
         return l10n.t({
             message:

--- a/extensions/mssql/src/controllers/connectionManager.ts
+++ b/extensions/mssql/src/controllers/connectionManager.ts
@@ -36,7 +36,7 @@ import {
     SecurityTokenRequest,
 } from "../models/contracts/azure";
 import * as ConnectionContracts from "../models/contracts/connection";
-import { ClearPooledConnectionsRequest, ConnectionSummary } from "../models/contracts/connection";
+import { ClearPooledConnectionsRequest } from "../models/contracts/connection";
 import * as LanguageServiceContracts from "../models/contracts/languageService";
 import {
     AuthenticationTypes,
@@ -867,12 +867,6 @@ export default class ConnectionManager {
             LocalizedConstants.Common.cancel,
         );
         if (selection === LocalizedConstants.enableTrustServerCertificate) {
-            if (profile.connectionString) {
-                // Append connection string with encryption options
-                profile.connectionString = profile.connectionString.concat(
-                    "; Encrypt=true; Trust Server Certificate=true;",
-                );
-            }
             profile.encrypt = EncryptOptions.Mandatory;
             profile.trustServerCertificate = true;
             await reconnectAction(profile);
@@ -937,49 +931,6 @@ export default class ConnectionManager {
             let connectionToSave: IConnectionInfo = Object.assign({}, connection.credentials);
             await this._connectionStore.addRecentlyUsed(connectionToSave);
         }
-    }
-
-    /**
-     * Populates a credential object based on the credential connection string
-     */
-    private async populateCredentialsFromConnectionString(
-        credentials: IConnectionInfo,
-        connectionSummary: ConnectionSummary,
-    ): Promise<IConnectionInfo> {
-        // populate credential details
-        credentials.database = connectionSummary.databaseName;
-        credentials.user = connectionSummary.userName;
-        credentials.server = connectionSummary.serverName;
-
-        // save credentials if needed
-        let isPasswordBased: boolean = ConnectionCredentials.isPasswordBasedConnectionString(
-            credentials.connectionString,
-        );
-        if (isPasswordBased) {
-            // save the connection string here
-            await this._connectionStore.saveProfileWithConnectionString(
-                credentials as IConnectionProfile,
-            );
-            // replace the conn string from the profile
-            credentials.connectionString = ConnectionStore.formatCredentialId(
-                credentials.server,
-                credentials.database,
-                credentials.user,
-                ConnectionStore.CRED_PROFILE_USER,
-                true,
-            );
-
-            // set auth type
-            credentials.authenticationType = Constants.sqlAuthentication;
-
-            // set savePassword to true so that credentials are automatically
-            // deleted if the settings file is manually changed
-            (credentials as IConnectionProfile).savePassword = true;
-        } else {
-            credentials.authenticationType = Constants.integratedauth;
-        }
-
-        return credentials;
     }
 
     /**
@@ -1781,8 +1732,7 @@ export default class ConnectionManager {
         telemetryActivity?: ActivityObject,
     ): Promise<IConnectionInfo> {
         const telemetryActivityErrorType = "ConnectionPreparationError";
-        // Verify that the connection info has server or connection string
-        if (!credentials.server && !credentials.connectionString) {
+        if (!credentials.server) {
             const error = new Error(LocalizedConstants.serverNameMissing);
             telemetryActivity?.endFailed(
                 error,
@@ -1823,15 +1773,6 @@ export default class ConnectionManager {
                 undefined,
             );
             throw passwordError;
-        }
-
-        // Handle connection string-based credentials
-        if (
-            credentials.connectionString?.includes(ConnectionStore.CRED_PREFIX) &&
-            credentials.connectionString?.includes("isConnectionString:true")
-        ) {
-            let connectionString = await this.connectionStore.lookupPassword(credentials, true);
-            credentials.connectionString = connectionString;
         }
 
         if (
@@ -1884,15 +1825,6 @@ export default class ConnectionManager {
         /**
          * Connection was successful
          */
-
-        // Legacy connection string code. TODO: MAYBE GET RID OF THIS.
-        if (connectionInfo.credentials.connectionString) {
-            connectionInfo.credentials = await this.populateCredentialsFromConnectionString(
-                connectionInfo.credentials,
-                result.connectionSummary,
-            );
-        }
-        // END legacy connection string code.
 
         // Saving server info to the map
         this._connectionCredentialsToServerInfoMap.set(
@@ -2311,7 +2243,6 @@ export default class ConnectionManager {
 
     /**
      * Perform startup checks for connections:
-     * - migrates legacy connection strings
      * - emits basic connection stats
      */
     private async performConnectionStartupChecks(): Promise<void> {
@@ -2322,22 +2253,12 @@ export default class ConnectionManager {
         const connectionGroups: IConnectionGroup[] =
             await this.connectionStore.readAllConnectionGroups();
 
-        const migrationTally = {
-            migrated: 0,
-            notNeeded: 0,
-            error: 0,
-        };
-
         const orderingTally = {
             orderedConnections: 0,
             orderedGroups: 0,
         };
 
         for (const connection of connections) {
-            const result = await this.migrateLegacyConnection(connection);
-
-            migrationTally[result] = (migrationTally[result] || 0) + 1;
-
             if (connection.order !== undefined) {
                 orderingTally.orderedConnections++;
             }
@@ -2349,93 +2270,14 @@ export default class ConnectionManager {
             }
         }
 
-        if (migrationTally.migrated > 0) {
-            this._logger.info(
-                `Completed migration of legacy Connection String connections. (${migrationTally.migrated} migrated, ${migrationTally.notNeeded} not needed, ${migrationTally.error} errored)`,
-            );
-        } else {
-            this._logger.info(
-                `No legacy Connection String connections found to migrate. (${migrationTally.notNeeded} not needed, ${migrationTally.error} errored)`,
-            );
-        }
-
         sendActionEvent(TelemetryViews.Connection, TelemetryActions.Stats, {
             additionalProps: {},
             additionalMeasurements: {
                 connectionCount: connections.length,
                 connectionGroupCount: connectionGroups.length,
-                ...migrationTally,
                 ...orderingTally,
             },
         });
-    }
-
-    private async migrateLegacyConnection(
-        profile: IConnectionProfile,
-    ): Promise<"notNeeded" | "migrated" | "error"> {
-        try {
-            if (Utils.isEmpty(profile.connectionString)) {
-                return "notNeeded"; // Not a connection string profile; skip
-            }
-
-            let connectionString = profile.connectionString;
-
-            // Get the real connection string from credentials store if necessary
-            if (connectionString.includes(ConnectionStore.CRED_CONNECTION_STRING_PREFIX)) {
-                const retrievedString = await this.connectionStore.lookupPassword(profile, true);
-                connectionString = retrievedString ?? connectionString;
-            }
-
-            // merge profile from connection string with existing profile
-            const connDetails = await this.parseConnectionString(connectionString);
-            const profileFromString = ConnectionCredentials.removeUndefinedProperties(
-                ConnectionCredentials.createConnectionInfo(connDetails),
-            );
-
-            const newProfile: IConnectionProfile = {
-                ...profileFromString,
-                ...profile,
-            };
-
-            const passwordIndex = connectionString.toLowerCase().indexOf("password=");
-
-            if (passwordIndex !== -1) {
-                // extract password from connection string
-                const passwordStart = passwordIndex + "password=".length;
-                const passwordEnd = connectionString.indexOf(";", passwordStart);
-
-                newProfile.password = connectionString.substring(
-                    passwordStart,
-                    passwordEnd === -1 ? undefined : passwordEnd, // if no further semicolon found, password must be the last item in the connection string
-                );
-
-                newProfile.savePassword = true;
-            }
-
-            // clear the old connection string from the profile as it no longer has useful information
-            newProfile.connectionString = "";
-
-            await this.connectionStore.saveProfile(newProfile);
-            return "migrated";
-        } catch (err) {
-            this._logger.error(
-                `Error migrating legacy connection with ID ${profile.id}: ${getErrorMessage(err)}`,
-            );
-
-            vscode.window.showErrorMessage(
-                LocalizedConstants.Connection.errorMigratingLegacyConnection(
-                    profile.id,
-                    getErrorMessage(err),
-                ),
-            );
-
-            sendErrorEvent(TelemetryViews.General, TelemetryActions.MigrateLegacyConnections, {
-                error: err,
-                includeErrorMessage: false,
-            });
-
-            return "error";
-        }
     }
 
     /**

--- a/extensions/mssql/src/models/connectionCredentials.ts
+++ b/extensions/mssql/src/models/connectionCredentials.ts
@@ -49,7 +49,6 @@ export class ConnectionCredentials implements IConnectionInfo {
     public multipleActiveResultSets: boolean | undefined;
     public packetSize: number | undefined;
     public typeSystemVersion: string | undefined;
-    public connectionString: string | undefined;
     public containerName: string | undefined;
 
     /**
@@ -63,7 +62,6 @@ export class ConnectionCredentials implements IConnectionInfo {
         if ((credentials as IConnectionProfile).id) {
             details.options["id"] = (credentials as IConnectionProfile).id;
         }
-        details.options["connectionString"] = credentials.connectionString;
         details.options["server"] = credentials.server;
         if (credentials.port && details.options["server"].indexOf(",") === -1) {
             // Port is appended to the server name in a connection string
@@ -118,7 +116,6 @@ export class ConnectionCredentials implements IConnectionInfo {
         const options = connDetails.options || {};
 
         const connInfo: IConnectionInfo = {
-            connectionString: options["connectionString"],
             server: options["server"],
             port: options["server"]?.includes(",")
                 ? parseInt(options["server"].split(",")[1])

--- a/extensions/mssql/src/models/connectionInfo.ts
+++ b/extensions/mssql/src/models/connectionInfo.ts
@@ -124,7 +124,7 @@ export function getSimpleConnectionDisplayName(connection: IConnectionInfo): str
     if (profile.profileName) {
         return profile.profileName;
     } else {
-        return connection.server ? connection.server : connection.connectionString;
+        return connection.server;
     }
 }
 
@@ -227,20 +227,19 @@ export function getUserNameOrDomainLogin(creds: IConnectionInfo, defaultValue?: 
  * @returns tooltip
  */
 export function getTooltip(connCreds: IConnectionInfo, serverInfo?: IServerInfo): string {
-    let tooltip: string = connCreds.connectionString
-        ? "Connection string: " + connCreds.connectionString + "\r\n"
-        : "Server: " +
-          connCreds.server +
-          "\r\n" +
-          "Database: " +
-          (connCreds.database ? connCreds.database : "<connection default>") +
-          "\r\n" +
-          (connCreds.authenticationType !== Constants.integratedauth
-              ? "User: " + connCreds.user + "\r\n"
-              : "") +
-          "Encryption Mode: " +
-          getEncryptionMode(connCreds.encrypt) +
-          "\r\n";
+    let tooltip: string =
+        "Server: " +
+        connCreds.server +
+        "\r\n" +
+        "Database: " +
+        (connCreds.database ? connCreds.database : "<connection default>") +
+        "\r\n" +
+        (connCreds.authenticationType !== Constants.integratedauth
+            ? "User: " + connCreds.user + "\r\n"
+            : "") +
+        "Encryption Mode: " +
+        getEncryptionMode(connCreds.encrypt) +
+        "\r\n";
 
     if (serverInfo && serverInfo.serverVersion) {
         tooltip += "Server version: " + serverInfo.serverVersion + "\r\n";

--- a/extensions/mssql/src/models/connectionProfile.ts
+++ b/extensions/mssql/src/models/connectionProfile.ts
@@ -12,6 +12,7 @@ import { uuid } from "../utils/utils";
 import { AccountStore } from "../azure/accountStore";
 import { AzureAuthType } from "./contracts/azure";
 import { ConfigTarget } from "../connectionconfig/connectionconfig";
+import { IConnectionInfo } from "vscode-mssql";
 
 // Concrete implementation of the IConnectionProfile interface
 
@@ -32,7 +33,7 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
     declare public accountId: string;
     declare public tenantId: string;
 
-    constructor(connectionCredentials?: ConnectionCredentials) {
+    constructor(connectionCredentials?: IConnectionInfo) {
         super();
         if (connectionCredentials) {
             this.accountId = connectionCredentials.accountId;
@@ -57,12 +58,8 @@ export class ConnectionProfile extends ConnectionCredentials implements IConnect
         return false;
     }
 
-    // Assumption: having connection string or server + profile name indicates all requirements were met
+    // Assumption: having a server and the required authentication fields indicates all requirements were met
     public isValidProfile(): boolean {
-        if (this.connectionString) {
-            return true;
-        }
-
         if (this.authenticationType) {
             if (
                 this.authenticationType === AuthenticationTypes[AuthenticationTypes.Integrated] ||

--- a/extensions/mssql/src/models/connectionStore.ts
+++ b/extensions/mssql/src/models/connectionStore.ts
@@ -46,10 +46,7 @@ export interface IConnectionStore {
     addSavedPassword(
         credentialsItem: IConnectionCredentialsQuickPickItem,
     ): Promise<IConnectionCredentialsQuickPickItem>;
-    lookupPassword(
-        connectionCredentials: IConnectionInfo,
-        isConnectionString?: boolean,
-    ): Promise<string>;
+    lookupPassword(connectionCredentials: IConnectionInfo): Promise<string>;
     storeSessionPassword(connectionCredentials: IConnectionInfo, password: string): void;
     shouldLookupSavedPassword(connectionCreds: IConnectionProfile): boolean;
     saveProfile(
@@ -61,7 +58,6 @@ export interface IConnectionStore {
     clearRecentlyUsed(): Promise<boolean>;
     removeRecentlyUsed(conn: IConnectionProfile, keepCredentialStore?: boolean): Promise<void>;
     saveProfilePasswordIfNeeded(profile: IConnectionProfile): Promise<boolean>;
-    saveProfileWithConnectionString(profile: IConnectionProfile): Promise<boolean>;
     removeProfile(profile: IConnectionProfile, keepCredentialStore?: boolean): Promise<boolean>;
     deleteCredential(profile: IConnectionProfile): Promise<void>;
     removeProfilePassword(connection: IConnectionInfo): Promise<void>;
@@ -132,9 +128,6 @@ export class ConnectionStore implements IConnectionStore {
     }
     public static get CRED_ITEMTYPE_PREFIX(): string {
         return "itemtype:";
-    }
-    public static get CRED_CONNECTION_STRING_PREFIX(): string {
-        return "isConnectionString:";
     }
     public static get CRED_PROFILE_PREFIX(): string {
         return "profile_id:";
@@ -208,9 +201,8 @@ export class ConnectionStore implements IConnectionStore {
         database?: string,
         user?: string,
         itemType?: string,
-        isConnectionString?: boolean,
     ): string {
-        if (Utils.isEmpty(server) && !isConnectionString) {
+        if (Utils.isEmpty(server)) {
             throw new ValidationException("Missing Server Name, which is required");
         }
         let cred: string[] = [ConnectionStore.CRED_PREFIX];
@@ -222,13 +214,6 @@ export class ConnectionStore implements IConnectionStore {
         ConnectionStore.pushIfNonEmpty(server, ConnectionStore.CRED_SERVER_PREFIX, cred);
         ConnectionStore.pushIfNonEmpty(database, ConnectionStore.CRED_DB_PREFIX, cred);
         ConnectionStore.pushIfNonEmpty(user, ConnectionStore.CRED_USER_PREFIX, cred);
-        if (isConnectionString) {
-            ConnectionStore.pushIfNonEmpty(
-                "true",
-                ConnectionStore.CRED_CONNECTION_STRING_PREFIX,
-                cred,
-            );
-        }
 
         return cred.join(ConnectionStore.CRED_SEPARATOR);
     }
@@ -304,12 +289,8 @@ export class ConnectionStore implements IConnectionStore {
     /**
      * Lookup password in credential store.
      * @param connectionCredentials Connection credentials of profile for password lookup
-     * @param isConnectionString Whether this is a connection string lookup
      */
-    public async lookupPassword(
-        connectionCredentials: IConnectionInfo,
-        isConnectionString: boolean = false,
-    ): Promise<string> {
+    public async lookupPassword(connectionCredentials: IConnectionInfo): Promise<string> {
         const profile = connectionCredentials as IConnectionProfile;
         let savedCredential: Credential;
 
@@ -345,7 +326,6 @@ export class ConnectionStore implements IConnectionStore {
             connectionCredentials.database,
             connectionCredentials.user,
             ConnectionStore.CRED_PROFILE_USER,
-            isConnectionString,
         );
 
         // We try to read from the credential store with the legacy format id
@@ -582,19 +562,11 @@ export class ConnectionStore implements IConnectionStore {
         return await this.doSaveCredential(profile, CredentialsQuickPickItemType.Profile);
     }
 
-    public async saveProfileWithConnectionString(profile: IConnectionProfile): Promise<boolean> {
-        if (!profile.connectionString) {
-            return Promise.resolve(true);
-        }
-        return await this.doSaveCredential(profile, CredentialsQuickPickItemType.Profile, true);
-    }
-
     private async doSaveCredential(
         conn: IConnectionInfo,
         type: CredentialsQuickPickItemType,
-        isConnectionString: boolean = false,
     ): Promise<boolean> {
-        let password = isConnectionString ? conn.connectionString : conn.password;
+        let password = conn.password;
 
         if (Utils.isEmpty(password)) {
             return true;

--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -198,9 +198,6 @@ export function isSameProfile(
     } else if (currentProfile.profileName) {
         // This has a profile name but expected does not - can break early
         return false;
-    } else if (currentProfile.connectionString || expectedProfile.connectionString) {
-        // If either profile uses connection strings, compare them directly
-        return currentProfile.connectionString === expectedProfile.connectionString;
     } else if (
         currentProfile.authenticationType === Constants.azureMfa &&
         expectedProfile.authenticationType === Constants.azureMfa
@@ -249,7 +246,6 @@ export enum MatchScore {
      * If a property is specified in the partial profile, it must match.  If a property is not specified
      * in the partial profile, it is ignored for matching purposes.
      *
-     * If either connection uses a connection string, the connection strings must match exactly and all other properties are ignored.
      */
     AllAvailableProps = 4,
 
@@ -272,15 +268,6 @@ export class ConnectionMatcher {
         // Check for ID match first (highest match confidence)
         if (current.id && expected.id && current.id === expected.id) {
             return MatchScore.Id;
-        }
-
-        // Check for connection string match; all-or-nothing when connection strings are involved
-        if (current.connectionString || expected.connectionString) {
-            if (current.connectionString === expected.connectionString) {
-                return MatchScore.AllAvailableProps;
-            } else {
-                return MatchScore.NotMatch;
-            }
         }
 
         // Check for connection information match (server, database, authentication info)
@@ -410,7 +397,6 @@ export class ConnectionMatcher {
             "password",
             "accountId",
             "profileName",
-            "connectionString",
             "savePassword",
             "id",
         ]);
@@ -429,7 +415,7 @@ export class ConnectionMatcher {
 
 /**
  * Compares 2 connections to see if they match. Logic for matching:
- * match on all key properties (connectionString or server, db, auth type, user) being identical.
+ * match on all key properties (server, db, auth type, user) being identical.
  * Other properties are ignored for this purpose
  *
  * @param conn the connection to check
@@ -446,35 +432,30 @@ export function isSameConnectionInfo(
     if (connId && expectedConnId) {
         return connId === expectedConnId;
     }
-    // If no id, compare the connection string or other properties
-    return conn.connectionString || expectedConn.connectionString
-        ? conn.connectionString === expectedConn.connectionString
-        : // Azure MFA connections
-          expectedConn.authenticationType === Constants.azureMfa &&
-            conn.authenticationType === Constants.azureMfa
-          ? ConnectionMatcher.serverMatches(
-                conn as IConnectionProfile,
-                expectedConn as IConnectionProfile,
-            ) &&
-            isSameDatabase(expectedConn.database, conn.database) &&
-            isSameAccountKey(expectedConn.accountId, conn.accountId)
-          : // Not Azure MFA connections
-            ConnectionMatcher.serverMatches(
-                conn as IConnectionProfile,
-                expectedConn as IConnectionProfile,
-            ) &&
-            isSameDatabase(expectedConn.database, conn.database) &&
-            isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType) &&
-            (conn.authenticationType === Constants.sqlAuthentication
-                ? conn.user === expectedConn.user
-                : isEmpty(conn.user) === isEmpty(expectedConn.user)) &&
-            (conn as IConnectionProfile).savePassword ===
-                (expectedConn as IConnectionProfile).savePassword;
+    return expectedConn.authenticationType === Constants.azureMfa &&
+        conn.authenticationType === Constants.azureMfa
+        ? ConnectionMatcher.serverMatches(
+              conn as IConnectionProfile,
+              expectedConn as IConnectionProfile,
+          ) &&
+              isSameDatabase(expectedConn.database, conn.database) &&
+              isSameAccountKey(expectedConn.accountId, conn.accountId)
+        : ConnectionMatcher.serverMatches(
+              conn as IConnectionProfile,
+              expectedConn as IConnectionProfile,
+          ) &&
+              isSameDatabase(expectedConn.database, conn.database) &&
+              isSameAuthenticationType(expectedConn.authenticationType, conn.authenticationType) &&
+              (conn.authenticationType === Constants.sqlAuthentication
+                  ? conn.user === expectedConn.user
+                  : isEmpty(conn.user) === isEmpty(expectedConn.user)) &&
+              (conn as IConnectionProfile).savePassword ===
+                  (expectedConn as IConnectionProfile).savePassword;
 }
 
 /**
  * Compares 2 connections to see if they match. Logic for matching:
- * match on properties like the (connectionString or server, auth type, user) being identical.
+ * match on properties like server, auth type, and user being identical.
  * Other properties are ignored for this purpose
  *
  * @param conn the connection to check
@@ -485,9 +466,7 @@ export function isSameScmpConnection(
     conn: IConnectionInfo,
     expectedConn: IConnectionInfo,
 ): boolean {
-    if (conn.connectionString) {
-        return conn.connectionString === expectedConn.connectionString;
-    } else if (
+    if (
         expectedConn.authenticationType === Constants.azureMfa &&
         conn.authenticationType === Constants.azureMfa
     ) {

--- a/extensions/mssql/src/mssqlProtocolHandler.ts
+++ b/extensions/mssql/src/mssqlProtocolHandler.ts
@@ -45,7 +45,6 @@ export class MssqlProtocolHandler {
     /**
      * Handles the given URI and returns connection information if applicable. Examples of URIs handled:
      * - vscode://ms-mssql.mssql/connect?server=myServer&database=dbName&user=sa&authenticationType=SqlLogin
-     * - vscode://ms-mssql.mssql/connect?connectionString=Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;
      *
      * @param uri - The URI to handle.
      * @returns The connection information or undefined if not applicable.
@@ -188,11 +187,6 @@ export class MssqlProtocolHandler {
         const args = new URLSearchParams(query);
 
         this.fillConnectionProperty(connectionInfo, args, "profileName");
-
-        const connString = this.fillConnectionProperty(connectionInfo, args, "connectionString");
-        if (connString) {
-            return connectionInfo as IConnectionProfile;
-        }
 
         this.fillConnectionProperty(connectionInfo, args, "tenantId");
         this.fillConnectionProperty(connectionInfo, args, "accountId");

--- a/extensions/mssql/src/objectExplorer/objectExplorerUtils.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerUtils.ts
@@ -40,13 +40,6 @@ export class ObjectExplorerUtils {
     // TODO: this function emulates one in STS; replace with call to STS to avoid mixups
     public static getNodeUriFromProfile(profile: IConnectionProfile): string {
         let uri: string;
-        if (profile.connectionString) {
-            let fields = profile.connectionString
-                .split(";")
-                .filter((s) => !s.toLowerCase().includes("password"));
-            uri = fields.join(";");
-            return uri;
-        }
         if (
             profile.authenticationType === Constants.sqlAuthentication ||
             profile.authenticationType === Constants.azureServicePrincipal

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -2753,18 +2753,7 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
             let profileMatch = await this.connectionMgr.findMatchingProfile(
                 connInfo as IConnectionProfile,
             );
-            if (
-                (!profileMatch.profile || profileMatch.score === utils.MatchScore.NotMatch) &&
-                connInfo.connectionString
-            ) {
-                // Prefer an exact connection-string identity, then fall back to the parsed fields
-                // so equivalent saved profiles can still be found.
-                const parsedConnInfo = { ...connInfo };
-                delete parsedConnInfo.connectionString;
-                profileMatch = await this.connectionMgr.findMatchingProfile(
-                    parsedConnInfo as IConnectionProfile,
-                );
-            }
+
             const { profile: connectionProfile, score } = profileMatch;
             let isConnected = false;
 

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -2740,10 +2740,21 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
             );
 
             const connectionOptions = endpoint.connectionDetails?.options ?? {};
+            const { connectionString, ...explicitConnectionOptions } = connectionOptions;
+            const parsedConnectionOptions = connectionString
+                ? (await this.connectionMgr.parseConnectionString(connectionString)).options
+                : {};
             const connInfo = {
-                ...connectionOptions,
-                server: connectionOptions.server || endpoint.serverName,
-                database: connectionOptions.database || endpoint.databaseName,
+                ...explicitConnectionOptions,
+                ...parsedConnectionOptions,
+                server:
+                    parsedConnectionOptions.server ??
+                    explicitConnectionOptions.server ??
+                    endpoint.serverName,
+                database:
+                    parsedConnectionOptions.database ??
+                    explicitConnectionOptions.database ??
+                    endpoint.databaseName,
             } as mssql.IConnectionInfo;
 
             this.logger.debug(

--- a/extensions/mssql/src/services/metadata/profileAuthAdapter.ts
+++ b/extensions/mssql/src/services/metadata/profileAuthAdapter.ts
@@ -83,7 +83,7 @@ export function stableProfileId(stored: StoredConnectionProfile): string {
 
 /** Credential-store seam (ConnectionStore.lookupPassword). */
 export interface ProfileSecretSource {
-    lookupPassword(credentials: unknown, isConnectionString?: boolean): Promise<string>;
+    lookupPassword(credentials: unknown): Promise<string>;
 }
 
 /** Extension-host seam for acquiring a SQL-resource token at physical-open time. */

--- a/extensions/mssql/src/sharedInterfaces/telemetry.ts
+++ b/extensions/mssql/src/sharedInterfaces/telemetry.ts
@@ -159,7 +159,6 @@ export enum TelemetryActions {
     ProvisionFabricDatabase = "ProvisionFabricDatabase",
     ConnectToFabricDatabase = "ConnectToFabricDatabase",
     LoadFromConnectionString = "LoadFromConnectionString",
-    MigrateLegacyConnections = "MigrateLegacyConnections",
     MigrateEditorConnectionBehavior = "MigrateEditorConnectionBehavior",
     FilterAzureSubscriptions = "FilterAzureSubscriptions",
     ScriptNode = "ScriptNode",

--- a/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionCardUtils.ts
+++ b/extensions/mssql/src/webviews/pages/ConnectionDialog/connectionCardUtils.ts
@@ -5,17 +5,6 @@
 
 import { IConnectionDialogProfile } from "../../../sharedInterfaces/connectionDialog";
 
-const redactConnectionStringSecrets = (connectionString?: string): string => {
-    if (!connectionString) {
-        return "";
-    }
-
-    return connectionString.replace(
-        /((?:password|pwd|access token)\s*=\s*)(?:'[^']*'|"[^"]*"|\{[^}]*\}|[^;]*)/gi,
-        "$1<redacted>",
-    );
-};
-
 export const getConnectionCardKey = (connection: IConnectionDialogProfile): string => {
     return [
         connection.id ?? "",
@@ -25,7 +14,6 @@ export const getConnectionCardKey = (connection: IConnectionDialogProfile): stri
         connection.profileName ?? "",
         connection.user ?? "",
         connection.accountId ?? "",
-        redactConnectionStringSecrets(connection.connectionString),
     ].join("|");
 };
 

--- a/extensions/mssql/test/unit/changePasswordService.test.ts
+++ b/extensions/mssql/test/unit/changePasswordService.test.ts
@@ -30,7 +30,6 @@ suite("ChangePasswordService", () => {
     const credentials: IConnectionInfo = {
         server: "test-server",
         user: "test-user",
-        connectionString: "Server=test-server;User ID=test-user;",
     } as IConnectionInfo;
 
     setup(() => {

--- a/extensions/mssql/test/unit/connectionCardUtils.test.ts
+++ b/extensions/mssql/test/unit/connectionCardUtils.test.ts
@@ -44,43 +44,6 @@ suite("ConnectionCardUtils", () => {
         );
     });
 
-    test("redacts secret connection string values from keys", () => {
-        const firstConnection: IConnectionDialogProfile = {
-            ...baseConnection,
-            connectionString:
-                "Server=server-a;Database=db-a;Password=supersecret;Access Token=token-one;Encrypt=True;",
-        };
-        const secondConnection: IConnectionDialogProfile = {
-            ...baseConnection,
-            connectionString:
-                "Server=server-a;Database=db-a;Password=anothersecret;Access Token=token-two;Encrypt=True;",
-        };
-
-        const firstKey = getConnectionCardKey(firstConnection);
-        const secondKey = getConnectionCardKey(secondConnection);
-
-        expect(firstKey).to.equal(secondKey);
-        expect(firstKey).to.contain("Password=<redacted>");
-        expect(firstKey).to.contain("Access Token=<redacted>");
-        expect(firstKey).to.not.contain("supersecret");
-        expect(firstKey).to.not.contain("token-one");
-    });
-
-    test("keeps non-secret connection string differences in keys", () => {
-        const firstConnection: IConnectionDialogProfile = {
-            ...baseConnection,
-            connectionString: "Server=server-a;Database=db-a;Encrypt=True;",
-        };
-        const secondConnection: IConnectionDialogProfile = {
-            ...baseConnection,
-            connectionString: "Server=server-a;Database=db-a;Encrypt=False;",
-        };
-
-        expect(getConnectionCardKey(firstConnection)).to.not.equal(
-            getConnectionCardKey(secondConnection),
-        );
-    });
-
     test("changes the list key when the ordered recent connections change", () => {
         const firstConnection: IConnectionDialogProfile = {
             ...baseConnection,

--- a/extensions/mssql/test/unit/connectionConfig.test.ts
+++ b/extensions/mssql/test/unit/connectionConfig.test.ts
@@ -14,7 +14,7 @@ import { IConnectionGroup, IConnectionProfile } from "../../src/models/interface
 import * as Constants from "../../src/constants/constants";
 import * as LocalizedConstants from "../../src/constants/locConstants";
 import { deepClone } from "../../src/models/utils";
-import { stubMessageBoxes } from "./utils";
+import { createStubLogger, stubMessageBoxes } from "./utils";
 
 const { expect } = chai;
 
@@ -194,6 +194,38 @@ suite("ConnectionConfig Tests", () => {
             expect(savedProfiles).to.have.lengthOf(1);
             expect(savedProfiles[0].id).to.not.be.undefined;
             expect(savedProfiles[0].groupId).to.equal(ConnectionConfig.ROOT_GROUP_ID);
+        });
+
+        test("Initialization ignores legacy connection string profiles", async () => {
+            const mockLogger = createStubLogger(sandbox);
+            mockGlobalConfigData.set(Constants.connectionGroupsArrayName, [
+                { name: "ROOT", id: ConnectionConfig.ROOT_GROUP_ID },
+            ]);
+            mockGlobalConfigData.set(Constants.connectionsArrayName, [
+                {
+                    id: "legacy-profile-id",
+                    groupId: ConnectionConfig.ROOT_GROUP_ID,
+                    connectionString: "Server=legacy-server;Integrated Security=true",
+                    profileName: "Legacy Profile",
+                },
+                {
+                    id: "valid-profile-id",
+                    groupId: ConnectionConfig.ROOT_GROUP_ID,
+                    server: "valid-server",
+                    authenticationType: "Integrated",
+                    profileName: "Valid Profile",
+                },
+            ]);
+
+            const connConfig = new ConnectionConfig(mockLogger);
+            await connConfig.initialized;
+
+            const profiles = await connConfig.getConnections();
+            expect(profiles.map((profile) => profile.id)).to.deep.equal(["valid-profile-id"]);
+            expect(mockLogger.warn).to.have.been.calledOnceWith(
+                sinon.match("Connection string found in connection profile 'Legacy Profile'"),
+            );
+            expect(mockLogger.warn).to.have.been.calledWith(sinon.match("Recreate the connection"));
         });
 
         test("Initialization doesn't make changes when all IDs are present", async () => {

--- a/extensions/mssql/test/unit/connectionConfig.test.ts
+++ b/extensions/mssql/test/unit/connectionConfig.test.ts
@@ -196,8 +196,9 @@ suite("ConnectionConfig Tests", () => {
             expect(savedProfiles[0].groupId).to.equal(ConnectionConfig.ROOT_GROUP_ID);
         });
 
-        test("Initialization ignores legacy connection string profiles", async () => {
+        test("Initialization removes and saves legacy connection string properties", async () => {
             const mockLogger = createStubLogger(sandbox);
+            const connectionString = "Server=legacy-server;Integrated Security=true";
             mockGlobalConfigData.set(Constants.connectionGroupsArrayName, [
                 { name: "ROOT", id: ConnectionConfig.ROOT_GROUP_ID },
             ]);
@@ -205,7 +206,8 @@ suite("ConnectionConfig Tests", () => {
                 {
                     id: "legacy-profile-id",
                     groupId: ConnectionConfig.ROOT_GROUP_ID,
-                    connectionString: "Server=legacy-server;Integrated Security=true",
+                    server: "explicit-server",
+                    connectionString,
                     profileName: "Legacy Profile",
                 },
                 {
@@ -220,12 +222,68 @@ suite("ConnectionConfig Tests", () => {
             const connConfig = new ConnectionConfig(mockLogger);
             await connConfig.initialized;
 
-            const profiles = await connConfig.getConnections();
-            expect(profiles.map((profile) => profile.id)).to.deep.equal(["valid-profile-id"]);
-            expect(mockLogger.warn).to.have.been.calledOnceWith(
-                sinon.match("Connection string found in connection profile 'Legacy Profile'"),
+            const savedProfiles = mockGlobalConfigData.get(
+                Constants.connectionsArrayName,
+            ) as IConnectionProfile[];
+            expect(savedProfiles.map((profile) => profile.id)).to.deep.equal([
+                "legacy-profile-id",
+                "valid-profile-id",
+            ]);
+            expect(savedProfiles[0]).to.include({ server: "explicit-server" });
+            expect(savedProfiles[0]).not.to.have.property("connectionString");
+
+            const expectedMessage = LocalizedConstants.Connection.connectionStringPropertyRemoved(
+                "Legacy Profile",
+                connectionString,
             );
-            expect(mockLogger.warn).to.have.been.calledWith(sinon.match("Recreate the connection"));
+            expect(mockLogger.warn).to.have.been.calledOnceWith(expectedMessage);
+            expect(messageBoxes.showInformationMessage).to.have.been.calledOnceWith(
+                expectedMessage,
+            );
+        });
+
+        test("Initialization deletes connection string profiles without a server", async () => {
+            const mockLogger = createStubLogger(sandbox);
+            const connectionString = "Server=legacy-server;Integrated Security=true";
+            mockGlobalConfigData.set(Constants.connectionGroupsArrayName, [
+                { name: "ROOT", id: ConnectionConfig.ROOT_GROUP_ID },
+            ]);
+            mockGlobalConfigData.set(Constants.connectionsArrayName, [
+                {
+                    id: "valid-profile-id",
+                    groupId: ConnectionConfig.ROOT_GROUP_ID,
+                    server: "valid-server",
+                    authenticationType: "Integrated",
+                    profileName: "Valid Profile",
+                },
+            ]);
+            mockWorkspaceConfigData.set(Constants.connectionsArrayName, [
+                {
+                    id: "legacy-profile-id",
+                    groupId: ConnectionConfig.ROOT_GROUP_ID,
+                    connectionString,
+                    profileName: "Legacy Profile",
+                },
+            ]);
+
+            const connConfig = new ConnectionConfig(mockLogger);
+            await connConfig.initialized;
+
+            const savedProfiles = mockGlobalConfigData.get(
+                Constants.connectionsArrayName,
+            ) as IConnectionProfile[];
+            expect(savedProfiles.map((profile) => profile.id)).to.deep.equal(["valid-profile-id"]);
+            expect(mockWorkspaceConfigData.get(Constants.connectionsArrayName)).to.deep.equal([]);
+
+            const expectedMessage =
+                LocalizedConstants.Connection.connectionDeletedAfterConnectionStringRemoval(
+                    "Legacy Profile",
+                    connectionString,
+                );
+            expect(mockLogger.warn).to.have.been.calledOnceWith(expectedMessage);
+            expect(messageBoxes.showInformationMessage).to.have.been.calledOnceWith(
+                expectedMessage,
+            );
         });
 
         test("Initialization doesn't make changes when all IDs are present", async () => {

--- a/extensions/mssql/test/unit/connectionCredentials.test.ts
+++ b/extensions/mssql/test/unit/connectionCredentials.test.ts
@@ -22,23 +22,6 @@ suite("ConnectionCredentials Tests", () => {
     });
 
     suite("ConnectionDetails conversion tests", () => {
-        // A connection string can be set alongside other properties for createConnectionDetails
-        test("createConnectionDetails sets properties in addition to the connection string", () => {
-            const credentials = new ConnectionCredentials();
-            credentials.connectionString = "server=some-server";
-            credentials.database = "some-db";
-
-            const connectionDetails = ConnectionCredentials.createConnectionDetails(credentials);
-            expect(
-                connectionDetails.options.connectionString,
-                "Connection string should match input credentials",
-            ).to.equal(credentials.connectionString);
-            expect(
-                connectionDetails.options.database,
-                "Database should match input credentials",
-            ).to.equal(credentials.database);
-        });
-
         test("createConnectionDetails sets properties from the connection string", () => {
             const connDetails: ConnectionDetails = {
                 options: {
@@ -96,7 +79,6 @@ suite("ConnectionCredentials Tests", () => {
                 multipleActiveResultSets: true,
                 packetSize: 37,
                 typeSystemVersion: "testTypeSystemVersion",
-                connectionString: "testConnectionString",
                 containerName: "",
             };
 

--- a/extensions/mssql/test/unit/connectionManager.test.ts
+++ b/extensions/mssql/test/unit/connectionManager.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import sinonChai from "sinon-chai";
 import * as chai from "chai";
 import { expect } from "chai";
-import { ConnectionDetails, IToken, IConnectionInfo } from "vscode-mssql";
+import { IToken, IConnectionInfo } from "vscode-mssql";
 import { ConnectionStore } from "../../src/models/connectionStore";
 import { ILogger } from "../../src/sharedInterfaces/logger";
 import ConnectionManager, {
@@ -17,8 +17,7 @@ import ConnectionManager, {
 import SqlToolsServerClient from "../../src/languageservice/serviceclient";
 import StatusView from "../../src/views/statusView";
 import { CredentialStore } from "../../src/credentialstore/credentialstore";
-import { IConnectionProfile, IConnectionProfileWithSource } from "../../src/models/interfaces";
-import { ParseConnectionStringRequest } from "../../src/models/contracts/connection";
+import { IConnectionProfile } from "../../src/models/interfaces";
 import * as ConnectionContracts from "../../src/models/contracts/connection";
 import * as Constants from "../../src/constants/constants";
 import { IAccount, RequestSecurityTokenParams } from "../../src/models/contracts/azure";
@@ -55,7 +54,6 @@ suite("ConnectionManager Tests", () => {
     let mockContext: vscode.ExtensionContext;
     let mockLogger: sinon.SinonStubbedInstance<ILogger>;
     let mockCredentialStore: sinon.SinonStubbedInstance<CredentialStore>;
-    let messageBoxes: ReturnType<typeof stubMessageBoxes>;
     let mockConnectionStore: sinon.SinonStubbedInstance<ConnectionStore>;
     let mockServiceClient: sinon.SinonStubbedInstance<SqlToolsServerClient>;
     let mockStatusView: sinon.SinonStubbedInstance<StatusView>;
@@ -66,7 +64,7 @@ suite("ConnectionManager Tests", () => {
     setup(async () => {
         sandbox = sinon.createSandbox();
         mockContext = stubExtensionContext(sandbox);
-        messageBoxes = stubMessageBoxes(sandbox);
+        stubMessageBoxes(sandbox);
         mockLogger = createStubLogger(sandbox);
         mockConnectionStore = sandbox.createStubInstance(ConnectionStore);
         mockCredentialStore = sandbox.createStubInstance(CredentialStore);
@@ -123,154 +121,11 @@ suite("ConnectionManager Tests", () => {
 
             await connectionManager.initialized; // Wait for initialization to complete
         });
-
-        test("Initialization migrates legacy Connection String connections in credential store", async () => {
-            const testServer = "localhost";
-            const testDatabase = "TestDb";
-            const testUser = "testUser";
-            const testPassword = "testPassword";
-            const testConnectionString = `Data Source=${testServer};Initial Catalog=${testDatabase};User Id=${testUser};Password=${testPassword}`;
-            const testCredentialId = `Microsoft.SqlTools|itemtype:Profile|server:${testServer}|db:${testDatabase}|user:${testUser}|isConnectionString:true`;
-            const testConnectionId = "00000000-1111-2222-3333-444444444444";
-
-            mockCredentialStore.readCredential.callsFake(async (credId: string) => {
-                return {
-                    credentialId: credId,
-                    password: testConnectionString,
-                };
-            });
-
-            mockConnectionStore.readAllConnections.resolves([
-                {
-                    id: testConnectionId,
-                    connectionString: testCredentialId,
-                    server: testServer,
-                    database: testDatabase,
-                    user: testUser,
-                } as IConnectionProfileWithSource,
-            ]);
-
-            mockConnectionStore.lookupPassword
-                .withArgs(sinon.match.any, true)
-                .resolves(testConnectionString);
-
-            let savedProfile: IConnectionProfile | undefined;
-
-            mockConnectionStore.saveProfile.callsFake(async (profile: IConnectionProfile) => {
-                savedProfile = profile;
-                return profile;
-            });
-
-            mockServiceClient.sendRequest
-                .withArgs(ParseConnectionStringRequest.type, sinon.match.any)
-                .resolves({
-                    options: {
-                        server: testServer,
-                        database: testDatabase,
-                        user: testUser,
-                        password: testPassword,
-                    },
-                } as ConnectionDetails);
-
-            connectionManager = createConnectionManager();
-
-            await connectionManager.initialized; // Wait for initialization to complete
-
-            expect(savedProfile, "Migrated profile should have been saved").to.not.be.undefined;
-
-            expect(savedProfile, "Saved profile should have the expected properties").to.deep.equal(
-                {
-                    id: testConnectionId,
-                    server: testServer,
-                    database: testDatabase,
-                    connectionString: "",
-                    savePassword: true,
-                    user: testUser,
-                    password: testPassword,
-                } as IConnectionProfile,
-            );
-        });
-
-        test("Initialization migrates legacy Connection String connections with no credential", async () => {
-            const testServer = "localhost";
-            const testDatabase = "TestDb";
-            const testConnectionString = `Data Source=${testServer};Initial Catalog=${testDatabase};Integrated Security=True;`;
-            const testConnectionId = "00000000-1111-2222-3333-444444444444";
-            mockCredentialStore.readCredential.callsFake(async (credId: string) => {
-                return {
-                    credentialId: credId,
-                    password: testConnectionString,
-                };
-            });
-
-            mockConnectionStore.readAllConnections.resolves([
-                {
-                    id: testConnectionId,
-                    connectionString: testConnectionString,
-                    server: testServer,
-                    database: testDatabase,
-                } as IConnectionProfileWithSource,
-            ]);
-
-            let savedProfile: IConnectionProfile | undefined;
-
-            mockConnectionStore.saveProfile.callsFake(async (profile: IConnectionProfile) => {
-                savedProfile = profile;
-                return profile;
-            });
-
-            mockServiceClient.sendRequest
-                .withArgs(ParseConnectionStringRequest.type, sinon.match.any)
-                .resolves({
-                    options: {
-                        server: testServer,
-                        database: testDatabase,
-                        authenticationType: "Integrated",
-                    },
-                } as ConnectionDetails);
-
-            connectionManager = createConnectionManager();
-
-            await connectionManager.initialized; // Wait for initialization to complete
-
-            expect(savedProfile, "Migrated profile should have been saved").to.not.be.undefined;
-
-            expect(savedProfile, "Saved profile should have the expected properties").to.deep.equal(
-                {
-                    id: testConnectionId,
-                    server: testServer,
-                    database: testDatabase,
-                    authenticationType: "Integrated",
-                    connectionString: "",
-                } as IConnectionProfile,
-            );
-        });
     });
 
     suite("Functionality tests", () => {
         setup(() => {
             connectionManager = createConnectionManager();
-        });
-
-        test("User is informed when legacy connection migration fails", async () => {
-            const erroringConnProfile: IConnectionProfile = {
-                connectionString: "some test connection string",
-                id: "00000000-1111-2222-3333-444444444444",
-            } as IConnectionProfile;
-
-            messageBoxes.showErrorMessage.resolves(undefined);
-
-            mockServiceClient.sendRequest
-                .withArgs(ParseConnectionStringRequest.type, sinon.match.any)
-                .rejects(new Error("Test error!"));
-
-            const result = await connectionManager["migrateLegacyConnection"](erroringConnProfile);
-
-            expect(result, "Migration should return that it errored instead of throwing").to.equal(
-                "error",
-            );
-
-            expect(messageBoxes.showErrorMessage).to.have.been.calledOnce;
         });
 
         test("strips a trailing comma from the server", () => {
@@ -967,34 +822,6 @@ suite("ConnectionManager Tests", () => {
             }
         });
 
-        test("should resolve credential-based connection string", async () => {
-            const credentialConnectionString = `${ConnectionStore.CRED_PREFIX}|isConnectionString:true`;
-            const resolvedConnectionString =
-                "Server=testServer;Database=testDB;User=testUser;Password=testPass;";
-
-            mockConnectionStore.lookupPassword.resolves(resolvedConnectionString);
-
-            const mockConnectionInfo = {
-                server: "testServer",
-                database: "testDB",
-                connectionString: credentialConnectionString,
-                savePassword: true,
-                user: "",
-                password: "",
-                email: "",
-                accountId: "",
-                tenantId: "",
-            } as unknown as IConnectionInfo;
-
-            const result = await testConnectionManager.prepareConnectionInfo(mockConnectionInfo);
-
-            expect(result.connectionString).to.equal(resolvedConnectionString);
-            expect(mockConnectionStore.lookupPassword).to.have.been.calledOnceWith(
-                mockConnectionInfo,
-                true,
-            );
-        });
-
         test("should clear Azure account token for Integrated authentication", async () => {
             const mockConnectionInfo = {
                 server: "testServer",
@@ -1034,26 +861,6 @@ suite("ConnectionManager Tests", () => {
             expect(handlePasswordBasedCredentialsStub).to.have.been.calledOnceWith(
                 mockConnectionInfo,
             );
-        });
-
-        test("should handle connection string without credential prefix", async () => {
-            const regularConnectionString =
-                "Server=testServer;Database=testDB;Integrated Security=true;";
-
-            const mockConnectionInfo = {
-                connectionString: regularConnectionString,
-                authenticationType: "",
-                user: "",
-                password: "",
-                email: "",
-                accountId: "",
-                tenantId: "",
-            } as unknown as IConnectionInfo;
-
-            const result = await testConnectionManager.prepareConnectionInfo(mockConnectionInfo);
-
-            expect(result.connectionString).to.equal(regularConnectionString);
-            expect(mockConnectionStore.lookupPassword).to.not.have.been.called;
         });
 
         test("should preserve other properties while processing", async () => {

--- a/extensions/mssql/test/unit/connectionProfile.test.ts
+++ b/extensions/mssql/test/unit/connectionProfile.test.ts
@@ -50,7 +50,6 @@ function createTestCredentials(): IConnectionInfo {
         multipleActiveResultSets: false,
         packetSize: 8192,
         typeSystemVersion: "Latest",
-        connectionString: "",
         containerName: "",
     };
     return creds;

--- a/extensions/mssql/test/unit/connectionStore.test.ts
+++ b/extensions/mssql/test/unit/connectionStore.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../src/models/interfaces";
 import { MatchScore } from "../../src/models/utils";
 import { Deferred } from "../../src/protocol";
-import { azureAuthConn, sqlAuthConn, connStringConn } from "./utils.test";
+import { azureAuthConn, sqlAuthConn } from "./utils.test";
 import { createStubLogger, stubExtensionContext } from "./utils";
 
 suite("ConnectionStore Tests", () => {
@@ -81,23 +81,10 @@ suite("ConnectionStore Tests", () => {
             testDatabase,
             testUser,
             ConnectionStore.CRED_MRU_USER,
-            false, // isConnectionString
         );
 
         expect(credentialId).to.equal(
             "Microsoft.SqlTools|itemtype:Mru|server:localhost|db:TestDb|user:testUser",
-        );
-
-        credentialId = ConnectionStore.formatCredentialId(
-            testServer,
-            testDatabase,
-            testUser,
-            undefined, // itemType
-            true, // isConnectionString
-        );
-
-        expect(credentialId).to.equal(
-            "Microsoft.SqlTools|itemtype:Profile|server:localhost|db:TestDb|user:testUser|isConnectionString:true",
         );
 
         credentialId = ConnectionStore.formatCredentialId(testServer, testDatabase);
@@ -126,7 +113,6 @@ suite("ConnectionStore Tests", () => {
             .resolves([
                 sqlAuthConn as IConnectionProfileWithSource,
                 azureAuthConn as IConnectionProfileWithSource,
-                connStringConn as IConnectionProfileWithSource,
             ]);
 
         let match = await connectionStore.findMatchingProfile(azureAuthConn);

--- a/extensions/mssql/test/unit/connectionUI.test.ts
+++ b/extensions/mssql/test/unit/connectionUI.test.ts
@@ -114,7 +114,7 @@ suite("Connection UI tests", () => {
             quickPickItemType: CredentialsQuickPickItemType.NewConnection,
             label: undefined,
         };
-        const mockConnection = { connectionString: "test" };
+        const mockConnection = { server: "test" };
 
         promptStub.resolves(mockConnection);
 
@@ -127,7 +127,7 @@ suite("Connection UI tests", () => {
 
     test("showConnections with recent and edit connection", async () => {
         const testCreds = new ConnectionCredentials();
-        testCreds.connectionString = "test";
+        testCreds.server = "test";
         const item: IConnectionCredentialsQuickPickItem = {
             connectionCreds: testCreds,
             quickPickItemType: CredentialsQuickPickItemType.Mru,

--- a/extensions/mssql/test/unit/databaseProjects/dialogTestUtils.ts
+++ b/extensions/mssql/test/unit/databaseProjects/dialogTestUtils.ts
@@ -84,7 +84,6 @@ export const mockConnectionInfo: vscodeMssql.IConnectionInfo = {
     multipleActiveResultSets: false,
     packetSize: 8192,
     typeSystemVersion: "Latest",
-    connectionString: "",
     commandTimeout: undefined,
     secureEnclaves: undefined,
     columnEncryptionSetting: undefined,

--- a/extensions/mssql/test/unit/mssqlProtocolHandler.test.ts
+++ b/extensions/mssql/test/unit/mssqlProtocolHandler.test.ts
@@ -72,17 +72,13 @@ suite("MssqlProtocolHandler Tests", () => {
             expect(connectProfileStub).to.not.have.been.called;
         });
 
-        test("Should find matching profile when connection string is provided", async () => {
+        test("Should ignore unsupported connection string parameters", async () => {
             const connString = `Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=${uuid()};`;
             const mockConnectionManager = sandbox.createStubInstance(ConnectionManager);
-
-            sandbox.stub(mockMainController, "connectionManager").get(() => {
-                return mockConnectionManager;
-            });
-
+            sandbox.stub(mockMainController, "connectionManager").get(() => mockConnectionManager);
             mockConnectionManager.findMatchingProfile.resolves({
-                profile: { connectionString: connString } as IConnectionProfile,
-                score: MatchScore.AllAvailableProps,
+                profile: undefined,
+                score: MatchScore.NotMatch,
             });
 
             await mssqlProtocolHandler.handleUri(
@@ -91,11 +87,11 @@ suite("MssqlProtocolHandler Tests", () => {
                 ),
             );
 
-            expect(connectProfileStub).to.have.been.calledOnceWith({
-                connectionString: connString,
-            });
-
-            expect(openConnectionDialogStub).to.not.have.been.called;
+            expect(openConnectionDialogStub).to.have.been.calledOnce;
+            expect(openConnectionDialogStub.firstCall.args[0]).not.to.have.property(
+                "connectionString",
+            );
+            expect(connectProfileStub).to.not.have.been.called;
         });
 
         test("Should find matching profile when parameters are provided", async () => {

--- a/extensions/mssql/test/unit/notebooks/notebookConnectionManager.test.ts
+++ b/extensions/mssql/test/unit/notebooks/notebookConnectionManager.test.ts
@@ -69,7 +69,6 @@ function makeConnectionInfo(overrides?: Partial<IConnectionInfo>): IConnectionIn
         multipleActiveResultSets: undefined,
         packetSize: undefined,
         typeSystemVersion: undefined,
-        connectionString: undefined,
         containerName: undefined,
         ...overrides,
     };

--- a/extensions/mssql/test/unit/objectExplorerUtils.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerUtils.test.ts
@@ -246,25 +246,6 @@ suite("Object Explorer Utils Tests", () => {
         expect(result).to.equal("testParentUri");
     });
 
-    test("should return connection string without password if present", () => {
-        // Setup
-        const profile: IConnectionProfile = {
-            connectionString: "Server=myServer;Database=myDb;User Id=myUser;Password=myPassword;",
-            server: "server",
-            database: "database",
-            authenticationType: Constants.sqlAuthentication,
-            user: "user",
-            profileName: "profile",
-            id: "id",
-        } as IConnectionProfile;
-
-        // Execute
-        const result = ObjectExplorerUtils.getNodeUriFromProfile(profile);
-
-        // Verify - should include all parts except the password
-        expect(result).to.equal("Server=myServer;Database=myDb;User Id=myUser;");
-    });
-
     test("should create URI for SQL authentication without connection string", () => {
         // Setup
         const profile: IConnectionProfile = {

--- a/extensions/mssql/test/unit/perFileConnection.test.ts
+++ b/extensions/mssql/test/unit/perFileConnection.test.ts
@@ -625,7 +625,6 @@ function createTestCredentials(): IConnectionInfo {
         multipleActiveResultSets: false,
         packetSize: 8192,
         typeSystemVersion: "Latest",
-        connectionString: "",
         containerName: "",
     };
     return creds;

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -293,7 +293,6 @@ suite("SchemaCompareWebViewController Tests", () => {
             multipleActiveResultSets: undefined,
             packetSize: undefined,
             typeSystemVersion: undefined,
-            connectionString: "",
             profileName: "",
             id: "",
             groupId: "",

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -1098,19 +1098,21 @@ suite("SchemaCompareWebViewController Tests", () => {
         openScmpStub.restore();
     });
 
-    test("SCMP endpoint profile matching falls back to parsed connection fields", async () => {
+    test("SCMP endpoint connection string properties override explicit properties", async () => {
+        const connectionString =
+            "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa";
         const endpoint = {
             endpointType: 0,
-            serverName: "localhost,2433",
-            databaseName: "OpsAnalytics",
+            serverName: "endpoint-server",
+            databaseName: "endpoint-database",
             connectionDetails: {
                 options: {
-                    connectionString:
-                        "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa",
-                    server: "localhost,2433",
-                    database: "OpsAnalytics",
-                    authenticationType: "SqlLogin",
-                    user: "sa",
+                    connectionString,
+                    server: "explicit-server",
+                    database: "explicit-database",
+                    authenticationType: "Integrated",
+                    user: "explicit-user",
+                    trustServerCertificate: true,
                 },
             },
         } as unknown as mssql.SchemaCompareEndpointInfo;
@@ -1123,66 +1125,36 @@ suite("SchemaCompareWebViewController Tests", () => {
             id: "docker-profile",
         } as unknown as IConnectionProfile;
 
-        connectionManagerStub.findMatchingProfile
-            .onFirstCall()
-            .resolves({ profile: undefined, score: utils.MatchScore.NotMatch })
-            .onSecondCall()
-            .resolves({
-                profile: savedProfile,
-                score: utils.MatchScore.ServerDatabaseAndAuth,
-            });
-        connectionManagerStub.getUriForScmpConnection.returns(undefined);
-        connectionManagerStub.connect.resolves(true);
-
-        await controller["constructEndpointInfo"](endpoint, "source");
-
-        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledTwice;
-        expect(connectionManagerStub.findMatchingProfile.firstCall.args[0]).to.include({
-            connectionString: "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa",
-            server: "localhost,2433",
-            database: "OpsAnalytics",
-        });
-        expect(connectionManagerStub.findMatchingProfile.secondCall.args[0]).to.deep.include({
-            server: "localhost,2433",
-            database: "OpsAnalytics",
-        });
-        expect(connectionManagerStub.findMatchingProfile.secondCall.args[0].connectionString).to.be
-            .undefined;
-    });
-
-    test("SCMP endpoint profile matching preserves exact connection string identity", async () => {
-        const connectionString =
-            "Data Source=localhost,2433;Initial Catalog=OpsAnalytics;User ID=sa";
-        const endpoint = {
-            endpointType: 0,
-            serverName: "localhost,2433",
-            databaseName: "OpsAnalytics",
-            connectionDetails: {
-                options: {
-                    connectionString,
-                    server: "localhost,2433",
-                    database: "OpsAnalytics",
-                    authenticationType: "SqlLogin",
-                    user: "sa",
-                },
+        connectionManagerStub.parseConnectionString.resolves({
+            options: {
+                server: "localhost,2433",
+                database: "OpsAnalytics",
+                authenticationType: "SqlLogin",
+                user: "sa",
             },
-        } as unknown as mssql.SchemaCompareEndpointInfo;
-        const savedProfile = {
-            connectionString,
-            id: "connection-string-profile",
-        } as unknown as IConnectionProfile;
-
+        } as mssql.ConnectionDetails);
         connectionManagerStub.findMatchingProfile.resolves({
             profile: savedProfile,
-            score: utils.MatchScore.AllAvailableProps,
+            score: utils.MatchScore.ServerDatabaseAndAuth,
         });
         connectionManagerStub.getUriForScmpConnection.returns(undefined);
         connectionManagerStub.connect.resolves(true);
 
         await controller["constructEndpointInfo"](endpoint, "source");
 
-        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledOnceWith(
-            sinon.match({ connectionString }),
+        expect(connectionManagerStub.parseConnectionString).to.have.been.calledOnceWith(
+            connectionString,
+        );
+        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledOnce;
+        expect(connectionManagerStub.findMatchingProfile).to.have.been.calledWithMatch({
+            server: "localhost,2433",
+            database: "OpsAnalytics",
+            authenticationType: "SqlLogin",
+            user: "sa",
+            trustServerCertificate: true,
+        });
+        expect(connectionManagerStub.findMatchingProfile.firstCall.args[0]).not.to.have.property(
+            "connectionString",
         );
     });
 

--- a/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
+++ b/extensions/mssql/test/unit/tableExplorerWebViewController.test.ts
@@ -54,7 +54,6 @@ suite("TableExplorerWebViewController - Reducers", () => {
         authenticationType: "SqlLogin",
         user: "test-user",
         password: "test-password",
-        connectionString: "",
         profileName: "test-profile",
         savePassword: true,
         emptyPasswordInput: false,

--- a/extensions/mssql/test/unit/utils.test.ts
+++ b/extensions/mssql/test/unit/utils.test.ts
@@ -250,15 +250,6 @@ suite("Utility Tests - isSameConnection", () => {
         authenticationType: authType,
         user: user,
     });
-    let connectionString =
-        "Server=my-server;Database=my-db;Authentication=Sql Password;User ID=my-user";
-    let connection3 = Object.assign(new ConnectionCredentials(), {
-        connectionString: connectionString,
-    });
-    let connection4 = Object.assign(new ConnectionCredentials(), {
-        connectionString: connectionString,
-    });
-
     test("should return true for matching non-connectionstring connections", () => {
         expect(Utils.isSameConnectionInfo(connection1, connection2)).to.equal(true);
     });
@@ -266,19 +257,6 @@ suite("Utility Tests - isSameConnection", () => {
     test("should return false for non-matching non-connectionstring connections", () => {
         connection2.server = "some-other-server";
         expect(Utils.isSameConnectionInfo(connection1, connection2)).to.equal(false);
-    });
-
-    test("should return true for matching connectionstring connections", () => {
-        expect(Utils.isSameConnectionInfo(connection3, connection4)).to.equal(true);
-    });
-
-    test("should return false for non-matching connectionstring connections", () => {
-        connection4.connectionString = "Server=some-other-server";
-        expect(Utils.isSameConnectionInfo(connection3, connection4)).to.equal(false);
-    });
-
-    test("should return false for connectionstring and non-connectionstring connections", () => {
-        expect(Utils.isSameConnectionInfo(connection1, connection3)).to.equal(false);
     });
 });
 
@@ -468,26 +446,6 @@ suite("ConnectionMatcher", () => {
                 } as IConnectionProfile,
                 expected: Utils.MatchScore.AllAvailableProps, // Falls back to property matching
             },
-            // Test connection string exact match
-            {
-                conn1: connStringConn,
-                conn2: connStringConn,
-                expected: Utils.MatchScore.AllAvailableProps,
-            },
-            // Test connection string mismatch
-            {
-                conn1: connStringConn,
-                conn2: {
-                    connectionString: connStringConn.connectionString + "Connection Timeout=77",
-                } as IConnectionProfile,
-                expected: Utils.MatchScore.NotMatch,
-            },
-            // Test connection string vs regular properties
-            {
-                conn1: sqlAuthConn,
-                conn2: connStringConn,
-                expected: Utils.MatchScore.NotMatch,
-            },
             // Test server only match
             {
                 conn1: sqlAuthConn,
@@ -636,7 +594,6 @@ suite("ConnectionMatcher", () => {
         const connections = [
             sqlAuthConn as IConnectionProfileWithSource,
             azureAuthConn as IConnectionProfileWithSource,
-            connStringConn as IConnectionProfileWithSource,
         ];
 
         let match = Utils.ConnectionMatcher.findMatchingProfile(azureAuthConn, connections);
@@ -745,8 +702,4 @@ export const azureAuthConn = {
     database: "db1",
     authenticationType: Constants.azureMfa,
     accountId: "00000.11111",
-} as IConnectionProfile;
-
-export const connStringConn = {
-    connectionString: "Server=myServer;Database=myDB;Integrated Security=true;",
 } as IConnectionProfile;

--- a/extensions/mssql/typings/vscode-mssql.d.ts
+++ b/extensions/mssql/typings/vscode-mssql.d.ts
@@ -297,11 +297,6 @@ declare module "vscode-mssql" {
         typeSystemVersion: string | undefined;
 
         /**
-         * Gets or sets the connection string to use for this connection.
-         */
-        connectionString: string | undefined;
-
-        /**
          * Gets or sets the name of the connection's container; undefined if the
          * connection is not hosted by a container
          */

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1773,6 +1773,11 @@
     <trans-unit id="++CODE++639a40e82b9a96f0cbeed5f006cf5634c8d1b990b3c83753c00a910fc268d2a6">
       <source xml:lang="en">Connection</source>
     </trans-unit>
+    <trans-unit id="++CODE++ca2dabddc14f86e23e67b73c13a2a7cdbe2207116666e122934712564be8844c">
+      <source xml:lang="en">Connection &apos;{0}&apos; was deleted because its &apos;connectionString&apos; property was removed and no &apos;server&apos; property was defined. Removed connection string: &apos;{1}&apos;.</source>
+      <note>{0} is the connection display name
+{1} is the connection string that was removed</note>
+    </trans-unit>
     <trans-unit id="++CODE++6c916d6a3ffb6e0c85ad115ae2e1f277af1bc76f11a7267fd818b798a796b26a">
       <source xml:lang="en">Connection Authentication</source>
     </trans-unit>
@@ -8509,6 +8514,11 @@
     </trans-unit>
     <trans-unit id="++CODE++33c3b491fa743d2c355067a31dceaf799d4baaef0778d786cf5aafa5406ecf47">
       <source xml:lang="en">Text tab - displays SQL text data</source>
+    </trans-unit>
+    <trans-unit id="++CODE++fd4cd1ebcce84a342f8bfad9435dafc4703f350e443812adf3724485e42d6894">
+      <source xml:lang="en">The &apos;connectionString&apos; property was removed from connection &apos;{0}&apos;. Removed connection string: &apos;{1}&apos;.</source>
+      <note>{0} is the connection display name
+{1} is the connection string that was removed</note>
     </trans-unit>
     <trans-unit id="++CODE++ad21b866cd78c8e2444ffe9593f592e88ed2fa82e200191a85e10725a0e321a7">
       <source xml:lang="en">The .NET SDK cannot be located. Project build will not work. Please install .NET 8 SDK or higher or update the .NET SDK location in settings if already installed.</source>


### PR DESCRIPTION
## Description

Remove `connectionString` as a supported connection profile property and delete the legacy migration path. Saved profiles containing the property are detected during connection configuration initialization, and the `connection string` property is removed.  If there's no `server` (rendering the profile unusable), the entire profile is removed.

This also removes profile-specific handling from connection matching, credentials, Object Explorer, URI handling, connection cards, typings, telemetry, and their associated tests. Connection-string parsing and other non-profile connection-string features remain supported.

For backward compatibility with saved Schema Compare files, a `connectionDetails.options.connectionString` value is parsed when the `.scmp` file is loaded. Parsed connection-string properties override explicitly serialized connection options, and the raw connection string is not passed into profile matching.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] Affected unit tests pass (`253 passing`, `3 pending`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [x] No regressions or UX breakage

## Validation

- `npm run build:extension`
- Affected MSSQL unit suites: `253 passing`, `3 pending`
- Targeted ESLint: `0 errors` (existing warnings remain)
- `git diff --check`

The VS Code test host emitted the existing non-fatal TextMate worker dynamic-import warning; the test command exited successfully.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
