### PR TITLE
Improve Fluent result grid rendering performance

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataController.ts
@@ -151,17 +151,15 @@ export function useFluentResultGridDataController({
         };
     }, [dataView]);
 
-    const previousResultIdentitySignatureRef = useRef<string | undefined>(undefined);
+    const previousResultIdentitySignatureRef = useRef<string | undefined>(resultIdentitySignature);
     useEffect(() => {
         const shouldResetData =
+            previousResultIdentitySignatureRef.current !== undefined &&
             previousResultIdentitySignatureRef.current !== resultIdentitySignature;
         previousResultIdentitySignatureRef.current = resultIdentitySignature;
 
         dataView.setLength(resultSetSummary.rowCount, shouldResetData);
         setDisplayedRowCount(resultSetSummary.rowCount);
-        if (shouldResetData) {
-            dataView.refresh(0);
-        }
     }, [dataView, resultIdentitySignature, resultSetSummary.rowCount]);
 
     useEffect(() => {

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataView.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataView.ts
@@ -45,7 +45,7 @@ export interface FluentResultGridRowStore<T extends Slick.SlickData> {
     setCollectionChangedCallback(callback: (startIndex: number, count: number) => void): void;
     setLength(length: number, resetData?: boolean): void;
     setRows?: (rows: FluentResultGridRow[], length?: number) => number;
-    resetAroundIndex?: (index: number) => void;
+    resetAroundIndex?: (index: number, forceReload?: boolean) => void;
     getItems(): T[];
     dispose(): void;
 }
@@ -225,6 +225,7 @@ class FluentResultGridInMemoryRowStore<T extends Slick.SlickData>
 }
 
 class FluentResultGridDataWindow<T extends Slick.SlickData> {
+    private isLoading = false;
     private rows: T[] | undefined;
     private length = 0;
     private offset = -1;
@@ -260,10 +261,24 @@ class FluentResultGridDataWindow<T extends Slick.SlickData> {
         return this.rows[index - this.offset];
     }
 
-    public positionWindow(offset: number, length: number, totalItems: number): void {
+    public positionWindow(
+        offset: number,
+        length: number,
+        totalItems: number,
+        forceReload = false,
+    ): void {
         const totalLength = toNonNegativeInteger(totalItems);
         const nextOffset = clamp(toNonNegativeInteger(offset), 0, totalLength);
         const nextLength = clamp(toNonNegativeInteger(length), 0, totalLength - nextOffset);
+
+        if (
+            !forceReload &&
+            this.offset === nextOffset &&
+            this.length === nextLength &&
+            (this.rows !== undefined || this.isLoading)
+        ) {
+            return;
+        }
 
         this.offset = nextOffset;
         this.length = nextLength;
@@ -271,23 +286,31 @@ class FluentResultGridDataWindow<T extends Slick.SlickData> {
 
         const currentRequestId = ++this.requestId;
         if (nextLength === 0) {
+            this.isLoading = false;
             return;
         }
 
+        this.isLoading = true;
         Promise.resolve(this.loadRows(nextOffset, nextLength)).then(
             (rows) => {
                 if (currentRequestId !== this.requestId || !Array.isArray(rows)) {
                     return;
                 }
 
+                this.isLoading = false;
                 this.rows = rows;
                 this.loadCompleteCallback(this.offset, this.offset + this.length);
             },
-            () => undefined,
+            () => {
+                if (currentRequestId === this.requestId) {
+                    this.isLoading = false;
+                }
+            },
         );
     }
 
     public dispose(): void {
+        this.isLoading = false;
         this.rows = undefined;
         this.length = 0;
         this.offset = -1;
@@ -378,8 +401,9 @@ class FluentResultGridWindowedRowStore<T extends Slick.SlickData>
             range.start < this.bufferWindowBefore.getStartIndex() ||
             range.end > this.bufferWindowAfter.getEndIndex()
         ) {
+            const forceReload = this.lengthChanged;
             this.lengthChanged = false;
-            this.resetAroundIndex(range.start);
+            this.resetAroundIndex(range.start, forceReload);
         } else if (range.end <= this.bufferWindowBefore.getEndIndex()) {
             const recycledWindow = this.bufferWindowAfter;
             this.bufferWindowAfter = this.window;
@@ -443,19 +467,29 @@ class FluentResultGridWindowedRowStore<T extends Slick.SlickData>
         );
     }
 
-    public resetAroundIndex(index: number): void {
+    public resetAroundIndex(index: number, forceReload = false): void {
         const targetIndex = clamp(toNonNegativeInteger(index), 0, this.length);
         const beforeStart = Math.max(0, targetIndex - this.windowSize * 1.5);
         const beforeEnd = Math.max(0, targetIndex - this.windowSize / 2);
-        this.bufferWindowBefore.positionWindow(beforeStart, beforeEnd - beforeStart, this.length);
+        this.bufferWindowBefore.positionWindow(
+            beforeStart,
+            beforeEnd - beforeStart,
+            this.length,
+            forceReload,
+        );
 
         const windowStart = beforeEnd;
         const windowEnd = Math.min(windowStart + this.windowSize, this.length);
-        this.window.positionWindow(windowStart, windowEnd - windowStart, this.length);
+        this.window.positionWindow(windowStart, windowEnd - windowStart, this.length, forceReload);
 
         const afterStart = windowEnd;
         const afterEnd = Math.min(afterStart + this.windowSize, this.length);
-        this.bufferWindowAfter.positionWindow(afterStart, afterEnd - afterStart, this.length);
+        this.bufferWindowAfter.positionWindow(
+            afterStart,
+            afterEnd - afterStart,
+            this.length,
+            forceReload,
+        );
     }
 
     public getItems(): T[] {
@@ -677,7 +711,7 @@ export class FluentResultGridDataView<T extends Slick.SlickData> implements Cust
     }
 
     public refresh(startIndex = 0): void {
-        this.rowStore.resetAroundIndex?.(toNonNegativeInteger(startIndex));
+        this.rowStore.resetAroundIndex?.(toNonNegativeInteger(startIndex), true);
 
         this.grid?.invalidateAllRows();
         this.grid?.updateRowCount();

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataView.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridDataView.ts
@@ -250,6 +250,10 @@ class FluentResultGridDataWindow<T extends Slick.SlickData> {
     }
 
     public getItem(index: number): T {
+        if (this.contains(index) && !this.rows && !this.isLoading) {
+            this.positionWindow(this.offset, this.length, this.getEndIndex());
+        }
+
         return this.rows?.[index - this.offset] ?? this.createPlaceholderRow(index);
     }
 
@@ -293,11 +297,15 @@ class FluentResultGridDataWindow<T extends Slick.SlickData> {
         this.isLoading = true;
         Promise.resolve(this.loadRows(nextOffset, nextLength)).then(
             (rows) => {
-                if (currentRequestId !== this.requestId || !Array.isArray(rows)) {
+                if (currentRequestId !== this.requestId) {
                     return;
                 }
 
                 this.isLoading = false;
+                if (!Array.isArray(rows) || rows.length !== nextLength) {
+                    return;
+                }
+
                 this.rows = rows;
                 this.loadCompleteCallback(this.offset, this.offset + this.length);
             },
@@ -799,6 +807,10 @@ export function createFluentResultGridDataView<T extends Slick.SlickData = Fluen
             dataSource.rowCount,
             async (offset, count) => {
                 const rows = await dataSource.getRows(offset, count);
+                if (!Array.isArray(rows)) {
+                    return rows;
+                }
+
                 return rows.map((row, rowOffset) =>
                     rowFactory.createRow(row, offset + rowOffset, columnCount),
                 );

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridLayout.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridLayout.ts
@@ -63,6 +63,31 @@ export function useFluentResultGridLayout({
 }): FluentResultGridLayoutController {
     const frozenPaneWheelCleanupRef = useRef<(() => void) | undefined>(undefined);
     const autoSizeRequestIdRef = useRef(0);
+    const autoSizeCanvasContextRef = useRef<CanvasRenderingContext2D | null | undefined>(undefined);
+    const autoSizeFontRef = useRef<string | undefined>(undefined);
+
+    const getAutoSizeCanvasContext = useCallback(() => {
+        if (autoSizeCanvasContextRef.current === undefined) {
+            autoSizeCanvasContextRef.current = document.createElement("canvas").getContext("2d");
+        }
+
+        const canvasContext = autoSizeCanvasContextRef.current;
+        if (!canvasContext) {
+            return undefined;
+        }
+
+        if (autoSizeFontRef.current === undefined) {
+            const computedStyle = containerRef.current
+                ? window.getComputedStyle(containerRef.current)
+                : undefined;
+            const fontSize =
+                parseInt(computedStyle?.fontSize ?? "", 10) || FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE;
+            const fontFamily = computedStyle?.fontFamily ?? "monospace";
+            autoSizeFontRef.current = `${fontSize}px ${fontFamily}`;
+        }
+        canvasContext.font = autoSizeFontRef.current;
+        return canvasContext;
+    }, [containerRef]);
 
     const refreshFrozenColumnLayout = useCallback(
         (grid: SlickGrid) => {
@@ -202,19 +227,12 @@ export function useFluentResultGridLayout({
                 return true;
             }
 
-            const canvasContext = document.createElement("canvas").getContext("2d");
+            const canvasContext = getAutoSizeCanvasContext();
             if (!canvasContext) {
                 return true;
             }
 
-            const computedStyle = containerRef.current
-                ? window.getComputedStyle(containerRef.current)
-                : undefined;
-            const fontSize =
-                parseInt(computedStyle?.fontSize ?? "", 10) || FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE;
-            const fontFamily = computedStyle?.fontFamily ?? "monospace";
-            canvasContext.font = `${fontSize}px ${fontFamily}`;
-
+            let columnsChanged = false;
             const resizedColumns = grid.getColumns().map((column, columnIndex) => {
                 if (column.id === FLUENT_RESULT_GRID_ROW_NUMBER_COLUMN_ID || columnIndex === 0) {
                     return column;
@@ -239,27 +257,32 @@ export function useFluentResultGridLayout({
                       }, 0)
                     : 0;
 
-                return {
-                    ...column,
-                    width: Math.max(
-                        FLUENT_RESULT_GRID_MIN_COLUMN_WIDTH,
-                        Math.min(
-                            FLUENT_RESULT_GRID_MAX_COLUMN_WIDTH,
-                            Math.ceil(Math.max(headerWidth, dataWidth)) + 1,
-                        ),
+                const width = Math.max(
+                    FLUENT_RESULT_GRID_MIN_COLUMN_WIDTH,
+                    Math.min(
+                        FLUENT_RESULT_GRID_MAX_COLUMN_WIDTH,
+                        Math.ceil(Math.max(headerWidth, dataWidth)) + 1,
                     ),
-                };
+                );
+                if (column.width === width) {
+                    return column;
+                }
+
+                columnsChanged = true;
+                return { ...column, width };
             });
 
             if (requestId !== undefined && autoSizeRequestIdRef.current !== requestId) {
                 return true;
             }
 
-            grid.setColumns(resizedColumns);
-            grid.invalidate();
+            if (columnsChanged) {
+                grid.setColumns(resizedColumns);
+                grid.invalidate();
+            }
             return true;
         },
-        [autoSizeColumnsMode, containerRef, dataView, latestRowCountRef, reactGridRef],
+        [autoSizeColumnsMode, dataView, getAutoSizeCanvasContext, latestRowCountRef, reactGridRef],
     );
 
     const scheduleAutoSizeColumns = useCallback(
@@ -312,17 +335,10 @@ export function useFluentResultGridLayout({
      */
     const autoSizeColumnByContent = useCallback(
         async (grid: SlickGrid, columnId: string): Promise<void> => {
-            const canvasContext = document.createElement("canvas").getContext("2d");
+            const canvasContext = getAutoSizeCanvasContext();
             if (!canvasContext) {
                 return;
             }
-
-            const computedStyle = containerRef.current
-                ? window.getComputedStyle(containerRef.current)
-                : undefined;
-            const fontSize =
-                parseInt(computedStyle?.fontSize ?? "", 10) || FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE;
-            canvasContext.font = `${fontSize}px ${computedStyle?.fontFamily ?? "monospace"}`;
 
             await autoSizeFluentResultGridColumnByContent({
                 grid,
@@ -341,7 +357,7 @@ export function useFluentResultGridLayout({
                 measureText: (text) => canvasContext.measureText(text).width,
             });
         },
-        [containerRef, dataView, latestRowCountRef],
+        [dataView, getAutoSizeCanvasContext, latestRowCountRef],
     );
 
     return {

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridLayout.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridLayout.ts
@@ -64,7 +64,6 @@ export function useFluentResultGridLayout({
     const frozenPaneWheelCleanupRef = useRef<(() => void) | undefined>(undefined);
     const autoSizeRequestIdRef = useRef(0);
     const autoSizeCanvasContextRef = useRef<CanvasRenderingContext2D | null | undefined>(undefined);
-    const autoSizeFontRef = useRef<string | undefined>(undefined);
 
     const getAutoSizeCanvasContext = useCallback(() => {
         if (autoSizeCanvasContextRef.current === undefined) {
@@ -76,16 +75,13 @@ export function useFluentResultGridLayout({
             return undefined;
         }
 
-        if (autoSizeFontRef.current === undefined) {
-            const computedStyle = containerRef.current
-                ? window.getComputedStyle(containerRef.current)
-                : undefined;
-            const fontSize =
-                parseInt(computedStyle?.fontSize ?? "", 10) || FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE;
-            const fontFamily = computedStyle?.fontFamily ?? "monospace";
-            autoSizeFontRef.current = `${fontSize}px ${fontFamily}`;
-        }
-        canvasContext.font = autoSizeFontRef.current;
+        const computedStyle = containerRef.current
+            ? window.getComputedStyle(containerRef.current)
+            : undefined;
+        const fontSize =
+            parseInt(computedStyle?.fontSize ?? "", 10) || FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE;
+        const fontFamily = computedStyle?.fontFamily || "monospace";
+        canvasContext.font = `${fontSize}px ${fontFamily}`;
         return canvasContext;
     }, [containerRef]);
 

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
@@ -134,6 +134,24 @@ export function restoreFluentResultGridColumnWidths(
     });
 }
 
+export function areFluentResultGridColumnLayoutsEqual(
+    currentColumns: readonly Column<FluentResultGridDataRow>[],
+    nextColumns: readonly Column<FluentResultGridDataRow>[],
+): boolean {
+    return (
+        currentColumns.length === nextColumns.length &&
+        currentColumns.every((column, index) => {
+            const nextColumn = nextColumns[index];
+            return (
+                nextColumn !== undefined &&
+                column.id === nextColumn.id &&
+                column.width === nextColumn.width &&
+                Boolean(column.hidden) === Boolean(nextColumn.hidden)
+            );
+        })
+    );
+}
+
 function isFluentResultGridStateDataColumn(column: Column<FluentResultGridDataRow>): boolean {
     return column.id !== FLUENT_RESULT_GRID_ROW_NUMBER_COLUMN_ID && !column.excludeFromGridMenu;
 }

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
@@ -41,6 +41,7 @@ import {
 } from "./fluentResultGridHeaderController";
 import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
+    areFluentResultGridColumnLayoutsEqual,
     createFluentResultGridIdentitySignature,
     getFluentResultGridRowHeight,
     getFluentResultGridStateForEmit,
@@ -312,11 +313,14 @@ export function useFluentResultGridController({
                     if (initialState.columnWidths?.length) {
                         layoutController.cancelAutoSizeColumns();
                     }
+                    const currentColumns = grid.getColumns() as Column<FluentResultGridDataRow>[];
                     const restoredColumns = restoreFluentResultGridColumnWidths(
-                        grid.getColumns() as Column<FluentResultGridDataRow>[],
+                        currentColumns,
                         initialState,
                     );
-                    grid.setColumns(restoredColumns);
+                    if (!areFluentResultGridColumnLayoutsEqual(currentColumns, restoredColumns)) {
+                        grid.setColumns(restoredColumns);
+                    }
                 }
 
                 dataController.filterStateRef.current = initialState?.filters ?? {};
@@ -336,15 +340,23 @@ export function useFluentResultGridController({
                 let restoredColumns = grid.getColumns() as Column<FluentResultGridDataRow>[];
                 if (Array.isArray(initialState?.hiddenColumnIds)) {
                     const hiddenColumnIds = new Set(initialState.hiddenColumnIds);
-                    restoredColumns = restoredColumns.map((column) =>
-                        isFluentResultGridDataColumn(column)
-                            ? {
-                                  ...column,
-                                  hidden: hiddenColumnIds.has(column.id.toString()),
-                              }
-                            : column,
-                    );
-                    grid.setColumns(restoredColumns);
+                    const columnsWithRestoredVisibility = restoredColumns.map((column) => {
+                        if (!isFluentResultGridDataColumn(column)) {
+                            return column;
+                        }
+
+                        const hidden = hiddenColumnIds.has(column.id.toString());
+                        return Boolean(column.hidden) === hidden ? column : { ...column, hidden };
+                    });
+                    if (
+                        !areFluentResultGridColumnLayoutsEqual(
+                            restoredColumns,
+                            columnsWithRestoredVisibility,
+                        )
+                    ) {
+                        grid.setColumns(columnsWithRestoredVisibility);
+                    }
+                    restoredColumns = columnsWithRestoredVisibility;
                 }
 
                 const restoredFrozenColumnIndex = normalizeFluentResultGridFrozenColumnIndex(

--- a/extensions/mssql/src/webviews/common/lazyMount.tsx
+++ b/extensions/mssql/src/webviews/common/lazyMount.tsx
@@ -9,15 +9,24 @@ import {
     useRef,
     useState,
     type CSSProperties,
+    type FocusEventHandler,
+    type HTMLAttributes,
     type ReactNode,
     type RefObject,
 } from "react";
+
+type LazyMountPlaceholderProps = Pick<
+    HTMLAttributes<HTMLDivElement>,
+    "aria-label" | "aria-busy" | "role" | "tabIndex"
+>;
 
 export interface LazyMountProps {
     children: ReactNode;
     className?: string;
     containerRef?: RefObject<HTMLDivElement | null>;
     enabled?: boolean;
+    onPlaceholderFocus?: FocusEventHandler<HTMLDivElement>;
+    placeholderProps?: LazyMountPlaceholderProps;
     rootRef?: RefObject<Element | null>;
     style?: CSSProperties;
 }
@@ -42,6 +51,8 @@ export function LazyMount({
     className,
     containerRef,
     enabled = true,
+    onPlaceholderFocus,
+    placeholderProps,
     rootRef,
     style,
 }: LazyMountProps) {
@@ -69,6 +80,14 @@ export function LazyMount({
             }
         },
         [containerRef],
+    );
+
+    const handlePlaceholderFocus = useCallback<FocusEventHandler<HTMLDivElement>>(
+        (event) => {
+            onPlaceholderFocus?.(event);
+            mountChildren();
+        },
+        [mountChildren, onPlaceholderFocus],
     );
 
     useLayoutEffect(() => {
@@ -116,7 +135,12 @@ export function LazyMount({
     }, [enabled, mountChildren, rootRef]);
 
     return (
-        <div ref={setContainer} className={className} style={style}>
+        <div
+            {...(!hasMounted ? placeholderProps : undefined)}
+            ref={setContainer}
+            className={className}
+            style={style}
+            onFocus={!hasMounted ? handlePlaceholderFocus : undefined}>
             {hasMounted ? children : null}
         </div>
     );

--- a/extensions/mssql/src/webviews/common/lazyMount.tsx
+++ b/extensions/mssql/src/webviews/common/lazyMount.tsx
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    useCallback,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type ReactNode,
+    type RefObject,
+} from "react";
+
+export interface LazyMountProps {
+    children: ReactNode;
+    className?: string;
+    containerRef?: RefObject<HTMLDivElement | null>;
+    enabled?: boolean;
+    rootRef?: RefObject<Element | null>;
+    style?: CSSProperties;
+}
+
+export function doLazyMountBoundsIntersect(element: Element, root: Element): boolean {
+    const elementBounds = element.getBoundingClientRect();
+    const rootBounds = root.getBoundingClientRect();
+    return (
+        elementBounds.bottom > rootBounds.top &&
+        elementBounds.top < rootBounds.bottom &&
+        elementBounds.right > rootBounds.left &&
+        elementBounds.left < rootBounds.right
+    );
+}
+
+/**
+ * Preserves a container's layout while deferring its children until the container first becomes
+ * visible. Unsupported or unavailable browser primitives fall back to rendering immediately.
+ */
+export function LazyMount({
+    children,
+    className,
+    containerRef,
+    enabled = true,
+    rootRef,
+    style,
+}: LazyMountProps) {
+    const [hasMounted, setHasMounted] = useState(!enabled);
+    const hasMountedRef = useRef(hasMounted);
+    const localContainerRef = useRef<HTMLDivElement | null>(null);
+    const observerRef = useRef<IntersectionObserver | undefined>(undefined);
+
+    const mountChildren = useCallback(() => {
+        if (hasMountedRef.current) {
+            return;
+        }
+
+        hasMountedRef.current = true;
+        observerRef.current?.disconnect();
+        observerRef.current = undefined;
+        setHasMounted(true);
+    }, []);
+
+    const setContainer = useCallback(
+        (element: HTMLDivElement | null) => {
+            localContainerRef.current = element;
+            if (containerRef) {
+                containerRef.current = element;
+            }
+        },
+        [containerRef],
+    );
+
+    useLayoutEffect(() => {
+        observerRef.current?.disconnect();
+        observerRef.current = undefined;
+
+        if (hasMountedRef.current) {
+            return;
+        }
+
+        const element = localContainerRef.current;
+        const root = rootRef?.current;
+        if (
+            !enabled ||
+            !element ||
+            !root ||
+            typeof globalThis.IntersectionObserver === "undefined"
+        ) {
+            mountChildren();
+            return;
+        }
+
+        try {
+            if (doLazyMountBoundsIntersect(element, root)) {
+                mountChildren();
+                return;
+            }
+
+            observerRef.current = new IntersectionObserver(
+                (entries) => {
+                    if (entries.some((entry) => entry.isIntersecting)) {
+                        mountChildren();
+                    }
+                },
+                { root },
+            );
+            observerRef.current.observe(element);
+        } catch {
+            mountChildren();
+        }
+
+        return () => {
+            observerRef.current?.disconnect();
+        };
+    }, [enabled, mountChildren, rootRef]);
+
+    return (
+        <div ref={setContainer} className={className} style={style}>
+            {hasMounted ? children : null}
+        </div>
+    );
+}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
@@ -892,6 +892,7 @@ export function QueryResultFluentResultGridView() {
             defaultCommands={defaultCommands}>
             <QueryResultsGridView
                 GridComponent={QueryResultFluentResultGrid}
+                deferOffscreenGridRendering
                 showExternalCommandBar={false}
             />
         </FluentResultGridProvider>

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
@@ -98,6 +98,8 @@ export const QueryResultsGridView = ({
     );
     const [maximizedGridKey, setMaximizedGridKey] = useState<string | undefined>(undefined);
     const gridRefs = useRef<Array<ResultGridHandle | undefined>>([]);
+    const [gridIndexToFocus, setGridIndexToFocus] = useState<number | undefined>(undefined);
+    const gridIndexToFocusRef = useRef<number | undefined>(undefined);
     const activeSelectionGridKeyRef = useRef<string | undefined>(undefined);
     const { keyBindings } = useVscodeWebview();
 
@@ -261,6 +263,44 @@ export const QueryResultsGridView = ({
         return undefined;
     }, [gridList, gridRefs]);
 
+    const focusGridAtIndex = useCallback(
+        (gridIndex: number): boolean => {
+            const gridDefinition = gridList[gridIndex];
+            if (!gridDefinition) {
+                return false;
+            }
+
+            const gridKey = `${gridDefinition.batchId}_${gridDefinition.resultId}`;
+            const gridContainer = gridContainerRefs.current.get(gridKey)?.current;
+            if (!gridContainer) {
+                return false;
+            }
+
+            gridContainer.scrollIntoView({ behavior: "smooth", block: "center" });
+            const grid = gridRefs.current[gridIndex];
+            if (grid) {
+                grid.focusGrid();
+                return true;
+            }
+
+            gridIndexToFocusRef.current = gridIndex;
+            setGridIndexToFocus(gridIndex);
+            return true;
+        },
+        [gridList],
+    );
+
+    const handleGridRef = useCallback((gridIndex: number, grid: ResultGridHandle | null) => {
+        gridRefs.current[gridIndex] = grid ?? undefined;
+        if (!grid || gridIndexToFocusRef.current !== gridIndex) {
+            return;
+        }
+
+        gridIndexToFocusRef.current = undefined;
+        setGridIndexToFocus(undefined);
+        requestAnimationFrame(() => grid.focusGrid());
+    }, []);
+
     // Keyboard shortcuts
     useEffect(() => {
         const handler = (event: KeyboardEvent) => {
@@ -299,16 +339,7 @@ export const QueryResultsGridView = ({
                 }
                 // Circular navigation
                 const newIndex = (activeGrid.gridIndex - 1 + gridList.length) % gridList.length;
-
-                // Scroll div into view before focusing grid
-                gridContainerRefs.current
-                    .get(`${activeGrid.gridDef.batchId}_${activeGrid.gridDef.resultId}`)
-                    ?.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-                const gridToFocus = gridRefs.current[newIndex];
-                if (gridToFocus) {
-                    gridToFocus.focusGrid();
-                    handled = true;
-                }
+                handled = focusGridAtIndex(newIndex);
             } else if (
                 eventMatchesShortcut(
                     event,
@@ -321,17 +352,7 @@ export const QueryResultsGridView = ({
                 }
                 // Circular navigation
                 const newIndex = (activeGrid.gridIndex + 1) % gridList.length;
-
-                // Scroll div into view before focusing grid
-                gridContainerRefs.current
-                    .get(`${activeGrid.gridDef.batchId}_${activeGrid.gridDef.resultId}`)
-                    ?.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-
-                const gridToFocus = gridRefs.current[newIndex];
-                if (gridToFocus) {
-                    gridToFocus.focusGrid();
-                    handled = true;
-                }
+                handled = focusGridAtIndex(newIndex);
             }
 
             if (handled) {
@@ -343,7 +364,7 @@ export const QueryResultsGridView = ({
         return () => {
             document.removeEventListener("keydown", handler, true);
         };
-    }, [keyBindings, gridList, getActiveGrid, viewMode, maximizedGridKey]);
+    }, [keyBindings, gridList, getActiveGrid, focusGridAtIndex, viewMode, maximizedGridKey]);
 
     const handleToggleMaximize = (gridKey: string) => {
         const isAlreadyMaximized = maximizedGridKey === gridKey;
@@ -539,7 +560,11 @@ export const QueryResultsGridView = ({
                             } as React.CSSProperties
                         }>
                         <LazyMount
-                            enabled={deferOffscreenGridRendering && !isMaximized}
+                            enabled={
+                                deferOffscreenGridRendering &&
+                                !isMaximized &&
+                                gridIndexToFocus !== index
+                            }
                             rootRef={gridViewContainerRef}
                             containerRef={containerRef}
                             style={{
@@ -554,7 +579,7 @@ export const QueryResultsGridView = ({
                                 key={gridKey}
                                 gridParentRef={containerRef}
                                 ref={(gridRef) => {
-                                    gridRefs.current[index] = gridRef ?? undefined;
+                                    handleGridRef(index, gridRef);
                                 }}
                                 batchId={item.batchId}
                                 resultId={item.resultId}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
@@ -25,6 +25,7 @@ import { perfMarkAfterNextPaint } from "../../common/perfMarks";
 import { eventMatchesShortcut } from "../../common/keyboardUtils";
 import { WebviewAction } from "../../../sharedInterfaces/webview";
 import debounce from "lodash/debounce";
+import { LazyMount } from "../../common/lazyMount";
 
 const useStyles = makeStyles({
     gridViewContainer: {
@@ -58,6 +59,7 @@ type ResultGridComponent = ForwardRefExoticComponent<
 
 export interface QueryResultsGridViewProps {
     GridComponent: ResultGridComponent;
+    deferOffscreenGridRendering?: boolean;
     showExternalCommandBar?: boolean;
 }
 
@@ -71,6 +73,7 @@ const BASE_ROW_PADDING = 12;
 
 export const QueryResultsGridView = ({
     GridComponent,
+    deferOffscreenGridRendering = false,
     showExternalCommandBar = true,
 }: QueryResultsGridViewProps) => {
     const classes = useStyles();
@@ -535,15 +538,17 @@ export const QueryResultsGridView = ({
                                 "--results-row-padding": `${gridSettings?.rowPadding ?? 0}px`,
                             } as React.CSSProperties
                         }>
-                        <div
+                        <LazyMount
+                            enabled={deferOffscreenGridRendering && !isMaximized}
+                            rootRef={gridViewContainerRef}
+                            containerRef={containerRef}
                             style={{
                                 flex: 1,
                                 minWidth: 0,
                                 minHeight: 0,
                                 height: "100%",
                                 overflow: "hidden",
-                            }}
-                            ref={containerRef}>
+                            }}>
                             <GridComponent
                                 gridId={gridKey}
                                 key={gridKey}
@@ -563,7 +568,7 @@ export const QueryResultsGridView = ({
                                     handleGridSelectionChange(gridKey, hasSelection)
                                 }
                             />
-                        </div>
+                        </LazyMount>
                         {showExternalCommandBar && (
                             <CommandBar
                                 uri={uri}

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultsGridView.tsx
@@ -26,6 +26,7 @@ import { eventMatchesShortcut } from "../../common/keyboardUtils";
 import { WebviewAction } from "../../../sharedInterfaces/webview";
 import debounce from "lodash/debounce";
 import { LazyMount } from "../../common/lazyMount";
+import { locConstants } from "../../common/locConstants";
 
 const useStyles = makeStyles({
     gridViewContainer: {
@@ -177,8 +178,9 @@ export const QueryResultsGridView = ({
         resultSetSummaries,
     ]);
 
-    // Perf-harness render-complete mark: fires only when the perf bridge is
-    // enabled (PERF_MODE runs); otherwise perfMarkAfterNextPaint is inert.
+    // Perf-harness first-readable-results mark: deferred offscreen result sets may still be
+    // unmounted at this boundary. The row and result-set counts are structural metadata, not
+    // mounted counts. This fires only when the perf bridge is enabled (PERF_MODE runs).
     const lastPerfMarkKey = useRef<string | undefined>(undefined);
     useEffect(() => {
         if (isExecuting === true) {
@@ -567,6 +569,19 @@ export const QueryResultsGridView = ({
                             }
                             rootRef={gridViewContainerRef}
                             containerRef={containerRef}
+                            placeholderProps={{
+                                "aria-busy": true,
+                                "aria-label": locConstants.queryResult.resultSet(
+                                    item.batchId,
+                                    item.resultId,
+                                ),
+                                role: "region",
+                                tabIndex: 0,
+                            }}
+                            onPlaceholderFocus={() => {
+                                gridIndexToFocusRef.current = index;
+                                setGridIndexToFocus(index);
+                            }}
                             style={{
                                 flex: 1,
                                 minWidth: 0,

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridTransforms";
 import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
+    areFluentResultGridColumnLayoutsEqual,
     getFluentResultGridCurrentViewState,
     getFluentResultGridInitialFrozenColumnIndex,
     normalizeFluentResultGridFrozenColumnIndex,
@@ -81,6 +82,7 @@ import {
 import { isFluentResultGridResizeHandleEvent } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridHeaderController";
 import { FluentResultGridSelectionModel } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridSelectionModel";
 import { dispatchFluentResultGridSelectionChange } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridSlickLifecycle";
+import { createFluentResultGridDataView } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridDataView";
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -211,6 +213,44 @@ suite("Fluent Result Grid", () => {
             expect(repeatedSchema.value).to.equal(first.value);
             expect(changedSchema).to.not.equal(first);
             expect(changedSchema.value).to.not.equal(first.value);
+        });
+    });
+
+    suite("data view", () => {
+        test("reuses loaded or in-flight windows until a reload is explicitly requested", async () => {
+            const getRows = sandbox
+                .stub()
+                .callsFake(async (offset: number, count: number) =>
+                    Array.from({ length: count }, (_value, index) => [
+                        cell((offset + index).toString()),
+                    ]),
+                );
+            const dataView = createFluentResultGridDataView({
+                dataSource: {
+                    kind: "windowed",
+                    rowCount: 100,
+                    getRows,
+                },
+                columnCount: 1,
+                windowSize: 50,
+            });
+
+            dataView.getItem(0);
+            expect(getRows).to.have.callCount(2);
+
+            dataView.setLength(101, false);
+            dataView.getItem(0);
+            expect(getRows).to.have.callCount(2);
+
+            await Promise.resolve();
+            await Promise.resolve();
+            dataView.setLength(102, false);
+            dataView.getItem(0);
+            expect(getRows).to.have.callCount(2);
+
+            dataView.refresh(0);
+            expect(getRows).to.have.callCount(4);
+            dataView.dispose();
         });
     });
 
@@ -398,6 +438,29 @@ suite("Fluent Result Grid", () => {
     });
 
     suite("state helpers", () => {
+        test("compares the column layout fields that require a SlickGrid reset", () => {
+            const columns = [
+                { id: "rowNumbers", field: "rowNumbers", width: 36 },
+                { id: "0", field: "0", width: 120, hidden: false },
+            ];
+
+            expect(
+                areFluentResultGridColumnLayoutsEqual(columns, [
+                    { ...columns[0] },
+                    { ...columns[1], hidden: undefined },
+                ]),
+            ).to.equal(true);
+            expect(
+                areFluentResultGridColumnLayoutsEqual(columns, [
+                    columns[0],
+                    { ...columns[1], width: 160 },
+                ]),
+            ).to.equal(false);
+            expect(
+                areFluentResultGridColumnLayoutsEqual(columns, [columns[1], columns[0]]),
+            ).to.equal(false);
+        });
+
         test("persists and restores the row number column width", () => {
             const currentColumns = [
                 { ...createFluentResultGridRowNumberColumn(), width: 80 },

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -253,41 +253,58 @@ suite("Fluent Result Grid", () => {
             dataView.dispose();
         });
 
-        test("retries an unchanged window after its in-flight load fails", async () => {
-            const rejectRequests: Array<(reason?: unknown) => void> = [];
-            const getRows = sandbox.stub().callsFake(
-                () =>
-                    new Promise<DbCellValue[][]>((_resolve, reject) => {
-                        rejectRequests.push(reject);
-                    }),
-            );
-            const dataView = createFluentResultGridDataView({
-                dataSource: {
-                    kind: "windowed",
-                    rowCount: 100,
-                    getRows,
-                },
-                columnCount: 1,
-                windowSize: 50,
+        const incompleteResponses: Array<{
+            name: string;
+            response: DbCellValue[][] | Error | undefined;
+        }> = [
+            { name: "an empty response", response: [] },
+            { name: "a partial response", response: [[cell("partial")]] },
+            { name: "a malformed response", response: undefined },
+            { name: "a rejected request", response: new Error("load failed") },
+        ];
+
+        for (const { name, response } of incompleteResponses) {
+            test(`retries an unchanged window through getItem after ${name}`, async () => {
+                let firstWindowRequestCount = 0;
+                const getRows = sandbox.stub().callsFake(async (offset: number, count: number) => {
+                    if (offset === 0 && firstWindowRequestCount++ === 0) {
+                        if (response instanceof Error) {
+                            throw response;
+                        }
+
+                        return response as DbCellValue[][];
+                    }
+
+                    return Array.from({ length: count }, (_value, index) => [
+                        cell((offset + index).toString()),
+                    ]);
+                });
+                const dataView = createFluentResultGridDataView({
+                    dataSource: {
+                        kind: "windowed",
+                        rowCount: 100,
+                        getRows,
+                    },
+                    columnCount: 1,
+                    windowSize: 50,
+                });
+
+                dataView.getItem(0);
+                expect(getRows).to.have.callCount(2);
+
+                await Promise.resolve();
+                await Promise.resolve();
+                dataView.getItem(0);
+                expect(getRows).to.have.callCount(3);
+
+                await Promise.resolve();
+                await Promise.resolve();
+                const loadedRow = dataView.getItem(0);
+                expect(getRows).to.have.callCount(3);
+                expect(loadedRow["0"]).to.include({ displayValue: "0" });
+                dataView.dispose();
             });
-            const rowStore = (
-                dataView as unknown as {
-                    rowStore: { resetAroundIndex: (index: number) => void };
-                }
-            ).rowStore;
-
-            dataView.getItem(0);
-            rowStore.resetAroundIndex(0);
-            expect(getRows).to.have.callCount(2);
-
-            rejectRequests.forEach((reject) => reject(new Error("load failed")));
-            await Promise.resolve();
-            await Promise.resolve();
-
-            rowStore.resetAroundIndex(0);
-            expect(getRows).to.have.callCount(4);
-            dataView.dispose();
-        });
+        }
     });
 
     suite("transforms", () => {

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -252,6 +252,42 @@ suite("Fluent Result Grid", () => {
             expect(getRows).to.have.callCount(4);
             dataView.dispose();
         });
+
+        test("retries an unchanged window after its in-flight load fails", async () => {
+            const rejectRequests: Array<(reason?: unknown) => void> = [];
+            const getRows = sandbox.stub().callsFake(
+                () =>
+                    new Promise<DbCellValue[][]>((_resolve, reject) => {
+                        rejectRequests.push(reject);
+                    }),
+            );
+            const dataView = createFluentResultGridDataView({
+                dataSource: {
+                    kind: "windowed",
+                    rowCount: 100,
+                    getRows,
+                },
+                columnCount: 1,
+                windowSize: 50,
+            });
+            const rowStore = (
+                dataView as unknown as {
+                    rowStore: { resetAroundIndex: (index: number) => void };
+                }
+            ).rowStore;
+
+            dataView.getItem(0);
+            rowStore.resetAroundIndex(0);
+            expect(getRows).to.have.callCount(2);
+
+            rejectRequests.forEach((reject) => reject(new Error("load failed")));
+            await Promise.resolve();
+            await Promise.resolve();
+
+            rowStore.resetAroundIndex(0);
+            expect(getRows).to.have.callCount(4);
+            dataView.dispose();
+        });
     });
 
     suite("transforms", () => {

--- a/extensions/mssql/test/unit/lazyMount.test.ts
+++ b/extensions/mssql/test/unit/lazyMount.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LazyMount } from "../../src/webviews/common/lazyMount";
+
+suite("LazyMount", () => {
+    test("keeps deferred result sets in the rendered keyboard focus order", () => {
+        const markup = renderToStaticMarkup(
+            createElement(
+                "div",
+                undefined,
+                createElement(LazyMount, {
+                    children: createElement("button", undefined, "First mounted grid"),
+                    enabled: true,
+                    placeholderProps: {
+                        "aria-busy": true,
+                        "aria-label": "Result set 1",
+                        role: "region",
+                        tabIndex: 0,
+                    },
+                }),
+                createElement(LazyMount, {
+                    children: createElement("button", undefined, "Second mounted grid"),
+                    enabled: true,
+                    placeholderProps: {
+                        "aria-busy": true,
+                        "aria-label": "Result set 2",
+                        role: "region",
+                        tabIndex: 0,
+                    },
+                }),
+            ),
+        );
+
+        expect(markup.match(/tabindex="0"/g)).to.have.length(2);
+        expect(markup.match(/role="region"/g)).to.have.length(2);
+        expect(markup).to.include('aria-label="Result set 1"');
+        expect(markup).to.include('aria-label="Result set 2"');
+        expect(markup).not.to.include("mounted grid");
+    });
+});


### PR DESCRIPTION
## Description

Improves time to first readable rows in the preview Fluent result grid:

- Avoids refetching row windows that are already loaded or in flight.
- Prevents the initial result-set identity check from forcing a redundant reset.
- Lazily mounts result grids below the fold while preserving scroll geometry.
- Reuses text-measurement resources and skips unchanged autosize layouts.
- Skips unchanged column-width and visibility restores.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`) — targeted Fluent Result Grid tests pass
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant (not applicable)
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)