### PR TITLE
Preserve precise Fluent grid scroll position

### DIFF
--- a/extensions/mssql/src/queryResult/utils.ts
+++ b/extensions/mssql/src/queryResult/utils.ts
@@ -330,6 +330,7 @@ export function registerCommonRequestHandlers(
             {
                 scrollLeft: message.scrollLeft,
                 scrollTop: message.scrollTop,
+                scrollTopOffset: message.scrollTopOffset,
             },
         );
     });

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -481,7 +481,10 @@ export namespace GetRowsRequest {
 export interface SetGridScrollPositionParams {
     uri: string;
     gridId: string;
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 
@@ -499,7 +502,10 @@ export interface GetGridScrollPositionParams {
 }
 
 export interface GetGridScrollPositionResponse {
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
@@ -9,7 +9,10 @@ import type {
     IDbColumn,
     ResultSetSummary,
 } from "../../../../sharedInterfaces/queryResult";
-import type { FluentResultGridState } from "../types/fluentResultGridState";
+import type {
+    FluentResultGridScrollPosition,
+    FluentResultGridState,
+} from "../types/fluentResultGridState";
 import {
     FLUENT_RESULT_GRID_DEFAULT_COLUMN_WIDTH,
     FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE,
@@ -20,6 +23,44 @@ import type { FluentResultGridDataRow } from "./fluentResultGridDataView";
 import { getFluentResultGridDataSelectionsFromRanges } from "./fluentResultGridSelection";
 
 export const FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX = 0;
+
+export function getFluentResultGridScrollTopOffset(grid: SlickGrid, topRow: number): number {
+    const rowHeight = grid.getOptions().rowHeight;
+    const viewportNode = grid.getViewportNode(0, topRow);
+    const rowBox = grid.getCellNodeBox(topRow, 0);
+    if (
+        typeof rowHeight !== "number" ||
+        rowHeight <= 0 ||
+        !viewportNode ||
+        !rowBox ||
+        !Number.isFinite(viewportNode.scrollTop) ||
+        !Number.isFinite(rowBox.top)
+    ) {
+        return 0;
+    }
+
+    return Math.min(rowHeight, Math.max(0, viewportNode.scrollTop - rowBox.top));
+}
+
+export function restoreFluentResultGridVerticalScrollPosition(
+    grid: SlickGrid,
+    scrollPosition: FluentResultGridScrollPosition,
+): void {
+    const rowHeight = grid.getOptions().rowHeight;
+    if (
+        typeof rowHeight !== "number" ||
+        rowHeight <= 0 ||
+        typeof scrollPosition.scrollTopOffset !== "number" ||
+        !Number.isFinite(scrollPosition.scrollTopOffset)
+    ) {
+        grid.scrollRowToTop(scrollPosition.scrollTop);
+        return;
+    }
+
+    const offset = Math.min(rowHeight, Math.max(0, scrollPosition.scrollTopOffset));
+    grid.scrollTo(scrollPosition.scrollTop * rowHeight + offset);
+    grid.render();
+}
 
 export function getFluentResultGridInitialFrozenColumnIndex(
     savedFrozenColumnIndex: number | undefined,
@@ -218,6 +259,7 @@ export function getFluentResultGridStateForEmit({
         scrollPosition: {
             scrollLeft: viewport.leftPx,
             scrollTop: viewport.top,
+            scrollTopOffset: getFluentResultGridScrollTopOffset(grid, viewport.top),
         },
     };
 }

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
@@ -48,6 +48,7 @@ import {
     normalizeFluentResultGridFrozenColumnIndex,
     normalizeFluentResultGridRowPadding,
     restoreFluentResultGridColumnWidths,
+    restoreFluentResultGridVerticalScrollPosition,
     stabilizeFluentResultGridColumnInfo,
     type FluentResultGridColumnInfoSnapshot,
 } from "./fluentResultGridState";
@@ -385,7 +386,10 @@ export function useFluentResultGridController({
                 if (initialState?.scrollPosition) {
                     requestAnimationFrame(() => {
                         if (initialState.scrollPosition) {
-                            grid.scrollRowToTop(initialState.scrollPosition.scrollTop);
+                            restoreFluentResultGridVerticalScrollPosition(
+                                grid,
+                                initialState.scrollPosition,
+                            );
                             layoutController.restoreHorizontalScrollPosition(
                                 grid,
                                 initialState.scrollPosition.scrollLeft,

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/types/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/types/fluentResultGridState.ts
@@ -24,7 +24,10 @@ export interface FluentResultGridSortState {
 }
 
 export interface FluentResultGridScrollPosition {
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
@@ -647,6 +647,7 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
                         gridId: props.gridId,
                         scrollLeft: state.scrollPosition.scrollLeft,
                         scrollTop: state.scrollPosition.scrollTop,
+                        scrollTopOffset: state.scrollPosition.scrollTopOffset,
                     },
                 );
             }

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -24,8 +24,10 @@ import {
     areFluentResultGridColumnLayoutsEqual,
     getFluentResultGridCurrentViewState,
     getFluentResultGridInitialFrozenColumnIndex,
+    getFluentResultGridStateForEmit,
     normalizeFluentResultGridFrozenColumnIndex,
     restoreFluentResultGridColumnWidths,
+    restoreFluentResultGridVerticalScrollPosition,
     stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
 import { isFluentResultGridHostCommand } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCommandUtils";
@@ -540,6 +542,60 @@ suite("Fluent Result Grid", () => {
             expect(viewState.rowNumberColumnWidth).to.equal(80);
             expect(restoredColumns[0].width).to.equal(80);
             expect(restoredColumns[1].width).to.equal(160);
+        });
+
+        test("persists the pixel offset within the top visible row", () => {
+            const columns = [{ id: "0", field: "0", width: 120 }];
+            const grid = {
+                getCellNodeBox: sandbox.stub().withArgs(10, 0).returns({ top: 260 }),
+                getColumns: sandbox.stub().returns(columns),
+                getOptions: sandbox.stub().returns({ frozenColumn: 0, rowHeight: 26 }),
+                getSelectionModel: sandbox.stub().returns(undefined),
+                getViewport: sandbox.stub().returns({ top: 10, leftPx: 40 }),
+                getViewportNode: sandbox.stub().withArgs(0, 10).returns({ scrollTop: 285.5 }),
+            } as unknown as SlickGrid;
+
+            const state = getFluentResultGridStateForEmit({
+                grid,
+                columnCount: 1,
+                frozenColumnIndex: FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
+                filters: {},
+                sort: undefined,
+            });
+
+            expect(state.scrollPosition).to.deep.equal({
+                scrollLeft: 40,
+                scrollTop: 10,
+                scrollTopOffset: 25.5,
+            });
+        });
+
+        test("restores the top row and its pixel offset when available", () => {
+            const scrollRowToTop = sandbox.stub();
+            const scrollTo = sandbox.stub();
+            const render = sandbox.stub();
+            const grid = {
+                getOptions: sandbox.stub().returns({ rowHeight: 26 }),
+                render,
+                scrollRowToTop,
+                scrollTo,
+            } as unknown as SlickGrid;
+
+            restoreFluentResultGridVerticalScrollPosition(grid, {
+                scrollLeft: 0,
+                scrollTop: 10,
+                scrollTopOffset: 25.5,
+            });
+
+            expect(scrollTo).to.have.been.calledWith(285.5);
+            expect(render).to.have.been.called;
+            expect(scrollRowToTop).not.to.have.been.called;
+
+            restoreFluentResultGridVerticalScrollPosition(grid, {
+                scrollLeft: 0,
+                scrollTop: 4,
+            });
+            expect(scrollRowToTop).to.have.been.calledWith(4);
         });
 
         test("persists selection columns by source identity after a reorder", () => {


### PR DESCRIPTION
## Summary

- preserve the pixel offset within the top visible Fluent result-grid row
- restore the exact vertical scroll position instead of snapping to the row boundary
- retain row-only fallback behavior for previously saved state

## Validation

- `npm run build:extension:typecheck`
- `npm run build:webviews`
- `npm run lint -- --target mssql`
- `npm test -- --target mssql --grep "Fluent Result Grid"` (84 passed)
- `npm test -- --target mssql` (full suite passed)

## Dependency

This is stacked on #22893 because it extends the Fluent result-grid state introduced there.