### PR TITLE
Preserve precise Fluent grid scroll position

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -4012,6 +4012,11 @@
     "Save .scmp file": "Save .scmp file",
     "Save source and target, options, and excluded elements": "Save source and target, options, and excluded elements",
     "Group differences by": "Group differences by",
+    "Layout": "Layout",
+    "Classic": "Classic",
+    "Simplified": "Simplified",
+    "Schema differences": "Schema differences",
+    "Object": "Object",
     "Source Name": "Source Name",
     "Target Name": "Target Name",
     "Change": "Change",
@@ -4035,6 +4040,27 @@
     "All schemas": "All schemas",
     "All object types": "All object types",
     "Clear filters": "Clear filters",
+    "Include or exclude all differences": "Include or exclude all differences",
+    "Included in script": "Included in script",
+    "Excluded from script": "Excluded from script",
+    "included in script": "included in script",
+    "excluded from script": "excluded from script",
+    "{0}, {1}, {2}, {3}/{0} is the schema object type{1} is the schema object name{2} is the update action{3} indicates whether the difference is included in the generated script": {
+        "message": "{0}, {1}, {2}, {3}",
+        "comment": [
+            "{0} is the schema object type",
+            "{1} is the schema object name",
+            "{2} is the update action",
+            "{3} indicates whether the difference is included in the generated script"
+        ]
+    },
+    "{0}, {1} differences/{0} is the schema difference group name{1} is the number of differences in the group": {
+        "message": "{0}, {1} differences",
+        "comment": [
+            "{0} is the schema difference group name",
+            "{1} is the number of differences in the group"
+        ]
+    },
     "{0} of {1} selected/{0} is the number of included schema differences{1} is the total number of schema differences": {
         "message": "{0} of {1} selected",
         "comment": [
@@ -4048,7 +4074,17 @@
     "Database Project": "Database Project",
     "Target": "Target",
     "Comparison Details": "Comparison Details",
+    "{0} / {1}/{0} is the one-based position of the selected schema difference{1} is the total number of visible schema differences": {
+        "message": "{0} / {1}",
+        "comment": [
+            "{0} is the one-based position of the selected schema difference",
+            "{1} is the total number of visible schema differences"
+        ]
+    },
     "Affected child objects": "Affected child objects",
+    "Constraints added": "Constraints added",
+    "Constraints changed": "Constraints changed",
+    "Constraints dropped": "Constraints dropped",
     "Constraints added: {0}/{0} is a comma-separated list of fully-qualified object names (e.g. '[dbo].[PK_Customers], [dbo].[UQ_Customers_Email]') that will be added under the selected parent object when the diff is applied.": {
         "message": "Constraints added: {0}",
         "comment": [

--- a/extensions/mssql/src/queryResult/utils.ts
+++ b/extensions/mssql/src/queryResult/utils.ts
@@ -330,6 +330,7 @@ export function registerCommonRequestHandlers(
             {
                 scrollLeft: message.scrollLeft,
                 scrollTop: message.scrollTop,
+                scrollTopOffset: message.scrollTopOffset,
             },
         );
     });

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -16,6 +16,8 @@ import {
     SchemaCompareIncludeExcludeAllRequest,
     SchemaCompareIncludeExcludeNodeRequest,
     SchemaCompareIncludeExcludeNodeResponse,
+    SchemaCompareGroupBy,
+    SchemaCompareLayout,
     SchemaCompareReducers,
     SchemaCompareServer,
     SchemaCompareWebViewState,
@@ -54,6 +56,8 @@ import { getConnectionDisplayName } from "../models/connectionInfo";
 import { buildDatabaseOptions } from "../utils/databaseUtils";
 
 const SCHEMA_COMPARE_VIEW_ID = "schemaCompare";
+const SCHEMA_COMPARE_LAYOUT_STATE_KEY = "mssql.schemaCompare.layout";
+const SCHEMA_COMPARE_GROUP_BY_STATE_KEY = "mssql.schemaCompare.groupBy";
 
 export class SchemaCompareWebViewController extends WebviewPanelController<
     SchemaCompareWebViewState,
@@ -92,6 +96,14 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
             SCHEMA_COMPARE_VIEW_ID,
             SCHEMA_COMPARE_VIEW_ID,
             {
+                layout: context.globalState.get<SchemaCompareLayout>(
+                    SCHEMA_COMPARE_LAYOUT_STATE_KEY,
+                    "classic",
+                ),
+                groupBy: context.globalState.get<SchemaCompareGroupBy>(
+                    SCHEMA_COMPARE_GROUP_BY_STATE_KEY,
+                    "type",
+                ),
                 isSqlProjectExtensionInstalled: false,
                 isComparisonInProgress: false,
                 isApplyInProgress: false,
@@ -448,6 +460,23 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
     }
 
     private registerRpcHandlers(): void {
+        this.registerReducer("setLayout", async (state, payload) => {
+            state.layout = payload.layout;
+            await this._context.globalState.update(SCHEMA_COMPARE_LAYOUT_STATE_KEY, payload.layout);
+            this.updateState(state);
+            return state;
+        });
+
+        this.registerReducer("setGroupBy", async (state, payload) => {
+            state.groupBy = payload.groupBy;
+            await this._context.globalState.update(
+                SCHEMA_COMPARE_GROUP_BY_STATE_KEY,
+                payload.groupBy,
+            );
+            this.updateState(state);
+            return state;
+        });
+
         this.registerReducer("isSqlProjectExtensionInstalled", async (state) => {
             this.logger.debug(
                 `Checking if SQL Database Projects extension is installed - OperationId: ${this.operationId}`,

--- a/extensions/mssql/src/sharedInterfaces/queryResult.ts
+++ b/extensions/mssql/src/sharedInterfaces/queryResult.ts
@@ -481,7 +481,10 @@ export namespace GetRowsRequest {
 export interface SetGridScrollPositionParams {
     uri: string;
     gridId: string;
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 
@@ -499,7 +502,10 @@ export interface GetGridScrollPositionParams {
 }
 
 export interface GetGridScrollPositionResponse {
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 

--- a/extensions/mssql/src/sharedInterfaces/schemaCompare.ts
+++ b/extensions/mssql/src/sharedInterfaces/schemaCompare.ts
@@ -34,6 +34,9 @@ export {
     TaskExecutionMode,
 };
 
+export type SchemaCompareLayout = "classic" | "simplified";
+export type SchemaCompareGroupBy = "none" | "type" | "action" | "schema";
+
 export interface SchemaCompareServer {
     profileName: string;
     server: string;
@@ -41,6 +44,8 @@ export interface SchemaCompareServer {
 }
 
 export interface SchemaCompareWebViewState {
+    layout: SchemaCompareLayout;
+    groupBy: SchemaCompareGroupBy;
     isSqlProjectExtensionInstalled: boolean;
     isComparisonInProgress: boolean;
     isApplyInProgress: boolean;
@@ -74,6 +79,9 @@ export interface SchemaCompareWebViewState {
 }
 
 export interface SchemaCompareReducers {
+    setLayout: { layout: SchemaCompareLayout };
+    setGroupBy: { groupBy: SchemaCompareGroupBy };
+
     isSqlProjectExtensionInstalled: {};
 
     listActiveServers: {};
@@ -161,6 +169,9 @@ export interface SchemaCompareContextProps extends CoreRPCs {
     differences: DiffEntry[];
     pendingDifferenceIds: ReadonlySet<number>;
     isIncludeExcludeAllInProgress: boolean;
+
+    setLayout: (layout: SchemaCompareLayout) => void;
+    setGroupBy: (groupBy: SchemaCompareGroupBy) => void;
 
     isSqlProjectExtensionInstalled: () => void;
 

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/fluentResultGridState.ts
@@ -9,7 +9,10 @@ import type {
     IDbColumn,
     ResultSetSummary,
 } from "../../../../sharedInterfaces/queryResult";
-import type { FluentResultGridState } from "../types/fluentResultGridState";
+import type {
+    FluentResultGridScrollPosition,
+    FluentResultGridState,
+} from "../types/fluentResultGridState";
 import {
     FLUENT_RESULT_GRID_DEFAULT_COLUMN_WIDTH,
     FLUENT_RESULT_GRID_DEFAULT_FONT_SIZE,
@@ -20,6 +23,44 @@ import type { FluentResultGridDataRow } from "./fluentResultGridDataView";
 import { getFluentResultGridDataSelectionsFromRanges } from "./fluentResultGridSelection";
 
 export const FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX = 0;
+
+export function getFluentResultGridScrollTopOffset(grid: SlickGrid, topRow: number): number {
+    const rowHeight = grid.getOptions().rowHeight;
+    const viewportNode = grid.getViewportNode(0, topRow);
+    const rowBox = grid.getCellNodeBox(topRow, 0);
+    if (
+        typeof rowHeight !== "number" ||
+        rowHeight <= 0 ||
+        !viewportNode ||
+        !rowBox ||
+        !Number.isFinite(viewportNode.scrollTop) ||
+        !Number.isFinite(rowBox.top)
+    ) {
+        return 0;
+    }
+
+    return Math.min(rowHeight, Math.max(0, viewportNode.scrollTop - rowBox.top));
+}
+
+export function restoreFluentResultGridVerticalScrollPosition(
+    grid: SlickGrid,
+    scrollPosition: FluentResultGridScrollPosition,
+): void {
+    const rowHeight = grid.getOptions().rowHeight;
+    if (
+        typeof rowHeight !== "number" ||
+        rowHeight <= 0 ||
+        typeof scrollPosition.scrollTopOffset !== "number" ||
+        !Number.isFinite(scrollPosition.scrollTopOffset)
+    ) {
+        grid.scrollRowToTop(scrollPosition.scrollTop);
+        return;
+    }
+
+    const offset = Math.min(rowHeight, Math.max(0, scrollPosition.scrollTopOffset));
+    grid.scrollTo(scrollPosition.scrollTop * rowHeight + offset);
+    grid.render();
+}
 
 export function getFluentResultGridInitialFrozenColumnIndex(
     savedFrozenColumnIndex: number | undefined,
@@ -200,6 +241,7 @@ export function getFluentResultGridStateForEmit({
         scrollPosition: {
             scrollLeft: viewport.leftPx,
             scrollTop: viewport.top,
+            scrollTopOffset: getFluentResultGridScrollTopOffset(grid, viewport.top),
         },
     };
 }

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/internal/useFluentResultGridController.ts
@@ -47,6 +47,7 @@ import {
     normalizeFluentResultGridFrozenColumnIndex,
     normalizeFluentResultGridRowPadding,
     restoreFluentResultGridColumnWidths,
+    restoreFluentResultGridVerticalScrollPosition,
     stabilizeFluentResultGridColumnInfo,
     type FluentResultGridColumnInfoSnapshot,
 } from "./fluentResultGridState";
@@ -373,7 +374,10 @@ export function useFluentResultGridController({
                 if (initialState?.scrollPosition) {
                     requestAnimationFrame(() => {
                         if (initialState.scrollPosition) {
-                            grid.scrollRowToTop(initialState.scrollPosition.scrollTop);
+                            restoreFluentResultGridVerticalScrollPosition(
+                                grid,
+                                initialState.scrollPosition,
+                            );
                             layoutController.restoreHorizontalScrollPosition(
                                 grid,
                                 initialState.scrollPosition.scrollLeft,

--- a/extensions/mssql/src/webviews/common/FluentResultGrid/types/fluentResultGridState.ts
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/types/fluentResultGridState.ts
@@ -24,7 +24,10 @@ export interface FluentResultGridSortState {
 }
 
 export interface FluentResultGridScrollPosition {
+    /** Index of the top visible row. */
     scrollTop: number;
+    /** Pixel offset within the top visible row. */
+    scrollTopOffset?: number;
     scrollLeft: number;
 }
 

--- a/extensions/mssql/src/webviews/common/locConstants.ts
+++ b/extensions/mssql/src/webviews/common/locConstants.ts
@@ -2387,7 +2387,12 @@ export class LocConstants {
                 "Save source and target, options, and excluded elements",
             ),
             groupDifferencesBy: l10n.t("Group differences by"),
+            layout: l10n.t("Layout"),
+            classicLayout: l10n.t("Classic"),
+            simplifiedLayout: l10n.t("Simplified"),
+            schemaDifferences: l10n.t("Schema differences"),
             type: l10n.t("Type"),
+            object: l10n.t("Object"),
             sourceName: l10n.t("Source Name"),
             include: l10n.t("Include"),
             action: l10n.t("Action"),
@@ -2424,6 +2429,34 @@ export class LocConstants {
             allSchemas: l10n.t("All schemas"),
             allObjectTypes: l10n.t("All object types"),
             clearFilters: l10n.t("Clear filters"),
+            includeAllDifferences: l10n.t("Include or exclude all differences"),
+            includedInScript: l10n.t("Included in script"),
+            excludedFromScript: l10n.t("Excluded from script"),
+            differenceRowLabel: (type: string, name: string, action: string, included: boolean) =>
+                l10n.t({
+                    message: "{0}, {1}, {2}, {3}",
+                    args: [
+                        type,
+                        name,
+                        action,
+                        included ? l10n.t("included in script") : l10n.t("excluded from script"),
+                    ],
+                    comment: [
+                        "{0} is the schema object type",
+                        "{1} is the schema object name",
+                        "{2} is the update action",
+                        "{3} indicates whether the difference is included in the generated script",
+                    ],
+                }),
+            differenceGroupLabel: (name: string, count: number) =>
+                l10n.t({
+                    message: "{0}, {1} differences",
+                    args: [name, count],
+                    comment: [
+                        "{0} is the schema difference group name",
+                        "{1} is the number of differences in the group",
+                    ],
+                }),
             selectedDifferencesSummary: (selectedCount: number, totalCount: number) =>
                 l10n.t({
                     message: "{0} of {1} selected",
@@ -2443,7 +2476,19 @@ export class LocConstants {
             source: l10n.t("Source"),
             target: l10n.t("Target"),
             compareDetails: l10n.t("Comparison Details"),
+            differencePosition: (current: number, total: number) =>
+                l10n.t({
+                    message: "{0} / {1}",
+                    args: [current, total],
+                    comment: [
+                        "{0} is the one-based position of the selected schema difference",
+                        "{1} is the total number of visible schema differences",
+                    ],
+                }),
             affectedChildrenRegionLabel: l10n.t("Affected child objects"),
+            constraintsAddedLabel: l10n.t("Constraints added"),
+            constraintsChangedLabel: l10n.t("Constraints changed"),
+            constraintsDroppedLabel: l10n.t("Constraints dropped"),
             affectedChildrenAdded: (names: string) =>
                 l10n.t({
                     message: "Constraints added: {0}",

--- a/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
+++ b/extensions/mssql/src/webviews/pages/QueryResult/queryResultFluentResultGrid.tsx
@@ -647,6 +647,7 @@ const QueryResultFluentResultGrid = forwardRef<ResultGridHandle, ResultGridProps
                         gridId: props.gridId,
                         scrollLeft: state.scrollPosition.scrollLeft,
                         scrollTop: state.scrollPosition.scrollTop,
+                        scrollTopOffset: state.scrollPosition.scrollTopOffset,
                     },
                 );
             }

--- a/extensions/mssql/src/webviews/pages/SchemaCompare/SchemaCompare.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaCompare/SchemaCompare.tsx
@@ -15,8 +15,7 @@ import { useSchemaCompareSelector } from "./schemaCompareSelector";
 import Message from "./components/Message";
 import { makeStyles } from "@fluentui/react-components";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-
-export type SchemaCompareGroupBy = "none" | "type" | "action" | "schema";
+import { SchemaCompareLayout } from "../../../sharedInterfaces/schemaCompare";
 
 const useStyles = makeStyles({
     container: {
@@ -57,7 +56,8 @@ export const SchemaComparePage = () => {
     const [showDrawer, setShowDrawer] = useState(false);
     const [showOptionsDrawer, setShowOptionsDrawer] = useState(false);
     const [endpointType, setEndpointType] = useState<"source" | "target">("source");
-    const [groupBy, setGroupBy] = useState<SchemaCompareGroupBy>("type");
+    const groupBy = useSchemaCompareSelector((s) => s.groupBy);
+    const layout = useSchemaCompareSelector((s) => s.layout);
     const [showComparisonDetails, setShowComparisonDetails] = useState(true);
     const [navigableDiffIds, setNavigableDiffIds] = useState<number[]>([]);
 
@@ -73,6 +73,13 @@ export const SchemaComparePage = () => {
     const handleDiffSelected = (id: number): void => {
         setSelectedDiffId(id);
         setShowComparisonDetails(true);
+    };
+
+    const handleOpenComparisonDetails = (): void => {
+        setShowComparisonDetails(true);
+        requestAnimationFrame(() => {
+            document.querySelector<HTMLElement>("[data-schema-compare-details]")?.focus();
+        });
     };
 
     const handlePreviousDiff = (): void => {
@@ -135,8 +142,15 @@ export const SchemaComparePage = () => {
                                     selectedDiffId={selectedDiffId}
                                     onDiffSelected={handleDiffSelected}
                                     groupBy={groupBy}
-                                    onGroupByChange={setGroupBy}
+                                    onGroupByChange={(nextGroupBy) =>
+                                        context.setGroupBy(nextGroupBy)
+                                    }
+                                    layout={layout}
+                                    onLayoutChange={(nextLayout: SchemaCompareLayout) =>
+                                        context.setLayout(nextLayout)
+                                    }
                                     onNavigableDiffIdsChange={setNavigableDiffIds}
+                                    onOpenComparisonDetails={handleOpenComparisonDetails}
                                 />
                             </Panel>
 
@@ -150,6 +164,11 @@ export const SchemaComparePage = () => {
                                         onNext={handleNextDiff}
                                         hasPrevious={navigableDiffIds.length > 1}
                                         hasNext={navigableDiffIds.length > 1}
+                                        currentPosition={Math.max(
+                                            navigableDiffIds.indexOf(selectedDiffId) + 1,
+                                            1,
+                                        )}
+                                        totalDifferences={navigableDiffIds.length}
                                     />
                                 </>
                             )}

--- a/extensions/mssql/src/webviews/pages/SchemaCompare/SchemaCompareStateProvider.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaCompare/SchemaCompareStateProvider.tsx
@@ -145,6 +145,12 @@ const SchemaCompareStateProvider: React.FC<SchemaCompareStateProviderProps> = ({
             differences,
             pendingDifferenceIds,
             isIncludeExcludeAllInProgress,
+            setLayout: function (layout: sc.SchemaCompareLayout): void {
+                extensionRpc.action("setLayout", { layout });
+            },
+            setGroupBy: function (groupBy: sc.SchemaCompareGroupBy): void {
+                extensionRpc.action("setGroupBy", { groupBy });
+            },
             isSqlProjectExtensionInstalled: function (): void {
                 extensionRpc.action("isSqlProjectExtensionInstalled", {});
             },

--- a/extensions/mssql/src/webviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaCompare/components/CompareDiffEditor.tsx
@@ -10,8 +10,8 @@ import {
     SchemaCompareWebViewState,
     SchemaUpdateAction,
 } from "../../../../sharedInterfaces/schemaCompare";
-import { Button, makeStyles, Text, Tooltip, tokens } from "@fluentui/react-components";
-import { ArrowLeft16Regular, ArrowRight16Regular } from "@fluentui/react-icons";
+import { Button, makeStyles, Text, Tooltip } from "@fluentui/react-components";
+import { ArrowLeft16Regular, ArrowRight16Regular, Info16Regular } from "@fluentui/react-icons";
 import { locConstants as loc } from "../../../common/locConstants";
 import { getDiffEditorModels, groupConstraintChildrenByAction } from "./compareDiffEditorUtils";
 import { DefinitionPanel } from "../../../common/definitionPanel";
@@ -42,17 +42,47 @@ const useStyles = makeStyles({
         },
     },
     affectedChildrenContainer: {
-        // Subtle banner above the diff editor that lists the names of the diff's
-        // hierarchical-child changes (constraints under a table, columns under a view, etc.)
-        // so the user can see what other objects this diff will touch when applied.
-        padding: "4px 12px",
-        backgroundColor: tokens.colorNeutralBackground2,
-        borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "8px",
+        padding: "8px 14px",
+        backgroundColor: "var(--vscode-textBlockQuote-background)",
+        borderBottom: "1px solid var(--vscode-editorGroup-border)",
+        borderLeft: "2px solid var(--vscode-charts-yellow)",
+    },
+    affectedChildrenIcon: {
+        flex: "0 0 auto",
+        marginTop: "1px",
+        color: "var(--vscode-charts-yellow)",
+    },
+    affectedChildrenLines: {
+        minWidth: 0,
     },
     affectedChildrenLine: {
         display: "block",
         fontSize: "12px",
         lineHeight: "1.5",
+    },
+    affectedChildrenLabel: {
+        fontWeight: 600,
+    },
+    affectedChildrenNames: {
+        fontFamily: "var(--vscode-editor-font-family)",
+        fontSize: "11.5px",
+        color: "var(--vscode-descriptionForeground)",
+    },
+    selectedDifferenceName: {
+        maxWidth: "320px",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        fontFamily: "var(--vscode-editor-font-family)",
+        color: "var(--vscode-descriptionForeground)",
+    },
+    differencePosition: {
+        whiteSpace: "nowrap",
+        color: "var(--vscode-descriptionForeground)",
+        fontVariantNumeric: "tabular-nums",
     },
 });
 
@@ -64,6 +94,8 @@ interface Props {
     onNext: () => void;
     hasPrevious: boolean;
     hasNext: boolean;
+    currentPosition: number;
+    totalDifferences: number;
 }
 
 const COMPARISON_DETAILS_TAB_ID = "comparisonDetails";
@@ -76,6 +108,8 @@ const CompareDiffEditor = ({
     onNext,
     hasPrevious,
     hasNext,
+    currentPosition,
+    totalDifferences,
 }: Props) => {
     const classes = useStyles();
     const schemaCompareResult = useSchemaCompareSelector((s) => s.schemaCompareResult);
@@ -83,6 +117,9 @@ const CompareDiffEditor = ({
     const compareResult = schemaCompareResult;
     const diff = compareResult?.differences[selectedDiffId];
     const { original, modified } = getDiffEditorModels(diff);
+    const selectedDifferenceName = (
+        diff?.sourceValue?.length ? diff.sourceValue : diff?.targetValue
+    )?.join(".");
 
     const affectedChildrenByAction = groupConstraintChildrenByAction(diff);
     const hasAffectedChildren = (Object.values(affectedChildrenByAction) as string[][]).some(
@@ -90,33 +127,54 @@ const CompareDiffEditor = ({
     );
 
     const content = (
-        <div className={classes.editorContainer}>
+        <div
+            className={classes.editorContainer}
+            data-schema-compare-details
+            role="region"
+            tabIndex={-1}
+            aria-label={loc.schemaCompare.compareDetails}>
             {hasAffectedChildren && (
                 <div
                     className={classes.affectedChildrenContainer}
                     role="region"
                     aria-label={loc.schemaCompare.affectedChildrenRegionLabel}>
-                    {!!affectedChildrenByAction[SchemaUpdateAction.Add]?.length && (
-                        <Text className={classes.affectedChildrenLine}>
-                            {loc.schemaCompare.affectedChildrenAdded(
-                                affectedChildrenByAction[SchemaUpdateAction.Add]!.join(", "),
-                            )}
-                        </Text>
-                    )}
-                    {!!affectedChildrenByAction[SchemaUpdateAction.Change]?.length && (
-                        <Text className={classes.affectedChildrenLine}>
-                            {loc.schemaCompare.affectedChildrenChanged(
-                                affectedChildrenByAction[SchemaUpdateAction.Change]!.join(", "),
-                            )}
-                        </Text>
-                    )}
-                    {!!affectedChildrenByAction[SchemaUpdateAction.Delete]?.length && (
-                        <Text className={classes.affectedChildrenLine}>
-                            {loc.schemaCompare.affectedChildrenDropped(
-                                affectedChildrenByAction[SchemaUpdateAction.Delete]!.join(", "),
-                            )}
-                        </Text>
-                    )}
+                    <Info16Regular className={classes.affectedChildrenIcon} aria-hidden />
+                    <div className={classes.affectedChildrenLines}>
+                        {!!affectedChildrenByAction[SchemaUpdateAction.Add]?.length && (
+                            <Text className={classes.affectedChildrenLine}>
+                                <span className={classes.affectedChildrenLabel}>
+                                    {loc.schemaCompare.constraintsAddedLabel}:{" "}
+                                </span>
+                                <span className={classes.affectedChildrenNames}>
+                                    {affectedChildrenByAction[SchemaUpdateAction.Add]!.join(", ")}
+                                </span>
+                            </Text>
+                        )}
+                        {!!affectedChildrenByAction[SchemaUpdateAction.Change]?.length && (
+                            <Text className={classes.affectedChildrenLine}>
+                                <span className={classes.affectedChildrenLabel}>
+                                    {loc.schemaCompare.constraintsChangedLabel}:{" "}
+                                </span>
+                                <span className={classes.affectedChildrenNames}>
+                                    {affectedChildrenByAction[SchemaUpdateAction.Change]!.join(
+                                        ", ",
+                                    )}
+                                </span>
+                            </Text>
+                        )}
+                        {!!affectedChildrenByAction[SchemaUpdateAction.Delete]?.length && (
+                            <Text className={classes.affectedChildrenLine}>
+                                <span className={classes.affectedChildrenLabel}>
+                                    {loc.schemaCompare.constraintsDroppedLabel}:{" "}
+                                </span>
+                                <span className={classes.affectedChildrenNames}>
+                                    {affectedChildrenByAction[SchemaUpdateAction.Delete]!.join(
+                                        ", ",
+                                    )}
+                                </span>
+                            </Text>
+                        )}
+                    </div>
                 </div>
             )}
             <div className={`${classes.editorHost} ${classes.deploymentDirectionIndicators}`}>
@@ -151,6 +209,11 @@ const CompareDiffEditor = ({
                     content,
                     headerActions: (
                         <>
+                            {selectedDifferenceName && (
+                                <Text className={classes.selectedDifferenceName}>
+                                    {selectedDifferenceName}
+                                </Text>
+                            )}
                             <Tooltip content={loc.common.previous} relationship="label">
                                 <Button
                                     size="small"
@@ -161,6 +224,14 @@ const CompareDiffEditor = ({
                                     onClick={onPrevious}
                                 />
                             </Tooltip>
+                            {totalDifferences > 0 && (
+                                <Text className={classes.differencePosition}>
+                                    {loc.schemaCompare.differencePosition(
+                                        currentPosition,
+                                        totalDifferences,
+                                    )}
+                                </Text>
+                            )}
                             <Tooltip content={loc.common.next} relationship="label">
                                 <Button
                                     size="small"

--- a/extensions/mssql/src/webviews/pages/SchemaCompare/components/SchemaDifferences.tsx
+++ b/extensions/mssql/src/webviews/pages/SchemaCompare/components/SchemaDifferences.tsx
@@ -41,15 +41,23 @@ import {
     Dismiss12Regular,
     Dismiss16Regular,
     Filter16Regular,
+    LayoutRowThree16Regular,
     Search16Regular,
     TextBulletListTree16Regular,
 } from "@fluentui/react-icons";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { SchemaUpdateAction } from "../../../../sharedInterfaces/schemaCompare";
+import {
+    SchemaCompareGroupBy,
+    SchemaCompareLayout,
+    SchemaUpdateAction,
+} from "../../../../sharedInterfaces/schemaCompare";
 import { locConstants as loc } from "../../../common/locConstants";
 import { DiffEntry } from "vscode-mssql";
 import { schemaCompareContext } from "../SchemaCompareStateProvider";
-import { SchemaCompareGroupBy } from "../SchemaCompare";
+import {
+    getSchemaDifferenceNavigationTarget,
+    SchemaDifferenceNavigationKey,
+} from "./schemaDifferencesUtils";
 
 type DiffRow = { kind: "diff" } & DiffEntry;
 type GroupRow = {
@@ -57,6 +65,9 @@ type GroupRow = {
     key: string;
     label: string;
     count: number;
+    addCount: number;
+    changeCount: number;
+    deleteCount: number;
     collapsed: boolean;
 };
 type Row = DiffRow | GroupRow;
@@ -70,6 +81,8 @@ interface FilterOption {
 const FILTER_ROW_HEIGHT = 28;
 const FILTER_VISIBLE_ROWS = 5;
 const GROUP_BY_MENU_NAME = "schemaCompareGroupBy";
+const LAYOUT_MENU_NAME = "schemaCompareLayout";
+const ROW_HEIGHT = 24;
 
 const VirtualizedFilterOptions = (props: {
     options: FilterOption[];
@@ -178,8 +191,30 @@ const highlightText = (
 };
 
 const useStyles = makeStyles({
-    HeaderCellPadding: {
-        padding: "0 8px",
+    dataGrid: {
+        "& [role='row']": {
+            height: `${ROW_HEIGHT}px`,
+            minHeight: `${ROW_HEIGHT}px`,
+        },
+        "& [role='columnheader']": {
+            alignItems: "center",
+            padding: "0 6px",
+            height: `${ROW_HEIGHT}px`,
+            minHeight: `${ROW_HEIGHT}px`,
+        },
+        "& .fui-DataGridHeaderCell__button": {
+            alignItems: "center",
+            height: `${ROW_HEIGHT}px`,
+            minHeight: `${ROW_HEIGHT}px`,
+        },
+        "& [role='gridcell']": {
+            padding: "0 6px",
+            height: `${ROW_HEIGHT}px`,
+            minHeight: `${ROW_HEIGHT}px`,
+        },
+        "& [data-action-stripe='true']": {
+            padding: 0,
+        },
     },
     selectedRow: {
         backgroundColor: "var(--vscode-list-activeSelectionBackground)",
@@ -188,6 +223,10 @@ const useStyles = makeStyles({
             backgroundColor: "var(--vscode-list-activeSelectionBackground)",
             color: "var(--vscode-list-activeSelectionForeground)",
         },
+    },
+    focusedRow: {
+        outline: "1px solid var(--vscode-focusBorder)",
+        outlineOffset: "-1px",
     },
     resizableContainer: {
         position: "relative",
@@ -199,14 +238,16 @@ const useStyles = makeStyles({
         overflow: "hidden",
         whiteSpace: "nowrap",
     },
-    alignSpinner: {
-        marginLeft: "8px",
-    },
     includeCell: {
         width: "100%",
         display: "flex",
         alignItems: "center",
-        justifyContent: "center",
+        justifyContent: "flex-start",
+        paddingLeft: "2px",
+        "& .fui-Checkbox__indicator": {
+            width: "14px",
+            height: "14px",
+        },
     },
     dataGridHeader: {
         backgroundColor: "var(--vscode-keybindingTable-headerBackground)",
@@ -400,6 +441,28 @@ const useStyles = makeStyles({
         gap: "6px",
         minWidth: 0,
     },
+    simplifiedObjectCell: {
+        minWidth: 0,
+        fontFamily: "var(--vscode-editor-font-family)",
+    },
+    simplifiedSchema: {
+        opacity: 0.65,
+    },
+    simplifiedRename: {
+        opacity: 0.65,
+    },
+    actionStripeCell: {
+        width: "100%",
+        height: "100%",
+        minHeight: `${ROW_HEIGHT}px`,
+        padding: 0,
+    },
+    actionStripe: {
+        display: "block",
+        width: "3px",
+        height: "100%",
+        minHeight: `${ROW_HEIGHT}px`,
+    },
     searchHighlight: {
         backgroundColor: "var(--vscode-editor-findMatchBackground)",
     },
@@ -410,6 +473,10 @@ const useStyles = makeStyles({
         borderBottom: "1px solid var(--vscode-sideBarSectionHeader-border)",
         "&:hover": {
             backgroundColor: "var(--vscode-list-hoverBackground)",
+        },
+        "&:focus": {
+            outline: "1px solid var(--vscode-focusBorder)",
+            outlineOffset: "-1px",
         },
     },
     groupHeaderCell: {
@@ -424,6 +491,8 @@ const useStyles = makeStyles({
         padding: "0 8px",
         width: "100%",
         height: "100%",
+        boxSizing: "border-box",
+        overflow: "hidden",
         background: "transparent",
         border: "none",
         color: "inherit",
@@ -432,11 +501,31 @@ const useStyles = makeStyles({
         textAlign: "left",
         userSelect: "none",
     },
+    groupHeaderSummary: {
+        display: "flex",
+        alignItems: "center",
+        gap: "6px",
+        marginLeft: "4px",
+        flex: "0 0 auto",
+        fontFamily: "var(--vscode-editor-font-family)",
+        fontSize: "11px",
+    },
+    groupAddCount: {
+        color: "var(--vscode-charts-green)",
+    },
+    groupChangeCount: {
+        color: "var(--vscode-charts-yellow)",
+    },
+    groupDeleteCount: {
+        color: "var(--vscode-charts-red)",
+    },
     groupHeaderLabel: {
         fontWeight: 600,
+        minWidth: 0,
     },
     groupHeaderCount: {
         opacity: 0.75,
+        flex: "0 0 auto",
     },
     groupHeaderChevron: {
         display: "flex",
@@ -449,12 +538,24 @@ interface Props {
     selectedDiffId: number;
     groupBy: SchemaCompareGroupBy;
     onGroupByChange: (value: SchemaCompareGroupBy) => void;
+    layout: SchemaCompareLayout;
+    onLayoutChange: (value: SchemaCompareLayout) => void;
     onNavigableDiffIdsChange: (ids: number[]) => void;
+    onOpenComparisonDetails: () => void;
 }
 
 export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
     (
-        { onDiffSelected, selectedDiffId, groupBy, onGroupByChange, onNavigableDiffIdsChange },
+        {
+            onDiffSelected,
+            selectedDiffId,
+            groupBy,
+            onGroupByChange,
+            layout,
+            onLayoutChange,
+            onNavigableDiffIdsChange,
+            onOpenComparisonDetails,
+        },
         ref,
     ) => {
         const classes = useStyles();
@@ -478,6 +579,8 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
             ) => void;
         } | null>(undefined as unknown as null);
         const previouslyScrolledDiffId = React.useRef<number | undefined>(undefined);
+        const previouslyFocusedDiffId = React.useRef(selectedDiffId);
+        const [focusedRowKey, setFocusedRowKey] = React.useState<string>(`diff:${selectedDiffId}`);
 
         const resizableRef = React.useRef<HTMLDivElement | null>(
             undefined as unknown as HTMLDivElement | null,
@@ -567,9 +670,7 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                     counts.set(difference.name, (counts.get(difference.name) ?? 0) + 1);
                 }
             });
-            return [...counts.entries()]
-                .sort(([left], [right]) => left.localeCompare(right))
-                .map(([key, count]) => ({ key, label: key, count }));
+            return [...counts.entries()].map(([key, count]) => ({ key, label: key, count }));
         }, [differences]);
 
         const toggleFilterValue = (
@@ -596,7 +697,70 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
 
         const emptyCell = <DataGridCell />;
 
-        const columns: TableColumnDefinition<Row>[] = [
+        const renderIncludeHeader = () => {
+            if (context.isIncludeExcludeAllInProgress) {
+                return (
+                    <Spinner
+                        size="extra-tiny"
+                        aria-label={loc.schemaCompare.includeExcludeAllOperationInProgress}
+                    />
+                );
+            }
+
+            return (
+                <Checkbox
+                    aria-label={loc.schemaCompare.includeAllDifferences}
+                    checked={
+                        diffInclusionLevel === "allIncluded"
+                            ? true
+                            : diffInclusionLevel === "mixed"
+                              ? "mixed"
+                              : false
+                    }
+                    onChange={(_event, data) =>
+                        void context.includeExcludeAllNodes(data.checked === true)
+                    }
+                    disabled={context.pendingDifferenceIds.size > 0}
+                />
+            );
+        };
+
+        const renderIncludeCell = (item: Row) => {
+            if (item.kind !== "diff") return emptyCell;
+            const isPending =
+                item.position !== undefined && context.pendingDifferenceIds.has(item.position);
+            return (
+                <DataGridCell className={classes.includeCell}>
+                    {isPending ? (
+                        <Spinner
+                            size="extra-tiny"
+                            aria-label={loc.schemaCompare.updatingDifferenceSelection}
+                        />
+                    ) : (
+                        <Checkbox
+                            tabIndex={-1}
+                            aria-label={
+                                item.included
+                                    ? loc.schemaCompare.includedInScript
+                                    : loc.schemaCompare.excludedFromScript
+                            }
+                            checked={item.included}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                event.currentTarget.closest<HTMLElement>("[role='row']")?.focus();
+                            }}
+                            onChange={(event, data) => {
+                                event.stopPropagation();
+                                handleIncludeExcludeNode(item, data.checked === true);
+                            }}
+                            disabled={context.isIncludeExcludeAllInProgress}
+                        />
+                    )}
+                </DataGridCell>
+            );
+        };
+
+        const classicColumns: TableColumnDefinition<Row>[] = [
             createTableColumn<Row>({
                 columnId: "type",
                 renderHeaderCell: () => loc.schemaCompare.type,
@@ -631,64 +795,8 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
             }),
             createTableColumn<Row>({
                 columnId: "include",
-                renderHeaderCell: () => {
-                    if (context.isIncludeExcludeAllInProgress) {
-                        return (
-                            <div className={classes.includeCell}>
-                                <Spinner
-                                    size="extra-tiny"
-                                    aria-label={
-                                        loc.schemaCompare.includeExcludeAllOperationInProgress
-                                    }
-                                    className={classes.alignSpinner}
-                                />
-                            </div>
-                        );
-                    }
-
-                    return (
-                        <div className={classes.includeCell}>
-                            <Checkbox
-                                checked={
-                                    diffInclusionLevel === "allIncluded"
-                                        ? true
-                                        : diffInclusionLevel === "mixed"
-                                          ? "mixed"
-                                          : false
-                                }
-                                onChange={(_event, data) =>
-                                    void context.includeExcludeAllNodes(data.checked === true)
-                                }
-                                disabled={context.pendingDifferenceIds.size > 0}
-                            />
-                        </div>
-                    );
-                },
-                renderCell: (item) => {
-                    if (item.kind !== "diff") return emptyCell;
-                    const isPending =
-                        item.position !== undefined &&
-                        context.pendingDifferenceIds.has(item.position);
-                    return (
-                        <DataGridCell className={classes.includeCell}>
-                            {isPending ? (
-                                <Spinner
-                                    size="extra-tiny"
-                                    aria-label={loc.schemaCompare.updatingDifferenceSelection}
-                                />
-                            ) : (
-                                <Checkbox
-                                    checked={item.included}
-                                    onChange={(event, data) => {
-                                        event.stopPropagation();
-                                        handleIncludeExcludeNode(item, data.checked === true);
-                                    }}
-                                    disabled={context.isIncludeExcludeAllInProgress}
-                                />
-                            )}
-                        </DataGridCell>
-                    );
-                },
+                renderHeaderCell: renderIncludeHeader,
+                renderCell: renderIncludeCell,
             }),
             createTableColumn<Row>({
                 columnId: "action",
@@ -736,6 +844,118 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                 },
             }),
         ];
+
+        const simplifiedColumns: TableColumnDefinition<Row>[] = [
+            createTableColumn<Row>({
+                columnId: "actionStripe",
+                renderHeaderCell: () => null,
+                renderCell: (item) => {
+                    if (item.kind !== "diff") return emptyCell;
+                    return (
+                        <DataGridCell
+                            className={classes.actionStripeCell}
+                            data-action-stripe="true"
+                            aria-hidden>
+                            <span
+                                className={mergeClasses(
+                                    classes.actionStripe,
+                                    getActionIndicatorClass(item.updateAction, classes),
+                                )}
+                            />
+                        </DataGridCell>
+                    );
+                },
+            }),
+            createTableColumn<Row>({
+                columnId: "include",
+                renderHeaderCell: renderIncludeHeader,
+                renderCell: renderIncludeCell,
+            }),
+            createTableColumn<Row>({
+                columnId: "action",
+                renderHeaderCell: () => loc.schemaCompare.action,
+                renderCell: (item) => {
+                    if (item.kind !== "diff") return emptyCell;
+                    return (
+                        <DataGridCell>
+                            <Text truncate>
+                                {highlightText(
+                                    getLabelForAction(item.updateAction),
+                                    filterText,
+                                    classes.searchHighlight,
+                                )}
+                            </Text>
+                        </DataGridCell>
+                    );
+                },
+            }),
+            createTableColumn<Row>({
+                columnId: "object",
+                renderHeaderCell: () => loc.schemaCompare.object,
+                renderCell: (item) => {
+                    if (item.kind !== "diff") return emptyCell;
+                    const sourceName = formatName(item.sourceValue);
+                    const targetName = formatName(item.targetValue);
+                    const displayName = sourceName || targetName;
+                    const [schema, ...objectNameParts] = displayName.split(".");
+                    const objectName = objectNameParts.join(".") || schema;
+                    const schemaPrefix = objectNameParts.length > 0 ? `${schema}.` : "";
+                    const isRenamed = !!sourceName && !!targetName && sourceName !== targetName;
+                    return (
+                        <DataGridCell>
+                            <Text truncate className={classes.simplifiedObjectCell}>
+                                {schemaPrefix && (
+                                    <span className={classes.simplifiedSchema}>
+                                        {highlightText(
+                                            schemaPrefix,
+                                            filterText,
+                                            classes.searchHighlight,
+                                        )}
+                                    </span>
+                                )}
+                                <span>
+                                    {highlightText(objectName, filterText, classes.searchHighlight)}
+                                </span>
+                                {isRenamed && (
+                                    <span className={classes.simplifiedRename}>
+                                        {" → "}
+                                        {highlightText(
+                                            targetName,
+                                            filterText,
+                                            classes.searchHighlight,
+                                        )}
+                                    </span>
+                                )}
+                            </Text>
+                        </DataGridCell>
+                    );
+                },
+            }),
+            ...(groupBy === "type"
+                ? []
+                : [
+                      createTableColumn<Row>({
+                          columnId: "type",
+                          renderHeaderCell: () => loc.schemaCompare.type,
+                          renderCell: (item) => {
+                              if (item.kind !== "diff") return emptyCell;
+                              return (
+                                  <DataGridCell>
+                                      <Text truncate className={classes.hideTextOverflow}>
+                                          {highlightText(
+                                              item.name,
+                                              filterText,
+                                              classes.searchHighlight,
+                                          )}
+                                      </Text>
+                                  </DataGridCell>
+                              );
+                          },
+                      }),
+                  ]),
+        ];
+
+        const columns = layout === "classic" ? classicColumns : simplifiedColumns;
 
         const [collapsedGroups, setCollapsedGroups] = React.useState<Set<string>>(new Set());
 
@@ -833,7 +1053,7 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                     if (bi === -1) return -1;
                     return ai - bi;
                 });
-            } else {
+            } else if (groupBy === "schema") {
                 keys.sort((a, b) => a.localeCompare(b));
             }
 
@@ -846,6 +1066,15 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                     key,
                     label: getLabel(key),
                     count: children.length,
+                    addCount: children.filter(
+                        (child) => child.updateAction === SchemaUpdateAction.Add,
+                    ).length,
+                    changeCount: children.filter(
+                        (child) => child.updateAction === SchemaUpdateAction.Change,
+                    ).length,
+                    deleteCount: children.filter(
+                        (child) => child.updateAction === SchemaUpdateAction.Delete,
+                    ).length,
                     collapsed,
                 });
                 if (!collapsed) {
@@ -884,26 +1113,134 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
             }
         }, [items, selectedDiffId]);
 
-        const toggleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>, diffEntry: DiffRow) => {
-            if (e.key === "Enter") {
-                if (diffEntry.position !== undefined) {
-                    onDiffSelected(diffEntry.position);
-                }
-                e.preventDefault();
+        const getRowKey = (item: Row): string =>
+            item.kind === "group" ? `group:${item.key}` : `diff:${item.position ?? ""}`;
+
+        const focusRenderedRow = (key: string): void => {
+            const renderedRows =
+                resizableRef.current?.querySelectorAll<HTMLElement>("[data-schema-row-key]");
+            Array.from(renderedRows ?? [])
+                .find((row) => row.dataset.schemaRowKey === key)
+                ?.focus();
+        };
+
+        React.useEffect(() => {
+            const selectedKey = `diff:${selectedDiffId}`;
+            const selectionChanged = previouslyFocusedDiffId.current !== selectedDiffId;
+            previouslyFocusedDiffId.current = selectedDiffId;
+            if (selectionChanged && items.some((item) => getRowKey(item) === selectedKey)) {
+                setFocusedRowKey(selectedKey);
+            } else if (!items.some((item) => getRowKey(item) === focusedRowKey)) {
+                const firstDiff = items.find((item) => item.kind === "diff");
+                setFocusedRowKey(
+                    firstDiff ? getRowKey(firstDiff) : items[0] ? getRowKey(items[0]) : "",
+                );
             }
+        }, [items, selectedDiffId]);
+
+        const focusRow = (item: Row, index: number): void => {
+            const key = getRowKey(item);
+            setFocusedRowKey(key);
+            if (item.kind === "diff" && item.position !== undefined) {
+                onDiffSelected(item.position);
+            }
+            virtualizedListRef.current?.scrollToItem(index, "smart");
+            requestAnimationFrame(() => focusRenderedRow(key));
+        };
+
+        const handleRowKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, item: Row): void => {
+            const currentIndex = items.findIndex(
+                (candidate) => getRowKey(candidate) === getRowKey(item),
+            );
+            if (currentIndex < 0) {
+                return;
+            }
+
+            const navigationKeys: readonly SchemaDifferenceNavigationKey[] = [
+                "ArrowUp",
+                "ArrowDown",
+                "Home",
+                "End",
+            ];
+            if (navigationKeys.includes(event.key as SchemaDifferenceNavigationKey)) {
+                const targetIndex = getSchemaDifferenceNavigationTarget(
+                    items.map((candidate) => candidate.kind),
+                    currentIndex,
+                    event.key as SchemaDifferenceNavigationKey,
+                );
+                event.preventDefault();
+                event.stopPropagation();
+                if (targetIndex !== undefined && targetIndex >= 0 && targetIndex !== currentIndex) {
+                    focusRow(items[targetIndex], targetIndex);
+                }
+                return;
+            }
+
+            switch (event.key) {
+                case "ArrowLeft":
+                    if (item.kind === "group" && !item.collapsed) {
+                        toggleGroupCollapsed(item.key);
+                    }
+                    break;
+                case "ArrowRight":
+                    if (item.kind === "group" && item.collapsed) {
+                        toggleGroupCollapsed(item.key);
+                    }
+                    break;
+                case " ":
+                    if (
+                        item.kind === "diff" &&
+                        !context.isIncludeExcludeAllInProgress &&
+                        item.position !== undefined &&
+                        !context.pendingDifferenceIds.has(item.position)
+                    ) {
+                        handleIncludeExcludeNode(item, !item.included);
+                    } else if (item.kind === "group") {
+                        toggleGroupCollapsed(item.key);
+                    }
+                    break;
+                case "Enter":
+                    if (item.kind === "diff") {
+                        if (item.position !== undefined) {
+                            onDiffSelected(item.position);
+                        }
+                        onOpenComparisonDetails();
+                    } else {
+                        toggleGroupCollapsed(item.key);
+                    }
+                    break;
+                default:
+                    return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
         };
 
         const renderRow: RowRenderer<Row> = ({ item, rowId }, style) => {
+            const rowKey = getRowKey(item);
             if (item.kind === "group") {
                 const Chevron = item.collapsed ? ChevronRightRegular : ChevronDownRegular;
                 return (
-                    <div key={rowId} role="row" style={style} className={classes.groupHeaderRow}>
+                    <div
+                        key={rowId}
+                        data-schema-row-key={rowKey}
+                        role="row"
+                        aria-label={loc.schemaCompare.differenceGroupLabel(item.label, item.count)}
+                        aria-expanded={!item.collapsed}
+                        aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Home End Space Enter"
+                        tabIndex={focusedRowKey === rowKey ? 0 : -1}
+                        style={style}
+                        className={classes.groupHeaderRow}
+                        onFocus={() => setFocusedRowKey(rowKey)}
+                        onClick={(event) => {
+                            event.currentTarget.focus();
+                            setFocusedRowKey(rowKey);
+                            toggleGroupCollapsed(item.key);
+                        }}
+                        onKeyDown={(event) => handleRowKeyDown(event, item)}>
                         <div role="gridcell" className={classes.groupHeaderCell}>
-                            <button
-                                type="button"
-                                aria-expanded={!item.collapsed}
-                                className={classes.groupHeaderButton}
-                                onClick={() => toggleGroupCollapsed(item.key)}>
+                            <div className={classes.groupHeaderButton}>
                                 <span className={classes.groupHeaderChevron}>
                                     <Chevron />
                                 </span>
@@ -916,7 +1253,26 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                                     {item.label}
                                 </Text>
                                 <Text className={classes.groupHeaderCount}>({item.count})</Text>
-                            </button>
+                                {layout === "simplified" && (
+                                    <span className={classes.groupHeaderSummary} aria-hidden>
+                                        {item.addCount > 0 && (
+                                            <span className={classes.groupAddCount}>
+                                                +{item.addCount}
+                                            </span>
+                                        )}
+                                        {item.changeCount > 0 && (
+                                            <span className={classes.groupChangeCount}>
+                                                ~{item.changeCount}
+                                            </span>
+                                        )}
+                                        {item.deleteCount > 0 && (
+                                            <span className={classes.groupDeleteCount}>
+                                                −{item.deleteCount}
+                                            </span>
+                                        )}
+                                    </span>
+                                )}
+                            </div>
                         </div>
                     </div>
                 );
@@ -925,52 +1281,95 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
             return (
                 <DataGridRow<Row>
                     key={rowId}
+                    data-schema-row-key={rowKey}
+                    tabIndex={focusedRowKey === rowKey ? 0 : -1}
                     aria-selected={item.position === selectedDiffId}
-                    className={item.position === selectedDiffId ? classes.selectedRow : undefined}
+                    aria-keyshortcuts="ArrowUp ArrowDown Home End Space Enter"
+                    aria-label={loc.schemaCompare.differenceRowLabel(
+                        item.name,
+                        formatName(item.sourceValue) || formatName(item.targetValue),
+                        getLabelForAction(item.updateAction),
+                        item.included,
+                    )}
+                    className={mergeClasses(
+                        item.position === selectedDiffId && classes.selectedRow,
+                        focusedRowKey === rowKey && classes.focusedRow,
+                    )}
                     style={style}
-                    onClick={() => {
+                    onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+                        event.currentTarget.focus();
+                        setFocusedRowKey(rowKey);
                         if (item.position !== undefined) {
                             onDiffSelected(item.position);
                         }
                     }}
-                    onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => toggleKeyDown(e, item)}>
+                    onFocus={(event: React.FocusEvent<HTMLDivElement>) => {
+                        if (event.target !== event.currentTarget) {
+                            return;
+                        }
+                        setFocusedRowKey(rowKey);
+                        if (item.position !== undefined) {
+                            onDiffSelected(item.position);
+                        }
+                    }}
+                    onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) =>
+                        handleRowKeyDown(event, item)
+                    }>
                     {({ renderCell }) => <>{renderCell(item)}</>}
                 </DataGridRow>
             );
         };
 
-        const includeColumnWidth = 60;
-        const columnPadding = 16;
-        // Balance the two columns on each side so Include starts at the grid's midpoint.
-        const sideContentWidth = Math.max(
-            (width - includeColumnWidth - columnPadding) / 2 - columnPadding * 2,
-            300,
-        );
-        const typeAndActionWidth = Math.max(100, Math.min(200, sideContentWidth * 0.3));
-        const nameWidth = Math.max(200, sideContentWidth - typeAndActionWidth);
-
-        const columnSizingOptions: TableColumnSizingOptions = {
+        const classicColumnSizingOptions: TableColumnSizingOptions = {
             type: {
-                minWidth: 100,
-                defaultWidth: typeAndActionWidth,
+                minWidth: 80,
+                defaultWidth: 120,
             },
             sourceName: {
-                minWidth: 200,
-                defaultWidth: nameWidth,
+                minWidth: 140,
+                defaultWidth: 300,
             },
             include: {
-                minWidth: 60,
-                defaultWidth: 60,
+                minWidth: 36,
+                defaultWidth: 40,
             },
             action: {
-                minWidth: 100,
-                defaultWidth: typeAndActionWidth,
+                minWidth: 75,
+                defaultWidth: 90,
             },
             targetName: {
-                minWidth: 200,
-                defaultWidth: nameWidth,
+                minWidth: 140,
+                defaultWidth: 300,
             },
         };
+        const simplifiedColumnSizingOptions: TableColumnSizingOptions = {
+            actionStripe: {
+                minWidth: 3,
+                defaultWidth: 3,
+            },
+            include: {
+                minWidth: 30,
+                defaultWidth: 34,
+            },
+            action: {
+                minWidth: 66,
+                defaultWidth: 90,
+            },
+            object: {
+                minWidth: 180,
+                defaultWidth: 420,
+            },
+            ...(groupBy === "type"
+                ? {}
+                : {
+                      type: {
+                          minWidth: 100,
+                          defaultWidth: 140,
+                      },
+                  }),
+        };
+        const columnSizingOptions =
+            layout === "classic" ? classicColumnSizingOptions : simplifiedColumnSizingOptions;
 
         const { totalCount, selectedCount, addCount, changeCount, deleteCount } =
             React.useMemo(() => {
@@ -1221,6 +1620,37 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                                 </MenuList>
                             </MenuPopover>
                         </Menu>
+                        <Menu
+                            checkedValues={{ [LAYOUT_MENU_NAME]: [layout] }}
+                            onCheckedValueChange={(_event, data) => {
+                                const next = data.checkedItems[0] as
+                                    | SchemaCompareLayout
+                                    | undefined;
+                                if (next) {
+                                    onLayoutChange(next);
+                                }
+                            }}>
+                            <MenuTrigger disableButtonEnhancement>
+                                <Button
+                                    appearance="subtle"
+                                    size="small"
+                                    icon={<LayoutRowThree16Regular />}
+                                    aria-label={loc.schemaCompare.layout}
+                                    title={loc.schemaCompare.layout}>
+                                    {loc.schemaCompare.layout}
+                                </Button>
+                            </MenuTrigger>
+                            <MenuPopover>
+                                <MenuList>
+                                    <MenuItemRadio name={LAYOUT_MENU_NAME} value="classic">
+                                        {loc.schemaCompare.classicLayout}
+                                    </MenuItemRadio>
+                                    <MenuItemRadio name={LAYOUT_MENU_NAME} value="simplified">
+                                        {loc.schemaCompare.simplifiedLayout}
+                                    </MenuItemRadio>
+                                </MenuList>
+                            </MenuPopover>
+                        </Menu>
                     </div>
                     <Text className={classes.selectedSummary}>
                         {loc.schemaCompare.selectedDifferencesSummary(selectedCount, totalCount)}
@@ -1228,10 +1658,14 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                 </div>
                 {width > 0 && (
                     <DataGrid
+                        key={`${layout}:${groupBy === "type" ? "grouped-type" : "with-type"}`}
+                        aria-label={loc.schemaCompare.schemaDifferences}
+                        className={classes.dataGrid}
                         items={items}
                         columns={columns}
-                        focusMode="composite"
+                        focusMode="row_unstable"
                         resizableColumns={true}
+                        resizableColumnsOptions={{ autoFitColumns: false }}
                         columnSizingOptions={columnSizingOptions}
                         getRowId={(item) => {
                             const row = item as Row;
@@ -1242,14 +1676,23 @@ export const SchemaDifferences = React.forwardRef<HTMLDivElement, Props>(
                         size="extra-small">
                         <DataGridHeader className={classes.dataGridHeader}>
                             <DataGridRow>
-                                {({ renderHeaderCell }) => (
-                                    <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
+                                {({ columnId, renderHeaderCell }) => (
+                                    <DataGridHeaderCell
+                                        focusMode="none"
+                                        className={
+                                            columnId === "include" ? classes.includeCell : undefined
+                                        }
+                                        data-action-stripe={
+                                            columnId === "actionStripe" ? "true" : undefined
+                                        }>
+                                        {renderHeaderCell()}
+                                    </DataGridHeaderCell>
                                 )}
                             </DataGridRow>
                         </DataGridHeader>
                         <DataGridBody<Row>
-                            itemSize={30}
-                            height={Math.max(height - 76, 0)}
+                            itemSize={ROW_HEIGHT}
+                            height={Math.max(height - 64, 0)}
                             width={"100%"}
                             listProps={{ ref: virtualizedListRef } as never}>
                             {renderRow}

--- a/extensions/mssql/src/webviews/pages/SchemaCompare/components/schemaDifferencesUtils.ts
+++ b/extensions/mssql/src/webviews/pages/SchemaCompare/components/schemaDifferencesUtils.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type SchemaDifferenceNavigationKey = "ArrowUp" | "ArrowDown" | "Home" | "End";
+
+/**
+ * Returns the row that should receive focus for a vertical navigation key. Group rows participate
+ * in arrow navigation, while Home and End go directly to the first or last visible difference.
+ */
+export function getSchemaDifferenceNavigationTarget(
+    rowKinds: readonly ("diff" | "group")[],
+    currentIndex: number,
+    key: SchemaDifferenceNavigationKey,
+): number | undefined {
+    if (currentIndex < 0 || currentIndex >= rowKinds.length || rowKinds.length === 0) {
+        return undefined;
+    }
+
+    switch (key) {
+        case "ArrowUp":
+            return Math.max(currentIndex - 1, 0);
+        case "ArrowDown":
+            return Math.min(currentIndex + 1, rowKinds.length - 1);
+        case "Home":
+            return rowKinds.indexOf("diff");
+        case "End":
+            return rowKinds.lastIndexOf("diff");
+    }
+}

--- a/extensions/mssql/test/unit/fluentResultGrid.test.ts
+++ b/extensions/mssql/test/unit/fluentResultGrid.test.ts
@@ -23,8 +23,10 @@ import {
     FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
     getFluentResultGridCurrentViewState,
     getFluentResultGridInitialFrozenColumnIndex,
+    getFluentResultGridStateForEmit,
     normalizeFluentResultGridFrozenColumnIndex,
     restoreFluentResultGridColumnWidths,
+    restoreFluentResultGridVerticalScrollPosition,
     stabilizeFluentResultGridColumnInfo,
 } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridState";
 import { isFluentResultGridHostCommand } from "../../src/webviews/common/FluentResultGrid/internal/fluentResultGridCommandUtils";
@@ -424,6 +426,60 @@ suite("Fluent Result Grid", () => {
             expect(viewState.rowNumberColumnWidth).to.equal(80);
             expect(restoredColumns[0].width).to.equal(80);
             expect(restoredColumns[1].width).to.equal(160);
+        });
+
+        test("persists the pixel offset within the top visible row", () => {
+            const columns = [{ id: "0", field: "0", width: 120 }];
+            const grid = {
+                getCellNodeBox: sandbox.stub().withArgs(10, 0).returns({ top: 260 }),
+                getColumns: sandbox.stub().returns(columns),
+                getOptions: sandbox.stub().returns({ frozenColumn: 0, rowHeight: 26 }),
+                getSelectionModel: sandbox.stub().returns(undefined),
+                getViewport: sandbox.stub().returns({ top: 10, leftPx: 40 }),
+                getViewportNode: sandbox.stub().withArgs(0, 10).returns({ scrollTop: 285.5 }),
+            } as unknown as SlickGrid;
+
+            const state = getFluentResultGridStateForEmit({
+                grid,
+                columnCount: 1,
+                frozenColumnIndex: FLUENT_RESULT_GRID_DEFAULT_FROZEN_COLUMN_INDEX,
+                filters: {},
+                sort: undefined,
+            });
+
+            expect(state.scrollPosition).to.deep.equal({
+                scrollLeft: 40,
+                scrollTop: 10,
+                scrollTopOffset: 25.5,
+            });
+        });
+
+        test("restores the top row and its pixel offset when available", () => {
+            const scrollRowToTop = sandbox.stub();
+            const scrollTo = sandbox.stub();
+            const render = sandbox.stub();
+            const grid = {
+                getOptions: sandbox.stub().returns({ rowHeight: 26 }),
+                render,
+                scrollRowToTop,
+                scrollTo,
+            } as unknown as SlickGrid;
+
+            restoreFluentResultGridVerticalScrollPosition(grid, {
+                scrollLeft: 0,
+                scrollTop: 10,
+                scrollTopOffset: 25.5,
+            });
+
+            expect(scrollTo).to.have.been.calledWith(285.5);
+            expect(render).to.have.been.called;
+            expect(scrollRowToTop).not.to.have.been.called;
+
+            restoreFluentResultGridVerticalScrollPosition(grid, {
+                scrollLeft: 0,
+                scrollTop: 4,
+            });
+            expect(scrollRowToTop).to.have.been.calledWith(4);
         });
 
         test("persists selection columns by source identity after a reorder", () => {

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -54,6 +54,8 @@ suite("SchemaCompareWebViewController Tests", () => {
     let connectionStoreStub: sinon.SinonStubbedInstance<ConnectionStore>;
     let connectionChangedEmitter: vscode.EventEmitter<void>;
     let requestHandlers: Map<string, (payload: any) => any>;
+    let globalStateGet: sinon.SinonStub;
+    let globalStateUpdate: sinon.SinonStub;
     const schemaCompareWebViewTitle = "Schema Compare";
     const operationId = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
     let generateOperationIdStub: sinon.SinonStub<[], string>;
@@ -202,6 +204,8 @@ suite("SchemaCompareWebViewController Tests", () => {
             });
 
         mockInitialState = {
+            layout: "classic",
+            groupBy: "type",
             isSqlProjectExtensionInstalled: false,
             isComparisonInProgress: false,
             isApplyInProgress: false,
@@ -240,9 +244,17 @@ suite("SchemaCompareWebViewController Tests", () => {
             cancelResultStatus: undefined,
         };
 
+        globalStateGet = sandbox
+            .stub()
+            .callsFake((_key: string, defaultValue?: unknown) => defaultValue);
+        globalStateUpdate = sandbox.stub().resolves();
         mockContext = {
             extensionUri: vscode.Uri.parse("file://test"),
             extensionPath: "path",
+            globalState: {
+                get: globalStateGet,
+                update: globalStateUpdate,
+            },
         } as unknown as vscode.ExtensionContext;
 
         IconUtils.initialize(mockContext.extensionUri);
@@ -396,6 +408,41 @@ suite("SchemaCompareWebViewController Tests", () => {
         expect(controller.panel.title, "Webview Title should match").to.equal(
             schemaCompareWebViewTitle,
         );
+    });
+
+    test("controller - defaults to the classic persisted layout", () => {
+        expect(controller.state.layout).to.equal("classic");
+        expect(globalStateGet).to.have.been.calledWith("mssql.schemaCompare.layout", "classic");
+    });
+
+    test("controller - defaults to the persisted type grouping", () => {
+        expect(controller.state.groupBy).to.equal("type");
+        expect(globalStateGet).to.have.been.calledWith("mssql.schemaCompare.groupBy", "type");
+    });
+
+    test("setLayout - persists the selected layout", async () => {
+        const state = { ...mockInitialState };
+
+        const result = await controller["_reducerHandlers"].get("setLayout")(state, {
+            layout: "simplified",
+        });
+
+        expect(result.layout).to.equal("simplified");
+        expect(globalStateUpdate).to.have.been.calledWith(
+            "mssql.schemaCompare.layout",
+            "simplified",
+        );
+    });
+
+    test("setGroupBy - persists the selected grouping", async () => {
+        const state = { ...mockInitialState };
+
+        const result = await controller["_reducerHandlers"].get("setGroupBy")(state, {
+            groupBy: "schema",
+        });
+
+        expect(result.groupBy).to.equal("schema");
+        expect(globalStateUpdate).to.have.been.calledWith("mssql.schemaCompare.groupBy", "schema");
     });
 
     test("start - resolves targetContext and calls launch with correct target", async () => {

--- a/extensions/mssql/test/unit/schemaDifferencesUtils.test.ts
+++ b/extensions/mssql/test/unit/schemaDifferencesUtils.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { getSchemaDifferenceNavigationTarget } from "../../src/webviews/pages/SchemaCompare/components/schemaDifferencesUtils";
+
+suite("SchemaDifferences keyboard navigation", () => {
+    const rows = ["group", "diff", "diff", "group", "diff"] as const;
+
+    test("ArrowUp and ArrowDown move through rendered rows", () => {
+        expect(getSchemaDifferenceNavigationTarget(rows, 2, "ArrowUp")).to.equal(1);
+        expect(getSchemaDifferenceNavigationTarget(rows, 2, "ArrowDown")).to.equal(3);
+    });
+
+    test("ArrowUp and ArrowDown stop at the list boundaries", () => {
+        expect(getSchemaDifferenceNavigationTarget(rows, 0, "ArrowUp")).to.equal(0);
+        expect(getSchemaDifferenceNavigationTarget(rows, rows.length - 1, "ArrowDown")).to.equal(
+            rows.length - 1,
+        );
+    });
+
+    test("Home and End select the first and last visible differences", () => {
+        expect(getSchemaDifferenceNavigationTarget(rows, 3, "Home")).to.equal(1);
+        expect(getSchemaDifferenceNavigationTarget(rows, 1, "End")).to.equal(4);
+    });
+
+    test("returns no target for an invalid current row", () => {
+        expect(getSchemaDifferenceNavigationTarget(rows, -1, "ArrowDown")).to.be.undefined;
+        expect(getSchemaDifferenceNavigationTarget([], 0, "Home")).to.be.undefined;
+    });
+});

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1310,6 +1310,9 @@
     <trans-unit id="++CODE++c7a8b036403ce2f163af46818ab619f6fdb6da9e16e6eb28bc547ecebcd7ad0b">
       <source xml:lang="en">Circular reference from project {0} to project {1}</source>
     </trans-unit>
+    <trans-unit id="++CODE++ae25d6481fc1741ffee4a95cd05de7b6375f7e1b0c63c006640b366094f2c4a9">
+      <source xml:lang="en">Classic</source>
+    </trans-unit>
     <trans-unit id="++CODE++83b12c2216efb4fdc924e1deb5182e905e4926ed0c1c324d467107f46d5a26a9">
       <source xml:lang="en">Clear</source>
     </trans-unit>
@@ -1890,13 +1893,22 @@
     <trans-unit id="++CODE++917801babf61b34ef1c1d96e3219bc6ba28693c81f2c5af5cc00a31d0793a317">
       <source xml:lang="en">Consider adding a name for this foreign key</source>
     </trans-unit>
+    <trans-unit id="++CODE++465eabab9bde19760846b72eb06f2498233548cac46595d805aa574d504110c3">
+      <source xml:lang="en">Constraints added</source>
+    </trans-unit>
     <trans-unit id="++CODE++1fb78b59d106ba2e4cd956f77e6e0c4bb1090e2d57ac69e73e49aef3fc65d6aa">
       <source xml:lang="en">Constraints added: {0}</source>
       <note>{0} is a comma-separated list of fully-qualified object names (e.g. &apos;[dbo].[PK_Customers], [dbo].[UQ_Customers_Email]&apos;) that will be added under the selected parent object when the diff is applied.</note>
     </trans-unit>
+    <trans-unit id="++CODE++eebd192e7f23ac2257f5366c5833064a3ea5639b4d7d4d1d29445c28ab012505">
+      <source xml:lang="en">Constraints changed</source>
+    </trans-unit>
     <trans-unit id="++CODE++bbbe9ad1983802ef25e78bbea25d0abdc86664e6a53f1459d4cc71cda0a25d8e">
       <source xml:lang="en">Constraints changed: {0}</source>
       <note>{0} is a comma-separated list of fully-qualified object names that will be altered under the selected parent object when the diff is applied.</note>
+    </trans-unit>
+    <trans-unit id="++CODE++7bee7db8de36619306e87e8f4dc35cad5737ee07d864839c4bc4bff0da4c3a2a">
+      <source xml:lang="en">Constraints dropped</source>
     </trans-unit>
     <trans-unit id="++CODE++c9d2fd860eb492e6f42e47058e7242c10daec76480b280a0886b242619243760">
       <source xml:lang="en">Constraints dropped: {0}</source>
@@ -3349,6 +3361,9 @@
     <trans-unit id="++CODE++01ae099f23b8fe85d27a9e26613eb2624bd76e11505385e3493f316afde824c2">
       <source xml:lang="en">Exclude Object Types</source>
     </trans-unit>
+    <trans-unit id="++CODE++8a2a30d7fa1829a6ecfc36aa01d3b7cef61dccb6291e254b5a66b77a6b5f8a60">
+      <source xml:lang="en">Excluded from script</source>
+    </trans-unit>
     <trans-unit id="++CODE++5f6395cfa3be1b2b7783b923ebc2736c923aeda2142cc740137eb871f8ec0e1f">
       <source xml:lang="en">Excluding folders is not yet supported</source>
     </trans-unit>
@@ -4628,6 +4643,9 @@
     <trans-unit id="++CODE++ac665fafc5f9732c9d322749a1f726be51f8b31d2ec83ecde83a6e1d2b632eda">
       <source xml:lang="en">Include all object types</source>
     </trans-unit>
+    <trans-unit id="++CODE++4ec34472d661ee6006e436cc302b6d561780eb0b22d21c9e9110b4ff31856a71">
+      <source xml:lang="en">Include or exclude all differences</source>
+    </trans-unit>
     <trans-unit id="++CODE++3f763b9cd0ea6431ca045177a0ef88702e20d566b4634c7efad944d1a4b1ef4d">
       <source xml:lang="en">Include permissions</source>
     </trans-unit>
@@ -4637,6 +4655,9 @@
     <trans-unit id="++CODE++38ccbbcbe0241e051909d6867d0528e4eff3bed6cbd9360cbaa67a0301f67066">
       <source xml:lang="en">Include {0}</source>
       <note>{0} is the entity name</note>
+    </trans-unit>
+    <trans-unit id="++CODE++8ae992fb19afbb34eedcd3f9183663145da97e5b1b40e449360bea6af64e8646">
+      <source xml:lang="en">Included in script</source>
     </trans-unit>
     <trans-unit id="++CODE++a19caa35e133f5a0e94975762741c4c73b09c8a830908934206474fea30817b0">
       <source xml:lang="en">Incomplete or orphaned connections</source>
@@ -4804,6 +4825,9 @@
     </trans-unit>
     <trans-unit id="++CODE++c7d299ed6b2896187b535a86fd6b04f01669a9b72528a8f2021fff2f42d9f6e3">
       <source xml:lang="en">Last Page</source>
+    </trans-unit>
+    <trans-unit id="++CODE++a511909161e1b84fb81b52028fc2ce79525a96b40ccda823caa4a66ee64772b5">
+      <source xml:lang="en">Layout</source>
     </trans-unit>
     <trans-unit id="++CODE++8d8cd546b58d91c300d3149ef40b8d98d3061dc38f15ea937d2ed785a3f25771">
       <source xml:lang="en">Learn More</source>
@@ -6023,6 +6047,9 @@
     </trans-unit>
     <trans-unit id="++CODE++17353b3f8f54bed0a811ad1ed6fb9f3505a0e039df3b934afb3e8bc11976a2ca">
       <source xml:lang="en">OLTP, built on Azure SQL</source>
+    </trans-unit>
+    <trans-unit id="++CODE++62a6da8735c18e2d66fe5de3dc5440252a1da49e3cbaa7c1d2d5068ad73ffba0">
+      <source xml:lang="en">Object</source>
     </trans-unit>
     <trans-unit id="++CODE++501ec8c3629bcdcd52b9d7895c90d04b0c0b969f1134ba024efe021f0a25d867">
       <source xml:lang="en">Object Explorer Filter</source>
@@ -7425,6 +7452,9 @@
     <trans-unit id="++CODE++22c32b443d8259ab1a9f2a388a56124f882e9356d7aeb64f41eb84ba2bdf48fd">
       <source xml:lang="en">Schema designer updated successfully.</source>
     </trans-unit>
+    <trans-unit id="++CODE++60aa3ddef33b076337901e45e7a08cee2075647c667509cb22451a7069ff608c">
+      <source xml:lang="en">Schema differences</source>
+    </trans-unit>
     <trans-unit id="++CODE++c55acbc843338cecc106d5428a6c2c6cd65129c6b5c440b6477f06206d844ded">
       <source xml:lang="en">Schema is required</source>
     </trans-unit>
@@ -8065,6 +8095,9 @@
     </trans-unit>
     <trans-unit id="++CODE++f6dd83003322db3c5d5ef293a8dc73363ae462529918cc8d17cc94f9988c0d45">
       <source xml:lang="en">Simple Container Management</source>
+    </trans-unit>
+    <trans-unit id="++CODE++aa86409ea7e147ea5324e4a83d49efc512f2527f7dbada91558cde583e1a8ec2">
+      <source xml:lang="en">Simplified</source>
     </trans-unit>
     <trans-unit id="++CODE++ab3134048412e796a4a423dc1963ca8ff12b535d546d314470407639777e0ac5">
       <source xml:lang="en">Smart performance</source>
@@ -9496,6 +9529,9 @@
     <trans-unit id="++CODE++e93cb41d4a7d2395d9bdfe4d8616f9b52762523bb44e75bf7701cd9d2e0d1cb7">
       <source xml:lang="en">equals</source>
     </trans-unit>
+    <trans-unit id="++CODE++2fbc383d3c49b83614aa419376b80ee04d986dfed814dfde2ce26e437635aa69">
+      <source xml:lang="en">excluded from script</source>
+    </trans-unit>
     <trans-unit id="++CODE++3b9c358f36f0a31b6ad3e14f309c7cf198ac9246e8316f9ce543d5b19ac02b80">
       <source xml:lang="en">file</source>
     </trans-unit>
@@ -9510,6 +9546,9 @@
     </trans-unit>
     <trans-unit id="++CODE++1b52f3a2e15148731314bf167145c54565ed2385a862b5eb7771eaf719e4f82e">
       <source xml:lang="en">hr</source>
+    </trans-unit>
+    <trans-unit id="++CODE++12dddf96612d48df0ad871a9612802de0957a3781556820e44215c68f824363a">
+      <source xml:lang="en">included in script</source>
     </trans-unit>
     <trans-unit id="++CODE++075b0e112ce5f3585bf21875b678fb678865a30c79d482cd01098957e6497c28">
       <source xml:lang="en">intelliSenseUpdated</source>
@@ -9615,6 +9654,11 @@
       <note>{0} is the task status
 {1} is the completion percent
 {2} is the task message</note>
+    </trans-unit>
+    <trans-unit id="++CODE++60f820e33dc2ebb9ace1ef9c084e6b0ce9c75e159edf59e955aa68a7b304783b">
+      <source xml:lang="en">{0} / {1}</source>
+      <note>{0} is the one-based position of the selected schema difference
+{1} is the total number of visible schema differences</note>
     </trans-unit>
     <trans-unit id="++CODE++08fefe04a78a12b9e4ac61ac107a5237d5d6993e0dc8c6706949b4c9fe54ca6f">
       <source xml:lang="en">{0} If the project was created in SSDT, it will continue to work in both tools. Do you want to update the project?</source>
@@ -9856,6 +9900,18 @@
       <source xml:lang="en">{0}, +{1} more</source>
       <note>{0} is the first changed property label
 {1} is the count of additional changed properties</note>
+    </trans-unit>
+    <trans-unit id="++CODE++cb0ea8066d092cc06095c116bd7b79ac93cc34d4c899ce19e465ac677f75bb27">
+      <source xml:lang="en">{0}, {1} differences</source>
+      <note>{0} is the schema difference group name
+{1} is the number of differences in the group</note>
+    </trans-unit>
+    <trans-unit id="++CODE++65f24f2f0e7e273592ce9abfdfe98800fe149834a4413bcf8565044f33eddbd9">
+      <source xml:lang="en">{0}, {1}, {2}, {3}</source>
+      <note>{0} is the schema object type
+{1} is the schema object name
+{2} is the update action
+{3} indicates whether the difference is included in the generated script</note>
     </trans-unit>
     <trans-unit id="++CODE++fbf6567d7b396892abbe6cccf81dca280649e099b853b805be1beb6af53d9229">
       <source xml:lang="en">{0}. {1}</source>


### PR DESCRIPTION
## Summary

- preserve the pixel offset within the top visible Fluent result-grid row
- restore the exact vertical scroll position instead of snapping to the row boundary
- retain row-only fallback behavior for previously saved state

## Validation

- `npm run build:extension:typecheck`
- `npm run build:webviews`
- `npm run lint -- --target mssql`
- `npm test -- --target mssql --grep "Fluent Result Grid"`
- `npm test -- --target mssql` (full suite passed before splitting the commit)