### PR TITLE
Fix Object Explorer node stuck on "Loading..." after applying a filter

### DIFF
--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -376,6 +376,9 @@ export class ObjectExplorerService {
                          * the database finishes resuming.
                          */
                         shouldRefresh = true;
+                        expandActivity.update({
+                            additionalProps: { isRefresh: shouldRefresh.toString() },
+                        });
                         continue;
                     }
                 }
@@ -621,14 +624,8 @@ export class ObjectExplorerService {
             `getNodeChildren: ${getNodeDescriptor(element)}, hadCache=${hadCache}, hasInFlight=${hasInFlight}`,
         );
 
-        /**
-         * Consume the refresh request up front and carry it forward as a local. Showing the loading
-         * node fires the tree-data-change event, which makes VS Code call back into this method
-         * while the load is still running; if the flag were still set, that internal callback would
-         * be mistaken for a second user-initiated refresh, queue another refresh, and show the
-         * loading node again — a cycle that never settles whenever the expand outlasts VS Code's
-         * tree refresh debounce.
-         */
+        // Consume the refresh before showing the loading node. That update makes VS Code request
+        // the children again, and the cleared flag prevents the callback from queuing a refresh.
         element.shouldRefresh = false;
 
         if (wasRefresh) {

--- a/extensions/mssql/src/objectExplorer/objectExplorerService.ts
+++ b/extensions/mssql/src/objectExplorer/objectExplorerService.ts
@@ -200,14 +200,19 @@ export class ObjectExplorerService {
     }
 
     /**
-     * Expands a node in the Object Explorer tree. If the node has the shouldRefresh flag set, it will be refreshed.
+     * Expands a node in the Object Explorer tree.
      * @param node The node to expand
      * @param sessionId The session ID to use for the expansion
+     * @param shouldRefresh Whether to re-populate the node on the server instead of expanding its
+     *   cached state. Defaults to the node's `shouldRefresh` flag for callers that still signal the
+     *   refresh that way; internal callers pass it explicitly so that clearing the flag early
+     *   cannot lose the request.
      * @returns The children of the expanded node
      */
     public async expandNode(
         node: TreeNodeInfo,
         sessionId: string,
+        shouldRefresh: boolean = node.shouldRefresh,
     ): Promise<vscode.TreeItem[] | undefined> {
         const expandActivity = startActivity(
             TelemetryViews.ObjectExplorer,
@@ -216,7 +221,7 @@ export class ObjectExplorerService {
                 additionalProps: {
                     nodeType: node.nodeType,
                     nodeSubType: node.nodeSubType,
-                    isRefresh: node.shouldRefresh.toString(),
+                    isRefresh: shouldRefresh.toString(),
                 },
             },
         );
@@ -274,7 +279,7 @@ export class ObjectExplorerService {
                         `expandNode: reusing in-flight expand for ${getNodeDescriptor(node)}`,
                     );
                     response = true;
-                } else if (node.shouldRefresh) {
+                } else if (shouldRefresh) {
                     this._logger.trace(
                         `expandNode: sending RefreshRequest for ${getNodeDescriptor(node)}`,
                     );
@@ -370,7 +375,7 @@ export class ObjectExplorerService {
                          * (clearing the cached error), which is what lets the retry succeed once
                          * the database finishes resuming.
                          */
-                        node.shouldRefresh = true;
+                        shouldRefresh = true;
                         continue;
                     }
                 }
@@ -616,6 +621,16 @@ export class ObjectExplorerService {
             `getNodeChildren: ${getNodeDescriptor(element)}, hadCache=${hadCache}, hasInFlight=${hasInFlight}`,
         );
 
+        /**
+         * Consume the refresh request up front and carry it forward as a local. Showing the loading
+         * node fires the tree-data-change event, which makes VS Code call back into this method
+         * while the load is still running; if the flag were still set, that internal callback would
+         * be mistaken for a second user-initiated refresh, queue another refresh, and show the
+         * loading node again — a cycle that never settles whenever the expand outlasts VS Code's
+         * tree refresh debounce.
+         */
+        element.shouldRefresh = false;
+
         if (wasRefresh) {
             this.cleanNodeChildren(element);
 
@@ -639,7 +654,7 @@ export class ObjectExplorerService {
          * Tree expansion is queued, so without this if multiple connections are expanding,
          * one blocked operation can delay the other.
          */
-        void this.getOrCreateNodeChildrenWithSession(element);
+        void this.getOrCreateNodeChildrenWithSession(element, wasRefresh);
         return this.setLoadingUiForNode(element);
     }
 
@@ -709,8 +724,13 @@ export class ObjectExplorerService {
      * Get or create the children of a node. If the node has a session ID, expand it.
      * If it doesn't, create a new session and expand it.
      * @param element The node to get or create children for
+     * @param shouldRefresh Whether to re-populate the node on the server instead of expanding its
+     *   cached state
      */
-    private async getOrCreateNodeChildrenWithSession(element: TreeNodeInfo): Promise<void> {
+    private async getOrCreateNodeChildrenWithSession(
+        element: TreeNodeInfo,
+        shouldRefresh = false,
+    ): Promise<void> {
         const existing = this._inFlightChildrenFetches.get(element);
 
         this._logger.trace(
@@ -724,9 +744,9 @@ export class ObjectExplorerService {
         const fetchPromise = (async () => {
             try {
                 if (element.sessionId) {
-                    await this.expandExistingNode(element);
+                    await this.expandExistingNode(element, shouldRefresh);
                 } else {
-                    await this.createSessionAndExpandNode(element);
+                    await this.createSessionAndExpandNode(element, shouldRefresh);
                 }
             } finally {
                 this._inFlightChildrenFetches.delete(element);
@@ -735,13 +755,11 @@ export class ObjectExplorerService {
                     this._logger.trace(
                         `getOrCreateNodeChildrenWithSession: starting queued refresh for ${getNodeDescriptor(element)}`,
                     );
-                    element.shouldRefresh = true;
                     element.loadingLabel = undefined;
                     this.cleanNodeChildren(element);
                     await this.setLoadingUiForNode(element);
-                    void this.getOrCreateNodeChildrenWithSession(element);
+                    void this.getOrCreateNodeChildrenWithSession(element, true);
                 } else {
-                    element.shouldRefresh = false;
                     this._logger.trace(
                         `getOrCreateNodeChildrenWithSession end: ${getNodeDescriptor(element)} - refresh callback follows`,
                     );
@@ -757,10 +775,15 @@ export class ObjectExplorerService {
     /**
      * Expand a node that already has a session ID.
      * @param element The node to expand
+     * @param shouldRefresh Whether to re-populate the node on the server instead of expanding its
+     *   cached state
      * @returns The children of the node
      */
-    private async expandExistingNode(element: TreeNodeInfo): Promise<vscode.TreeItem[]> {
-        const children = await this.expandNode(element, element.sessionId);
+    private async expandExistingNode(
+        element: TreeNodeInfo,
+        shouldRefresh = false,
+    ): Promise<vscode.TreeItem[]> {
+        const children = await this.expandNode(element, element.sessionId, shouldRefresh);
         if (children?.length === 0) {
             const noItemsNode = [new NoItemsNode(element)];
             this._treeNodeToChildrenMap.set(element, noItemsNode);
@@ -775,9 +798,14 @@ export class ObjectExplorerService {
      * If the session was created but the connected node was not created, show the sign in node.
      * Otherwise, expand the existing node.
      * @param element The node to create a session for and expand
+     * @param shouldRefresh Whether to re-populate the node on the server instead of expanding its
+     *   cached state
      * @returns The children of the node
      */
-    private async createSessionAndExpandNode(element: TreeNodeInfo): Promise<vscode.TreeItem[]> {
+    private async createSessionAndExpandNode(
+        element: TreeNodeInfo,
+        shouldRefresh = false,
+    ): Promise<vscode.TreeItem[]> {
         const sessionResult = await this.createSession(element.connectionProfile);
 
         if (sessionResult?.shouldRetryOnFailure) {
@@ -794,7 +822,7 @@ export class ObjectExplorerService {
         if (!sessionResult.connectionNode) {
             return this.createSignInNode(element);
         } else {
-            const children = this.expandExistingNode(element);
+            const children = this.expandExistingNode(element, shouldRefresh);
             setTimeout(() => this._refreshCallback(element), 0);
             return children;
         }

--- a/extensions/mssql/test/unit/objectExplorerProvider.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerProvider.test.ts
@@ -231,6 +231,7 @@ suite("Object Explorer Provider Tests", function () {
         expect(expandStub).to.have.been.calledOnceWithExactly(
             parentTreeNode,
             parentTreeNode.sessionId,
+            false, // a first expand of a never-expanded node is not a refresh
         );
 
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/extensions/mssql/test/unit/objectExplorerService.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerService.test.ts
@@ -207,6 +207,7 @@ suite("OE Service Tests", () => {
         let sandbox: sinon.SinonSandbox;
         let endStub: sinon.SinonStub;
         let endFailedStub: sinon.SinonStub;
+        let updateStub: sinon.SinonStub;
         let startActivityStub: sinon.SinonStub;
 
         setup(() => {
@@ -221,12 +222,13 @@ suite("OE Service Tests", () => {
             mockConnectionStore.readAllConnectionGroups.resolves([createMockRootConnectionGroup()]);
             endStub = sandbox.stub();
             endFailedStub = sandbox.stub();
+            updateStub = sandbox.stub();
             startActivityStub = sandbox.stub(telemetry, "startActivity").returns({
                 end: endStub,
                 endFailed: endFailedStub,
                 correlationId: "",
                 startTime: 0,
-                update: sandbox.stub(),
+                update: updateStub,
             });
             objectExplorerService = new ObjectExplorerService(mockConnectionManager, () => {});
             objectExplorerService.initialized.resolve();
@@ -521,6 +523,12 @@ suite("OE Service Tests", () => {
             expect(mockClient.sendRequest.args[1][0], "Retry request is a refresh").to.equal(
                 RefreshRequest.type,
             );
+            expect(
+                updateStub,
+                "Telemetry should record that the retry uses a refresh",
+            ).to.have.been.calledOnceWithExactly({
+                additionalProps: { isRefresh: "true" },
+            });
 
             expect(
                 mockConnectionManager.shouldRetryForPausedServerlessDatabase.calledOnce,
@@ -837,21 +845,16 @@ suite("OE Service Tests", () => {
         });
 
         test("a filtered refresh settles even when the expand outlasts the tree refresh debounce", async () => {
-            /**
-             * Applying an Object Explorer filter marks the node for refresh and fires the tree
-             * data change event. VS Code answers that event by calling getChildren again, and the
-             * loading node the service returns fires the event once more. If those internal
-             * callbacks are mistaken for fresh user refreshes, each one queues another refresh and
-             * the node never leaves "Loading...". Drive that real feedback loop here with an expand
-             * slow enough to still be in flight when the tree calls back.
-             */
+            // Loading updates make VS Code request the node's children again. Simulate a slow
+            // filtered refresh and verify those callbacks do not keep queuing more refreshes.
             const TREE_REFRESH_DELAY_MS = 5;
             const EXPAND_LATENCY_MS = 40;
             const MAX_SIMULATED_TREE_FETCHES = 100;
+            const clock = sandbox.useFakeTimers();
+            sandbox.stub(ObjectExplorerUtils, "iconPath").callsFake(() => undefined);
 
             const connectionProfile = createMockConnectionProfile({ id: "conn1" });
             let simulatedTreeFetches = 0;
-            const treeRefreshTimers: NodeJS.Timeout[] = [];
 
             // Stands in for ObjectExplorerProvider.refresh(), which fires onDidChangeTreeData and
             // makes VS Code re-fetch the node's children after a short debounce.
@@ -860,9 +863,7 @@ suite("OE Service Tests", () => {
                     return;
                 }
                 simulatedTreeFetches++;
-                treeRefreshTimers.push(
-                    setTimeout(() => void loopingService.getChildren(node), TREE_REFRESH_DELAY_MS),
-                );
+                setTimeout(() => void loopingService.getChildren(node), TREE_REFRESH_DELAY_MS);
             });
             loopingService.initialized.resolve();
             setUpOETreeRoot(loopingService, [connectionProfile]);
@@ -892,31 +893,27 @@ suite("OE Service Tests", () => {
                 .withArgs(ExpandRequest.type, sinon.match.any)
                 .callsFake(respondAfterLatency);
 
-            try {
-                // What applying a filter does: set the filters, then refresh the node.
-                connectionNode.filters = [
-                    { name: "Name", operator: 9, value: "cdwi" },
-                ] as import("vscode-mssql").NodeFilter[];
-                connectionNode.shouldRefresh = true;
-                void loopingService.getChildren(connectionNode);
+            // Applying a filter sets the filters, then refreshes the node.
+            connectionNode.filters = [
+                { name: "Name", operator: 9, value: "cdwi" },
+            ] as import("vscode-mssql").NodeFilter[];
+            connectionNode.shouldRefresh = true;
+            void loopingService.getChildren(connectionNode);
 
-                await new Promise((resolve) => setTimeout(resolve, 400));
+            await clock.tickAsync(400);
 
-                expect(
-                    mockClient.sendRequest,
-                    "One filter apply should send exactly one refresh, not a self-sustaining loop",
-                ).to.have.been.calledOnceWithExactly(RefreshRequest.type, sinon.match.any);
-                expect(
-                    connectionNode.shouldRefresh,
-                    "Refresh flag should be cleared once the refresh has been dispatched",
-                ).to.be.false;
-                expect(
-                    (loopingService as any)._refreshQueuedAfterInFlight.has(connectionNode),
-                    "No refresh should remain queued after the load settles",
-                ).to.be.false;
-            } finally {
-                treeRefreshTimers.forEach((timer) => clearTimeout(timer));
-            }
+            expect(
+                mockClient.sendRequest,
+                "One filter apply should send exactly one refresh, not a self-sustaining loop",
+            ).to.have.been.calledOnceWithExactly(RefreshRequest.type, sinon.match.any);
+            expect(
+                connectionNode.shouldRefresh,
+                "Refresh flag should be cleared once the refresh has been dispatched",
+            ).to.be.false;
+            expect(
+                (loopingService as any)._refreshQueuedAfterInFlight.has(connectionNode),
+                "No refresh should remain queued after the load settles",
+            ).to.be.false;
         });
 
         test("expandNode should handle error response from SQL Tools Service", async () => {

--- a/extensions/mssql/test/unit/objectExplorerService.test.ts
+++ b/extensions/mssql/test/unit/objectExplorerService.test.ts
@@ -25,7 +25,10 @@ import { ConnectionNode } from "../../src/objectExplorer/nodes/connectionNode";
 import { TreeNodeInfo } from "../../src/objectExplorer/nodes/treeNodeInfo";
 import { CloseSessionRequest } from "../../src/models/contracts/objectExplorer/closeSessionRequest";
 import { Deferred } from "../../src/protocol";
-import { ExpandRequest } from "../../src/models/contracts/objectExplorer/expandNodeRequest";
+import {
+    ExpandRequest,
+    ExpandResponse,
+} from "../../src/models/contracts/objectExplorer/expandNodeRequest";
 import {
     ActivityObject,
     ActivityStatus,
@@ -831,6 +834,89 @@ suite("OE Service Tests", () => {
                 (objectExplorerService as any)._refreshQueuedAfterInFlight.has(connectionNode),
                 "Queued refresh marker should be cleared",
             ).to.be.false;
+        });
+
+        test("a filtered refresh settles even when the expand outlasts the tree refresh debounce", async () => {
+            /**
+             * Applying an Object Explorer filter marks the node for refresh and fires the tree
+             * data change event. VS Code answers that event by calling getChildren again, and the
+             * loading node the service returns fires the event once more. If those internal
+             * callbacks are mistaken for fresh user refreshes, each one queues another refresh and
+             * the node never leaves "Loading...". Drive that real feedback loop here with an expand
+             * slow enough to still be in flight when the tree calls back.
+             */
+            const TREE_REFRESH_DELAY_MS = 5;
+            const EXPAND_LATENCY_MS = 40;
+            const MAX_SIMULATED_TREE_FETCHES = 100;
+
+            const connectionProfile = createMockConnectionProfile({ id: "conn1" });
+            let simulatedTreeFetches = 0;
+            const treeRefreshTimers: NodeJS.Timeout[] = [];
+
+            // Stands in for ObjectExplorerProvider.refresh(), which fires onDidChangeTreeData and
+            // makes VS Code re-fetch the node's children after a short debounce.
+            const loopingService = new ObjectExplorerService(mockConnectionManager, (node) => {
+                if (simulatedTreeFetches >= MAX_SIMULATED_TREE_FETCHES) {
+                    return;
+                }
+                simulatedTreeFetches++;
+                treeRefreshTimers.push(
+                    setTimeout(() => void loopingService.getChildren(node), TREE_REFRESH_DELAY_MS),
+                );
+            });
+            loopingService.initialized.resolve();
+            setUpOETreeRoot(loopingService, [connectionProfile]);
+
+            const connectionNode = (loopingService as any)._connectionNodes.get(
+                connectionProfile.id,
+            ) as ConnectionNode;
+            connectionNode.sessionId = "session123";
+
+            const respondAfterLatency = () => {
+                setTimeout(
+                    () =>
+                        loopingService.handleExpandNodeNotification({
+                            sessionId: connectionNode.sessionId,
+                            nodePath: connectionNode.nodePath,
+                            nodes: [],
+                            errorMessage: "",
+                        } as ExpandResponse),
+                    EXPAND_LATENCY_MS,
+                );
+                return Promise.resolve(true);
+            };
+            mockClient.sendRequest
+                .withArgs(RefreshRequest.type, sinon.match.any)
+                .callsFake(respondAfterLatency);
+            mockClient.sendRequest
+                .withArgs(ExpandRequest.type, sinon.match.any)
+                .callsFake(respondAfterLatency);
+
+            try {
+                // What applying a filter does: set the filters, then refresh the node.
+                connectionNode.filters = [
+                    { name: "Name", operator: 9, value: "cdwi" },
+                ] as import("vscode-mssql").NodeFilter[];
+                connectionNode.shouldRefresh = true;
+                void loopingService.getChildren(connectionNode);
+
+                await new Promise((resolve) => setTimeout(resolve, 400));
+
+                expect(
+                    mockClient.sendRequest,
+                    "One filter apply should send exactly one refresh, not a self-sustaining loop",
+                ).to.have.been.calledOnceWithExactly(RefreshRequest.type, sinon.match.any);
+                expect(
+                    connectionNode.shouldRefresh,
+                    "Refresh flag should be cleared once the refresh has been dispatched",
+                ).to.be.false;
+                expect(
+                    (loopingService as any)._refreshQueuedAfterInFlight.has(connectionNode),
+                    "No refresh should remain queued after the load settles",
+                ).to.be.false;
+            } finally {
+                treeRefreshTimers.forEach((timer) => clearTimeout(timer));
+            }
         });
 
         test("expandNode should handle error response from SQL Tools Service", async () => {


### PR DESCRIPTION
Fixes #22874

## Problem

Applying an Object Explorer filter (for example `Name` / `Not Contains`) leaves the node spinning on "Loading..." forever, and the extension becomes unresponsive until VS Code is killed.


## Root cause

Applying a filter marks the node for refresh and fires the tree data change event. VS Code answers that event by calling `getChildren` again, and the loading node the service returns fires the event once more.

Because `shouldRefresh` stayed set for the whole duration of the in-flight expand, those internal callbacks were indistinguishable from a fresh user refresh:

1. `getNodeChildren` reads `element.shouldRefresh` (still `true`) and sees an in-flight fetch, so it queues another refresh and returns `setLoadingUiForNode`.
2. `setLoadingUiForNode` fires the refresh callback, so VS Code calls `getChildren` again — back to step 1.
3. When the expand finally completes, the queued marker starts a **whole new expand**, and the cycle restarts.

Whenever the expand outlasts VS Code's tree refresh debounce, this never settles: the spinner never resolves and the tree re-renders continuously.

Applying a filter reliably lands in that window because a marked-for-refresh node sends a `RefreshRequest`, which re-populates the node on the server via SMO rather than expanding cached state — comfortably slower than the debounce on a real server. A fast cached expand beats the debounce and settles, which is why this looked like "only filtering is broken".

## Fix

Consume the refresh request up front in `getNodeChildren` and carry it forward as an explicit argument through `getOrCreateNodeChildrenWithSession` → `expandExistingNode` / `createSessionAndExpandNode` → `expandNode`. An internal loading-UI callback now reads as an ordinary re-entrant `getChildren` and returns the cached loading node without queuing anything, while a genuine second user refresh still queues correctly.

`expandNode` keeps defaulting its new `shouldRefresh` parameter to the node's flag, so its existing external callers are unchanged.

## Testing

- New regression test drives the real feedback loop — refresh callback → `getChildren` → loading node → refresh callback — with an expand slow enough to still be in flight when the tree calls back. It fails on `main` (the loop keeps issuing requests) and passes here with exactly one `RefreshRequest`.
- Adjusted one exact-args assertion in `objectExplorerProvider.test.ts` for the new parameter.
- Full MSSQL unit suite: 4857 passed, 0 failed, 10 skipped.
- Lint and typecheck clean