### PR TITLE
Improve pre-commit rejection messages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,38 +1,32 @@
 #!/usr/bin/env sh
 
-# Git clients display hook output in dialogs that do not support terminal colors.
+# Git clients display hook output in dialogs that do not support terminal formatting.
 export NO_COLOR=1
 export FORCE_COLOR=0
+export NO_TERMINAL_SEPARATORS=1
 
 if ! output=$(node scripts/localization-extract.js --staged 2>&1); then
     echo "Commit blocked: translation files could not be generated."
     echo "Open Git Log or Show Command Output for details. Fix the reported error, then try committing again."
-    echo "To rerun this check: node scripts/localization-extract.js --staged"
     printf '\n%s\n' "$output"
     exit 1
 fi
-if ! git diff --quiet -- \
+localization_changes=$(git diff --name-only -- \
     extensions/*/l10n/bundle.l10n.json \
     packages/extension-toolkit/l10n/bundle.l10n.json \
     localization/xliff/data-workspace.xlf \
     localization/xliff/extension-toolkit.xlf \
     localization/xliff/sql-database-projects.xlf \
-    localization/xliff/vscode-mssql.xlf; then
+    localization/xliff/vscode-mssql.xlf)
+if [ -n "$localization_changes" ]; then
     echo "Commit blocked: updated translation files need to be staged."
     echo "The localization check generated changes from your staged files. Stage the files listed below, then try committing again."
-    git diff --name-only -- \
-        extensions/*/l10n/bundle.l10n.json \
-        packages/extension-toolkit/l10n/bundle.l10n.json \
-        localization/xliff/data-workspace.xlf \
-        localization/xliff/extension-toolkit.xlf \
-        localization/xliff/sql-database-projects.xlf \
-        localization/xliff/vscode-mssql.xlf
+    printf '\n%s\n' "$localization_changes"
     exit 1
 fi
 if ! output=$(npm run --silent precommit 2>&1); then
     echo "Commit blocked: checks on staged files failed."
     echo "Open Git Log or Show Command Output for details. Fix the reported errors, stage your changes, then try committing again."
-    echo "To rerun these checks: npm run precommit"
     printf '\n%s\n' "$output"
     exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
 
 # Git clients display hook output in dialogs that do not support terminal formatting.
-export NO_COLOR=1
-export FORCE_COLOR=0
-export NO_TERMINAL_SEPARATORS=1
+if [ ! -t 1 ]; then
+    export NO_COLOR=1
+    export FORCE_COLOR=0
+    export NO_TERMINAL_SEPARATORS=1
+fi
 
 if ! output=$(node scripts/localization-extract.js --staged 2>&1); then
     echo "Commit blocked: translation files could not be generated."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,16 @@
 #!/usr/bin/env sh
 
-node scripts/localization-extract.js --staged || exit 1
+# Git clients display hook output in dialogs that do not support terminal colors.
+export NO_COLOR=1
+export FORCE_COLOR=0
+
+if ! output=$(node scripts/localization-extract.js --staged 2>&1); then
+    echo "Commit blocked: translation files could not be generated."
+    echo "Open Git Log or Show Command Output for details. Fix the reported error, then try committing again."
+    echo "To rerun this check: node scripts/localization-extract.js --staged"
+    printf '\n%s\n' "$output"
+    exit 1
+fi
 if ! git diff --quiet -- \
     extensions/*/l10n/bundle.l10n.json \
     packages/extension-toolkit/l10n/bundle.l10n.json \
@@ -8,7 +18,21 @@ if ! git diff --quiet -- \
     localization/xliff/extension-toolkit.xlf \
     localization/xliff/sql-database-projects.xlf \
     localization/xliff/vscode-mssql.xlf; then
-    echo "Localization outputs changed. Review and stage them before committing."
+    echo "Commit blocked: updated translation files need to be staged."
+    echo "The localization check generated changes from your staged files. Stage the files listed below, then try committing again."
+    git diff --name-only -- \
+        extensions/*/l10n/bundle.l10n.json \
+        packages/extension-toolkit/l10n/bundle.l10n.json \
+        localization/xliff/data-workspace.xlf \
+        localization/xliff/extension-toolkit.xlf \
+        localization/xliff/sql-database-projects.xlf \
+        localization/xliff/vscode-mssql.xlf
     exit 1
 fi
-npm run precommit
+if ! output=$(npm run --silent precommit 2>&1); then
+    echo "Commit blocked: checks on staged files failed."
+    echo "Open Git Log or Show Command Output for details. Fix the reported errors, stage your changes, then try committing again."
+    echo "To rerun these checks: npm run precommit"
+    printf '\n%s\n' "$output"
+    exit 1
+fi

--- a/scripts/terminal-logger.js
+++ b/scripts/terminal-logger.js
@@ -15,7 +15,10 @@ const colors = {
     cyan: "\x1b[36m",
 };
 
-const useColor = process.stdout.isTTY && !process.env.NO_COLOR && process.env.FORCE_COLOR !== "0";
+const forceColor = process.env.FORCE_COLOR;
+const useColor =
+    !process.env.NO_COLOR &&
+    (forceColor !== undefined ? forceColor !== "0" : Boolean(process.stdout.isTTY));
 const useSeparators = process.env.NO_TERMINAL_SEPARATORS !== "1";
 if (!useColor) {
     for (const color of Object.keys(colors)) {

--- a/scripts/terminal-logger.js
+++ b/scripts/terminal-logger.js
@@ -16,6 +16,7 @@ const colors = {
 };
 
 const useColor = process.stdout.isTTY && !process.env.NO_COLOR && process.env.FORCE_COLOR !== "0";
+const useSeparators = process.env.NO_TERMINAL_SEPARATORS !== "1";
 if (!useColor) {
     for (const color of Object.keys(colors)) {
         colors[color] = "";
@@ -68,7 +69,7 @@ const logger = {
      * Log a separator line for visual organization
      */
     separator: () => {
-        if (useColor) {
+        if (useSeparators) {
             console.log(`${colors.cyan}${"─".repeat(60)}${colors.reset}`);
         }
     },

--- a/scripts/terminal-logger.js
+++ b/scripts/terminal-logger.js
@@ -15,6 +15,13 @@ const colors = {
     cyan: "\x1b[36m",
 };
 
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR && process.env.FORCE_COLOR !== "0";
+if (!useColor) {
+    for (const color of Object.keys(colors)) {
+        colors[color] = "";
+    }
+}
+
 /**
  * Enhanced logging utility for build scripts
  * Provides consistent, colored terminal output with meaningful icons
@@ -60,7 +67,11 @@ const logger = {
     /**
      * Log a separator line for visual organization
      */
-    separator: () => console.log(`${colors.cyan}${"─".repeat(60)}${colors.reset}`),
+    separator: () => {
+        if (useColor) {
+            console.log(`${colors.cyan}${"─".repeat(60)}${colors.reset}`);
+        }
+    },
 
     /**
      * Log a header with separator lines above and below


### PR DESCRIPTION
## Description

Makes pre-commit failures readable in Git clients: plain output, no decorative separators or repeated retry commands, and the failure reason first. Normal `NO_COLOR` output keeps its separator lines.

| Before | After |
| --- | --- |
| <img width="301" height="345" alt="Git rejection before" src="https://github.com/user-attachments/assets/e76bed6e-f1d0-47b5-a3b7-4769213012a8" /> | <img width="271" height="288" alt="Git rejection after" src="https://github.com/user-attachments/assets/7687bac5-add5-419a-b166-f2b3f5e6fe0c" /> |

## Validation

- `npm run lint:repo`
- `npx prettier --check scripts/terminal-logger.js`
- `sh -n .husky/pre-commit`
- Verified separator behavior with and without `NO_TERMINAL_SEPARATORS`
