### PR TITLE
Keep leading and repeated spaces visible in the results grid

### DIFF
--- a/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
+++ b/extensions/mssql/src/webviews/common/FluentResultGrid/FluentResultGrid.css
@@ -374,7 +374,8 @@
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    /* `pre` keeps leading and repeated spaces visible; `nowrap` would collapse them. */
+    white-space: pre;
 }
 
 .fluent-result-grid .slick-cell a.grid-cell-value-container {


### PR DESCRIPTION
## Description

Fixes #22914.

|Before|After|
|-------|----|
|  <img width="918" height="224" alt="image" src="https://github.com/user-attachments/assets/c2edf49d-7139-43d9-be24-3a2e27db0c42" /> |  <img width="950" height="232" alt="image" src="https://github.com/user-attachments/assets/20a81233-3afd-410f-bf25-34a528fc6d09" /> |


## Code Changes Checklist

- [ ] New or updated **unit tests** added — CSS-only change; verified by rendering the stylesheet in a browser rather than in the unit suite
- [ ] All existing tests pass (`npm run test`) — ran the `fluentResultGrid` unit tests locally (77 passed); full suite left to CI
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant — not applicable
- [x] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
