### PR TITLE
Fix editor stuck on "A query is already running" with no way to cancel

### DIFF
--- a/extensions/mssql/l10n/bundle.l10n.json
+++ b/extensions/mssql/l10n/bundle.l10n.json
@@ -65,6 +65,9 @@
         "comment": ["{0} is the document name"]
     },
     "A query is already running for this editor session. Please cancel this query or wait for its completion.": "A query is already running for this editor session. Please cancel this query or wait for its completion.",
+    "Cancel query": "Cancel query",
+    "The service is no longer running a query for this editor. The editor's execution state has been reset.": "The service is no longer running a query for this editor. The editor's execution state has been reset.",
+    "The cancel request did not complete in time. The editor's execution state has been reset.": "The cancel request did not complete in time. The editor's execution state has been reset.",
     "Started executing query at ": "Started executing query at ",
     "Line {0}/{0} is the line number": {
         "message": "Line {0}",

--- a/extensions/mssql/src/constants/constants.ts
+++ b/extensions/mssql/src/constants/constants.ts
@@ -176,6 +176,11 @@ export const defaultConnectionTimeout = 15;
 export const azureSqlDbConnectionTimeout = 30;
 export const defaultCommandTimeout = 30;
 export const stsImmediateActivityTimeout = 5000; // 5 seconds
+// Upper bound for a query cancel round-trip to SQL Tools Service before the editor is reset.
+export const queryCancelRequestTimeoutMs = 15000; // 15 seconds
+// Grace period for a completion notification to arrive after the service reported that it has
+// no running query for an editor we still consider executing.
+export const queryCancelOrphanGraceMs = 2000; // 2 seconds
 export const azureDatabase = "Azure";
 export const azureMfa = "AzureMFA";
 export const azureServicePrincipal = "ActiveDirectoryServicePrincipal";

--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -121,6 +121,13 @@ export function msgFinishedExecute(documentName: string) {
 export let msgRunQueryInProgress = l10n.t(
     "A query is already running for this editor session. Please cancel this query or wait for its completion.",
 );
+export let msgRunQueryInProgressCancelAction = l10n.t("Cancel query");
+export let msgQueryNoLongerRunning = l10n.t(
+    "The service is no longer running a query for this editor. The editor's execution state has been reset.",
+);
+export let msgCancelQueryTimedOut = l10n.t(
+    "The cancel request did not complete in time. The editor's execution state has been reset.",
+);
 export let runQueryBatchStartMessage = l10n.t("Started executing query at ");
 export function runQueryBatchStartLine(lineNumber: number) {
     return l10n.t({

--- a/extensions/mssql/src/controllers/queryRunner.ts
+++ b/extensions/mssql/src/controllers/queryRunner.ts
@@ -124,6 +124,7 @@ export default class QueryRunner {
     private _uriToQueryStringMap = new Map<string, string>();
     private _registeredNotificationUris = new Set<string>();
     private _executionSource: QueryExecutionSource = "document";
+    private _orphanedQueryRecoveryTimer: ReturnType<typeof setTimeout> | undefined;
     private static _runningQueries = [];
 
     private _startFailedEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
@@ -258,7 +259,7 @@ export default class QueryRunner {
      * @returns A promise that resolves to the result of the cancel operation.
      * @throws An error if the cancellation fails or times out.
      */
-    public async cancel(): Promise<QueryCancelResult> {
+    public async cancel(options?: { silent?: boolean }): Promise<QueryCancelResult> {
         const cancelQueryActivity = startActivity(
             TelemetryViews.QueryEditor,
             TelemetryActions.CancelQuery,
@@ -275,17 +276,31 @@ export default class QueryRunner {
                     );
                 }
             }, Constants.stsImmediateActivityTimeout);
-            const cancelationResult = await this._client.sendRequest(
-                QueryCancelRequest.type,
-                cancelParams,
+            // Never wait forever on the service: an unanswered cancel would otherwise leave the
+            // editor blocked with "a query is already running" and no way out.
+            const cancelationResult = await Utils.withTimeout(
+                this._client.sendRequest(QueryCancelRequest.type, cancelParams),
+                Constants.queryCancelRequestTimeoutMs,
+                LocalizedConstants.msgCancelQueryTimedOut,
             );
             cancelRequestCompleted = true;
             cancelQueryActivity?.end(ActivityStatus.Succeeded);
+            if (cancelationResult?.messages && this._isExecuting) {
+                // The service has no live query for this editor (it finished, was disposed, or
+                // the service was restarted). If its completion notification does not arrive
+                // shortly, reset the editor ourselves instead of staying "executing" forever.
+                this._logger.warn(
+                    `Cancel for ${this._ownerUri} found no running query on the service: ${cancelationResult.messages}`,
+                );
+                this.scheduleOrphanedQueryRecovery();
+            }
             return cancelationResult;
         } catch (error) {
             cancelRequestCompleted = true;
             this._handleQueryCleanup(
-                LocalizedConstants.QueryEditor.queryCancelFailed(error),
+                options?.silent
+                    ? undefined
+                    : LocalizedConstants.QueryEditor.queryCancelFailed(error),
                 error,
             );
             cancelQueryActivity?.endFailed(error, false);
@@ -298,7 +313,7 @@ export default class QueryRunner {
      */
     public async resetQueryRunner(): Promise<void> {
         try {
-            await this.cancel();
+            await this.cancel({ silent: true });
         } catch {
             // Suppress any errors
         }
@@ -313,6 +328,36 @@ export default class QueryRunner {
     }
 
     /**
+     * Called after the service reported that it has no running query for this editor while we
+     * still believe one is executing. Gives an in-flight completion a short grace period, then
+     * resets the editor so the user can run queries again.
+     */
+    private scheduleOrphanedQueryRecovery(): void {
+        this.clearOrphanedQueryRecovery();
+        this._orphanedQueryRecoveryTimer = setTimeout(() => {
+            this._orphanedQueryRecoveryTimer = undefined;
+            if (!this._isExecuting) {
+                return;
+            }
+            this._logger.warn(
+                `No completion arrived for ${this._ownerUri}; resetting its execution state`,
+            );
+            this._handleQueryCleanup(
+                undefined,
+                new Error(LocalizedConstants.msgQueryNoLongerRunning),
+            );
+            void vscode.window.showInformationMessage(LocalizedConstants.msgQueryNoLongerRunning);
+        }, Constants.queryCancelOrphanGraceMs);
+    }
+
+    private clearOrphanedQueryRecovery(): void {
+        if (this._orphanedQueryRecoveryTimer !== undefined) {
+            clearTimeout(this._orphanedQueryRecoveryTimer);
+            this._orphanedQueryRecoveryTimer = undefined;
+        }
+    }
+
+    /**
      * Runs a query against the database for the current statement based on the cursor position.
      */
     public async runStatement(
@@ -321,12 +366,6 @@ export default class QueryRunner {
         executionPlanOptions?: ExecutionPlanOptions,
     ): Promise<void> {
         this._executionSource = "document";
-        await this.setupQueryExecution({
-            startLine: line,
-            startColumn: column,
-            endLine: 0,
-            endColumn: 0,
-        });
 
         let optionsParams: QueryExecuteStatementParams = {
             ownerUri: this._ownerUri,
@@ -356,6 +395,14 @@ export default class QueryRunner {
                     );
                 }
             }, Constants.stsImmediateActivityTimeout);
+            // Everything that marks the editor as executing happens inside this try block so
+            // that any failure before the request is sent is cleaned up below.
+            this.setupQueryExecution({
+                startLine: line,
+                startColumn: column,
+                endLine: 0,
+                endColumn: 0,
+            });
             this.markQuerySubmitted();
             await this._client.sendRequest(QueryExecuteStatementRequest.type, optionsParams);
             this._startEmitter.fire(this.uri);
@@ -378,33 +425,6 @@ export default class QueryRunner {
         promise?: Deferred<boolean>,
     ): Promise<void> {
         this._executionSource = "document";
-        await this.setupQueryExecution(selection);
-
-        // Setting up options
-        let executeOptions: QueryExecuteParams = {
-            ownerUri: this._ownerUri,
-            executionPlanOptions: executionPlanOptions,
-            querySelection: selection,
-        };
-
-        // Getting query text
-        const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this._ownerUri));
-        let queryString: string;
-        if (selection) {
-            let range = new vscode.Range(
-                new vscode.Position(selection.startLine, selection.startColumn),
-                new vscode.Position(selection.endLine, selection.endColumn),
-            );
-            queryString = doc.getText(range);
-        } else {
-            queryString = doc.getText();
-        }
-        this._uriToQueryStringMap.set(this._ownerUri, queryString);
-
-        // Setting up completion promise.
-        if (promise) {
-            this._uriToQueryPromiseMap.set(this._ownerUri, promise);
-        }
 
         const queryType = selection ? "selection" : "document";
         const runQueryActivity = startActivity(
@@ -429,6 +449,37 @@ export default class QueryRunner {
                     );
                 }
             }, Constants.stsImmediateActivityTimeout);
+            // Everything that marks the editor as executing happens inside this try block so
+            // that any failure before the request is sent (for example reading the document)
+            // is cleaned up below instead of leaving the editor "executing" forever.
+            this.setupQueryExecution(selection);
+
+            // Setting up completion promise.
+            if (promise) {
+                this._uriToQueryPromiseMap.set(this._ownerUri, promise);
+            }
+
+            // Setting up options
+            let executeOptions: QueryExecuteParams = {
+                ownerUri: this._ownerUri,
+                executionPlanOptions: executionPlanOptions,
+                querySelection: selection,
+            };
+
+            // Getting query text
+            const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this._ownerUri));
+            let queryString: string;
+            if (selection) {
+                let range = new vscode.Range(
+                    new vscode.Position(selection.startLine, selection.startColumn),
+                    new vscode.Position(selection.endLine, selection.endColumn),
+                );
+                queryString = doc.getText(range);
+            } else {
+                queryString = doc.getText();
+            }
+            this._uriToQueryStringMap.set(this._ownerUri, queryString);
+
             this.markQuerySubmitted();
             await this._client.sendRequest(QueryExecuteRequest.type, executeOptions);
             this._startEmitter.fire(this.uri);
@@ -453,12 +504,6 @@ export default class QueryRunner {
      */
     public async runQueryString(query: string, promise?: Deferred<boolean>): Promise<void> {
         this._executionSource = "quickQuery";
-        await this.setupQueryExecution(undefined);
-
-        this._uriToQueryStringMap.set(this._ownerUri, query);
-        if (promise) {
-            this._uriToQueryPromiseMap.set(this._ownerUri, promise);
-        }
 
         const executeParams: QueryExecuteStringParams = {
             ownerUri: this._ownerUri,
@@ -486,6 +531,13 @@ export default class QueryRunner {
                     );
                 }
             }, Constants.stsImmediateActivityTimeout);
+            // Everything that marks the editor as executing happens inside this try block so
+            // that any failure before the request is sent is cleaned up below.
+            this.setupQueryExecution(undefined);
+            this._uriToQueryStringMap.set(this._ownerUri, query);
+            if (promise) {
+                this._uriToQueryPromiseMap.set(this._ownerUri, promise);
+            }
             this.markQuerySubmitted();
             await this._client.sendRequest(QueryExecuteStringRequest.type, executeParams);
             this._startEmitter.fire(this.uri);
@@ -531,11 +583,12 @@ export default class QueryRunner {
     // handle the result of the notification
     public handleQueryComplete(result: QueryExecuteCompleteNotificationResult): void {
         this._logger.info(LocalizedConstants.msgFinishedExecute(this._ownerUri));
+        this.clearOrphanedQueryRecovery();
 
         // Store the batch sets we got back as a source of "truth"
         this._isExecuting = false;
         this._hasCompleted = true;
-        this._batchSets = result.batchSummaries;
+        this._batchSets = result.batchSummaries ?? [];
 
         // We're done with this query so shut down any waiting mechanisms
         const promise = this._uriToQueryPromiseMap.get(result.ownerUri);
@@ -543,31 +596,40 @@ export default class QueryRunner {
             promise.resolve();
             this._uriToQueryPromiseMap.delete(result.ownerUri);
         }
-        this._statusView.executedQuery(result.ownerUri);
-        this._statusView.setExecutionTime(
-            result.ownerUri,
-            Utils.durationToDisplay(this._totalElapsedMilliseconds, { format: "clock" }),
-        );
-        let hasError = this._batchSets.some((batch) => batch.hasError === true);
-        Perf.marker("mssql.query.complete", "end", {
-            rowCount: this._batchSets.reduce(
-                (total, batch) =>
-                    total +
-                    (batch.resultSetSummaries?.reduce((n, rs) => n + (rs.rowCount ?? 0), 0) ?? 0),
-                0,
-            ),
-            hasError,
-        });
-        this.removeRunningQuery();
-        this.unregisterAllNotificationUris();
-        this._completeEmitter.fire({
-            totalMilliseconds: Utils.durationToDisplay(this._totalElapsedMilliseconds, {
-                format: "clock",
-            }),
-            totalElapsedMilliseconds: this._totalElapsedMilliseconds,
-            hasError,
-            isFullExecutionComplete: true,
-        });
+        const hasError = this._batchSets.some((batch) => batch.hasError === true);
+        try {
+            this._statusView.executedQuery(result.ownerUri);
+            this._statusView.setExecutionTime(
+                result.ownerUri,
+                Utils.durationToDisplay(this._totalElapsedMilliseconds, { format: "clock" }),
+            );
+            Perf.marker("mssql.query.complete", "end", {
+                rowCount: this._batchSets.reduce(
+                    (total, batch) =>
+                        total +
+                        (batch.resultSetSummaries?.reduce((n, rs) => n + (rs.rowCount ?? 0), 0) ??
+                            0),
+                    0,
+                ),
+                hasError,
+            });
+        } catch (error) {
+            this._logger.error(
+                `Error while finalizing query completion for ${result.ownerUri}: ${getErrorMessage(error)}`,
+            );
+        } finally {
+            // Always release the editor, even if a status update above failed.
+            this.removeRunningQuery();
+            this.unregisterAllNotificationUris();
+            this._completeEmitter.fire({
+                totalMilliseconds: Utils.durationToDisplay(this._totalElapsedMilliseconds, {
+                    format: "clock",
+                }),
+                totalElapsedMilliseconds: this._totalElapsedMilliseconds,
+                hasError,
+                isFullExecutionComplete: true,
+            });
+        }
         sendActionEvent(TelemetryViews.QueryEditor, TelemetryActions.QueryExecutionCompleted);
     }
 
@@ -692,6 +754,7 @@ export default class QueryRunner {
      * @param error Optional error message to send to pending promises of query run. If not provided, the promise will be resolved.
      */
     private _handleQueryCleanup(errorMsg?: String, error?: Error): void {
+        this.clearOrphanedQueryRecovery();
         this._isExecuting = false;
         this._hasCompleted = true;
         this.removeRunningQuery();

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -357,14 +357,14 @@ export class SqlOutputContentProvider {
             );
 
             if (!runner) {
-                this.releaseExecutionSlot(uri, slot);
+                this.releaseExecutionSlot(slot);
                 if (promise) {
                     promise.reject(false);
                 }
                 return;
             }
 
-            if (!this.ownsExecutionSlot(uri, slot)) {
+            if (!this.ownsExecutionSlot(slot)) {
                 // The user cancelled while this run was still being set up.
                 if (promise) {
                     promise.reject(false);
@@ -389,7 +389,7 @@ export class SqlOutputContentProvider {
                 promise,
             );
         } catch (error) {
-            this.releaseExecutionSlot(uri, slot);
+            this.releaseExecutionSlot(slot);
             if (promise) {
                 promise.reject(false);
             }
@@ -427,12 +427,12 @@ export class SqlOutputContentProvider {
                 title,
             );
             if (!runner) {
-                this.releaseExecutionSlot(uri, slot);
+                this.releaseExecutionSlot(slot);
                 promise?.reject(false);
                 return;
             }
 
-            if (!this.ownsExecutionSlot(uri, slot)) {
+            if (!this.ownsExecutionSlot(slot)) {
                 // The user cancelled while this run was still being set up.
                 promise?.reject(false);
                 return;
@@ -441,7 +441,7 @@ export class SqlOutputContentProvider {
             this.releaseExecutionSlotOnComplete(runner, slot);
             await runner.runQueryString(query, promise);
         } catch (error) {
-            this.releaseExecutionSlot(uri, slot);
+            this.releaseExecutionSlot(slot);
             promise?.reject(false);
             logger.error(`Error running query string for ${uri}: ${getErrorMessage(error)}`);
         }
@@ -474,11 +474,11 @@ export class SqlOutputContentProvider {
             );
 
             if (!runner) {
-                this.releaseExecutionSlot(uri, slot);
+                this.releaseExecutionSlot(slot);
                 return;
             }
 
-            if (!this.ownsExecutionSlot(uri, slot)) {
+            if (!this.ownsExecutionSlot(slot)) {
                 // The user cancelled while this run was still being set up.
                 return;
             }
@@ -491,7 +491,7 @@ export class SqlOutputContentProvider {
                 includeActualExecutionPlanXml: includeExecutionPlanXml,
             });
         } catch (_error) {
-            this.releaseExecutionSlot(uri, slot);
+            this.releaseExecutionSlot(slot);
             throw _error;
         }
     }
@@ -511,16 +511,27 @@ export class SqlOutputContentProvider {
         return slot;
     }
 
-    private ownsExecutionSlot(uri: string, slot: symbol): boolean {
-        return this._queryExecutionInFlightUris.get(uri) === slot;
+    /**
+     * Returns the editor URI that currently holds the slot. Slots are matched by token rather than
+     * by the URI a run started with, because Save As moves a slot to the editor's new URI.
+     */
+    private findExecutionSlotUri(slot: symbol): string | undefined {
+        for (const [uri, owner] of this._queryExecutionInFlightUris) {
+            if (owner === slot) {
+                return uri;
+            }
+        }
+        return undefined;
     }
 
-    /**
-     * Releases the execution slot for an editor. With a slot token only that owner's slot is
-     * released; without one the slot is released unconditionally (user-driven recovery).
-     */
-    private releaseExecutionSlot(uri: string, slot?: symbol): void {
-        if (slot === undefined || this._queryExecutionInFlightUris.get(uri) === slot) {
+    private ownsExecutionSlot(slot: symbol): boolean {
+        return this.findExecutionSlotUri(slot) !== undefined;
+    }
+
+    /** Releases a run's execution slot, wherever Save As has moved it. */
+    private releaseExecutionSlot(slot: symbol): void {
+        const uri = this.findExecutionSlotUri(slot);
+        if (uri !== undefined) {
             this._queryExecutionInFlightUris.delete(uri);
         }
     }
@@ -532,7 +543,7 @@ export class SqlOutputContentProvider {
     private releaseExecutionSlotOnComplete(runner: QueryRunner, slot: symbol): void {
         const listener = runner.onComplete(() => {
             listener.dispose();
-            this.releaseExecutionSlot(runner.uri, slot);
+            this.releaseExecutionSlot(slot);
         });
     }
 
@@ -912,7 +923,7 @@ export class SqlOutputContentProvider {
             if (uri !== undefined && this._queryExecutionInFlightUris.has(uri)) {
                 // A run for this editor is still being set up, or its setup is stuck. Treat the
                 // cancel as abandoning that run so the editor does not stay blocked.
-                this.releaseExecutionSlot(uri);
+                this._queryExecutionInFlightUris.delete(uri);
                 return;
             }
             vscode.window.showInformationMessage(LocalizedConstants.msgCancelQueryNotRunning);

--- a/extensions/mssql/src/models/sqlOutputContentProvider.ts
+++ b/extensions/mssql/src/models/sqlOutputContentProvider.ts
@@ -57,7 +57,9 @@ export class SqlOutputContentProvider {
     private _queryResultsMap: Map<string, QueryRunnerState> = new Map<string, QueryRunnerState>();
     private _queryResultWebviewController: QueryResultWebviewController;
     private _actualPlanStatuses: string[] = [];
-    private _queryExecutionInFlightUris: Set<string> = new Set();
+    // One execution slot per editor URI. The token identifies the run that owns the slot so a
+    // stale release (or a cancel during setup) can never clear a newer run's slot.
+    private _queryExecutionInFlightUris: Map<string, symbol> = new Map();
     // Throttled state update functions per result URI (messages, results, etc.)
     private _stateUpdateThrottles: Map<string, ReturnType<typeof throttle>> = new Map();
     private _queryCompletionSoundService: QueryCompletionSoundService;
@@ -339,7 +341,8 @@ export class SqlOutputContentProvider {
         executionPlanOptions?: ExecutionPlanOptions,
         promise?: Deferred<boolean>,
     ): Promise<void> {
-        if (!this.tryAcquireExecutionSlot(uri)) {
+        const slot = this.tryAcquireExecutionSlot(uri);
+        if (!slot) {
             if (promise) {
                 promise.reject(false);
             }
@@ -354,14 +357,22 @@ export class SqlOutputContentProvider {
             );
 
             if (!runner) {
-                this.releaseExecutionSlot(uri);
+                this.releaseExecutionSlot(uri, slot);
                 if (promise) {
                     promise.reject(false);
                 }
                 return;
             }
 
-            this.releaseExecutionSlotOnComplete(runner);
+            if (!this.ownsExecutionSlot(uri, slot)) {
+                // The user cancelled while this run was still being set up.
+                if (promise) {
+                    promise.reject(false);
+                }
+                return;
+            }
+
+            this.releaseExecutionSlotOnComplete(runner, slot);
 
             const includeExecutionPlanXml =
                 executionPlanOptions?.includeActualExecutionPlanXml ??
@@ -378,7 +389,7 @@ export class SqlOutputContentProvider {
                 promise,
             );
         } catch (error) {
-            this.releaseExecutionSlot(uri);
+            this.releaseExecutionSlot(uri, slot);
             if (promise) {
                 promise.reject(false);
             }
@@ -403,7 +414,8 @@ export class SqlOutputContentProvider {
         title: string,
         promise?: Deferred<boolean>,
     ): Promise<void> {
-        if (!this.tryAcquireExecutionSlot(uri)) {
+        const slot = this.tryAcquireExecutionSlot(uri);
+        if (!slot) {
             promise?.reject(false);
             return;
         }
@@ -415,15 +427,21 @@ export class SqlOutputContentProvider {
                 title,
             );
             if (!runner) {
-                this.releaseExecutionSlot(uri);
+                this.releaseExecutionSlot(uri, slot);
                 promise?.reject(false);
                 return;
             }
 
-            this.releaseExecutionSlotOnComplete(runner);
+            if (!this.ownsExecutionSlot(uri, slot)) {
+                // The user cancelled while this run was still being set up.
+                promise?.reject(false);
+                return;
+            }
+
+            this.releaseExecutionSlotOnComplete(runner, slot);
             await runner.runQueryString(query, promise);
         } catch (error) {
-            this.releaseExecutionSlot(uri);
+            this.releaseExecutionSlot(uri, slot);
             promise?.reject(false);
             logger.error(`Error running query string for ${uri}: ${getErrorMessage(error)}`);
         }
@@ -443,7 +461,8 @@ export class SqlOutputContentProvider {
         selection: ISelectionData,
         title: string,
     ): Promise<void> {
-        if (!this.tryAcquireExecutionSlot(uri)) {
+        const slot = this.tryAcquireExecutionSlot(uri);
+        if (!slot) {
             return;
         }
 
@@ -455,11 +474,16 @@ export class SqlOutputContentProvider {
             );
 
             if (!runner) {
-                this.releaseExecutionSlot(uri);
+                this.releaseExecutionSlot(uri, slot);
                 return;
             }
 
-            this.releaseExecutionSlotOnComplete(runner);
+            if (!this.ownsExecutionSlot(uri, slot)) {
+                // The user cancelled while this run was still being set up.
+                return;
+            }
+
+            this.releaseExecutionSlotOnComplete(runner, slot);
 
             const includeExecutionPlanXml = this._actualPlanStatuses.includes(uri);
 
@@ -467,34 +491,66 @@ export class SqlOutputContentProvider {
                 includeActualExecutionPlanXml: includeExecutionPlanXml,
             });
         } catch (_error) {
-            this.releaseExecutionSlot(uri);
+            this.releaseExecutionSlot(uri, slot);
             throw _error;
         }
     }
 
-    private tryAcquireExecutionSlot(uri: string): boolean {
+    /**
+     * Claims the execution slot for an editor. Returns the slot token, or undefined (after
+     * telling the user) when a run for the editor is already in flight.
+     */
+    private tryAcquireExecutionSlot(uri: string): symbol | undefined {
         if (this._queryExecutionInFlightUris.has(uri)) {
-            vscode.window.showInformationMessage(LocalizedConstants.msgRunQueryInProgress);
-            return false;
+            this.showQueryInProgressMessage(uri);
+            return undefined;
         }
 
-        this._queryExecutionInFlightUris.add(uri);
-        return true;
+        const slot = Symbol(uri);
+        this._queryExecutionInFlightUris.set(uri, slot);
+        return slot;
     }
 
-    private releaseExecutionSlot(uri: string): void {
-        this._queryExecutionInFlightUris.delete(uri);
+    private ownsExecutionSlot(uri: string, slot: symbol): boolean {
+        return this._queryExecutionInFlightUris.get(uri) === slot;
+    }
+
+    /**
+     * Releases the execution slot for an editor. With a slot token only that owner's slot is
+     * released; without one the slot is released unconditionally (user-driven recovery).
+     */
+    private releaseExecutionSlot(uri: string, slot?: symbol): void {
+        if (slot === undefined || this._queryExecutionInFlightUris.get(uri) === slot) {
+            this._queryExecutionInFlightUris.delete(uri);
+        }
     }
 
     /**
      * Subscribes to the runner's onComplete event to release the execution slot
      * when the query finishes (whether successfully or with an error).
      */
-    private releaseExecutionSlotOnComplete(runner: QueryRunner): void {
+    private releaseExecutionSlotOnComplete(runner: QueryRunner, slot: symbol): void {
         const listener = runner.onComplete(() => {
             listener.dispose();
-            this.releaseExecutionSlot(runner.uri);
+            this.releaseExecutionSlot(runner.uri, slot);
         });
+    }
+
+    /**
+     * Tells the user a query is already running for the editor and offers to cancel it.
+     * Cancelling also recovers an editor whose query is gone on the service side, so this is
+     * the way out of a stuck "already running" state without reloading the window.
+     */
+    private showQueryInProgressMessage(uri: string): void {
+        void (async () => {
+            const choice = await vscode.window.showInformationMessage(
+                LocalizedConstants.msgRunQueryInProgress,
+                LocalizedConstants.msgRunQueryInProgressCancelAction,
+            );
+            if (choice === LocalizedConstants.msgRunQueryInProgressCancelAction) {
+                await this.cancelQuery(uri);
+            }
+        })();
     }
 
     private async initializeRunnerAndWebviewState(
@@ -550,7 +606,7 @@ export class SqlOutputContentProvider {
 
             // If the query is already in progress, don't attempt to send it
             if (existingRunner.isExecutingQuery) {
-                vscode.window.showInformationMessage(LocalizedConstants.msgRunQueryInProgress);
+                this.showQueryInProgressMessage(uri);
                 return;
             } else {
                 // Cancel any lingering queries that haven't been disposed yet
@@ -852,6 +908,13 @@ export class SqlOutputContentProvider {
         }
 
         if (queryRunner === undefined || !queryRunner.isExecutingQuery) {
+            const uri = typeof input === "string" ? input : input?.uri;
+            if (uri !== undefined && this._queryExecutionInFlightUris.has(uri)) {
+                // A run for this editor is still being set up, or its setup is stuck. Treat the
+                // cancel as abandoning that run so the editor does not stay blocked.
+                this.releaseExecutionSlot(uri);
+                return;
+            }
             vscode.window.showInformationMessage(LocalizedConstants.msgCancelQueryNotRunning);
             return;
         }
@@ -912,6 +975,13 @@ export class SqlOutputContentProvider {
 
     public async updateQueryRunnerUri(oldUri: string, newUri: string): Promise<void> {
         this.migrateThrottledUpdateUri(oldUri, newUri);
+
+        // Keep the execution slot with the editor: the runner releases it under its new URI.
+        const slot = this._queryExecutionInFlightUris.get(oldUri);
+        if (slot !== undefined && oldUri !== newUri) {
+            this._queryExecutionInFlightUris.delete(oldUri);
+            this._queryExecutionInFlightUris.set(newUri, slot);
+        }
 
         const queryRunnerState = this._queryResultsMap.get(oldUri);
         if (queryRunnerState) {

--- a/extensions/mssql/src/models/utils.ts
+++ b/extensions/mssql/src/models/utils.ts
@@ -928,3 +928,31 @@ export function validateDatabaseNameFormat(databaseName: string): {
 
     return { isValid: true, errorType: DatabaseNameValidationError.None };
 }
+
+/**
+ * Settles with the given promise, or rejects with an Error carrying `timeoutMessage` if the
+ * promise has not settled within `timeoutMs`. The timer is cleared as soon as the promise
+ * settles, so a completed operation leaves nothing pending.
+ * @param promise The operation to wait for.
+ * @param timeoutMs Maximum time to wait, in milliseconds.
+ * @param timeoutMessage Message of the Error the returned promise rejects with on timeout.
+ */
+export function withTimeout<T>(
+    promise: Thenable<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+        Promise.resolve(promise).then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (error) => {
+                clearTimeout(timer);
+                reject(error);
+            },
+        );
+    });
+}

--- a/extensions/mssql/test/unit/queryStuckState.test.ts
+++ b/extensions/mssql/test/unit/queryStuckState.test.ts
@@ -288,6 +288,59 @@ suite("Query execution stuck-state recovery (#22921)", () => {
         onComplete.dispose();
     });
 
+    test("saving an untitled editor during run setup still starts the run and releases the slot", async () => {
+        const untitledUri = "untitled:Untitled-1";
+        const fileUri = "file:///repro/saved.sql";
+        let finishSetup: () => void;
+        const setupGate = new Promise<void>((resolve) => {
+            finishSetup = resolve;
+        });
+        const onComplete = new vscode.EventEmitter<void>();
+        const mockRunner = {
+            uri: untitledUri,
+            runQuery: sandbox.stub().resolves(),
+            onComplete: onComplete.event,
+            updateQueryRunnerUri: sandbox.stub(),
+        } as unknown as QueryRunner;
+        sandbox
+            .stub(
+                contentProvider as unknown as { initializeRunnerAndWebviewState: unknown },
+                "initializeRunnerAndWebviewState",
+            )
+            .callsFake(async () => {
+                await setupGate;
+                return mockRunner;
+            });
+
+        // Run in Untitled-1 while setup (for example the reset cancel) is still in progress.
+        const run = contentProvider.runQuery(
+            statusView as unknown as StatusView,
+            untitledUri,
+            undefined,
+            title,
+        );
+        // Save As before setup finishes: the execution slot moves to the file URI.
+        await contentProvider.updateQueryRunnerUri(untitledUri, fileUri);
+        (mockRunner as unknown as { uri: string }).uri = fileUri;
+        finishSetup!();
+        await run;
+
+        expect(mockRunner.runQuery, "the run must not be treated as cancelled").to.have.been.called;
+
+        // The query finishes and the saved editor can run again.
+        onComplete.fire(undefined as unknown as void);
+        expect(contentProvider["_queryExecutionInFlightUris"].has(fileUri)).to.equal(false);
+        await contentProvider.runQuery(
+            statusView as unknown as StatusView,
+            fileUri,
+            undefined,
+            title,
+        );
+        expect(timesShown(LocConstants.msgRunQueryInProgress)).to.equal(0);
+
+        onComplete.dispose();
+    });
+
     test("cancel during run setup releases the editor and the abandoned run does not start", async () => {
         let finishReset: () => void;
         const resetGate = new Promise<void>((resolve) => {

--- a/extensions/mssql/test/unit/queryStuckState.test.ts
+++ b/extensions/mssql/test/unit/queryStuckState.test.ts
@@ -1,0 +1,332 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Regression tests for microsoft/vscode-mssql#22921 ("A query is already running for this
+ * editor session" with no way to cancel).
+ *
+ * Each test drives the real SqlOutputContentProvider and QueryRunner with a stubbed service
+ * client through one way the editor used to end up permanently marked as executing, and asserts
+ * that the editor becomes usable again.
+ */
+
+import * as vscode from "vscode";
+import * as sinon from "sinon";
+import * as chai from "chai";
+import sinonChai from "sinon-chai";
+import {
+    QueryRunnerState,
+    SqlOutputContentProvider,
+} from "../../src/models/sqlOutputContentProvider";
+import StatusView from "../../src/views/statusView";
+import { ExecutionPlanService } from "../../src/services/executionPlanService";
+import QueryRunner from "../../src/controllers/queryRunner";
+import { QueryNotificationHandler } from "../../src/controllers/queryNotificationHandler";
+import SqlToolsServerClient from "../../src/languageservice/serviceclient";
+import { QueryExecuteRequest } from "../../src/models/contracts/queryExecute";
+import { QueryCancelRequest } from "../../src/models/contracts/queryCancel";
+import * as Constants from "../../src/constants/constants";
+import * as LocConstants from "../../src/constants/locConstants";
+import * as stubs from "./stubs";
+import { stubMessageBoxes, stubVscodeWorkspace } from "./utils";
+import { Perf } from "../../src/perf/perfTelemetry";
+import { ISelectionData } from "../../src/models/interfaces";
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+suite("Query execution stuck-state recovery (#22921)", () => {
+    const uri = "file:///repro/query.sql";
+    const title = "query.sql";
+    const selection: ISelectionData = { startLine: 0, startColumn: 0, endLine: 0, endColumn: 8 };
+
+    let sandbox: sinon.SinonSandbox;
+    let messageBoxes: ReturnType<typeof stubMessageBoxes>;
+    let vscodeWorkspace: ReturnType<typeof stubVscodeWorkspace>;
+    let statusView: sinon.SinonStubbedInstance<StatusView>;
+    let contentProvider: SqlOutputContentProvider;
+    let client: sinon.SinonStubbedInstance<SqlToolsServerClient>;
+    let notificationHandler: sinon.SinonStubbedInstance<QueryNotificationHandler>;
+
+    function createRunner(runnerUri: string = uri): QueryRunner {
+        return new QueryRunner(
+            runnerUri,
+            title,
+            statusView as unknown as StatusView,
+            client,
+            notificationHandler,
+        );
+    }
+
+    function timesShown(message: string): number {
+        return messageBoxes.showInformationMessage
+            .getCalls()
+            .filter((call) => call.args[0] === message).length;
+    }
+
+    function useFakeTimers(): sinon.SinonFakeTimers {
+        return sandbox.useFakeTimers({
+            toFake: ["setTimeout", "clearTimeout"],
+            shouldClearNativeTimers: true,
+        });
+    }
+
+    function stubExecuteAccepted(): void {
+        client.sendRequest.withArgs(QueryExecuteRequest.type, sinon.match.object).resolves({});
+    }
+
+    function stubCancelAnsweredWithNoQuery(): void {
+        client.sendRequest
+            .withArgs(QueryCancelRequest.type, sinon.match.object)
+            .resolves({ messages: "Query is not active" });
+    }
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        messageBoxes = stubMessageBoxes(sandbox);
+        vscodeWorkspace = stubVscodeWorkspace(sandbox);
+        vscodeWorkspace.openTextDocument.resolves({
+            getText: () => "select 1",
+        } as unknown as vscode.TextDocument);
+        sandbox
+            .stub(vscode.workspace, "getConfiguration")
+            .returns(stubs.createWorkspaceConfiguration({}));
+        const disposable = { dispose: () => {} } as vscode.Disposable;
+        sandbox.stub(vscode.window, "registerWebviewViewProvider").returns(disposable);
+        sandbox.stub(vscode.commands, "registerCommand").returns(disposable);
+        sandbox.stub(Perf, "marker");
+        QueryRunner["_runningQueries"] = [];
+
+        client = sandbox.createStubInstance(SqlToolsServerClient);
+        notificationHandler = sandbox.createStubInstance(QueryNotificationHandler);
+        statusView = sandbox.createStubInstance(StatusView);
+
+        const context = {
+            extensionPath: "test_uri",
+            subscriptions: [],
+        } as unknown as vscode.ExtensionContext;
+        const executionPlanService = sandbox.createStubInstance(ExecutionPlanService);
+        contentProvider = new SqlOutputContentProvider(
+            context,
+            statusView as unknown as StatusView,
+            executionPlanService as unknown as ExecutionPlanService,
+        );
+    });
+
+    teardown(() => {
+        QueryRunner["_runningQueries"] = [];
+        sandbox.restore();
+    });
+
+    test("cancel recovers the editor when the service reports it has no query to cancel", async () => {
+        const clock = useFakeTimers();
+        stubExecuteAccepted();
+        stubCancelAnsweredWithNoQuery();
+        const runner = createRunner();
+        contentProvider.setResultsMap = new Map([[uri, new QueryRunnerState(runner)]]);
+
+        await runner.runQuery(selection);
+        expect(runner.isExecutingQuery).to.equal(true);
+        // The completion notification never arrives.
+
+        await contentProvider.cancelQuery(uri);
+        // A completion that is still in flight gets a short grace period...
+        expect(runner.isExecutingQuery).to.equal(true);
+        await clock.tickAsync(Constants.queryCancelOrphanGraceMs + 1);
+        // ...after which the editor is reset and the user is told why.
+        expect(runner.isExecutingQuery).to.equal(false);
+        expect(QueryRunner["_runningQueries"]).to.be.empty;
+        expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+            LocConstants.msgQueryNoLongerRunning,
+        );
+
+        // Running again works.
+        await contentProvider.runQuery(statusView as unknown as StatusView, uri, selection, title);
+        expect(timesShown(LocConstants.msgRunQueryInProgress)).to.equal(0);
+        expect(client.sendRequest.withArgs(QueryExecuteRequest.type, sinon.match.object)).to.have
+            .been.calledTwice;
+    });
+
+    test("an unanswered cancel request times out and resets the editor", async () => {
+        const clock = useFakeTimers();
+        stubExecuteAccepted();
+        client.sendRequest
+            .withArgs(QueryCancelRequest.type, sinon.match.object)
+            .returns(new Promise<never>(() => {}));
+        const runner = createRunner();
+        contentProvider.setResultsMap = new Map([[uri, new QueryRunnerState(runner)]]);
+        await runner.runQuery(selection);
+
+        const cancel = contentProvider.cancelQuery(uri);
+        await clock.tickAsync(Constants.queryCancelRequestTimeoutMs + 1);
+        await cancel;
+
+        expect(runner.isExecutingQuery).to.equal(false);
+        expect(messageBoxes.showErrorMessage).to.have.been.called;
+
+        // The service answers again; running works.
+        stubCancelAnsweredWithNoQuery();
+        await contentProvider.runQuery(statusView as unknown as StatusView, uri, selection, title);
+        expect(timesShown(LocConstants.msgRunQueryInProgress)).to.equal(0);
+    });
+
+    test("the in-progress message offers to cancel, which recovers a query the service no longer has", async () => {
+        const clock = useFakeTimers();
+        stubExecuteAccepted();
+        stubCancelAnsweredWithNoQuery();
+        messageBoxes.showInformationMessage.resolves(
+            LocConstants.msgRunQueryInProgressCancelAction,
+        );
+        const runner = createRunner();
+        contentProvider.setResultsMap = new Map([[uri, new QueryRunnerState(runner)]]);
+        await runner.runQuery(selection);
+
+        // Run again while stuck: the message is shown with a Cancel action, which the user picks.
+        await contentProvider.runQuery(statusView as unknown as StatusView, uri, selection, title);
+        expect(messageBoxes.showInformationMessage).to.have.been.calledWith(
+            LocConstants.msgRunQueryInProgress,
+            LocConstants.msgRunQueryInProgressCancelAction,
+        );
+        await clock.tickAsync(Constants.queryCancelOrphanGraceMs + 1);
+
+        expect(client.sendRequest).to.have.been.calledWith(
+            QueryCancelRequest.type,
+            sinon.match.object,
+        );
+        expect(runner.isExecutingQuery).to.equal(false);
+    });
+
+    test("a failure while reading the editor text does not leave the editor marked as executing", async () => {
+        stubExecuteAccepted();
+        vscodeWorkspace.openTextDocument.rejects(
+            new Error("simulated: the editor document could not be opened"),
+        );
+        const runner = createRunner();
+        let completed = false;
+        runner.onComplete(() => {
+            completed = true;
+        });
+
+        let thrown: unknown;
+        try {
+            await runner.runQuery(selection);
+        } catch (error) {
+            thrown = error;
+        }
+        expect(thrown, "runQuery should surface the failure").to.not.equal(undefined);
+
+        expect(client.sendRequest).to.not.have.been.calledWith(
+            QueryExecuteRequest.type,
+            sinon.match.object,
+        );
+        expect(runner.isExecutingQuery).to.equal(false);
+        expect(completed, "listeners are told the run ended").to.equal(true);
+        expect(QueryRunner["_runningQueries"]).to.be.empty;
+        expect(notificationHandler.unregisterRunner).to.have.been.calledWith(uri);
+    });
+
+    test("a failing status update on completion still releases the editor", async () => {
+        stubExecuteAccepted();
+        statusView.setExecutionTime.throws(new Error("simulated status bar failure"));
+        const runner = createRunner();
+        let completed = false;
+        runner.onComplete(() => {
+            completed = true;
+        });
+        await runner.runQuery(selection);
+
+        runner.handleQueryComplete({ ownerUri: uri, batchSummaries: [] });
+
+        expect(runner.isExecutingQuery).to.equal(false);
+        expect(completed).to.equal(true);
+        expect(QueryRunner["_runningQueries"]).to.be.empty;
+    });
+
+    test("saving an untitled editor mid-query releases the original execution slot on completion", async () => {
+        const untitledUri = "untitled:Untitled-1";
+        const fileUri = "file:///repro/saved.sql";
+        const onComplete = new vscode.EventEmitter<void>();
+        const mockRunner = {
+            uri: untitledUri,
+            runQuery: sandbox.stub().resolves(),
+            onComplete: onComplete.event,
+            updateQueryRunnerUri: sandbox.stub(),
+        } as unknown as QueryRunner;
+        sandbox
+            .stub(
+                contentProvider as unknown as { initializeRunnerAndWebviewState: unknown },
+                "initializeRunnerAndWebviewState",
+            )
+            .resolves(mockRunner);
+
+        // Run in Untitled-1; the slot for the untitled URI is taken.
+        await contentProvider.runQuery(
+            statusView as unknown as StatusView,
+            untitledUri,
+            undefined,
+            title,
+        );
+        // Save As while the query runs: everything is re-keyed to the file URI.
+        await contentProvider.updateQueryRunnerUri(untitledUri, fileUri);
+        (mockRunner as unknown as { uri: string }).uri = fileUri;
+        // The query finishes. Release happens under the runner's new URI.
+        onComplete.fire(undefined as unknown as void);
+        expect(contentProvider["_queryExecutionInFlightUris"].has(fileUri)).to.equal(false);
+
+        // VS Code reuses the name: a brand-new Untitled-1 editor is opened and run.
+        await contentProvider.runQuery(
+            statusView as unknown as StatusView,
+            untitledUri,
+            undefined,
+            title,
+        );
+        expect(timesShown(LocConstants.msgRunQueryInProgress)).to.equal(0);
+        expect(mockRunner.runQuery).to.have.been.calledTwice;
+
+        onComplete.dispose();
+    });
+
+    test("cancel during run setup releases the editor and the abandoned run does not start", async () => {
+        let finishReset: () => void;
+        const resetGate = new Promise<void>((resolve) => {
+            finishReset = resolve;
+        });
+        const onComplete = new vscode.EventEmitter<void>();
+        const mockRunner = {
+            uri,
+            isExecutingQuery: false,
+            // Re-using an idle runner first sends a cancel to the service; here that request is
+            // slow to return (unresponsive service).
+            resetQueryRunner: () => resetGate,
+            resetHasCompleted: sandbox.stub(),
+            runQuery: sandbox.stub().resolves(),
+            onComplete: onComplete.event,
+        } as unknown as QueryRunner;
+        contentProvider.setResultsMap = new Map([[uri, new QueryRunnerState(mockRunner)]]);
+
+        // First run parks inside createQueryRunner while holding the execution slot.
+        const firstRun = contentProvider.runQuery(
+            statusView as unknown as StatusView,
+            uri,
+            selection,
+            title,
+        );
+        // Second run is refused.
+        await contentProvider.runQuery(statusView as unknown as StatusView, uri, selection, title);
+        expect(timesShown(LocConstants.msgRunQueryInProgress)).to.equal(1);
+
+        // Cancel abandons the pending run instead of claiming nothing is running.
+        await contentProvider.cancelQuery(uri);
+        expect(timesShown(LocConstants.msgCancelQueryNotRunning)).to.equal(0);
+        expect(contentProvider["_queryExecutionInFlightUris"].has(uri)).to.equal(false);
+
+        // When the slow setup finally finishes, the abandoned run must not start.
+        finishReset!();
+        await firstRun;
+        expect(mockRunner.runQuery).to.not.have.been.called;
+
+        onComplete.dispose();
+    });
+});

--- a/extensions/mssql/test/unit/utils.test.ts
+++ b/extensions/mssql/test/unit/utils.test.ts
@@ -750,3 +750,48 @@ export const azureAuthConn = {
 export const connStringConn = {
     connectionString: "Server=myServer;Database=myDB;Integrated Security=true;",
 } as IConnectionProfile;
+
+suite("Utility Tests - withTimeout", () => {
+    let clock: sinon.SinonFakeTimers;
+
+    setup(() => {
+        clock = sinon.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    });
+
+    teardown(() => {
+        clock.restore();
+    });
+
+    test("resolves with the value when the promise settles in time", async () => {
+        const result = await Utils.withTimeout(Promise.resolve("done"), 1000, "too slow");
+
+        expect(result).to.equal("done");
+        expect(clock.countTimers(), "the timer is cleared once the promise settles").to.equal(0);
+    });
+
+    test("propagates a rejection from the promise", async () => {
+        let caught: Error | undefined;
+        try {
+            await Utils.withTimeout(Promise.reject(new Error("boom")), 1000, "too slow");
+        } catch (error) {
+            caught = error as Error;
+        }
+
+        expect(caught?.message).to.equal("boom");
+        expect(clock.countTimers(), "the timer is cleared once the promise settles").to.equal(0);
+    });
+
+    test("rejects with the timeout message when the promise never settles", async () => {
+        let caught: Error | undefined;
+        const observed = Utils.withTimeout(new Promise<never>(() => {}), 1000, "too slow").catch(
+            (error) => {
+                caught = error as Error;
+            },
+        );
+
+        await clock.tickAsync(1001);
+        await observed;
+
+        expect(caught?.message).to.equal("too slow");
+    });
+});

--- a/localization/xliff/vscode-mssql.xlf
+++ b/localization/xliff/vscode-mssql.xlf
@@ -1017,6 +1017,9 @@
       <source xml:lang="en">Cancel failed: {0}</source>
       <note>{0} is the error message</note>
     </trans-unit>
+    <trans-unit id="++CODE++bb446d765ac5ce4aed459491227b909ff24de5026f8c7ee8451c1db46a8b6ade">
+      <source xml:lang="en">Cancel query</source>
+    </trans-unit>
     <trans-unit id="++CODE++d6efd131712ed1115d720d4cfdb68b1819ad1de1587f4c2176c9c055c7c03a67">
       <source xml:lang="en">Cancel schema compare failed: &apos;{0}&apos;</source>
       <note>{0} is the error message returned from the cancel operation</note>
@@ -8575,6 +8578,9 @@
     <trans-unit id="++CODE++1a4205e9f5cc50eaf70719b64956352b74a99badba266027a6244def0d016b73">
       <source xml:lang="en">The behavior when a user tries to update a row with data that is involved in a foreign key relationship.</source>
     </trans-unit>
+    <trans-unit id="++CODE++d7c54293989298ee3944f49558ec6882f3cdee331b1959779bb00e2e6921be28">
+      <source xml:lang="en">The cancel request did not complete in time. The editor&apos;s execution state has been reset.</source>
+    </trans-unit>
     <trans-unit id="++CODE++b3ed9d46f7671d126e86925d532363313c1f6795e877d3d348d134f6e7051bc3">
       <source xml:lang="en">The client secret for your Microsoft Entra app registration.</source>
     </trans-unit>
@@ -8718,6 +8724,9 @@
     </trans-unit>
     <trans-unit id="++CODE++30dc10f2e5d6502d78b8e778df18e5f010e5ec3fa432d4e92c526d86a84375e0">
       <source xml:lang="en">The selected {0} file &apos;{1}&apos; does not exist or is not a file.</source>
+    </trans-unit>
+    <trans-unit id="++CODE++221a6647042e962a326162fd3dcdd7a1e01f628fb4eedc3ecc4b2c33038109fe">
+      <source xml:lang="en">The service is no longer running a query for this editor. The editor&apos;s execution state has been reset.</source>
     </trans-unit>
     <trans-unit id="++CODE++13c88dccbc0c16d34702d4b664c78552a13156f154731119eaaa1dfc41be428d">
       <source xml:lang="en">The system database references need to be updated to build the project &apos;{0}&apos;. If the project was created in SSDT, it will continue to work in both tools. Do you want to update the project?</source>


### PR DESCRIPTION
## Description

Issue #22921

Several paths left an editor permanently marked as executing, so every run showed "A query is already running for this editor session" and cancel did nothing.

- Cancel always recovers the editor: the request times out, and a "no query" reply from the service resets the editor if no completion follows.
- Run state is set inside the `try` and released in a `finally` on completion, so errors can no longer leave it set.
- The execution slot belongs to the run, follows the editor on Save As, and is released by a cancel during setup.
- The in-progress message now offers **Cancel query**. Adds a shared `withTimeout` helper.

Service side: microsoft/sqltoolsservice#2815.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [x] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)
