### PR TITLE
Fix Schema Compare project apply and legacy .scmp loading

### DIFF
--- a/extensions/mssql/src/constants/locConstants.ts
+++ b/extensions/mssql/src/constants/locConstants.ts
@@ -2125,6 +2125,22 @@ export class SchemaCompare {
             args: [connectionId],
             comment: ["{0} is the saved connection ID"],
         });
+    public static classicScmpProjectNotFound = (projectName: string) =>
+        l10n.t({
+            message: "The classic .scmp project '{0}' could not be found in the current workspace.",
+            args: [projectName],
+            comment: ["{0} is the SQL project name stored in a classic .scmp file"],
+        });
+    public static classicScmpProjectAmbiguous = (projectName: string) =>
+        l10n.t({
+            message:
+                "The classic .scmp project '{0}' matches multiple projects in the current workspace. Open only the intended project and try again.",
+            args: [projectName],
+            comment: ["{0} is the SQL project name stored in a classic .scmp file"],
+        });
+    public static classicScmpSqlProjectsRequired = l10n.t(
+        "This classic .scmp file contains a SQL project reference. Install or enable the SQL Database Projects extension, then try again.",
+    );
     public static Yes = l10n.t("Yes");
     public static No = l10n.t("No");
     public static optionsChangedMessage = l10n.t(

--- a/extensions/mssql/src/databaseProjects/controllers/projectController.ts
+++ b/extensions/mssql/src/databaseProjects/controllers/projectController.ts
@@ -33,7 +33,6 @@ import {
 import { TelemetryActions, TelemetryReporter, TelemetryViews } from "../common/telemetry";
 import {
     AddItemOptions,
-    EntryType,
     IDatabaseReferenceProjectEntry,
     ISqlProject,
     ItemType,
@@ -42,7 +41,7 @@ import {
 import { createNewProjectFromDatabaseWithQuickpick } from "../dialogs/createProjectFromDatabaseQuickpick";
 import { UpdateProjectFromDatabaseWithQuickpick } from "../dialogs/updateProjectFromDatabaseQuickpick";
 import { addDatabaseReferenceQuickpick } from "../dialogs/addDatabaseReferenceQuickpick";
-import { FileProjectEntry, SqlProjectReferenceProjectEntry } from "../models/projectEntry";
+import { SqlProjectReferenceProjectEntry } from "../models/projectEntry";
 import { UpdateProjectAction, UpdateProjectDataModel } from "../models/api/updateProject";
 import { SqlCmdVariableTreeItem } from "../models/tree/sqlcmdVariableTreeItem";
 import { DeploymentScenario, ExtractTarget, ProjectType, TaskExecutionMode } from "../common/enums";
@@ -2246,7 +2245,9 @@ export class ProjectsController {
     }
 
     public async getProjectScriptFiles(projectFilePath: string): Promise<string[]> {
-        const project = await Project.openProject(projectFilePath);
+        // Schema Compare may request the same project repeatedly after files have changed on disk.
+        // Force STS to discard its cached project so each comparison sees the current file list.
+        const project = await Project.openProject(projectFilePath, false, true);
 
         return project.sqlObjectScripts
             .filter((f) => f.fsUri.fsPath.endsWith(constants.sqlFileExtension))
@@ -2281,34 +2282,20 @@ export class ProjectsController {
             TaskExecutionMode.execute as unknown as mssqlVscode.TaskExecutionMode,
         );
 
-        if (!result.errorMessage) {
+        if (result.success && !result.errorMessage) {
             const project = await Project.openProject(projectFilePath);
 
-            let toAdd: vscode.Uri[] = [];
-            result.addedFiles.forEach((f: any) => toAdd.push(vscode.Uri.file(f)));
-            const relativePaths = toAdd.map((f) =>
-                path.relative(project.projectFolderPath, f.fsPath),
+            const relativePathsToAdd = result.addedFiles.map((filePath) =>
+                path.relative(project.projectFolderPath, filePath),
             );
 
-            await project.addSqlObjectScripts(relativePaths);
+            await project.addSqlObjectScripts(relativePathsToAdd);
 
-            let toRemove: vscode.Uri[] = [];
-            result.deletedFiles.forEach((f: any) => toRemove.push(vscode.Uri.file(f)));
-
-            let toRemoveEntries: FileProjectEntry[] = [];
-            toRemove.forEach((f) =>
-                toRemoveEntries.push(
-                    new FileProjectEntry(
-                        f,
-                        f.fsPath.replace(projectPath + "\\", ""),
-                        EntryType.File,
-                    ),
-                ),
-            );
-
-            toRemoveEntries.forEach(
-                async (f) => await project.excludeSqlObjectScript(f.fsUri.fsPath),
-            );
+            for (const filePath of result.deletedFiles) {
+                await project.excludeSqlObjectScript(
+                    path.relative(project.projectFolderPath, filePath),
+                );
+            }
 
             await this.buildProject(project);
         }

--- a/extensions/mssql/src/schemaCompare/schemaCompareUtils.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareUtils.ts
@@ -8,6 +8,7 @@ import * as mssql from "vscode-mssql";
 import * as os from "os";
 import * as path from "path";
 import { promises as fs } from "fs";
+import { DOMParser, Element as XmlElement, XMLSerializer } from "@xmldom/xmldom";
 import { uuid } from "../utils/utils";
 import {
     SchemaCompareEndpointType,
@@ -27,6 +28,138 @@ import { ILogger } from "../sharedInterfaces/logger";
  */
 export const sqlDatabaseProjectsPublishChanges =
     "sqlDatabaseProjects.schemaComparePublishProjectChanges";
+const sqlDatabaseProjectsExtensionId = "ms-mssql.sql-database-projects-vscode";
+
+export interface ScmpProjectEndpointDetails {
+    projectGuid?: string;
+    projectName: string;
+    projectFilePath: string;
+    targetScripts: string[];
+    dataSchemaProvider: string;
+}
+
+/**
+ * Upgrades the project endpoints written by classic SSDT Schema Compare. Those endpoints only
+ * persist a project GUID and name; portable DacFx requires the project path, scripts, and DSP.
+ */
+export function upgradeLegacyScmpProjectEndpoints(
+    content: string,
+    projects: ScmpProjectEndpointDetails[],
+): { content: string; changed: boolean } {
+    const document = new DOMParser().parseFromString(content, "application/xml");
+    const providers = Array.from(document.getElementsByTagName("ProjectBasedModelProvider"));
+    let changed = false;
+
+    const directChildText = (element: XmlElement, name: string): string | undefined => {
+        for (let index = 0; index < element.childNodes.length; index++) {
+            const child = element.childNodes.item(index);
+            if (child?.nodeType === 1 && child.nodeName === name) {
+                return child.textContent?.trim();
+            }
+        }
+        return undefined;
+    };
+    const normalizeGuid = (value: string | undefined): string | undefined =>
+        value?.replace(/[{}]/g, "").toLowerCase();
+
+    for (const provider of providers) {
+        if (directChildText(provider, "ProjectFilePath")) {
+            continue;
+        }
+
+        const projectGuid = normalizeGuid(directChildText(provider, "ProjectGuid"));
+        const projectName = directChildText(provider, "Name") ?? "unknown project";
+        let matches = projectGuid
+            ? projects.filter((project) => normalizeGuid(project.projectGuid) === projectGuid)
+            : [];
+        if (matches.length === 0) {
+            matches = projects.filter(
+                (project) => project.projectName.toLowerCase() === projectName.toLowerCase(),
+            );
+        }
+
+        if (matches.length !== 1) {
+            throw new Error(
+                matches.length === 0
+                    ? locConstants.SchemaCompare.classicScmpProjectNotFound(projectName)
+                    : locConstants.SchemaCompare.classicScmpProjectAmbiguous(projectName),
+            );
+        }
+
+        const match = matches[0];
+        const append = (name: string, value: string) => {
+            const element = document.createElement(name);
+            element.appendChild(document.createTextNode(value));
+            provider.appendChild(element);
+        };
+        append("ProjectFilePath", match.projectFilePath);
+        append("TargetScripts", `[${match.targetScripts.join(",")}]`);
+        append("Dsp", match.dataSchemaProvider);
+        append("FolderStructure", "SchemaObjectType");
+        changed = true;
+    }
+
+    return {
+        content: changed ? new XMLSerializer().serializeToString(document) : content,
+        changed,
+    };
+}
+
+async function prepareScmpForPortableDacFx(filePath: string): Promise<{
+    filePath: string;
+    cleanup?: () => Promise<void>;
+}> {
+    const content = await fs.readFile(filePath, "utf8");
+    if (!content.includes("<ProjectBasedModelProvider") || !content.includes("<ProjectGuid")) {
+        return { filePath };
+    }
+
+    const extension = vscode.extensions.getExtension(sqlDatabaseProjectsExtensionId);
+    if (!extension) {
+        throw new Error(locConstants.SchemaCompare.classicScmpSqlProjectsRequired);
+    }
+    const projectApi = (await extension.activate()) as {
+        getProjectScriptFiles(projectFilePath: string): Promise<string[]>;
+        getProjectDatabaseSchemaProvider(projectFilePath: string): Promise<string>;
+    };
+    const projectUris = await vscode.workspace.findFiles(
+        "**/*.sqlproj",
+        "**/{node_modules,.git,bin,obj}/**",
+    );
+    const projects = await Promise.all(
+        projectUris.map(async (uri): Promise<ScmpProjectEndpointDetails> => {
+            const projectContent = await fs.readFile(uri.fsPath, "utf8");
+            const projectDocument = new DOMParser().parseFromString(
+                projectContent,
+                "application/xml",
+            );
+            const projectGuid = projectDocument
+                .getElementsByTagName("ProjectGuid")
+                .item(0)
+                ?.textContent?.trim();
+            return {
+                projectGuid,
+                projectName: path.parse(uri.fsPath).name,
+                projectFilePath: uri.fsPath,
+                targetScripts: await projectApi.getProjectScriptFiles(uri.fsPath),
+                dataSchemaProvider: await projectApi.getProjectDatabaseSchemaProvider(uri.fsPath),
+            };
+        }),
+    );
+    const upgraded = upgradeLegacyScmpProjectEndpoints(content, projects);
+    if (!upgraded.changed) {
+        return { filePath };
+    }
+
+    const temporaryPath = path.join(os.tmpdir(), `vscode-mssql-${uuid()}.scmp`);
+    await fs.writeFile(temporaryPath, upgraded.content, "utf8");
+    return {
+        filePath: temporaryPath,
+        cleanup: async () => {
+            await fs.unlink(temporaryPath).catch(() => undefined);
+        },
+    };
+}
 
 /**
  * Generates a unique operation ID.
@@ -265,20 +398,15 @@ export async function publishDatabaseChanges(
 export async function publishProjectChanges(
     operationId: string,
     payload: SchemaCompareReducers["publishProjectChanges"],
-    schemaCompareService: mssql.ISchemaCompareService,
 ): Promise<mssql.SchemaComparePublishProjectResult> {
-    // Extract the directory path from the project file path
-    // The service expects a directory path, and not a file path.
-    const projectDirectoryPath = path.dirname(payload.targetProjectPath);
-
-    const result = await schemaCompareService.publishProjectChanges(
+    // SQL Projects owns the .sqlproj and must add or remove explicit Build entries after
+    // DacFx changes the files. Calling the Schema Compare service directly bypasses that work.
+    return (await vscode.commands.executeCommand<mssql.SchemaComparePublishProjectResult>(
+        sqlDatabaseProjectsPublishChanges,
         operationId,
-        projectDirectoryPath,
+        payload.targetProjectPath,
         payload.targetFolderStructure,
-        payload.taskExecutionMode,
-    );
-
-    return result;
+    )) as mssql.SchemaComparePublishProjectResult;
 }
 
 /**
@@ -407,7 +535,13 @@ export async function openScmp(
     );
     logger?.debug(`[schemaCompareUtils] Calling schemaCompareService.openScmp`);
 
-    const result = await schemaCompareService.openScmp(filePath);
+    const preparedScmp = await prepareScmpForPortableDacFx(filePath);
+    let result: mssql.SchemaCompareOpenScmpResult;
+    try {
+        result = await schemaCompareService.openScmp(preparedScmp.filePath);
+    } finally {
+        await preparedScmp.cleanup?.();
+    }
 
     logger?.debug(
         `[schemaCompareUtils] openScmp service returned - success: ${result?.success}, hasErrorMessage: ${!!result?.errorMessage}`,

--- a/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareWebViewController.ts
@@ -1385,15 +1385,11 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
                             },
                         });
 
-                        publishResult = await publishProjectChanges(
-                            this.operationId,
-                            {
-                                targetProjectPath: state.targetEndpointInfo.projectFilePath,
-                                targetFolderStructure: state.targetEndpointInfo.extractTarget,
-                                taskExecutionMode: TaskExecutionMode.execute,
-                            },
-                            this.schemaCompareService,
-                        );
+                        publishResult = await publishProjectChanges(this.operationId, {
+                            targetProjectPath: state.targetEndpointInfo.projectFilePath,
+                            targetFolderStructure: state.targetEndpointInfo.extractTarget,
+                            taskExecutionMode: TaskExecutionMode.execute,
+                        });
 
                         endActivity.end(ActivityStatus.Succeeded, {
                             additionalProps: {
@@ -1586,11 +1582,7 @@ export class SchemaCompareWebViewController extends WebviewPanelController<
             );
 
             try {
-                const result = await publishProjectChanges(
-                    this.operationId,
-                    payload,
-                    this.schemaCompareService,
-                );
+                const result = await publishProjectChanges(this.operationId, payload);
 
                 if (result.success) {
                     this.logger.debug(

--- a/extensions/mssql/test/unit/databaseProjects/projectController.test.ts
+++ b/extensions/mssql/test/unit/databaseProjects/projectController.test.ts
@@ -1365,6 +1365,100 @@ suite("ProjectsController", function (): void {
         });
 
         suite("Publishing and script generation", function (): void {
+            test("getProjectScriptFiles reloads the project from disk", async function (): Promise<void> {
+                const projectFilePath = path.join("test", "project.sqlproj");
+                const scriptPath = path.join("test", "Table.sql");
+                const project = {
+                    sqlObjectScripts: [
+                        {
+                            fsUri: vscode.Uri.file(scriptPath),
+                        },
+                    ],
+                } as Project;
+                const openProjectStub = sandbox.stub(Project, "openProject").resolves(project);
+
+                const projController = new ProjectsController(testContext.outputChannel);
+                const scripts = await projController.getProjectScriptFiles(projectFilePath);
+
+                expect(scripts).to.deep.equal([vscode.Uri.file(scriptPath).fsPath]);
+                expect(openProjectStub.calledOnceWithExactly(projectFilePath, false, true)).to.be
+                    .true;
+            });
+
+            test("schemaComparePublishProjectChanges updates project entries before building", async function (): Promise<void> {
+                const projectFilePath = path.join("C:", "test", "project.sqlproj");
+                const addedFilePath = path.join("C:", "test", "Tables", "Added.sql");
+                const deletedFilePath = path.join("C:", "test", "Tables", "Deleted.sql");
+                const project = new Project(projectFilePath);
+                const addSqlObjectScriptsStub = sandbox
+                    .stub(project, "addSqlObjectScripts")
+                    .resolves();
+                const excludeSqlObjectScriptStub = sandbox
+                    .stub(project, "excludeSqlObjectScript")
+                    .resolves();
+                sandbox.stub(Project, "openProject").resolves(project);
+
+                const publishProjectChangesStub = sandbox.stub().resolves({
+                    success: true,
+                    errorMessage: undefined,
+                    changedFiles: [],
+                    addedFiles: [addedFilePath],
+                    deletedFiles: [deletedFilePath],
+                } as vscodeMssql.SchemaComparePublishProjectResult);
+                sandbox.stub(utils, "getSchemaCompareService").resolves({
+                    publishProjectChanges: publishProjectChangesStub,
+                } as unknown as vscodeMssql.ISchemaCompareService);
+
+                const projController = new ProjectsController(testContext.outputChannel);
+                const buildProjectStub = sandbox.stub(projController, "buildProject").resolves("");
+
+                const result = await projController.schemaComparePublishProjectChanges(
+                    "operation-id",
+                    projectFilePath,
+                    ExtractTarget.schemaObjectType,
+                );
+
+                expect(result.success).to.be.true;
+                expect(
+                    addSqlObjectScriptsStub.calledOnceWithExactly([
+                        path.relative(project.projectFolderPath, addedFilePath),
+                    ]),
+                ).to.be.true;
+                expect(
+                    excludeSqlObjectScriptStub.calledOnceWithExactly(
+                        path.join("Tables", "Deleted.sql"),
+                    ),
+                ).to.be.true;
+                expect(excludeSqlObjectScriptStub.calledBefore(buildProjectStub)).to.be.true;
+            });
+
+            test("schemaComparePublishProjectChanges leaves the project unchanged on failure", async function (): Promise<void> {
+                const projectFilePath = path.join("C:", "test", "project.sqlproj");
+                const openProjectStub = sandbox.stub(Project, "openProject");
+                sandbox.stub(utils, "getSchemaCompareService").resolves({
+                    publishProjectChanges: sandbox.stub().resolves({
+                        success: false,
+                        errorMessage: undefined,
+                        changedFiles: [],
+                        addedFiles: [],
+                        deletedFiles: [],
+                    } as vscodeMssql.SchemaComparePublishProjectResult),
+                } as unknown as vscodeMssql.ISchemaCompareService);
+
+                const projController = new ProjectsController(testContext.outputChannel);
+                const buildProjectStub = sandbox.stub(projController, "buildProject").resolves("");
+
+                const result = await projController.schemaComparePublishProjectChanges(
+                    "operation-id",
+                    projectFilePath,
+                    ExtractTarget.schemaObjectType,
+                );
+
+                expect(result.success).to.be.false;
+                expect(openProjectStub.notCalled).to.be.true;
+                expect(buildProjectStub.notCalled).to.be.true;
+            });
+
             test("publishProject should invoke mssql.publishDatabaseProject command with correct project path", async function (): Promise<void> {
                 const proj = await testUtils.createTestProject(
                     this.test,

--- a/extensions/mssql/test/unit/schemaCompareUtils.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareUtils.test.ts
@@ -6,6 +6,7 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
 import * as path from "path";
+import * as vscode from "vscode";
 import * as mssql from "vscode-mssql";
 
 import * as schemaCompareUtils from "../../src/schemaCompare/schemaCompareUtils";
@@ -34,11 +35,10 @@ suite("Schema Compare Utils Tests", () => {
         sandbox.restore();
     });
 
-    test("publishProjectChanges should call schemaCompareService with project directory path", async () => {
+    test("publishProjectChanges should route through SQL Projects so the project file is updated", async () => {
         // Arrange
         const operationId = "test-operation-id";
         const projectFilePath = path.join("path", "to", "project.sqlproj");
-        const projectDirectoryPath = path.dirname(projectFilePath);
         const extractTarget = ExtractTarget.schemaObjectType;
         const taskExecutionMode = TaskExecutionMode.execute;
 
@@ -56,29 +56,62 @@ suite("Schema Compare Utils Tests", () => {
             deletedFiles: [],
         };
 
-        mockSchemaCompareService.publishProjectChanges.resolves(expectedResult);
+        const executeCommandStub = sandbox
+            .stub(vscode.commands, "executeCommand")
+            .withArgs(
+                schemaCompareUtils.sqlDatabaseProjectsPublishChanges,
+                operationId,
+                projectFilePath,
+                extractTarget,
+            )
+            .resolves(expectedResult);
 
         // Act
-        const result = await schemaCompareUtils.publishProjectChanges(
-            operationId,
-            payload,
-            mockSchemaCompareService as unknown as mssql.ISchemaCompareService,
-        );
+        const result = await schemaCompareUtils.publishProjectChanges(operationId, payload);
 
         // Assert
         expect(result).to.deep.equal(expectedResult);
-        expect(mockSchemaCompareService.publishProjectChanges.calledOnce).to.be.true;
-        expect(mockSchemaCompareService.publishProjectChanges.firstCall.args[0]).to.equal(
-            operationId,
+        expect(executeCommandStub.calledOnce).to.be.true;
+        expect(mockSchemaCompareService.publishProjectChanges.notCalled).to.be.true;
+    });
+
+    test("upgradeLegacyScmpProjectEndpoints resolves a classic project endpoint", () => {
+        const classicScmp = `<?xml version="1.0" encoding="utf-8"?>
+<SchemaComparison>
+  <SourceModelProvider>
+    <ProjectBasedModelProvider>
+      <ProjectGuid>{67CBC824-A49E-4E9B-A947-360F3DFE65C3}</ProjectGuid>
+      <Name>Database43</Name>
+    </ProjectBasedModelProvider>
+  </SourceModelProvider>
+</SchemaComparison>`;
+
+        const upgraded = schemaCompareUtils.upgradeLegacyScmpProjectEndpoints(classicScmp, [
+            {
+                projectGuid: "67cbc824-a49e-4e9b-a947-360f3dfe65c3",
+                projectName: "Database43",
+                projectFilePath: "C:\\src\\Database43\\Database43.sqlproj",
+                targetScripts: ["C:\\src\\Database43\\dbo\\Table1.sql"],
+                dataSchemaProvider: "160",
+            },
+        ]);
+
+        expect(upgraded.changed).to.be.true;
+        expect(upgraded.content).to.contain(
+            "<ProjectFilePath>C:\\src\\Database43\\Database43.sqlproj</ProjectFilePath>",
         );
-        expect(mockSchemaCompareService.publishProjectChanges.firstCall.args[1]).to.equal(
-            projectDirectoryPath,
+        expect(upgraded.content).to.contain(
+            "<TargetScripts>[C:\\src\\Database43\\dbo\\Table1.sql]</TargetScripts>",
         );
-        expect(mockSchemaCompareService.publishProjectChanges.firstCall.args[2]).to.equal(
-            extractTarget,
-        );
-        expect(mockSchemaCompareService.publishProjectChanges.firstCall.args[3]).to.equal(
-            taskExecutionMode,
-        );
+        expect(upgraded.content).to.contain("<Dsp>160</Dsp>");
+        expect(upgraded.content).to.contain("<FolderStructure>SchemaObjectType</FolderStructure>");
+    });
+
+    test("upgradeLegacyScmpProjectEndpoints reports an unresolved classic project", () => {
+        const classicScmp = `<SchemaComparison><SourceModelProvider><ProjectBasedModelProvider><ProjectGuid>{missing}</ProjectGuid><Name>MissingProject</Name></ProjectBasedModelProvider></SourceModelProvider></SchemaComparison>`;
+
+        expect(() =>
+            schemaCompareUtils.upgradeLegacyScmpProjectEndpoints(classicScmp, []),
+        ).to.throw("MissingProject");
     });
 });

--- a/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
+++ b/extensions/mssql/test/unit/schemaCompareWebViewController.test.ts
@@ -832,7 +832,7 @@ suite("SchemaCompareWebViewController Tests", () => {
         expect(
             publishProjectChangesStub.firstCall.args,
             "publishProjectChanges should be called with correct arguments",
-        ).to.deep.equal([operationId, payload, schemaCompareService]);
+        ).to.deep.equal([operationId, payload]);
 
         expect(
             actualResult.schemaComparePublishProjectResult,


### PR DESCRIPTION
## Description

- Route project Apply through SQL Database Projects so project entries remain synchronized with added and deleted files.
- Reload project scripts before comparison so changes on disk are not hidden by cached project data.
- Resolve classic SSDT `.scmp` project endpoints using matching projects in the current workspace.
- Fixes #20025 and fixes #19390.

Validation: extension type-check, lint, and the affected unit-test suites passed.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/vscode-mssql/blob/main/CONTRIBUTING.md)
- [ ] Telemetry/logging updated if relevant
- [ ] No regressions or UX breakage

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/vscode-mssql/blob/main/.github/REVIEW_GUIDELINES.md)

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| Apply changes to a SQL project | <!-- Add before screenshot --> | <!-- Add after screenshot --> |
| Open a classic SSDT `.scmp` file | <!-- Add before screenshot --> | <!-- Add after screenshot --> |
